### PR TITLE
[codex] Harden scanner trust and report stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ jobs:
 
 For PR comments, add `pull-requests: write` to the job's `permissions` and set `pr_comment: "true"`.
 
-Inputs: `config`, `ci_mode` (`advisory` or `strict`), `fail_on`, `baseline`, `baseline_mode`, `output_dir`, `upload_artifact`, `pr_comment`, `github_token`, `shipgate_version`.
+Inputs: `config`, `ci_mode` (`advisory` or `strict`), `fail_on`, `baseline`, `baseline_mode`, `no_plugins`, `output_dir`, `upload_artifact`, `pr_comment`, `github_token`, `shipgate_version`.
 
 Outputs: `status`, `critical_count`, `high_count`, `medium_count`, `baseline_new_count`, `report_json`, `report_markdown`, `exit_code`.
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     required: false
     default: new-findings
     description: Baseline comparison mode. v0.2 supports new-findings.
+  no_plugins:
+    required: false
+    default: "false"
+    description: Force third-party check plugins off even when AGENTS_SHIPGATE_ENABLE_PLUGINS is set.
   output_dir:
     required: false
     default: agents-shipgate-reports
@@ -102,6 +106,7 @@ runs:
         FAIL_ON: ${{ inputs.fail_on }}
         BASELINE: ${{ inputs.baseline }}
         BASELINE_MODE: ${{ inputs.baseline_mode }}
+        NO_PLUGINS: ${{ inputs.no_plugins }}
         OUTPUT_DIR: ${{ inputs.output_dir }}
       run: |
         args=(
@@ -116,6 +121,9 @@ runs:
         fi
         if [ -n "${BASELINE}" ]; then
           args+=(--baseline "${BASELINE}" --baseline-mode "${BASELINE_MODE}")
+        fi
+        if [ "${NO_PLUGINS}" = "true" ]; then
+          args+=(--no-plugins)
         fi
         set +e
         agents-shipgate "${args[@]}"

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -15,6 +15,10 @@ The baseline contains active, unsuppressed findings only. Suppressed findings
 are intentionally excluded because they already carry an explicit review reason
 in `shipgate.yaml`.
 
+Severity values in the baseline are the report-visible severities after
+`checks.severity_overrides` are applied. Matching still uses fingerprints, not
+severity, so changing an override does not create a new baseline identity.
+
 ## Apply The Baseline
 
 ```bash
@@ -43,4 +47,5 @@ Reports keep the v0.1 payload contract and add v0.2 fields:
 Baseline matching uses `findings[].fingerprint`. The fingerprint algorithm is
 documented as v1: `sha256(check_id | tool_name | canonical evidence)[:16]`,
 rendered as `fp_<digest>`. It intentionally excludes severity overrides, report
-paths, warnings, timestamps, and baseline status.
+paths, warnings, timestamps, `default_severity` audit evidence, and baseline
+status.

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -212,7 +212,7 @@ agents-shipgate list-checks --json
 agents-shipgate explain SHIP-POLICY-APPROVAL-MISSING
 ```
 
-Third-party packages can register checks through the `agents_shipgate.checks` Python entry-point group. Plugins are disabled by default because loading them imports third-party Python modules. Set `AGENTS_SHIPGATE_ENABLE_PLUGINS=1` to opt in. A plugin check should expose a callable with the same `ScanContext -> list[Finding]` shape as built-ins and may attach `AGENTS_SHIPGATE_METADATA` as either a `CheckMetadata` instance or a compatible dictionary.
+Third-party packages can register checks through the `agents_shipgate.checks` Python entry-point group. Plugins are disabled by default because loading them imports third-party Python modules. Set `AGENTS_SHIPGATE_ENABLE_PLUGINS=1` to opt in, or pass `--no-plugins` to force them off for a scan or catalog command. Reports include `loaded_plugins` provenance for every third-party check entry point that ran. A plugin check should expose a callable with the same `ScanContext -> list[Finding]` shape as built-ins and may attach `AGENTS_SHIPGATE_METADATA` as either a `CheckMetadata` instance or a compatible dictionary.
 
 ## OpenAI Agents SDK Static Extraction
 

--- a/docs/report-schema.v0.2.json
+++ b/docs/report-schema.v0.2.json
@@ -16,6 +16,7 @@
     "findings",
     "recommended_actions",
     "generated_reports",
+    "loaded_plugins",
     "tool_inventory",
     "source_warnings"
   ],
@@ -92,6 +93,14 @@
     },
     "generated_reports": {
       "type": "object"
+    },
+    "loaded_plugins": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "value", "distribution", "version", "check_id"],
+        "additionalProperties": true
+      }
     },
     "tool_inventory": {
       "type": "array",

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -24,7 +24,13 @@ By default Agents Shipgate does not:
 - `file://`, `http://`, and other external `$ref` values are left as inert schema values.
 - OpenAI Agents SDK enrichment uses `ast.parse` only. It does not import or execute Python modules.
 - `openai_api` artifacts are local prompt, JSON, YAML, or JSONL files. Agents Shipgate parses them locally and does not call OpenAI APIs, validate model availability, estimate pricing, or execute traces.
-- Third-party check plugins are disabled by default. Setting `AGENTS_SHIPGATE_ENABLE_PLUGINS=1` opts into importing and running installed plugin entry points.
+- Third-party check plugins are disabled by default. Setting `AGENTS_SHIPGATE_ENABLE_PLUGINS=1` opts into importing and running installed plugin entry points. Use `--no-plugins` to force plugins off for a scan even when the environment variable is set.
+
+## Plugin Trust Boundary
+
+Plugins are Python code. When plugin loading is enabled, Agents Shipgate imports every installed non-core entry point in the `agents_shipgate.checks` group and runs callable checks from those entry points. The default zero-execution guarantee stops at that opt-in boundary.
+
+JSON and Markdown reports include loaded plugin provenance so CI reviewers can see which third-party check packages contributed to the scan. Treat plugin packages like other CI dependencies: pin versions, audit transitive dependencies, and avoid enabling plugins in untrusted environments unless those packages are approved.
 
 ## Failure Policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,4 +63,7 @@ target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82"]
+select = ["E4", "E7", "E9", "F", "I", "B", "UP"]
+ignore = [
+  "B008", # Typer commands intentionally use Option() defaults.
+]

--- a/samples/support_refund_agent/agents/refund_agent.py
+++ b/samples/support_refund_agent/agents/refund_agent.py
@@ -1,5 +1,6 @@
 from agents import Agent, function_tool
 
+
 @function_tool
 def send_email_preview(recipient: str, subject: str, body: str) -> str:
     """Render a customer email preview without sending it."""

--- a/src/agents_shipgate/__main__.py
+++ b/src/agents_shipgate/__main__.py
@@ -1,6 +1,5 @@
 from agents_shipgate.cli.main import app
 
-
 if __name__ == "__main__":
     app()
 

--- a/src/agents_shipgate/checks/api.py
+++ b/src/agents_shipgate/checks/api.py
@@ -12,7 +12,6 @@ from agents_shipgate.core.risk_hints import (
     risk_tags,
 )
 
-
 BROAD_TEXT_NAMES = {
     "action",
     "body",

--- a/src/agents_shipgate/checks/base.py
+++ b/src/agents_shipgate/checks/base.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from agents_shipgate.core.context import ScanContext
-from agents_shipgate.core.models import Finding, SourceReference, Tool, parse_confidence, parse_severity
+from agents_shipgate.core.models import (
+    Finding,
+    SourceReference,
+    Tool,
+    parse_confidence,
+    parse_severity,
+)
 
 
 def tool_finding(

--- a/src/agents_shipgate/checks/documentation.py
+++ b/src/agents_shipgate/checks/documentation.py
@@ -6,7 +6,6 @@ from agents_shipgate.checks.base import tool_finding
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.risk_hints import is_high_risk_tool, is_write_tool
 
-
 SECRET_PATTERNS = [
     re.compile(r"\bsk-[A-Za-z0-9_-]{16,}"),
     re.compile(r"\bghp_[A-Za-z0-9_]{16,}"),

--- a/src/agents_shipgate/checks/manifest_scope.py
+++ b/src/agents_shipgate/checks/manifest_scope.py
@@ -12,7 +12,6 @@ from agents_shipgate.core.risk_hints import (
     risk_tags,
 )
 
-
 STOPWORDS = {
     "a",
     "an",

--- a/src/agents_shipgate/checks/policy.py
+++ b/src/agents_shipgate/checks/policy.py
@@ -4,7 +4,6 @@ from agents_shipgate.checks.base import tool_finding
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.risk_hints import has_risk_tag, is_effectively_read_only, risk_tags
 
-
 APPROVAL_TAGS = {
     "financial_action",
     "destructive",

--- a/src/agents_shipgate/checks/registry.py
+++ b/src/agents_shipgate/checks/registry.py
@@ -2,13 +2,23 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
+from dataclasses import dataclass
 from importlib.metadata import entry_points
 from typing import Any
 
-from agents_shipgate.checks import api, auth, documentation, inventory, manifest_consistency, manifest_scope, policy, schema, side_effects
+from agents_shipgate.checks import (
+    api,
+    auth,
+    documentation,
+    inventory,
+    manifest_consistency,
+    manifest_scope,
+    policy,
+    schema,
+    side_effects,
+)
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.models import CheckMetadata, Finding
-
 
 BUILTIN_CHECKS: list[Callable[[ScanContext], list[Finding]]] = [
     inventory.run,
@@ -54,9 +64,23 @@ CHECK_METADATA: list[CheckMetadata] = [
 ]
 
 
-def run_checks(context: ScanContext) -> list[Finding]:
+@dataclass(frozen=True)
+class LoadedPluginCheck:
+    check: Callable[[ScanContext], list[Finding]]
+    info: dict[str, str | None]
+
+
+def run_checks(
+    context: ScanContext,
+    *,
+    plugins_enabled: bool | None = None,
+    loaded_plugins: list[dict[str, str | None]] | None = None,
+) -> list[Finding]:
     findings: list[Finding] = []
-    for check in check_functions():
+    plugin_checks = _plugin_check_records(plugins_enabled=plugins_enabled)
+    if loaded_plugins is not None:
+        loaded_plugins.extend(record.info for record in plugin_checks)
+    for check in [*BUILTIN_CHECKS, *(record.check for record in plugin_checks)]:
         findings.extend(check(context))
     findings.extend(
         manifest_consistency.run(
@@ -67,9 +91,9 @@ def run_checks(context: ScanContext) -> list[Finding]:
     return findings
 
 
-def check_catalog() -> list[CheckMetadata]:
+def check_catalog(*, plugins_enabled: bool | None = None) -> list[CheckMetadata]:
     metadata = [*CHECK_METADATA]
-    for check in _plugin_checks():
+    for check in _plugin_checks(plugins_enabled=plugins_enabled):
         plugin_metadata = getattr(check, "AGENTS_SHIPGATE_METADATA", None)
         if plugin_metadata is None:
             continue
@@ -80,26 +104,102 @@ def check_catalog() -> list[CheckMetadata]:
     return sorted(metadata, key=lambda check: check.id)
 
 
-def check_functions() -> list[Callable[[ScanContext], list[Finding]]]:
-    return [*BUILTIN_CHECKS, *_plugin_checks()]
+def check_functions(
+    *, plugins_enabled: bool | None = None
+) -> list[Callable[[ScanContext], list[Finding]]]:
+    return [*BUILTIN_CHECKS, *_plugin_checks(plugins_enabled=plugins_enabled)]
 
 
-def _plugin_checks() -> list[Callable[[ScanContext], list[Finding]]]:
-    if not _plugins_enabled():
+def _plugin_checks(
+    *, plugins_enabled: bool | None = None
+) -> list[Callable[[ScanContext], list[Finding]]]:
+    return [
+        record.check
+        for record in _plugin_check_records(plugins_enabled=plugins_enabled)
+    ]
+
+
+def _plugin_check_records(
+    *,
+    plugins_enabled: bool | None = None,
+) -> list[LoadedPluginCheck]:
+    if not _plugins_enabled(plugins_enabled):
         return []
-    checks: list[Callable[[ScanContext], list[Finding]]] = []
+    checks: list[LoadedPluginCheck] = []
     for entry_point in entry_points(group="agents_shipgate.checks"):
-        if entry_point.value.startswith("agents_shipgate.checks."):
+        if _is_builtin_entry_point(entry_point):
             continue
         loaded = entry_point.load()
         if callable(loaded):
-            checks.append(loaded)
+            checks.append(
+                LoadedPluginCheck(
+                    check=loaded,
+                    info=_plugin_info(entry_point, loaded),
+                )
+            )
     return checks
 
 
-def _plugins_enabled() -> bool:
+def _plugins_enabled(override: bool | None = None) -> bool:
+    if override is not None:
+        return override
     value = os.environ.get("AGENTS_SHIPGATE_ENABLE_PLUGINS", "")
     return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _is_builtin_entry_point(entry_point: Any) -> bool:
+    dist = getattr(entry_point, "dist", None)
+    distribution_name = _distribution_name(dist)
+    if _normalize_distribution_name(distribution_name) == "agents-shipgate":
+        return True
+    if dist is None:
+        return str(getattr(entry_point, "value", "")).startswith(
+            "agents_shipgate.checks."
+        )
+    return False
+
+
+def _plugin_info(
+    entry_point: Any,
+    loaded: Callable[[ScanContext], list[Finding]],
+) -> dict[str, str | None]:
+    metadata = getattr(loaded, "AGENTS_SHIPGATE_METADATA", None)
+    check_id: str | None = None
+    if isinstance(metadata, CheckMetadata):
+        check_id = metadata.id
+    elif isinstance(metadata, dict) and isinstance(metadata.get("id"), str):
+        check_id = metadata["id"]
+    dist = getattr(entry_point, "dist", None)
+    return {
+        "name": str(getattr(entry_point, "name", "")) or None,
+        "value": str(getattr(entry_point, "value", "")) or None,
+        "distribution": _distribution_name(dist),
+        "version": _distribution_version(dist),
+        "check_id": check_id,
+    }
+
+
+def _distribution_name(dist: Any) -> str | None:
+    if dist is None:
+        return None
+    metadata = getattr(dist, "metadata", None)
+    if metadata is not None:
+        name = metadata.get("Name")
+        if isinstance(name, str):
+            return name
+    name = getattr(dist, "name", None)
+    return str(name) if name else None
+
+
+def _distribution_version(dist: Any) -> str | None:
+    if dist is None:
+        return None
+    version = getattr(dist, "version", None)
+    return str(version) if version else None
+
+
+def _normalize_distribution_name(value: str | None) -> str:
+    return (value or "").replace("_", "-").lower()
 
 
 def _metadata_from_plugin(value: Any) -> CheckMetadata:

--- a/src/agents_shipgate/checks/schema.py
+++ b/src/agents_shipgate/checks/schema.py
@@ -5,7 +5,6 @@ from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.models import Tool, ToolParameter
 from agents_shipgate.core.risk_hints import has_risk_tag, is_effectively_read_only, is_write_tool
 
-
 BROAD_FREE_TEXT_NAMES = {
     "action",
     "body",

--- a/src/agents_shipgate/checks/side_effects.py
+++ b/src/agents_shipgate/checks/side_effects.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from agents_shipgate.checks.base import tool_finding
 from agents_shipgate.core.context import ScanContext
-from agents_shipgate.core.risk_hints import has_risk_tag, is_effectively_read_only, is_write_tool, risk_tags
+from agents_shipgate.core.risk_hints import (
+    has_risk_tag,
+    is_effectively_read_only,
+    is_write_tool,
+    risk_tags,
+)
 
 
 def run(context: ScanContext):

--- a/src/agents_shipgate/ci/exit_policy.py
+++ b/src/agents_shipgate/ci/exit_policy.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from agents_shipgate.core.models import ReadinessReport, Severity
 
-
 GATE_FAILURE_EXIT_CODE = 20
 
 

--- a/src/agents_shipgate/cli/discovery.py
+++ b/src/agents_shipgate/cli/discovery.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 OPENAPI_PATTERNS = (
     "*openapi*.yaml",
     "*openapi*.yml",

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-from difflib import get_close_matches
 import glob
 import json
 import logging
+import re
+from difflib import get_close_matches
 from pathlib import Path
 
 import typer
 
 from agents_shipgate import __version__
+from agents_shipgate.checks.registry import check_catalog
 from agents_shipgate.cli.discovery import discover_manifest_paths, render_manifest_template
 from agents_shipgate.cli.scan import inspect_sources, run_scan
-from agents_shipgate.checks.registry import check_catalog
 from agents_shipgate.core.baseline import write_baseline
-from agents_shipgate.core.errors import ConfigError, InputParseError, AgentsShipgateError
+from agents_shipgate.core.errors import AgentsShipgateError, ConfigError, InputParseError
 from agents_shipgate.core.findings import SEVERITY_ORDER
 from agents_shipgate.core.logging import configure_logging
-
 
 app = typer.Typer(
     name="agents-shipgate",
@@ -79,11 +79,18 @@ def scan(
         "new-findings",
         "--baseline-mode",
         help="Baseline comparison mode. v0.2 supports new-findings only.",
+        hidden=True,
     ),
     deep_import: bool = typer.Option(
         False,
         "--deep-import",
         help="Deferred. Explicit import execution is not supported yet.",
+        hidden=True,
+    ),
+    no_plugins: bool = typer.Option(
+        False,
+        "--no-plugins",
+        help="Do not load third-party check plugins even when AGENTS_SHIPGATE_ENABLE_PLUGINS is set.",
     ),
     verbose: bool = typer.Option(False, "--verbose", help="Show debug extraction details."),
 ) -> None:
@@ -105,6 +112,7 @@ def scan(
                 baseline_path=baseline,
                 baseline_mode=baseline_mode,
                 deep_import=deep_import,
+                plugins_enabled=False if no_plugins else None,
                 verbose=verbose,
             )
             _print_cli_summary(report, ci_mode or "advisory", exit_code, verbose=verbose)
@@ -118,6 +126,7 @@ def scan(
             baseline=baseline,
             baseline_mode=baseline_mode,
             deep_import=deep_import,
+            plugins_enabled=False if no_plugins else None,
             verbose=verbose,
         )
     except ConfigError as exc:
@@ -142,10 +151,15 @@ def scan(
 
 @app.command("list-checks")
 def list_checks(
-    json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of text.")
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of text."),
+    no_plugins: bool = typer.Option(
+        False,
+        "--no-plugins",
+        help="Do not load third-party check plugins even when AGENTS_SHIPGATE_ENABLE_PLUGINS is set.",
+    ),
 ) -> None:
     """List the built-in check catalog."""
-    checks = check_catalog()
+    checks = check_catalog(plugins_enabled=False if no_plugins else None)
     if json_output:
         typer.echo(json.dumps([check.model_dump() for check in checks], indent=2))
         return
@@ -156,9 +170,16 @@ def list_checks(
 
 
 @app.command()
-def explain(check_id: str) -> None:
+def explain(
+    check_id: str,
+    no_plugins: bool = typer.Option(
+        False,
+        "--no-plugins",
+        help="Do not load third-party check plugins even when AGENTS_SHIPGATE_ENABLE_PLUGINS is set.",
+    ),
+) -> None:
     """Explain why a check exists and when it fires."""
-    checks = check_catalog()
+    checks = check_catalog(plugins_enabled=False if no_plugins else None)
     check = next((item for item in checks if item.id == check_id), None)
     if not check:
         matches = get_close_matches(check_id, [item.id for item in checks], n=1)
@@ -341,6 +362,7 @@ def _run_multi_scan(
     baseline: Path | None,
     baseline_mode: str,
     deep_import: bool,
+    plugins_enabled: bool | None,
     verbose: bool,
 ) -> int:
     typer.echo(f"Agents Shipgate {__version__}")
@@ -351,30 +373,55 @@ def _run_multi_scan(
         output_dir = None
         if out is not None:
             output_dir = out / _safe_output_name(config_path)
-        report, scan_exit_code = run_scan(
-            config_path=config_path,
-            output_dir=output_dir,
-            formats=formats,
-            ci_mode=ci_mode,
-            fail_on=fail_on,
-            baseline_path=baseline,
-            baseline_mode=baseline_mode,
-            deep_import=deep_import,
-            verbose=verbose,
-        )
+        try:
+            report, scan_exit_code = run_scan(
+                config_path=config_path,
+                output_dir=output_dir,
+                formats=formats,
+                ci_mode=ci_mode,
+                fail_on=fail_on,
+                baseline_path=baseline,
+                baseline_mode=baseline_mode,
+                deep_import=deep_import,
+                plugins_enabled=plugins_enabled,
+                verbose=verbose,
+            )
+        except ConfigError as exc:
+            scan_exit_code = 2
+            typer.echo(f"{config_path}: config_error - {exc}", err=True)
+        except InputParseError as exc:
+            scan_exit_code = 3
+            typer.echo(f"{config_path}: input_parse_error - {exc}", err=True)
+        except AgentsShipgateError as exc:
+            scan_exit_code = 4
+            typer.echo(f"{config_path}: agents_shipgate_error - {exc}", err=True)
+        except Exception as exc:  # noqa: BLE001 - multi-scan boundary.
+            scan_exit_code = 4
+            if verbose:
+                logger.exception("unhandled exception while scanning %s", config_path)
+            typer.echo(f"{config_path}: internal_error - {exc}", err=True)
+        else:
+            typer.echo(
+                f"{config_path}: {report.summary.status} "
+                f"(critical={report.summary.critical_count}, high={report.summary.high_count})"
+            )
         exit_code = max(exit_code, scan_exit_code)
-        typer.echo(
-            f"{config_path}: {report.summary.status} "
-            f"(critical={report.summary.critical_count}, high={report.summary.high_count})"
-        )
     typer.echo("")
     typer.echo(f"Exit code: {exit_code}")
     return exit_code
 
 
 def _safe_output_name(config_path: Path) -> str:
-    parent = config_path.parent.as_posix().strip("./").replace("/", "__")
-    return parent or "root"
+    parent = config_path.parent
+    try:
+        display_parent = parent.resolve().relative_to(Path.cwd().resolve())
+    except ValueError:
+        display_parent = parent.resolve()
+    raw = display_parent.as_posix()
+    if raw in {"", "."}:
+        return "root"
+    safe = re.sub(r"[^A-Za-z0-9_-]+", "_", raw).strip("_")
+    return safe or "root"
 
 
 def _print_cli_summary(report, ci_mode: str, exit_code: int, *, verbose: bool = False) -> None:

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -14,8 +14,8 @@ from agents_shipgate.core.baseline import apply_baseline, load_baseline
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.errors import ConfigError, InputParseError
 from agents_shipgate.core.findings import (
-    apply_suppressions,
     apply_severity_overrides,
+    apply_suppressions,
     assign_finding_ids,
     build_report,
     tool_inventory,
@@ -30,9 +30,9 @@ from agents_shipgate.core.models import (
 )
 from agents_shipgate.core.risk_hints import enrich_tools_with_risk_hints
 from agents_shipgate.inputs.mcp import load_mcp_tools
-from agents_shipgate.inputs.openapi import load_openapi_tools
 from agents_shipgate.inputs.openai_api import load_openai_api_artifacts
 from agents_shipgate.inputs.openai_sdk_static import load_openai_sdk_static_tools
+from agents_shipgate.inputs.openapi import load_openapi_tools
 from agents_shipgate.report.json_report import write_json_report
 from agents_shipgate.report.markdown import write_markdown_report
 
@@ -49,6 +49,7 @@ def run_scan(
     baseline_path: Path | None = None,
     baseline_mode: str = "new-findings",
     deep_import: bool = False,
+    plugins_enabled: bool | None = None,
     verbose: bool = False,
 ) -> tuple[ReadinessReport, int]:
     if deep_import:
@@ -112,7 +113,12 @@ def run_scan(
         config_path=config_path.resolve(),
         api_artifacts=api_artifacts,
     )
-    findings = run_checks(context)
+    loaded_plugins: list[dict[str, str | None]] = []
+    findings = run_checks(
+        context,
+        plugins_enabled=plugins_enabled,
+        loaded_plugins=loaded_plugins,
+    )
     assign_finding_ids(findings)
     apply_severity_overrides(findings, manifest.severity_overrides())
     apply_suppressions(findings, manifest.checks.ignore)
@@ -152,6 +158,7 @@ def run_scan(
             key: _relative_display_path(path, base_dir)
             for key, path in generated_paths.items()
         },
+        loaded_plugins=loaded_plugins,
         source_warnings=warnings,
         api_surface=api_artifacts.surface_summary() if api_artifacts else None,
         baseline=baseline_summary,

--- a/src/agents_shipgate/config/loader.py
+++ b/src/agents_shipgate/config/loader.py
@@ -10,7 +10,6 @@ from pydantic import ValidationError
 from agents_shipgate.config.schema import AgentsShipgateManifest
 from agents_shipgate.core.errors import ConfigError
 
-
 KNOWN_MANIFEST_FIELDS = {
     "agent",
     "annotations",

--- a/src/agents_shipgate/config/schema.py
+++ b/src/agents_shipgate/config/schema.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from agents_shipgate.core.models import Severity
 
-
 STRICT_MODEL_CONFIG = ConfigDict(extra="forbid")
 
 

--- a/src/agents_shipgate/core/baseline.py
+++ b/src/agents_shipgate/core/baseline.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import BaselineSummary, Finding, ReadinessReport, Severity
 
-
 BASELINE_SCHEMA_VERSION = "0.2"
 
 

--- a/src/agents_shipgate/core/findings.py
+++ b/src/agents_shipgate/core/findings.py
@@ -2,23 +2,36 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections import Counter
+from collections import Counter, defaultdict
 
 from agents_shipgate.config.schema import AgentsShipgateManifest, SuppressionConfig
-from agents_shipgate.core.models import BaselineSummary, Finding, ReadinessReport, ReportSummary, Severity, Tool, ToolSurfaceSummary
+from agents_shipgate.core.models import (
+    BaselineSummary,
+    Finding,
+    ReadinessReport,
+    ReportSummary,
+    Severity,
+    Tool,
+    ToolSurfaceSummary,
+    confidence_rank,
+)
 from agents_shipgate.core.risk_hints import is_high_risk_tool, risk_tags
 
-
 SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+FINGERPRINT_EXCLUDED_EVIDENCE_KEYS = {"default_severity"}
 
 
 def assign_finding_ids(findings: list[Finding]) -> list[Finding]:
-    seen: dict[str, int] = {}
+    by_fingerprint: dict[str, list[Finding]] = defaultdict(list)
     for finding in findings:
-        base_id = finding_fingerprint(finding)
-        finding.fingerprint = base_id
-        seen[base_id] = seen.get(base_id, 0) + 1
-        finding.id = base_id if seen[base_id] == 1 else f"{base_id}_{seen[base_id]}"
+        finding.fingerprint = finding_fingerprint(finding)
+        by_fingerprint[finding.fingerprint].append(finding)
+    for finding in findings:
+        assert finding.fingerprint is not None
+        if len(by_fingerprint[finding.fingerprint]) == 1:
+            finding.id = finding.fingerprint
+            continue
+        finding.id = f"{finding.fingerprint}_{_collision_discriminator(finding)}"
     return findings
 
 
@@ -39,6 +52,8 @@ def apply_severity_overrides(
     for finding in findings:
         override = overrides.get(finding.check_id)
         if override:
+            # Keep this audit field out of fingerprinting so overrides can be
+            # applied before or after ID assignment without changing identity.
             finding.evidence.setdefault("default_severity", finding.severity)
             finding.severity = override
     return findings
@@ -122,6 +137,7 @@ def build_report(
     tools: list[Tool],
     findings: list[Finding],
     generated_reports: dict[str, str],
+    loaded_plugins: list[dict[str, object]] | None = None,
     source_warnings: list[str] | None = None,
     api_surface: dict[str, object] | None = None,
     baseline: BaselineSummary | None = None,
@@ -138,6 +154,7 @@ def build_report(
         findings=findings,
         recommended_actions=recommended_actions(findings),
         generated_reports=generated_reports,
+        loaded_plugins=loaded_plugins or [],
         tool_inventory=tool_inventory(tools),
         source_warnings=source_warnings or [],
     )
@@ -178,6 +195,7 @@ def _canonicalize_for_fingerprint(value):
         return {
             key: _canonicalize_for_fingerprint(value[key])
             for key in sorted(value)
+            if key not in FINGERPRINT_EXCLUDED_EVIDENCE_KEYS
         }
     if isinstance(value, list):
         items = [_canonicalize_for_fingerprint(item) for item in value]
@@ -190,20 +208,38 @@ def _canonicalize_for_fingerprint(value):
     return value
 
 
+def _collision_discriminator(finding: Finding) -> str:
+    identity = {
+        "agent_id": finding.agent_id,
+        "category": finding.category,
+        "check_id": finding.check_id,
+        "confidence": finding.confidence,
+        "recommendation": finding.recommendation,
+        "source": finding.source.model_dump(mode="json") if finding.source else None,
+        "title": finding.title,
+        "tool_id": finding.tool_id,
+        "tool_name": finding.tool_name,
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            _canonicalize_for_fingerprint(identity),
+            sort_keys=True,
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()[:8]
+    return digest
+
+
 def _risk_tag_confidence(tool: Tool, min_confidence: str) -> dict[str, str]:
-    threshold = _confidence_rank(min_confidence)
+    threshold = confidence_rank(min_confidence)
     by_tag: dict[str, str] = {}
     for hint in tool.risk_hints:
-        if _confidence_rank(hint.confidence) < threshold:
+        if confidence_rank(hint.confidence) < threshold:
             continue
         current = by_tag.get(hint.tag)
-        if current is None or _confidence_rank(hint.confidence) > _confidence_rank(current):
+        if current is None or confidence_rank(hint.confidence) > confidence_rank(current):
             by_tag[hint.tag] = hint.confidence
     return dict(sorted(by_tag.items()))
-
-
-def _confidence_rank(confidence: str) -> int:
-    return {"low": 1, "medium": 2, "high": 3}.get(confidence, 0)
 
 
 def _has_mixed_evidence(tools: list[Tool]) -> bool:

--- a/src/agents_shipgate/core/models.py
+++ b/src/agents_shipgate/core/models.py
@@ -4,7 +4,6 @@ from typing import Any, Literal, cast, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-
 Severity = Literal["info", "low", "medium", "high", "critical"]
 Confidence = Literal["low", "medium", "high"]
 BaselineStatus = Literal["new", "matched", "resolved"]
@@ -20,6 +19,10 @@ def parse_confidence(value: str) -> Confidence:
     if value not in get_args(Confidence):
         raise ValueError(f"Unsupported confidence: {value}")
     return cast(Confidence, value)
+
+
+def confidence_rank(confidence: str | None) -> int:
+    return {"low": 1, "medium": 2, "high": 3}.get(confidence or "", 0)
 
 
 class SourceReference(BaseModel):
@@ -239,6 +242,7 @@ class ReadinessReport(BaseModel):
     findings: list[Finding] = Field(default_factory=list)
     recommended_actions: list[str] = Field(default_factory=list)
     generated_reports: dict[str, str] = Field(default_factory=dict)
+    loaded_plugins: list[dict[str, Any]] = Field(default_factory=list)
     tool_inventory: list[dict[str, Any]] = Field(default_factory=list)
     source_warnings: list[str] = Field(default_factory=list)
 

--- a/src/agents_shipgate/core/risk_hints.py
+++ b/src/agents_shipgate/core/risk_hints.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from agents_shipgate.config.schema import AgentsShipgateManifest
-from agents_shipgate.core.models import Tool, ToolRiskHint, parse_confidence
-
+from agents_shipgate.core.models import Tool, ToolRiskHint, confidence_rank, parse_confidence
 
 HIGH_RISK_TAGS = {
     "destructive",
@@ -34,19 +33,19 @@ def has_risk_tag(tool: Tool, tags: Iterable[str], min_confidence: str | None = N
     best_confidence = 0
     for hint in tool.risk_hints:
         if hint.tag in wanted:
-            best_confidence = max(best_confidence, _confidence_rank(hint.confidence))
+            best_confidence = max(best_confidence, confidence_rank(hint.confidence))
     if min_confidence:
-        return best_confidence >= _confidence_rank(min_confidence)
+        return best_confidence >= confidence_rank(min_confidence)
     return best_confidence > 0
 
 
 def risk_tags(tool: Tool, min_confidence: str | None = None) -> list[str]:
-    threshold = _confidence_rank(min_confidence) if min_confidence else 0
+    threshold = confidence_rank(min_confidence) if min_confidence else 0
     return sorted(
         {
             hint.tag
             for hint in tool.risk_hints
-            if _confidence_rank(hint.confidence) >= threshold
+            if confidence_rank(hint.confidence) >= threshold
         }
     )
 
@@ -160,7 +159,7 @@ def _add_hint(
     confidence_value = confidence if confidence in {"low", "medium", "high"} else "medium"
     for existing in tool.risk_hints:
         if existing.tag == tag and existing.source == source:
-            if _confidence_rank(confidence_value) > _confidence_rank(existing.confidence):
+            if confidence_rank(confidence_value) > confidence_rank(existing.confidence):
                 existing.confidence = parse_confidence(confidence_value)
                 existing.evidence.update(evidence)
             return
@@ -172,7 +171,3 @@ def _add_hint(
             evidence={key: value for key, value in evidence.items() if value is not None},
         )
     )
-
-
-def _confidence_rank(confidence: str) -> int:
-    return {"low": 1, "medium": 2, "high": 3}.get(confidence, 0)

--- a/src/agents_shipgate/inputs/common.py
+++ b/src/agents_shipgate/inputs/common.py
@@ -10,10 +10,23 @@ import yaml
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import ToolParameter
 
-
 HTTP_METHODS = {"get", "put", "post", "delete", "patch", "options", "head", "trace"}
 MAX_INPUT_FILE_BYTES = 10 * 1024 * 1024
 CONVENTIONAL_TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._-]{0,128}$")
+
+
+def resolve_input_path(base_dir: Path, value: str) -> Path:
+    base = base_dir.resolve()
+    raw_path = Path(value)
+    path = raw_path if raw_path.is_absolute() else base / raw_path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise InputParseError(
+            f"Input path {value!r} resolves outside manifest directory: {resolved}"
+        ) from exc
+    return resolved
 
 
 def load_structured_file(path: Path) -> Any:

--- a/src/agents_shipgate/inputs/mcp.py
+++ b/src/agents_shipgate/inputs/mcp.py
@@ -8,6 +8,7 @@ from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool
 from agents_shipgate.inputs.common import (
     load_structured_file,
+    resolve_input_path,
     schema_to_parameters,
     stable_tool_id,
     tool_name_warning,
@@ -16,7 +17,7 @@ from agents_shipgate.inputs.common import (
 
 def load_mcp_tools(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSource:
     assert source.path is not None
-    path = (base_dir / source.path).resolve()
+    path = resolve_input_path(base_dir, source.path)
     source_ref = source.path
     data = load_structured_file(path)
     warnings: list[str] = []

--- a/src/agents_shipgate/inputs/openai_api.py
+++ b/src/agents_shipgate/inputs/openai_api.py
@@ -19,11 +19,11 @@ from agents_shipgate.core.models import (
 from agents_shipgate.inputs.common import (
     load_structured_file,
     load_text_file,
+    resolve_input_path,
     schema_to_parameters,
     stable_tool_id,
     tool_name_warning,
 )
-
 
 PROMPT_SUFFIXES = {".md", ".markdown", ".txt"}
 
@@ -345,8 +345,7 @@ def _looks_like_json_schema(value: dict[str, Any]) -> bool:
 
 
 def _resolve(base_dir: Path, value: str) -> Path:
-    path = Path(value)
-    return path if path.is_absolute() else base_dir / path
+    return resolve_input_path(base_dir, value)
 
 
 def _display_path(path: Path, base_dir: Path) -> str:

--- a/src/agents_shipgate/inputs/openai_sdk_static.py
+++ b/src/agents_shipgate/inputs/openai_sdk_static.py
@@ -7,7 +7,7 @@ from typing import Any
 from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool, ToolParameter
-from agents_shipgate.inputs.common import stable_tool_id
+from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id
 
 
 def load_openai_sdk_static_tools(
@@ -20,7 +20,7 @@ def load_openai_sdk_static_tools(
             source_type="openai_agents_sdk",
             warnings=["OpenAI Agents SDK source has no entrypoint"],
         )
-    path = (base_dir / entrypoint).resolve()
+    path = resolve_input_path(base_dir, entrypoint)
     if not path.exists():
         return LoadedToolSource(
             source_id=source.id,

--- a/src/agents_shipgate/inputs/openapi.py
+++ b/src/agents_shipgate/inputs/openapi.py
@@ -10,11 +10,11 @@ from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool
 from agents_shipgate.inputs.common import (
     HTTP_METHODS,
     load_structured_file,
+    resolve_input_path,
     schema_to_parameters,
     stable_tool_id,
     tool_name_warning,
 )
-
 
 MAX_SCHEMA_RESOLVE_DEPTH = 32
 MAX_SCHEMA_RESOLVE_NODES = 5000
@@ -22,7 +22,7 @@ MAX_SCHEMA_RESOLVE_NODES = 5000
 
 def load_openapi_tools(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSource:
     assert source.path is not None
-    path = (base_dir / source.path).resolve()
+    path = resolve_input_path(base_dir, source.path)
     document = load_structured_file(path)
     if not isinstance(document, dict):
         raise InputParseError(f"OpenAPI file must contain an object: {path}")

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from agents_shipgate.core.findings import SEVERITY_ORDER
 from agents_shipgate.core.models import Finding, ReadinessReport
 
-
 DISCLAIMER = (
     "Agents Shipgate is an advisory release-readiness scanner. It does not certify "
     "agent safety or compliance. Findings are based on static configuration, declared "
@@ -47,6 +46,7 @@ def render_markdown_report(report: ReadinessReport) -> str:
     _append_baseline(lines, report)
     _append_recommended_actions(lines, report.recommended_actions)
     _append_source_warnings(lines, report)
+    _append_loaded_plugins(lines, report)
     _append_tool_surface(lines, report)
     _append_api_surface(lines, report)
     _append_findings_by_category(lines, report.findings)
@@ -108,6 +108,22 @@ def _append_source_warnings(lines: list[str], report: ReadinessReport) -> None:
     lines.extend(["## Source Warnings", ""])
     for warning in report.source_warnings:
         lines.append(f"- {_safe_markdown_text(warning)}")
+    lines.append("")
+
+
+def _append_loaded_plugins(lines: list[str], report: ReadinessReport) -> None:
+    if not report.loaded_plugins:
+        return
+    lines.extend(["## Loaded Plugins", ""])
+    for plugin in report.loaded_plugins:
+        distribution = plugin.get("distribution") or "unknown distribution"
+        version = plugin.get("version")
+        check_id = plugin.get("check_id") or "unknown check"
+        suffix = f" {version}" if version else ""
+        lines.append(
+            f"- {_safe_markdown_text(distribution)}{_safe_markdown_text(suffix)}: "
+            f"{_safe_markdown_text(check_id)}"
+        )
     lines.append("")
 
 

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -44,6 +44,8 @@ def test_action_preserves_reports_before_applying_exit_code():
     assert "steps.scan.outputs.exit_code" in text
     assert "FAIL_ON: ${{ inputs.fail_on }}" in text
     assert "BASELINE: ${{ inputs.baseline }}" in text
+    assert "NO_PLUGINS: ${{ inputs.no_plugins }}" in text
+    assert "args+=(--no-plugins)" in text
 
 
 def test_action_pr_comment_truncates_user_controlled_text():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 import json
+from pathlib import Path
 
 from typer.testing import CliRunner
 
-from agents_shipgate.cli.main import app
-
+from agents_shipgate.cli.main import _safe_output_name, app
 
 runner = CliRunner()
 
@@ -89,6 +89,15 @@ def test_cli_list_checks_outputs_catalog():
     assert "SHIP-POLICY-APPROVAL-MISSING" in result.output
 
 
+def test_cli_scan_help_hides_deferred_flags():
+    result = runner.invoke(app, ["scan", "--help"])
+
+    assert result.exit_code == 0
+    assert "--deep-import" not in result.output
+    assert "--baseline-mode" not in result.output
+    assert "--no-plugins" in result.output
+
+
 def test_cli_explain_outputs_check_details():
     result = runner.invoke(app, ["explain", "SHIP-POLICY-APPROVAL-MISSING"])
 
@@ -169,6 +178,77 @@ def test_cli_scan_workspace_writes_separate_report_dirs(tmp_path):
     assert result.exit_code == 0
     assert "Scanning 2 manifests" in result.output
     assert len(list(tmp_path.glob("*/report.json"))) == 2
+
+
+def test_cli_scan_workspace_continues_after_config_error(tmp_path):
+    workspace = tmp_path / "workspace"
+    valid = workspace / "valid"
+    invalid = workspace / "invalid"
+    valid.mkdir(parents=True)
+    invalid.mkdir()
+    (valid / "tools.json").write_text(
+        """
+{
+  "tools": [
+    {
+      "name": "docs.lookup",
+      "description": "Look up internal documentation metadata.",
+      "annotations": {"readOnlyHint": true}
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    (valid / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: valid-workspace
+agent:
+  name: valid-agent
+  declared_purpose:
+    - read documentation
+environment:
+  target: local
+tool_sources:
+  - id: tools
+    type: mcp
+    path: tools.json
+""",
+        encoding="utf-8",
+    )
+    (invalid / "shipgate.yaml").write_text("version: '0.1'\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "--workspace",
+            str(workspace),
+            "--out",
+            str(tmp_path / "reports"),
+            "--format",
+            "json",
+            "--ci-mode",
+            "advisory",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "valid/shipgate.yaml: no_release_blockers_detected" in result.output
+    assert "invalid/shipgate.yaml: config_error" in result.output
+    assert len(list((tmp_path / "reports").glob("*/report.json"))) == 1
+
+
+def test_safe_output_name_normalizes_unsafe_segments():
+    output_name = _safe_output_name(Path("../../etc/passwd/shipgate.yaml"))
+
+    assert output_name
+    assert "/" not in output_name
+    assert "\\" not in output_name
+    assert ":" not in output_name
+    assert ".." not in output_name
 
 
 def test_cli_verbose_json_logs(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from agents_shipgate.checks import registry
 from agents_shipgate.cli.main import _safe_output_name, app
 
 runner = CliRunner()
@@ -95,7 +96,33 @@ def test_cli_scan_help_hides_deferred_flags():
     assert result.exit_code == 0
     assert "--deep-import" not in result.output
     assert "--baseline-mode" not in result.output
-    assert "--no-plugins" in result.output
+
+
+def test_cli_scan_no_plugins_forces_plugins_off(monkeypatch, tmp_path):
+    class FakeEntryPoint:
+        value = "acme_shipgate_checks:run"
+
+        def load(self):
+            raise AssertionError("plugin should not be loaded")
+
+    monkeypatch.setattr(registry, "entry_points", lambda group: [FakeEntryPoint()])
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "--config",
+            "samples/clean_read_only_agent/shipgate.yaml",
+            "--out",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--no-plugins",
+        ],
+        env={"AGENTS_SHIPGATE_ENABLE_PLUGINS": "1"},
+    )
+
+    assert result.exit_code == 0
 
 
 def test_cli_explain_outputs_check_details():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@ import pytest
 from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.errors import ConfigError
 
-
 SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 
 

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -3,6 +3,7 @@ from agents_shipgate.core.findings import (
     apply_severity_overrides,
     apply_suppressions,
     assign_finding_ids,
+    finding_fingerprint,
     summarize_findings,
 )
 from agents_shipgate.core.models import Finding, Tool
@@ -63,6 +64,37 @@ def test_finding_ids_are_stable_across_ordering():
     assert second.id == second_id
 
 
+def test_colliding_finding_ids_use_stable_discriminator():
+    first = Finding(
+        check_id="SHIP-A",
+        title="A",
+        severity="high",
+        category="test",
+        tool_name="tool_a",
+        evidence={"field": "same"},
+        recommendation="Fix A.",
+    )
+    second = Finding(
+        check_id="SHIP-A",
+        title="B",
+        severity="high",
+        category="test",
+        tool_name="tool_a",
+        evidence={"field": "same"},
+        recommendation="Fix B.",
+    )
+
+    assign_finding_ids([first, second])
+    first_id = first.id
+    second_id = second.id
+    assign_finding_ids([second, first])
+
+    assert first.fingerprint == second.fingerprint
+    assert first.id == first_id
+    assert second.id == second_id
+    assert first.id != second.id
+
+
 def test_finding_fingerprint_is_stable_across_severity_override():
     finding = Finding(
         check_id="SHIP-DOC-MISSING-DESCRIPTION",
@@ -81,6 +113,23 @@ def test_finding_fingerprint_is_stable_across_severity_override():
     assert finding.severity == "critical"
     assert finding.fingerprint == fingerprint
     assert finding.evidence["default_severity"] == "medium"
+
+
+def test_finding_fingerprint_ignores_default_severity_evidence():
+    finding = Finding(
+        check_id="SHIP-DOC-MISSING-DESCRIPTION",
+        title="Missing description",
+        severity="medium",
+        category="documentation",
+        tool_name="docs.short",
+        evidence={"description_length": 5},
+        recommendation="Add a description.",
+    )
+    fingerprint = finding_fingerprint(finding)
+
+    apply_severity_overrides([finding], {"SHIP-DOC-MISSING-DESCRIPTION": "critical"})
+
+    assert finding_fingerprint(finding) == fingerprint
 
 
 def test_finding_fingerprint_sorts_list_evidence_values():

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -8,7 +8,6 @@ from agents_shipgate.inputs.mcp import load_mcp_tools
 from agents_shipgate.inputs.openai_sdk_static import load_openai_sdk_static_tools
 from agents_shipgate.inputs.openapi import load_openapi_tools
 
-
 BASE = Path("samples/support_refund_agent")
 
 
@@ -116,6 +115,23 @@ def test_mcp_loader_warns_on_duplicate_and_non_conventional_names(tmp_path):
     assert len(loaded.tools) == 2
     assert any("non-conventional" in warning for warning in loaded.warnings)
     assert any("Duplicate MCP tool name" in warning for warning in loaded.warnings)
+
+
+def test_mcp_loader_rejects_path_traversal(tmp_path):
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"tools": []}', encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+
+    try:
+        load_mcp_tools(
+            ToolSourceConfig(id="outside", type="mcp", path="../outside.json"),
+            project,
+        )
+    except InputParseError as exc:
+        assert "resolves outside manifest directory" in str(exc)
+    else:
+        raise AssertionError("Expected InputParseError")
 
 
 def test_json_content_with_yaml_extension_is_parsed_as_json(tmp_path):

--- a/tests/test_manifest_consistency.py
+++ b/tests/test_manifest_consistency.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 from agents_shipgate.cli.scan import run_scan
 

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -7,7 +7,6 @@ from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.inputs.openai_api import load_openai_api_artifacts
 
-
 SAMPLE = Path("samples/simple_openai_api_agent/shipgate.yaml")
 
 

--- a/tests/test_openapi_fuzz.py
+++ b/tests/test_openapi_fuzz.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 from agents_shipgate.config.schema import ToolSourceConfig
 from agents_shipgate.inputs.openapi import load_openapi_tools

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from agents_shipgate.checks import registry
+from agents_shipgate.cli.scan import run_scan
+
+
+class FakeDist:
+    metadata = {"Name": "acme-shipgate-checks"}
+    version = "1.2.3"
 
 
 def test_plugin_checks_disabled_by_default(monkeypatch):
@@ -52,3 +60,82 @@ def test_plugin_checks_load_only_when_enabled(monkeypatch):
     assert registry._plugin_checks() == [plugin]
     catalog = registry.check_catalog()
     assert any(check.id == "ACME-CHECK" for check in catalog)
+
+
+def test_plugin_checks_can_be_forced_off(monkeypatch):
+    loaded = {"called": False}
+
+    class FakeEntryPoint:
+        value = "acme_shipgate_checks:run"
+
+        def load(self):
+            loaded["called"] = True
+            return lambda context: []
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_ENABLE_PLUGINS", "1")
+    monkeypatch.setattr(registry, "entry_points", lambda group: [FakeEntryPoint()])
+
+    assert registry._plugin_checks(plugins_enabled=False) == []
+    assert loaded["called"] is False
+
+
+def test_builtin_distribution_entry_points_are_skipped(monkeypatch):
+    loaded = {"called": False}
+
+    class BuiltinDist:
+        metadata = {"Name": "agents-shipgate"}
+        version = "0.2.0"
+
+    class FakeEntryPoint:
+        dist = BuiltinDist()
+        value = "agents_shipgate.checks.evil:run"
+
+        def load(self):
+            loaded["called"] = True
+            return lambda context: []
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_ENABLE_PLUGINS", "1")
+    monkeypatch.setattr(registry, "entry_points", lambda group: [FakeEntryPoint()])
+
+    assert registry._plugin_checks() == []
+    assert loaded["called"] is False
+
+
+def test_report_includes_loaded_plugin_provenance(monkeypatch, tmp_path):
+    def plugin(context):
+        return []
+
+    plugin.AGENTS_SHIPGATE_METADATA = {
+        "id": "ACME-CHECK",
+        "category": "custom",
+        "default_severity": "medium",
+        "description": "Custom plugin check.",
+    }
+
+    class FakeEntryPoint:
+        name = "acme"
+        value = "acme_shipgate_checks:run"
+        dist = FakeDist()
+
+        def load(self):
+            return plugin
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_ENABLE_PLUGINS", "1")
+    monkeypatch.setattr(registry, "entry_points", lambda group: [FakeEntryPoint()])
+
+    report, _ = run_scan(
+        config_path=Path("samples/clean_read_only_agent/shipgate.yaml"),
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    assert report.loaded_plugins == [
+        {
+            "name": "acme",
+            "value": "acme_shipgate_checks:run",
+            "distribution": "acme-shipgate-checks",
+            "version": "1.2.3",
+            "check_id": "ACME-CHECK",
+        }
+    ]

--- a/tests/test_property_loaders.py
+++ b/tests/test_property_loaders.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 
-from hypothesis import HealthCheck, given, settings, strategies as st
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 from agents_shipgate.config.schema import ToolSourceConfig
 from agents_shipgate.inputs.mcp import load_mcp_tools
 from agents_shipgate.inputs.openapi import load_openapi_tools
-
 
 TOOL_NAMES = st.from_regex(r"[A-Za-z][A-Za-z0-9._-]{0,24}", fullmatch=True)
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,11 +1,10 @@
-from pathlib import Path
 import json
+from pathlib import Path
 
 from jsonschema import validate
 
 from agents_shipgate.cli.scan import run_scan
 from agents_shipgate.report.markdown import render_markdown_report
-
 
 SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 EXPECTED_MARKDOWN = Path("samples/support_refund_agent/expected/report.md")
@@ -59,6 +58,8 @@ def test_json_report_contains_integration_contract_keys(tmp_path):
     assert "severity" in payload["findings"][0]
     assert "fingerprint" in payload["findings"][0]
     assert "tool_inventory" in payload
+    assert "loaded_plugins" in payload
+    assert payload["loaded_plugins"] == []
     assert payload["schema_version"] == "0.1"
     assert payload["report_schema_version"] == "0.2"
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from agents_shipgate.cli.scan import run_scan
 from agents_shipgate.core.baseline import write_baseline
 
-
 SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 
 
@@ -219,6 +218,12 @@ ci:
     assert finding.severity == "critical"
     assert finding.evidence["default_severity"] == "medium"
     assert exit_code == 20
+
+    baseline = write_baseline(report, tmp_path / "severity-baseline.json")
+    saved = next(
+        item for item in baseline.findings if item.check_id == "SHIP-DOC-MISSING-DESCRIPTION"
+    )
+    assert saved.severity == "critical"
 
 
 def test_read_only_refund_lookup_is_not_critical(tmp_path):


### PR DESCRIPTION
## Summary

- Harden third-party plugin loading with a CLI/action kill switch, distribution-based built-in filtering, and loaded plugin provenance in reports.
- Stabilize finding IDs for fingerprint collisions and keep severity override audit evidence out of fingerprint identity.
- Make workspace multi-scan continue after per-manifest errors, sanitize output names, and block input path traversal outside the manifest directory.
- Tighten Ruff lint coverage and update docs, report schema, action metadata, and tests.

## Validation

- `python -m ruff check .`
- `python -m pytest`
- `python -m compileall -q src tests`
- `git diff --check`