### PR TITLE
[codex] Harden post-v0.2 scanner edge cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -45,3 +46,9 @@ jobs:
 
       - name: Generate SBOM
         run: cyclonedx-py environment --pyproject pyproject.toml -o sbom.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: sbom
+          path: sbom.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: pypi
 
     steps:

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -216,7 +216,7 @@ Third-party packages can register checks through the `agents_shipgate.checks` Py
 
 ## OpenAI Agents SDK Static Extraction
 
-SDK extraction is optional enrichment. v0.1 detects Python functions decorated directly with `@function_tool`, `@function_tool(...)`, `@agents.function_tool`, or `@openai_agents.function_tool`, such as:
+SDK extraction is optional enrichment. Agents Shipgate detects Python functions decorated directly with `@function_tool`, `@function_tool(...)`, `@agents.function_tool`, `@openai_agents.function_tool`, or simple import aliases such as `from agents import function_tool as ft`, for example:
 
 ```python
 @function_tool

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -67,7 +67,7 @@ openai_api:
 - `mcp`: local exported MCP tools JSON.
 - `openai_agents_sdk`: optional static Python AST extraction.
 
-When two sources declare the same tool name, Agents Shipgate keeps the higher-fidelity source and emits a source warning. Current precedence is OpenAI API artifacts, then OpenAPI, then MCP JSON, then SDK static extraction.
+When two sources declare the same tool name, Agents Shipgate keeps the higher-fidelity source, merges non-schema metadata such as annotations, auth scopes, risk hints, and owner, and emits a source warning. Current precedence is OpenAI API artifacts, then OpenAPI, then MCP JSON, then SDK static extraction.
 
 ## OpenAI API Artifacts
 
@@ -202,7 +202,7 @@ checks:
     SHIP-AUTH-MISSING-SCOPE: critical
 ```
 
-For compatibility with early design-partner manifests, top-level `check_severity_overrides` is also accepted and is applied after `checks.severity_overrides`.
+For compatibility with early design-partner manifests, top-level `check_severity_overrides` is also accepted and is applied after `checks.severity_overrides`. Prefer `checks.severity_overrides`; the top-level alias is legacy compatibility.
 
 ## Risk Overrides
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,10 +31,12 @@ AGENTS_SHIPGATE_LOG_FORMAT=json agents-shipgate doctor --config shipgate.yaml --
 
 ## The SDK Extractor Finds Nothing
 
-The OpenAI Agents SDK extractor is AST-only. It recognizes direct `function_tool` decorators such as:
+The OpenAI Agents SDK extractor is AST-only. It recognizes direct `function_tool` decorators and simple import aliases such as:
 
 ```python
-@function_tool
+from agents import function_tool as ft
+
+@ft
 def lookup_customer(customer_id: str) -> str:
     ...
 ```

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -20,6 +20,7 @@ By default Agents Shipgate does not:
 ## Input Parsing
 
 - YAML is parsed with `yaml.safe_load`.
+- Declared local input paths are resolved relative to the manifest directory and rejected if they escape that base directory. This prevents a manifest from reading sibling repositories or absolute host files unless the source is first copied or symlinked into the reviewed workspace.
 - OpenAPI `$ref` resolution only follows internal JSON pointers beginning with `#/`.
 - `file://`, `http://`, and other external `$ref` values are left as inert schema values.
 - OpenAI Agents SDK enrichment uses `ast.parse` only. It does not import or execute Python modules.

--- a/samples/simple_openai_api_agent/expected/report.md
+++ b/samples/simple_openai_api_agent/expected/report.md
@@ -2,7 +2,7 @@
 
 Project: simple-openai-api-agent
 Agent: api-refund-assistant
-Target: production_like
+Target: production\_like
 
 Result: REVIEW - static findings require human review.
 Status: Warnings detected
@@ -16,36 +16,36 @@ Human review: recommended
 
 ## Top Findings
 
-1. create_refund function schema is not strict enough
-   Evidence: issues=\['missing_strict_true', 'additional_properties_not_false', 'properties_missing_from_required:amount,reason', 'risky_field_unbounded:amount'\]; risk_tags=\['financial_action', 'write'\]
-   Recommendation: Make create_refund a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
+1. create\_refund function schema is not strict enough
+   Evidence: issues=\['missing\_strict\_true', 'additional\_properties\_not\_false', 'properties\_missing\_from\_required:amount,reason', 'risky\_field\_unbounded:amount'\]; risk\_tags=\['financial\_action', 'write'\]
+   Recommendation: Make create\_refund a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
 
-2. send_customer_email function schema is not strict enough
-   Evidence: issues=\['broad_free_text:message'\]; risk_tags=\['customer_communication', 'external_write', 'write'\]
-   Recommendation: Make send_customer_email a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
+2. send\_customer\_email function schema is not strict enough
+   Evidence: issues=\['broad\_free\_text:message'\]; risk\_tags=\['customer\_communication', 'external\_write', 'write'\]
+   Recommendation: Make send\_customer\_email a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
 
-3. create_refund may be retried without idempotency evidence
-   Evidence: retry_policy={'max_attempts': 2}; risk_tags=\['financial_action', 'write'\]
-   Recommendation: Add idempotency evidence for create_refund or avoid retrying this side effect.
+3. create\_refund may be retried without idempotency evidence
+   Evidence: retry\_policy=\{'max\_attempts': 2\}; risk\_tags=\['financial\_action', 'write'\]
+   Recommendation: Add idempotency evidence for create\_refund or avoid retrying this side effect.
 
-4. send_customer_email may be retried without idempotency evidence
-   Evidence: retry_policy={'max_attempts': 2}; risk_tags=\['customer_communication', 'external_write', 'write'\]
-   Recommendation: Add idempotency evidence for send_customer_email or avoid retrying this side effect.
+4. send\_customer\_email may be retried without idempotency evidence
+   Evidence: retry\_policy=\{'max\_attempts': 2\}; risk\_tags=\['customer\_communication', 'external\_write', 'write'\]
+   Recommendation: Add idempotency evidence for send\_customer\_email or avoid retrying this side effect.
 
 5. Prompt says read-only or advise-only while write/high-risk tools are enabled
-   Evidence: tools=\['create_refund', 'send_customer_email'\]
+   Evidence: tools=\['create\_refund', 'send\_customer\_email'\]
    Recommendation: Align prompt scope with enabled tools or remove write/high-risk tools.
 
 ## Recommended Next Actions
 
-- Make create_refund a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
-- Make send_customer_email a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
-- Add idempotency evidence for create_refund or avoid retrying this side effect.
-- Add idempotency evidence for send_customer_email or avoid retrying this side effect.
+- Make create\_refund a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
+- Make send\_customer\_email a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.
+- Add idempotency evidence for create\_refund or avoid retrying this side effect.
+- Add idempotency evidence for send\_customer\_email or avoid retrying this side effect.
 - Align prompt scope with enabled tools or remove write/high-risk tools.
-- Declare auth scopes for create_refund in OpenAPI, MCP metadata, or the manifest before release review.
-- Declare auth scopes for send_customer_email in OpenAPI, MCP metadata, or the manifest before release review.
-- Declare an owner for each high-risk production tool in risk_overrides.tools.
+- Declare auth scopes for create\_refund in OpenAPI, MCP metadata, or the manifest before release review.
+- Declare auth scopes for send\_customer\_email in OpenAPI, MCP metadata, or the manifest before release review.
+- Declare an owner for each high-risk production tool in risk\_overrides.tools.
 
 ## Tool Surface Summary
 
@@ -69,48 +69,48 @@ Human review: recommended
 
 ### Api
 
-- HIGH: SHIP-API-FUNCTION-SCHEMA-STRICTNESS [create_refund] - create_refund function schema is not strict enough
-- HIGH: SHIP-API-FUNCTION-SCHEMA-STRICTNESS [send_customer_email] - send_customer_email function schema is not strict enough
-- HIGH: SHIP-API-OPERATIONAL-READINESS [create_refund] - create_refund may be retried without idempotency evidence
-- HIGH: SHIP-API-OPERATIONAL-READINESS [send_customer_email] - send_customer_email may be retried without idempotency evidence
+- HIGH: SHIP-API-FUNCTION-SCHEMA-STRICTNESS [create\_refund] - create\_refund function schema is not strict enough
+- HIGH: SHIP-API-FUNCTION-SCHEMA-STRICTNESS [send\_customer\_email] - send\_customer\_email function schema is not strict enough
+- HIGH: SHIP-API-OPERATIONAL-READINESS [create\_refund] - create\_refund may be retried without idempotency evidence
+- HIGH: SHIP-API-OPERATIONAL-READINESS [send\_customer\_email] - send\_customer\_email may be retried without idempotency evidence
 - HIGH: SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH - Prompt says read-only or advise-only while write/high-risk tools are enabled
 - MEDIUM: SHIP-API-OPERATIONAL-READINESS - OpenAI API flow lacks timeout metadata
-- MEDIUM: SHIP-API-OPERATIONAL-READINESS - Trace sample shows create_refund without approval
-- MEDIUM: SHIP-API-OPERATIONAL-READINESS [create_refund] - create_refund lacks success/failure output modeling
+- MEDIUM: SHIP-API-OPERATIONAL-READINESS - Trace sample shows create\_refund without approval
+- MEDIUM: SHIP-API-OPERATIONAL-READINESS [create\_refund] - create\_refund lacks success/failure output modeling
 - MEDIUM: SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH - Prompt lacks approval/confirmation language for high-risk tools
-- MEDIUM: SHIP-API-STRUCTURED-OUTPUT-READINESS - Response format schemas/refund_decision.schema.json is under-specified
+- MEDIUM: SHIP-API-STRUCTURED-OUTPUT-READINESS - Response format schemas/refund\_decision.schema.json is under-specified
 
 ### Auth
 
-- HIGH: SHIP-AUTH-MISSING-SCOPE [create_refund] - create_refund lacks declared auth scopes
-- HIGH: SHIP-AUTH-MISSING-SCOPE [send_customer_email] - send_customer_email lacks declared auth scopes
+- HIGH: SHIP-AUTH-MISSING-SCOPE [create\_refund] - create\_refund lacks declared auth scopes
+- HIGH: SHIP-AUTH-MISSING-SCOPE [send\_customer\_email] - send\_customer\_email lacks declared auth scopes
 
 ### Manifest
 
-- HIGH: SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING [create_refund] - create_refund is high-risk but has no owner
-- HIGH: SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING [send_customer_email] - send_customer_email is high-risk but has no owner
+- HIGH: SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING [create\_refund] - create\_refund is high-risk but has no owner
+- HIGH: SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING [send\_customer\_email] - send\_customer\_email is high-risk but has no owner
 
 ### Schema
 
-- HIGH: SHIP-SCHEMA-BROAD-FREE-TEXT [send_customer_email] - send_customer_email accepts broad free-form action input
-- HIGH: SHIP-SCHEMA-MISSING-BOUNDS [create_refund] - create_refund.amount has no maximum bound
+- HIGH: SHIP-SCHEMA-BROAD-FREE-TEXT [send\_customer\_email] - send\_customer\_email accepts broad free-form action input
+- HIGH: SHIP-SCHEMA-MISSING-BOUNDS [create\_refund] - create\_refund.amount has no maximum bound
 
 ### Scope
 
-- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [create_refund] - create_refund appears to overlap with a prohibited action
-- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [send_customer_email] - send_customer_email appears to overlap with a prohibited action
+- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [create\_refund] - create\_refund appears to overlap with a prohibited action
+- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [send\_customer\_email] - send\_customer\_email appears to overlap with a prohibited action
 
 ### Side Effects
 
-- HIGH: SHIP-SIDEFX-IDEMPOTENCY-MISSING [create_refund] - create_refund lacks idempotency evidence
-- HIGH: SHIP-SIDEFX-IDEMPOTENCY-MISSING [send_customer_email] - send_customer_email lacks idempotency evidence
+- HIGH: SHIP-SIDEFX-IDEMPOTENCY-MISSING [create\_refund] - create\_refund lacks idempotency evidence
+- HIGH: SHIP-SIDEFX-IDEMPOTENCY-MISSING [send\_customer\_email] - send\_customer\_email lacks idempotency evidence
 
 ## Appendix: Normalized Tool Inventory
 
 | Tool | Source | Risk Tags | Risk Confidence | Auth Scopes | Owner |
 | --- | --- | --- | --- | --- | --- |
-| create_refund | openai_api | financial_action, write | financial_action=high, write=medium | - | - |
-| send_customer_email | openai_api | customer_communication, external_write, write | customer_communication=high, external_write=high, write=medium | - | - |
+| create\_refund | openai\_api | financial\_action, write | financial\_action=high, write=medium | \- | \- |
+| send\_customer\_email | openai\_api | customer\_communication, external\_write, write | customer\_communication=high, external\_write=high, write=medium | \- | \- |
 
 
 ## Disclaimer

--- a/samples/support_refund_agent/expected/report.md
+++ b/samples/support_refund_agent/expected/report.md
@@ -2,7 +2,7 @@
 
 Project: support-refund-agent
 Agent: refund-assistant
-Target: production_like
+Target: production\_like
 
 Result: BLOCKED - release blockers detected.
 Status: Release blockers detected
@@ -16,36 +16,36 @@ Human review: recommended
 
 ## Top Findings
 
-1. stripe.create_refund lacks a declared approval policy
-   Evidence: risk_tags=\['external_write', 'financial_action', 'write'\]; policy_match=None
-   Recommendation: Declare an approval policy for stripe.create_refund or remove this tool from the release.
+1. stripe.create\_refund lacks a declared approval policy
+   Evidence: risk\_tags=\['external\_write', 'financial\_action', 'write'\]; policy\_match=None
+   Recommendation: Declare an approval policy for stripe.create\_refund or remove this tool from the release.
 
-2. stripe.create_refund lacks idempotency evidence
-   Evidence: risk_tags=\['external_write', 'financial_action', 'write'\]; retry_policy_known=True
-   Recommendation: Add an idempotency key, idempotent annotation, or declared idempotency policy for stripe.create_refund.
+2. stripe.create\_refund lacks idempotency evidence
+   Evidence: risk\_tags=\['external\_write', 'financial\_action', 'write'\]; retry\_policy\_known=True
+   Recommendation: Add an idempotency key, idempotent annotation, or declared idempotency policy for stripe.create\_refund.
 
 3. Manifest declares broad permission scopes
-   Evidence: scopes=\['stripe:*'\]
+   Evidence: scopes=\['stripe:\*'\]
    Recommendation: Replace broad manifest permission scopes with the narrowest scopes needed for this release.
 
-4. shopify.cancel_order requires scopes not declared in the manifest
-   Evidence: tool_scopes=\['shopify:orders:write'\]; manifest_scopes=\['zendesk:tickets:read', 'zendesk:tickets:write', 'stripe:*'\]; missing_scopes=\['shopify:orders:write'\]
-   Recommendation: Add the required scopes for shopify.cancel_order to permissions.scopes or narrow the tool's declared auth requirements.
+4. shopify.cancel\_order requires scopes not declared in the manifest
+   Evidence: tool\_scopes=\['shopify:orders:write'\]; manifest\_scopes=\['zendesk:tickets:read', 'zendesk:tickets:write', 'stripe:\*'\]; missing\_scopes=\['shopify:orders:write'\]
+   Recommendation: Add the required scopes for shopify.cancel\_order to permissions.scopes or narrow the tool's declared auth requirements.
 
-5. support.search_kb requires scopes not declared in the manifest
-   Evidence: tool_scopes=\['support:kb:read'\]; manifest_scopes=\['zendesk:tickets:read', 'zendesk:tickets:write', 'stripe:*'\]; missing_scopes=\['support:kb:read'\]
-   Recommendation: Add the required scopes for support.search_kb to permissions.scopes or narrow the tool's declared auth requirements.
+5. support.search\_kb requires scopes not declared in the manifest
+   Evidence: tool\_scopes=\['support:kb:read'\]; manifest\_scopes=\['zendesk:tickets:read', 'zendesk:tickets:write', 'stripe:\*'\]; missing\_scopes=\['support:kb:read'\]
+   Recommendation: Add the required scopes for support.search\_kb to permissions.scopes or narrow the tool's declared auth requirements.
 
 ## Recommended Next Actions
 
-- Declare an approval policy for stripe.create_refund or remove this tool from the release.
-- Add an idempotency key, idempotent annotation, or declared idempotency policy for stripe.create_refund.
+- Declare an approval policy for stripe.create\_refund or remove this tool from the release.
+- Add an idempotency key, idempotent annotation, or declared idempotency policy for stripe.create\_refund.
 - Replace broad manifest permission scopes with the narrowest scopes needed for this release.
-- Add the required scopes for shopify.cancel_order to permissions.scopes or narrow the tool's declared auth requirements.
-- Add the required scopes for support.search_kb to permissions.scopes or narrow the tool's declared auth requirements.
-- Add the required scopes for gmail.send_customer_email to permissions.scopes or narrow the tool's declared auth requirements.
+- Add the required scopes for shopify.cancel\_order to permissions.scopes or narrow the tool's declared auth requirements.
+- Add the required scopes for support.search\_kb to permissions.scopes or narrow the tool's declared auth requirements.
+- Add the required scopes for gmail.send\_customer\_email to permissions.scopes or narrow the tool's declared auth requirements.
 - Replace wildcard tool exposure with an explicit tool allowlist before release review.
-- Declare an owner for each high-risk production tool in risk_overrides.tools.
+- Declare an owner for each high-risk production tool in risk\_overrides.tools.
 
 ## Source Warnings
 
@@ -64,54 +64,54 @@ Human review: recommended
 ### Auth
 
 - HIGH: SHIP-AUTH-MANIFEST-BROAD-SCOPE - Manifest declares broad permission scopes
-- HIGH: SHIP-AUTH-SCOPE-COVERAGE-MISSING [gmail.send_customer_email] - gmail.send_customer_email requires scopes not declared in the manifest
-- HIGH: SHIP-AUTH-SCOPE-COVERAGE-MISSING [shopify.cancel_order] - shopify.cancel_order requires scopes not declared in the manifest
-- HIGH: SHIP-AUTH-SCOPE-COVERAGE-MISSING [support.search_kb] - support.search_kb requires scopes not declared in the manifest
+- HIGH: SHIP-AUTH-SCOPE-COVERAGE-MISSING [gmail.send\_customer\_email] - gmail.send\_customer\_email requires scopes not declared in the manifest
+- HIGH: SHIP-AUTH-SCOPE-COVERAGE-MISSING [shopify.cancel\_order] - shopify.cancel\_order requires scopes not declared in the manifest
+- HIGH: SHIP-AUTH-SCOPE-COVERAGE-MISSING [support.search\_kb] - support.search\_kb requires scopes not declared in the manifest
 
 ### Inventory
 
-- HIGH: SHIP-INVENTORY-WILDCARD-TOOLS [wildcard_mcp_tools.*] - Wildcard tool exposure declared
+- HIGH: SHIP-INVENTORY-WILDCARD-TOOLS [wildcard\_mcp\_tools.\*] - Wildcard tool exposure declared
 
 ### Manifest
 
-- HIGH: SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING [shopify.cancel_order] - shopify.cancel_order is high-risk but has no owner
+- HIGH: SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING [shopify.cancel\_order] - shopify.cancel\_order is high-risk but has no owner
 - MEDIUM: SHIP-MANIFEST-UNUSED-SCOPE - Manifest declares unused permission scope zendesk:tickets:read
 
 ### Policy
 
-- CRITICAL: SHIP-POLICY-APPROVAL-MISSING [stripe.create_refund] - stripe.create_refund lacks a declared approval policy
-- HIGH: SHIP-POLICY-CONFIRMATION-MISSING [gmail.send_customer_email] - gmail.send_customer_email lacks a declared confirmation policy
-- HIGH: SHIP-POLICY-CONFIRMATION-MISSING [stripe.create_refund] - stripe.create_refund lacks a declared confirmation policy
+- CRITICAL: SHIP-POLICY-APPROVAL-MISSING [stripe.create\_refund] - stripe.create\_refund lacks a declared approval policy
+- HIGH: SHIP-POLICY-CONFIRMATION-MISSING [gmail.send\_customer\_email] - gmail.send\_customer\_email lacks a declared confirmation policy
+- HIGH: SHIP-POLICY-CONFIRMATION-MISSING [stripe.create\_refund] - stripe.create\_refund lacks a declared confirmation policy
 
 ### Schema
 
-- HIGH: SHIP-SCHEMA-BROAD-FREE-TEXT [gmail.send_customer_email] - gmail.send_customer_email accepts broad free-form action input
-- HIGH: SHIP-SCHEMA-BROAD-FREE-TEXT [zendesk.update_ticket] - zendesk.update_ticket accepts broad free-form action input
-- HIGH: SHIP-SCHEMA-MISSING-BOUNDS [stripe.create_refund] - stripe.create_refund.amount has no maximum bound
-- MEDIUM: SHIP-SCHEMA-FREEFORM-OUTPUT [send_email_preview] - send_email_preview returns free-form text output
+- HIGH: SHIP-SCHEMA-BROAD-FREE-TEXT [gmail.send\_customer\_email] - gmail.send\_customer\_email accepts broad free-form action input
+- HIGH: SHIP-SCHEMA-BROAD-FREE-TEXT [zendesk.update\_ticket] - zendesk.update\_ticket accepts broad free-form action input
+- HIGH: SHIP-SCHEMA-MISSING-BOUNDS [stripe.create\_refund] - stripe.create\_refund.amount has no maximum bound
+- MEDIUM: SHIP-SCHEMA-FREEFORM-OUTPUT [send\_email\_preview] - send\_email\_preview returns free-form text output
 
 ### Scope
 
-- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [gmail.send_customer_email] - gmail.send_customer_email appears to overlap with a prohibited action
-- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [stripe.create_refund] - stripe.create_refund appears to overlap with a prohibited action
+- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [gmail.send\_customer\_email] - gmail.send\_customer\_email appears to overlap with a prohibited action
+- HIGH: SHIP-SCOPE-PROHIBITED-TOOL-PRESENT [stripe.create\_refund] - stripe.create\_refund appears to overlap with a prohibited action
 
 ### Side Effects
 
-- CRITICAL: SHIP-SIDEFX-IDEMPOTENCY-MISSING [stripe.create_refund] - stripe.create_refund lacks idempotency evidence
-- HIGH: SHIP-SIDEFX-IDEMPOTENCY-MISSING [gmail.send_customer_email] - gmail.send_customer_email lacks idempotency evidence
+- CRITICAL: SHIP-SIDEFX-IDEMPOTENCY-MISSING [stripe.create\_refund] - stripe.create\_refund lacks idempotency evidence
+- HIGH: SHIP-SIDEFX-IDEMPOTENCY-MISSING [gmail.send\_customer\_email] - gmail.send\_customer\_email lacks idempotency evidence
 
 ## Appendix: Normalized Tool Inventory
 
 | Tool | Source | Risk Tags | Risk Confidence | Auth Scopes | Owner |
 | --- | --- | --- | --- | --- | --- |
-| gmail.send_customer_email | mcp | customer_communication, external_write | customer_communication=medium, external_write=medium | gmail:send | support-platform |
-| refund_status_lookup | openapi | read_only | read_only=high | - | - |
-| send_email_preview | sdk_function | read_only | read_only=high | - | - |
-| shopify.cancel_order | openapi | destructive, write | destructive=high, write=high | shopify:orders:write | - |
-| stripe.create_refund | openapi | external_write, financial_action, write | external_write=high, financial_action=high, write=high | stripe:refunds:write | payments-platform |
-| support.search_kb | mcp | read_only | read_only=high | support:kb:read | support-platform |
-| wildcard_mcp_tools.* | mcp | - | - | - | - |
-| zendesk.update_ticket | openapi | write | write=high | zendesk:tickets:write | - |
+| gmail.send\_customer\_email | mcp | customer\_communication, external\_write | customer\_communication=medium, external\_write=medium | gmail:send | support-platform |
+| refund\_status\_lookup | openapi | read\_only | read\_only=high | \- | \- |
+| send\_email\_preview | sdk\_function | read\_only | read\_only=high | \- | \- |
+| shopify.cancel\_order | openapi | destructive, write | destructive=high, write=high | shopify:orders:write | \- |
+| stripe.create\_refund | openapi | external\_write, financial\_action, write | external\_write=high, financial\_action=high, write=high | stripe:refunds:write | payments-platform |
+| support.search\_kb | mcp | read\_only | read\_only=high | support:kb:read | support-platform |
+| wildcard\_mcp\_tools.\* | mcp | \- | \- | \- | \- |
+| zendesk.update\_ticket | openapi | write | write=high | zendesk:tickets:write | \- |
 
 
 ## Disclaimer

--- a/src/agents_shipgate/checks/api.py
+++ b/src/agents_shipgate/checks/api.py
@@ -4,6 +4,10 @@ from typing import Any
 
 from agents_shipgate.checks.base import agent_finding, tool_finding
 from agents_shipgate.core.context import ScanContext
+from agents_shipgate.core.heuristics import (
+    BROAD_FREE_TEXT_PARAMETER_NAMES,
+    RISKY_NUMERIC_PARAMETER_NAMES,
+)
 from agents_shipgate.core.models import Tool, ToolParameter
 from agents_shipgate.core.risk_hints import (
     has_risk_tag,
@@ -12,18 +16,6 @@ from agents_shipgate.core.risk_hints import (
     risk_tags,
 )
 
-BROAD_TEXT_NAMES = {
-    "action",
-    "body",
-    "command",
-    "content",
-    "instructions",
-    "message",
-    "prompt",
-    "update",
-    "updates",
-}
-RISKY_NUMERIC_NAMES = {"amount", "amt", "count", "qty", "quantity", "limit", "cap", "size"}
 READ_ONLY_PROMPT_TERMS = (
     "advise only",
     "advice only",
@@ -379,7 +371,7 @@ def _needs_idempotency(tool: Tool, artifacts) -> bool:
 
 def _risky_field_without_bounds_or_enum(parameter: ToolParameter) -> bool:
     name = parameter.name.lower()
-    risky_name = any(token in name for token in RISKY_NUMERIC_NAMES)
+    risky_name = any(token in name for token in RISKY_NUMERIC_PARAMETER_NAMES)
     return (
         risky_name
         and parameter.type in {"number", "integer"}
@@ -390,7 +382,7 @@ def _risky_field_without_bounds_or_enum(parameter: ToolParameter) -> bool:
 
 def _broad_free_text(parameter: ToolParameter) -> bool:
     return (
-        parameter.name.lower() in BROAD_TEXT_NAMES
+        parameter.name.lower() in BROAD_FREE_TEXT_PARAMETER_NAMES
         and parameter.type in {None, "string", "object"}
         and not parameter.enum
     )

--- a/src/agents_shipgate/checks/auth.py
+++ b/src/agents_shipgate/checks/auth.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from agents_shipgate.checks.base import agent_finding, tool_finding
 from agents_shipgate.core.context import ScanContext
-from agents_shipgate.core.risk_hints import has_risk_tag, is_write_tool
+from agents_shipgate.core.heuristics import is_broad_scope
+from agents_shipgate.core.risk_hints import has_risk_tag, is_write_tool, risk_tags
 
 
 def run(context: ScanContext):
     findings = []
-    broad_global_scopes = [scope for scope in context.manifest.permissions.scopes if _is_broad_scope(scope)]
+    broad_global_scopes = [
+        scope for scope in context.manifest.permissions.scopes if is_broad_scope(scope)
+    ]
     if broad_global_scopes:
         findings.append(
             agent_finding(
@@ -30,7 +33,7 @@ def run(context: ScanContext):
                     title=f"{tool.name} lacks declared auth scopes",
                     severity="high",
                     category="auth",
-                    evidence={"risk_tags": [hint.tag for hint in tool.risk_hints if hint.confidence in {"medium", "high"}]},
+                    evidence={"risk_tags": risk_tags(tool, min_confidence="medium")},
                     confidence="medium",
                     recommendation=f"Declare auth scopes for {tool.name} in OpenAPI, MCP metadata, or the manifest before release review.",
                     context=context,
@@ -62,7 +65,7 @@ def run(context: ScanContext):
                     context=context,
                 )
             )
-        broad_scopes = [scope for scope in tool.auth.scopes if _is_broad_scope(scope)]
+        broad_scopes = [scope for scope in tool.auth.scopes if is_broad_scope(scope)]
         if broad_scopes:
             findings.append(
                 tool_finding(
@@ -78,12 +81,6 @@ def run(context: ScanContext):
                 )
             )
     return findings
-
-
-def _is_broad_scope(scope: str) -> bool:
-    lowered = scope.lower()
-    return lowered in {"*", "admin"} or lowered.endswith(":*") or "write-all" in lowered or "admin" in lowered
-
 
 def _tool_requires_scope(tool) -> bool:
     return is_write_tool(tool) or has_risk_tag(

--- a/src/agents_shipgate/checks/manifest_consistency.py
+++ b/src/agents_shipgate/checks/manifest_consistency.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from agents_shipgate.checks.base import agent_finding, tool_finding
 from agents_shipgate.config.schema import PolicyToolEntry
 from agents_shipgate.core.context import ScanContext
+from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.core.risk_hints import is_high_risk_tool, risk_tags
 
 
@@ -129,7 +130,7 @@ def _unused_manifest_scopes(context: ScanContext) -> list:
     for manifest_scope in manifest_scopes:
         if any(_scope_covers_tool_scope(manifest_scope, tool_scope) for tool_scope in tool_scopes):
             continue
-        severity = "high" if _is_broad_write_or_admin_scope(manifest_scope) else "medium"
+        severity = "high" if is_broad_scope(manifest_scope) else "medium"
         findings.append(
             agent_finding(
                 check_id="SHIP-MANIFEST-UNUSED-SCOPE",
@@ -154,13 +155,3 @@ def _scope_covers_tool_scope(manifest_scope: str, tool_scope: str) -> bool:
     if declared in {"*", required}:
         return True
     return declared.endswith(":*") and required.startswith(declared[:-1])
-
-
-def _is_broad_write_or_admin_scope(scope: str) -> bool:
-    lowered = scope.lower()
-    return (
-        lowered in {"*", "admin"}
-        or lowered.endswith(":*")
-        or "admin" in lowered
-        or "write-all" in lowered
-    )

--- a/src/agents_shipgate/checks/manifest_scope.py
+++ b/src/agents_shipgate/checks/manifest_scope.py
@@ -114,9 +114,9 @@ def run(context: ScanContext):
 def _purpose_is_read_only(purpose_text: str) -> bool:
     if not purpose_text:
         return False
-    normalized = purpose_text.replace("_", "-")
-    has_read_terms = any(term in normalized for term in READ_ONLY_TERMS)
-    has_write_terms = any(term in normalized for term in WRITE_TERMS)
+    tokens = _tokens(purpose_text.replace("_", "-"))
+    has_read_terms = bool(tokens & READ_ONLY_TERMS)
+    has_write_terms = bool(tokens & WRITE_TERMS)
     return has_read_terms and not has_write_terms
 
 

--- a/src/agents_shipgate/checks/schema.py
+++ b/src/agents_shipgate/checks/schema.py
@@ -2,31 +2,12 @@ from __future__ import annotations
 
 from agents_shipgate.checks.base import tool_finding
 from agents_shipgate.core.context import ScanContext
+from agents_shipgate.core.heuristics import (
+    BROAD_FREE_TEXT_PARAMETER_NAMES,
+    RISKY_NUMERIC_PARAMETER_NAMES,
+)
 from agents_shipgate.core.models import Tool, ToolParameter
 from agents_shipgate.core.risk_hints import has_risk_tag, is_effectively_read_only, is_write_tool
-
-BROAD_FREE_TEXT_NAMES = {
-    "action",
-    "body",
-    "command",
-    "content",
-    "instructions",
-    "message",
-    "prompt",
-    "update",
-    "updates",
-}
-
-BOUNDED_NUMERIC_NAMES = {
-    "amount",
-    "count",
-    "limit",
-    "max",
-    "maximum",
-    "quantity",
-    "refund_amount",
-    "total",
-}
 
 
 def run(context: ScanContext):
@@ -82,7 +63,7 @@ def run(context: ScanContext):
 
 
 def _is_broad_free_text(parameter: ToolParameter) -> bool:
-    if parameter.name.lower() not in BROAD_FREE_TEXT_NAMES:
+    if parameter.name.lower() not in BROAD_FREE_TEXT_PARAMETER_NAMES:
         return False
     if parameter.enum:
         return False
@@ -91,7 +72,7 @@ def _is_broad_free_text(parameter: ToolParameter) -> bool:
 
 def _is_missing_bound(parameter: ToolParameter) -> bool:
     return (
-        parameter.name.lower() in BOUNDED_NUMERIC_NAMES
+        parameter.name.lower() in RISKY_NUMERIC_PARAMETER_NAMES
         and parameter.type in {"number", "integer"}
         and parameter.maximum is None
     )

--- a/src/agents_shipgate/cli/discovery.py
+++ b/src/agents_shipgate/cli/discovery.py
@@ -21,13 +21,32 @@ MODEL_CONFIG_PATTERNS = ("openai-config.json",)
 TEST_CASE_PATTERNS = ("tests/*openai*cases*.json", "tests/*api*cases*.json")
 TRACE_SAMPLE_PATTERNS = ("traces/*.json", "traces/*.jsonl")
 POLICY_RULE_PATTERNS = ("policies/*openai*.yaml", "policies/*api*.yaml")
+SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".mypy_cache",
+    ".next",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "agents-shipgate-reports",
+    "build",
+    "dist",
+    "env",
+    "node_modules",
+    "target",
+    "venv",
+}
 
 
 def discover_manifest_paths(workspace: Path) -> list[Path]:
     return sorted(
         path
         for path in workspace.rglob("shipgate.yaml")
-        if ".git" not in path.parts and "agents-shipgate-reports" not in path.parts
+        if not _skip(path)
     )
 
 
@@ -190,7 +209,7 @@ def _discover_patterns(workspace: Path, patterns: tuple[str, ...]) -> list[str]:
 
 
 def _skip(path: Path) -> bool:
-    return any(part in {".git", "agents-shipgate-reports", "__pycache__"} for part in path.parts)
+    return any(part in SKIP_DIRS for part in path.parts)
 
 
 def _relative(path: Path, base: Path) -> str:

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -245,14 +245,14 @@ def _flatten_and_deduplicate_tools(
                 by_name[tool.name] = tool
                 continue
             if _source_priority(tool) > _source_priority(existing):
-                by_name[tool.name] = tool
                 kept, dropped = tool, existing
             else:
                 kept, dropped = existing, tool
+            by_name[tool.name] = _merge_duplicate_tool_metadata(kept, dropped)
             warnings.append(
                 "Duplicate tool name "
                 f"{tool.name!r}; kept {kept.source_type} source {kept.source_id!r} "
-                f"and ignored {dropped.source_type} source {dropped.source_id!r}."
+                f"and merged metadata from {dropped.source_type} source {dropped.source_id!r}."
             )
     return list(by_name.values()), warnings
 
@@ -264,6 +264,42 @@ def _source_priority(tool: Tool) -> int:
         "mcp": 20,
         "sdk_function": 10,
     }.get(tool.source_type, 0)
+
+
+def _merge_duplicate_tool_metadata(kept: Tool, dropped: Tool) -> Tool:
+    merged = kept.model_copy(deep=True)
+    merged.annotations = {**dropped.annotations, **merged.annotations}
+    seen_hints = {_risk_hint_key(hint) for hint in merged.risk_hints}
+    for hint in dropped.risk_hints:
+        key = _risk_hint_key(hint)
+        if key in seen_hints:
+            continue
+        merged.risk_hints.append(hint.model_copy(deep=True))
+        seen_hints.add(key)
+    merged.auth = merged.auth.model_copy(deep=True)
+    merged.auth.scopes = _merge_string_values(merged.auth.scopes, dropped.auth.scopes)
+    if not merged.auth.type:
+        merged.auth.type = dropped.auth.type
+    if not merged.auth.credential_mode:
+        merged.auth.credential_mode = dropped.auth.credential_mode
+    if not merged.auth.source and dropped.auth.source:
+        merged.auth.source = dropped.auth.source
+    if merged.owner is None:
+        merged.owner = dropped.owner
+    return merged
+
+
+def _risk_hint_key(hint) -> tuple[str, str, str, str]:
+    evidence = json.dumps(hint.evidence, sort_keys=True, default=str)
+    return hint.tag, hint.source, hint.confidence, evidence
+
+
+def _merge_string_values(primary: list[str], secondary: list[str]) -> list[str]:
+    merged: list[str] = []
+    for value in [*primary, *secondary]:
+        if value not in merged:
+            merged.append(value)
+    return merged
 
 
 def _build_agent(

--- a/src/agents_shipgate/config/loader.py
+++ b/src/agents_shipgate/config/loader.py
@@ -2,70 +2,13 @@ from __future__ import annotations
 
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import yaml
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from agents_shipgate.config.schema import AgentsShipgateManifest
 from agents_shipgate.core.errors import ConfigError
-
-KNOWN_MANIFEST_FIELDS = {
-    "agent",
-    "annotations",
-    "ci",
-    "confidence",
-    "credential_mode",
-    "declared_purpose",
-    "deep_import",
-    "directory",
-    "downstream_critical_fields",
-    "entrypoint",
-    "environment",
-    "fail_on",
-    "formats",
-    "function_schemas",
-    "id",
-    "ignore",
-    "instructions_preview",
-    "mode",
-    "model_config",
-    "name",
-    "object",
-    "openai_api",
-    "optional",
-    "output",
-    "owner",
-    "path",
-    "permissions",
-    "policies",
-    "pr_comment",
-    "project",
-    "prohibited_actions",
-    "prompt_files",
-    "reason",
-    "repo",
-    "response_formats",
-    "require_approval_for_tools",
-    "require_confirmation_for_tools",
-    "require_idempotency_for_tools",
-    "risk_overrides",
-    "scopes",
-    "sdk",
-    "severity_overrides",
-    "static_extract",
-    "tags",
-    "target",
-    "test_cases",
-    "tool",
-    "tool_sources",
-    "tools",
-    "trace_samples",
-    "trust",
-    "type",
-    "upload_artifact",
-    "version",
-}
 
 
 def load_yaml_file(path: Path) -> dict[str, Any]:
@@ -118,3 +61,33 @@ def _field_suggestion(error: dict[str, Any]) -> str | None:
     field = str(loc[-1])
     matches = get_close_matches(field, KNOWN_MANIFEST_FIELDS, n=1, cutoff=0.72)
     return matches[0] if matches else None
+
+
+def _collect_field_names(
+    model: type[BaseModel], seen: set[type[BaseModel]] | None = None
+) -> set[str]:
+    seen = seen or set()
+    if model in seen:
+        return set()
+    seen.add(model)
+
+    names: set[str] = set()
+    for name, field in model.model_fields.items():
+        names.add(name)
+        if isinstance(field.alias, str):
+            names.add(field.alias)
+        for inner_model in _inner_models(field.annotation):
+            names.update(_collect_field_names(inner_model, seen))
+    return names
+
+
+def _inner_models(annotation: object) -> set[type[BaseModel]]:
+    models: set[type[BaseModel]] = set()
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        models.add(annotation)
+    for arg in get_args(annotation):
+        models.update(_inner_models(arg))
+    return models
+
+
+KNOWN_MANIFEST_FIELDS = frozenset(_collect_field_names(AgentsShipgateManifest))

--- a/src/agents_shipgate/config/loader.py
+++ b/src/agents_shipgate/config/loader.py
@@ -60,7 +60,9 @@ def _field_suggestion(error: dict[str, Any]) -> str | None:
         return None
     field = str(loc[-1])
     matches = get_close_matches(field, KNOWN_MANIFEST_FIELDS, n=1, cutoff=0.72)
-    return matches[0] if matches else None
+    if not matches or matches[0] == field:
+        return None
+    return matches[0]
 
 
 def _collect_field_names(

--- a/src/agents_shipgate/config/schema.py
+++ b/src/agents_shipgate/config/schema.py
@@ -82,7 +82,9 @@ def _parse_artifact_entries(value: Any) -> list[ArtifactPathConfig]:
         raise TypeError("artifact entries must be a list")
     entries: list[ArtifactPathConfig] = []
     for item in value:
-        if isinstance(item, str):
+        if isinstance(item, ArtifactPathConfig):
+            entries.append(item)
+        elif isinstance(item, str):
             entries.append(ArtifactPathConfig(path=item))
         elif isinstance(item, dict):
             entries.append(ArtifactPathConfig.model_validate(item))
@@ -98,7 +100,9 @@ def _parse_named_artifact_entries(value: Any) -> list[NamedArtifactPathConfig]:
         raise TypeError("artifact entries must be a list")
     entries: list[NamedArtifactPathConfig] = []
     for item in value:
-        if isinstance(item, str):
+        if isinstance(item, NamedArtifactPathConfig):
+            entries.append(item)
+        elif isinstance(item, str):
             entries.append(NamedArtifactPathConfig(path=item))
         elif isinstance(item, dict):
             entries.append(NamedArtifactPathConfig.model_validate(item))
@@ -172,7 +176,9 @@ def _parse_policy_entries(value: Any) -> list[PolicyToolEntry]:
         raise TypeError("policy value must be a list")
     entries: list[PolicyToolEntry] = []
     for item in value:
-        if isinstance(item, str):
+        if isinstance(item, PolicyToolEntry):
+            entries.append(item)
+        elif isinstance(item, str):
             entries.append(PolicyToolEntry(tool=item))
         elif isinstance(item, dict):
             entries.append(PolicyToolEntry.model_validate(item))
@@ -276,7 +282,7 @@ class OutputConfig(BaseModel):
 class AgentsShipgateManifest(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
-    version: Literal["0.1"]
+    version: str
     project: ProjectConfig
     agent: AgentConfig
     environment: EnvironmentConfig

--- a/src/agents_shipgate/core/baseline.py
+++ b/src/agents_shipgate/core/baseline.py
@@ -55,6 +55,7 @@ def baseline_from_report(report: ReadinessReport) -> BaselineFile:
 
 def write_baseline(report: ReadinessReport, path: Path) -> BaselineFile:
     baseline = baseline_from_report(report)
+    baseline = _preserve_created_at_when_content_matches(baseline, path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         baseline.model_dump_json(indent=2, exclude_none=False) + "\n",
@@ -111,3 +112,21 @@ def _active_findings(findings: list[Finding]) -> list[Finding]:
 
 def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _preserve_created_at_when_content_matches(
+    baseline: BaselineFile, path: Path
+) -> BaselineFile:
+    if not path.exists():
+        return baseline
+    try:
+        existing = load_baseline(path)
+    except InputParseError:
+        return baseline
+    if _baseline_content_identity(existing) != _baseline_content_identity(baseline):
+        return baseline
+    return baseline.model_copy(update={"created_at": existing.created_at})
+
+
+def _baseline_content_identity(baseline: BaselineFile) -> dict[str, object]:
+    return baseline.model_dump(mode="json", exclude={"created_at"})

--- a/src/agents_shipgate/core/heuristics.py
+++ b/src/agents_shipgate/core/heuristics.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+BROAD_FREE_TEXT_PARAMETER_NAMES = {
+    "action",
+    "body",
+    "command",
+    "content",
+    "instructions",
+    "message",
+    "prompt",
+    "update",
+    "updates",
+}
+
+RISKY_NUMERIC_PARAMETER_NAMES = {
+    "amount",
+    "amt",
+    "cap",
+    "count",
+    "limit",
+    "max",
+    "maximum",
+    "qty",
+    "quantity",
+    "refund_amount",
+    "size",
+    "total",
+}
+
+
+def is_broad_scope(scope: str) -> bool:
+    normalized = scope.strip().lower()
+    return (
+        normalized in {"*", "admin"}
+        or normalized.endswith(":*")
+        or normalized.endswith("/*")
+        or "admin" in normalized
+        or "write-all" in normalized
+        or "write_all" in normalized
+    )

--- a/src/agents_shipgate/core/logging.py
+++ b/src/agents_shipgate/core/logging.py
@@ -24,7 +24,7 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(payload, sort_keys=True, default=str)
 
 
-def configure_logging(*, verbose: bool = False) -> None:
+def configure_logging(*, verbose: bool = False, force: bool = True) -> None:
     level = logging.DEBUG if verbose else logging.WARNING
     handler = logging.StreamHandler(sys.stderr)
     if os.environ.get("AGENTS_SHIPGATE_LOG_FORMAT") == "json":
@@ -32,7 +32,11 @@ def configure_logging(*, verbose: bool = False) -> None:
     else:
         handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
     root = logging.getLogger("agents_shipgate")
-    root.handlers.clear()
+    if root.handlers and not force:
+        root.setLevel(level)
+        return
+    if force:
+        root.handlers.clear()
     root.addHandler(handler)
     root.setLevel(level)
     root.propagate = False

--- a/src/agents_shipgate/core/risk_hints.py
+++ b/src/agents_shipgate/core/risk_hints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 
 from agents_shipgate.config.schema import AgentsShipgateManifest
@@ -16,6 +17,74 @@ HIGH_RISK_TAGS = {
 }
 
 WRITE_TAGS = {"write", "destructive", "external_write"}
+
+# Keyword classifier sets. Word-tokenized, so each keyword must match a full
+# alphabetic token in the tool name or description (or in the joined auth
+# scopes). This avoids substring false positives like "deploy" matching the
+# token "deployments" — listing deployments is a read, not an infra change.
+# Plurals are listed explicitly where production scopes commonly use them
+# (e.g. "stripe:refunds:write"). Compound forms like "deployment" or
+# "deployments" are intentionally NOT included for write-implying tags so
+# read-only listings don't trip mutation flags.
+READ_ONLY_KEYWORDS = {
+    "get",
+    "list",
+    "lookup",
+    "preview",
+    "search",
+    "status",
+    "view",
+}
+WRITE_KEYWORDS = {
+    "cancel",
+    "charge",
+    "create",
+    "delete",
+    "issue",
+    "refund",
+    "remove",
+    "send",
+    "update",
+    "write",
+}
+DESTRUCTIVE_KEYWORDS = {"cancel", "delete", "destroy", "remove"}
+FINANCIAL_KEYWORDS = {
+    "billing",
+    "charge",
+    "charges",
+    "invoice",
+    "invoices",
+    "payment",
+    "payments",
+    "refund",
+    "refunds",
+}
+COMMS_KEYWORDS = {"email", "emails", "message", "messages", "sms"}
+EXTERNAL_ACTION_KEYWORDS = {"customer", "external", "send"}
+SENSITIVE_KEYWORDS = {
+    "credential",
+    "credentials",
+    "personal",
+    "pii",
+    "secret",
+    "secrets",
+    "ssn",
+}
+CODE_EXEC_KEYWORDS = {"bash", "command", "execute", "python", "shell"}
+INFRASTRUCTURE_KEYWORDS = {
+    "aws",
+    "azure",
+    "cluster",
+    "clusters",
+    "deploy",
+    "droplet",
+    "droplets",
+    "gcp",
+    "kubernetes",
+    "terraform",
+}
+
+_KEYWORD_GATED_SOURCE_TYPES = {"openai_api", "sdk_function"}
 
 
 def enrich_tools_with_risk_hints(
@@ -70,68 +139,103 @@ def is_write_tool(tool: Tool) -> bool:
     return has_risk_tag(tool, WRITE_TAGS, min_confidence="medium")
 
 
+def _tokenize(text: str) -> set[str]:
+    return set(re.findall(r"[a-z]+", text.lower()))
+
+
 def _add_automatic_hints(tool: Tool) -> None:
-    text = f"{tool.name} {tool.description or ''}".lower()
+    text = f"{tool.name} {tool.description or ''}"
+    tokens = _tokenize(text)
+    scope_tokens = _tokenize(" ".join(tool.auth.scopes))
     method = str(tool.annotations.get("httpMethod") or "").upper()
 
-    if tool.source_type == "openai_api" and any(
-        word in text for word in ["get", "list", "lookup", "search", "status", "preview"]
-    ):
-        _add_hint(tool, "read_only", "openai_api_keyword", "medium", {})
-    if tool.source_type == "openai_api" and any(
-        word in text
-        for word in [
-            "create",
-            "update",
-            "write",
-            "send",
-            "refund",
-            "cancel",
-            "delete",
-            "remove",
-            "charge",
-            "issue",
-        ]
-    ):
-        _add_hint(tool, "write", "openai_api_keyword", "medium", {})
-
-    if tool.source_type == "sdk_function" and "preview" in text and not method:
+    # SDK preview-only safety net runs first so subsequent classifiers can
+    # rely on is_effectively_read_only short-circuiting. A function named
+    # *_preview that does not declare an HTTP method is treated as read-only
+    # at high confidence and exempt from name-keyword write inference.
+    is_sdk_preview = (
+        tool.source_type == "sdk_function" and "preview" in tokens and not method
+    )
+    if is_sdk_preview:
         _add_hint(tool, "read_only", "keyword", "high", {"preview_only": True})
+
+    keyword_eligible = (
+        tool.source_type in _KEYWORD_GATED_SOURCE_TYPES and not is_sdk_preview
+    )
+    keyword_source = (
+        "openai_api_keyword"
+        if tool.source_type == "openai_api"
+        else "sdk_keyword"
+        if tool.source_type == "sdk_function"
+        else "keyword"
+    )
+
+    if keyword_eligible and READ_ONLY_KEYWORDS & tokens:
+        _add_hint(tool, "read_only", keyword_source, "medium", {})
+    if keyword_eligible and WRITE_KEYWORDS & tokens:
+        _add_hint(tool, "write", keyword_source, "medium", {})
     if tool.annotations.get("readOnlyHint") is True:
         _add_hint(tool, "read_only", "mcp_annotation", "high", {"readOnlyHint": True})
     if tool.annotations.get("destructiveHint") is True:
         _add_hint(tool, "destructive", "mcp_annotation", "high", {"destructiveHint": True})
         _add_hint(tool, "write", "mcp_annotation", "high", {"destructiveHint": True})
-    if method == "DELETE" or any(word in text for word in ["cancel", "delete", "remove"]):
-        _add_hint(tool, "destructive", "openapi_method" if method else "keyword", "high" if method == "DELETE" else "medium", {"method": method or None})
+
+    if method == "DELETE" or DESTRUCTIVE_KEYWORDS & tokens:
+        _add_hint(
+            tool,
+            "destructive",
+            "openapi_method" if method else "keyword",
+            "high" if method == "DELETE" else "medium",
+            {"method": method or None},
+        )
     if method in {"POST", "PUT", "PATCH", "DELETE"}:
         _add_hint(tool, "write", "openapi_method", "high", {"method": method})
 
-    scopes = " ".join(tool.auth.scopes).lower()
-    financial_in_text = any(word in text for word in ["refund", "payment", "charge", "invoice"])
-    financial_in_scope = any(word in scopes for word in ["refund", "payment", "charge", "invoice"])
+    financial_in_text = bool(FINANCIAL_KEYWORDS & tokens)
+    financial_in_scope = bool(FINANCIAL_KEYWORDS & scope_tokens)
     if financial_in_text or financial_in_scope:
         if is_effectively_read_only(tool):
             confidence = "low"
-        elif is_write_tool(tool) or "write" in scopes:
+        elif is_write_tool(tool) or "write" in scope_tokens:
             confidence = "high"
         else:
             confidence = "low"
-        _add_hint(tool, "financial_action", "auth_scope" if financial_in_scope else "keyword", confidence, {"scopes": tool.auth.scopes, "method": method or None})
-    if any(word in text or word in scopes for word in ["send_email", "email", "sms", "message", "customer_email"]):
-        confidence = "high" if is_write_tool(tool) else "low" if is_effectively_read_only(tool) else "medium"
+        _add_hint(
+            tool,
+            "financial_action",
+            "auth_scope" if financial_in_scope else "keyword",
+            confidence,
+            {"scopes": tool.auth.scopes, "method": method or None},
+        )
+    if COMMS_KEYWORDS & (tokens | scope_tokens):
+        confidence = (
+            "high"
+            if is_write_tool(tool)
+            else "low"
+            if is_effectively_read_only(tool)
+            else "medium"
+        )
         _add_hint(tool, "customer_communication", "keyword", confidence, {"method": method or None})
-        if not is_effectively_read_only(tool) and any(word in text for word in ["send", "external", "customer"]):
-            _add_hint(tool, "external_write", "keyword", confidence, {"method": method or None})
-    if any(word in text or word in scopes for word in ["ssn", "pii", "personal data", "secret", "credential"]):
+        if (
+            not is_effectively_read_only(tool)
+            and EXTERNAL_ACTION_KEYWORDS & tokens
+        ):
+            _add_hint(
+                tool, "external_write", "keyword", confidence, {"method": method or None}
+            )
+    if SENSITIVE_KEYWORDS & (tokens | scope_tokens):
         _add_hint(tool, "sensitive_data_access", "keyword", "medium", {})
-    if any(word in text for word in ["shell", "execute", "command", "python", "bash"]):
+    if CODE_EXEC_KEYWORDS & tokens:
         _add_hint(tool, "code_execution", "keyword", "medium", {})
-    if any(word in text for word in ["deploy", "kubernetes", "terraform", "aws", "gcp", "azure"]):
+    if INFRASTRUCTURE_KEYWORDS & tokens:
         _add_hint(tool, "infrastructure_change", "keyword", "medium", {})
 
+    # GET endpoints without any mutation evidence are read-only with high
+    # confidence. Bumping from medium to high lets is_effectively_read_only
+    # short-circuit policy/scope checks for clear reads, even when they pick
+    # up a topical keyword like "kubernetes" elsewhere in the path.
     if method == "GET" and not has_risk_tag(tool, WRITE_TAGS):
-        _add_hint(tool, "read_only", "openapi_method", "medium", {"method": method})
+        _add_hint(tool, "read_only", "openapi_method", "high", {"method": method})
 
 
 def _apply_manual_override(manifest: AgentsShipgateManifest, tool: Tool) -> None:

--- a/src/agents_shipgate/inputs/openai_api.py
+++ b/src/agents_shipgate/inputs/openai_api.py
@@ -147,7 +147,12 @@ def load_openai_api_artifacts(
         artifacts.policy_rule_files.append(
             _display_path(_resolve(base_dir, policy_ref.path), base_dir)
         )
-        artifacts.policy_rules.update(data)
+        _merge_policy_rules(
+            artifacts.policy_rules,
+            data,
+            source_ref=policy_ref.path,
+            warnings=artifacts.warnings,
+        )
 
     return (
         LoadedToolSource(
@@ -174,6 +179,43 @@ def _load_required_or_optional(
             raise
         warnings.append(f"Optional OpenAI API {kind} artifact {ref.path!r} failed to load.")
         return None
+
+
+def _merge_policy_rules(
+    target: dict[str, Any],
+    incoming: dict[str, Any],
+    *,
+    source_ref: str,
+    warnings: list[str],
+) -> None:
+    for key, value in incoming.items():
+        if key not in target:
+            target[key] = value
+            continue
+        warnings.append(
+            f"OpenAI API policy_rules key {key!r} from {source_ref!r} overlaps an earlier policy file; merging values."
+        )
+        target[key] = _merge_policy_value(target[key], value)
+
+
+def _merge_policy_value(existing: Any, incoming: Any) -> Any:
+    if isinstance(existing, list) and isinstance(incoming, list):
+        return _merge_list_values(existing, incoming)
+    if isinstance(existing, dict) and isinstance(incoming, dict):
+        return {**existing, **incoming}
+    return incoming
+
+
+def _merge_list_values(existing: list[Any], incoming: list[Any]) -> list[Any]:
+    merged: list[Any] = []
+    seen: set[str] = set()
+    for item in [*existing, *incoming]:
+        marker = json.dumps(item, sort_keys=True, default=str)
+        if marker in seen:
+            continue
+        merged.append(item)
+        seen.add(marker)
+    return merged
 
 
 def _load_trace_sample(

--- a/src/agents_shipgate/inputs/openai_sdk_static.py
+++ b/src/agents_shipgate/inputs/openai_sdk_static.py
@@ -106,10 +106,11 @@ def _function_to_tool(
         "properties": properties,
         "required": [param.name for param in parameters if param.required],
     }
+    description = _description(node, decorator_names) or ast.get_docstring(node)
     return Tool(
         id=stable_tool_id(tool_name),
         name=tool_name,
-        description=ast.get_docstring(node),
+        description=description,
         source_type="sdk_function",
         source_id=source.id,
         source_ref=source_ref,
@@ -153,15 +154,31 @@ def _parameter(arg: ast.arg, *, required: bool) -> ToolParameter:
 def _tool_name(
     node: ast.FunctionDef | ast.AsyncFunctionDef, decorator_names: set[str]
 ) -> str:
+    return _decorator_kwarg_string(node, decorator_names, "name_override") or node.name
+
+
+def _description(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, decorator_names: set[str]
+) -> str | None:
+    return _decorator_kwarg_string(node, decorator_names, "description_override")
+
+
+def _decorator_kwarg_string(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    decorator_names: set[str],
+    kwarg_name: str,
+) -> str | None:
     for decorator in node.decorator_list:
         call = decorator if isinstance(decorator, ast.Call) else None
         if not call or _decorator_name(call.func) not in decorator_names:
             continue
         for keyword in call.keywords:
-            if keyword.arg == "name_override" and isinstance(keyword.value, ast.Constant):
-                if isinstance(keyword.value.value, str) and keyword.value.value:
-                    return keyword.value.value
-    return node.name
+            if keyword.arg != kwarg_name or not isinstance(keyword.value, ast.Constant):
+                continue
+            value = keyword.value.value
+            if isinstance(value, str) and value:
+                return value
+    return None
 
 
 def _annotation_to_string(annotation: ast.AST | None) -> str | None:

--- a/src/agents_shipgate/inputs/openai_sdk_static.py
+++ b/src/agents_shipgate/inputs/openai_sdk_static.py
@@ -9,6 +9,10 @@ from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool, ToolParameter
 from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id
 
+DEFAULT_FUNCTION_TOOL_DECORATORS = frozenset(
+    {"function_tool", "agents.function_tool", "openai_agents.function_tool"}
+)
+
 
 def load_openai_sdk_static_tools(
     source: ToolSourceConfig, manifest: AgentsShipgateManifest, base_dir: Path
@@ -33,10 +37,11 @@ def load_openai_sdk_static_tools(
         raise InputParseError(
             f"Unable to parse OpenAI Agents SDK entrypoint {path}: {exc.msg}"
         ) from exc
+    decorator_names = _function_tool_decorator_names(tree)
     tools = [
-        _function_to_tool(node, source, entrypoint)
+        _function_to_tool(node, source, entrypoint, decorator_names)
         for node in ast.walk(tree)
-        if _is_function_tool(node)
+        if _is_function_tool(node, decorator_names)
     ]
     return LoadedToolSource(
         source_id=source.id,
@@ -45,12 +50,26 @@ def load_openai_sdk_static_tools(
     )
 
 
-def _is_function_tool(node: ast.AST) -> bool:
+def _function_tool_decorator_names(tree: ast.Module) -> set[str]:
+    names = set(DEFAULT_FUNCTION_TOOL_DECORATORS)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in {"agents", "openai_agents"}:
+            for alias in node.names:
+                if alias.name == "function_tool":
+                    names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in {"agents", "openai_agents"}:
+                    names.add(f"{alias.asname or alias.name}.function_tool")
+    return names
+
+
+def _is_function_tool(node: ast.AST, decorator_names: set[str]) -> bool:
     if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return False
     for decorator in node.decorator_list:
         name = _decorator_name(decorator)
-        if name in {"function_tool", "agents.function_tool", "openai_agents.function_tool"}:
+        if name in decorator_names:
             return True
     return False
 
@@ -67,9 +86,12 @@ def _decorator_name(decorator: ast.AST) -> str | None:
 
 
 def _function_to_tool(
-    node: ast.FunctionDef | ast.AsyncFunctionDef, source: ToolSourceConfig, source_ref: str
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    source: ToolSourceConfig,
+    source_ref: str,
+    decorator_names: set[str],
 ) -> Tool:
-    tool_name = _tool_name(node)
+    tool_name = _tool_name(node, decorator_names)
     parameters = _parameters(node)
     return_type = _annotation_to_string(node.returns)
     signature = f"{tool_name}({', '.join(param.name for param in parameters)})"
@@ -128,14 +150,12 @@ def _parameter(arg: ast.arg, *, required: bool) -> ToolParameter:
     )
 
 
-def _tool_name(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+def _tool_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, decorator_names: set[str]
+) -> str:
     for decorator in node.decorator_list:
         call = decorator if isinstance(decorator, ast.Call) else None
-        if not call or _decorator_name(call.func) not in {
-            "function_tool",
-            "agents.function_tool",
-            "openai_agents.function_tool",
-        }:
+        if not call or _decorator_name(call.func) not in decorator_names:
             continue
         for keyword in call.keywords:
             if keyword.arg == "name_override" and isinstance(keyword.value, ast.Constant):

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from pathlib import Path
 
@@ -11,6 +12,24 @@ DISCLAIMER = (
     "agent safety or compliance. Findings are based on static configuration, declared "
     "policies, tool schemas, and optional SDK metadata. Runtime behavior, actual tool "
     "routing, and output interpretation are not verified."
+)
+MARKDOWN_ESCAPE_CHARS = (
+    "\\",
+    "`",
+    "*",
+    "_",
+    "{",
+    "}",
+    "[",
+    "]",
+    "(",
+    ")",
+    "#",
+    "+",
+    "!",
+    "|",
+    "<",
+    ">",
 )
 
 
@@ -243,6 +262,8 @@ def _result_line(report: ReadinessReport) -> str:
 
 def _safe_markdown_text(value: object) -> str:
     text = "" if value is None else str(value)
-    for char in ("\\", "`", "[", "]", "(", ")", "|"):
+    for char in MARKDOWN_ESCAPE_CHARS:
         text = text.replace(char, f"\\{char}")
+    text = re.sub(r"(?m)^(\s*)-", r"\1\\-", text)
+    text = re.sub(r"(?m)^(\s*\d+)\.", r"\1\\.", text)
     return text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,6 +70,34 @@ tool_sources:
         load_manifest(manifest_path)
 
 
+def test_misplaced_known_field_does_not_suggest_itself(tmp_path):
+    manifest_path = tmp_path / "shipgate.yaml"
+    manifest_path.write_text(
+        """
+version: "0.1"
+project:
+  name: misplaced
+agent:
+  name: misplaced-agent
+declared_purpose:
+  - misplaced at the wrong nesting level
+environment:
+  target: local
+tool_sources:
+  - id: tools
+    type: mcp
+    path: tools.json
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigError) as info:
+        load_manifest(manifest_path)
+    message = str(info.value)
+    assert "declared_purpose" in message
+    assert "Did you mean declared_purpose" not in message
+
+
 def test_known_manifest_fields_are_derived_from_schema():
     assert "function_schemas" in KNOWN_MANIFEST_FIELDS
     assert "policy_rules" in KNOWN_MANIFEST_FIELDS

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.config.loader import KNOWN_MANIFEST_FIELDS, load_manifest
 from agents_shipgate.core.errors import ConfigError
 
 SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
@@ -68,6 +68,13 @@ tool_sources:
 
     with pytest.raises(ConfigError, match="Did you mean declared_purpose"):
         load_manifest(manifest_path)
+
+
+def test_known_manifest_fields_are_derived_from_schema():
+    assert "function_schemas" in KNOWN_MANIFEST_FIELDS
+    assert "policy_rules" in KNOWN_MANIFEST_FIELDS
+    assert "model_config" in KNOWN_MANIFEST_FIELDS
+    assert "check_severity_overrides" in KNOWN_MANIFEST_FIELDS
 
 
 def test_missing_default_config_points_to_init_command(tmp_path, monkeypatch):

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -449,6 +449,58 @@ def summarize(case_id: str) -> str:
     assert [tool.name for tool in loaded.tools] == ["support.lookup", "summarize"]
 
 
+def test_openai_sdk_static_reads_description_override(tmp_path):
+    agent_path = tmp_path / "agent.py"
+    agent_path.write_text(
+        """
+from agents import function_tool
+
+@function_tool(
+    name_override="faq_lookup_tool",
+    description_override="Lookup frequently asked questions.",
+)
+async def faq_lookup_tool(question: str) -> str:
+    return ""
+""",
+        encoding="utf-8",
+    )
+
+    manifest = load_manifest(BASE / "shipgate.yaml")
+    loaded = load_openai_sdk_static_tools(
+        ToolSourceConfig(id="sdk", type="openai_agents_sdk", path=str(agent_path)),
+        manifest,
+        tmp_path,
+    )
+
+    assert len(loaded.tools) == 1
+    assert loaded.tools[0].name == "faq_lookup_tool"
+    assert loaded.tools[0].description == "Lookup frequently asked questions."
+
+
+def test_openai_sdk_static_description_override_takes_precedence_over_docstring(tmp_path):
+    agent_path = tmp_path / "agent.py"
+    agent_path.write_text(
+        """
+from agents import function_tool
+
+@function_tool(description_override="Override wins.")
+def lookup(customer_id: str) -> str:
+    \"\"\"Original docstring should not be used.\"\"\"
+    return ""
+""",
+        encoding="utf-8",
+    )
+
+    manifest = load_manifest(BASE / "shipgate.yaml")
+    loaded = load_openai_sdk_static_tools(
+        ToolSourceConfig(id="sdk", type="openai_agents_sdk", path=str(agent_path)),
+        manifest,
+        tmp_path,
+    )
+
+    assert loaded.tools[0].description == "Override wins."
+
+
 def test_openai_sdk_static_rejects_fake_function_tool_decorator(tmp_path):
     agent_path = tmp_path / "agent.py"
     agent_path.write_text(

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -421,6 +421,34 @@ def lookup(customer_id: str, limit: int = 10, *, include_notes: bool = False) ->
     assert tool.input_schema["required"] == ["customer_id"]
 
 
+def test_openai_sdk_static_detects_aliased_function_tool_import(tmp_path):
+    agent_path = tmp_path / "agent.py"
+    agent_path.write_text(
+        """
+from agents import function_tool as ft
+import openai_agents as oa
+
+@ft(name_override="support.lookup")
+def lookup(customer_id: str) -> str:
+    return ""
+
+@oa.function_tool
+def summarize(case_id: str) -> str:
+    return ""
+""",
+        encoding="utf-8",
+    )
+
+    manifest = load_manifest(BASE / "shipgate.yaml")
+    loaded = load_openai_sdk_static_tools(
+        ToolSourceConfig(id="sdk", type="openai_agents_sdk", path=str(agent_path)),
+        manifest,
+        tmp_path,
+    )
+
+    assert [tool.name for tool in loaded.tools] == ["support.lookup", "summarize"]
+
+
 def test_openai_sdk_static_rejects_fake_function_tool_decorator(tmp_path):
     agent_path = tmp_path / "agent.py"
     agent_path.write_text(

--- a/tests/test_manifest_scope.py
+++ b/tests/test_manifest_scope.py
@@ -1,0 +1,7 @@
+from agents_shipgate.checks.manifest_scope import _purpose_is_read_only
+
+
+def test_purpose_read_only_detection_uses_tokens_not_substrings():
+    assert not _purpose_is_read_only("interview customer support agents")
+    assert not _purpose_is_read_only("preview and review generated reports")
+    assert _purpose_is_read_only("read-only ticket lookups")

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -4,6 +4,7 @@ import pytest
 
 from agents_shipgate.cli.scan import inspect_sources, run_scan
 from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.config.schema import ArtifactPathConfig, OpenAIApiConfig
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.inputs.openai_api import load_openai_api_artifacts
 
@@ -241,6 +242,48 @@ def test_openai_api_policy_rules_supplement_manifest_policies(tmp_path):
         and finding.tool_name == "send_customer_email"
         for finding in report.findings
     )
+
+
+def test_openai_api_policy_rules_merge_overlapping_files(tmp_path):
+    (tmp_path / "policy-a.yaml").write_text(
+        """
+approval_required:
+  - create_refund
+tool_output_schemas:
+  create_refund:
+    success_fields: [refund_id]
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "policy-b.yaml").write_text(
+        """
+approval_required:
+  - send_customer_email
+tool_output_schemas:
+  send_customer_email:
+    success_fields: [message_id]
+""",
+        encoding="utf-8",
+    )
+    config = OpenAIApiConfig(
+        policy_rules=[
+            ArtifactPathConfig(path="policy-a.yaml"),
+            ArtifactPathConfig(path="policy-b.yaml"),
+        ]
+    )
+
+    _, artifacts = load_openai_api_artifacts(config, tmp_path)
+
+    assert artifacts is not None
+    assert artifacts.policy_rules["approval_required"] == [
+        "create_refund",
+        "send_customer_email",
+    ]
+    assert sorted(artifacts.policy_rules["tool_output_schemas"]) == [
+        "create_refund",
+        "send_customer_email",
+    ]
+    assert any("overlaps an earlier policy file" in warning for warning in artifacts.warnings)
 
 
 def test_doctor_includes_openai_api_artifacts():

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from jsonschema import validate
 
 from agents_shipgate.cli.scan import run_scan
-from agents_shipgate.report.markdown import render_markdown_report
+from agents_shipgate.report.markdown import _safe_markdown_text, render_markdown_report
 
 SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 EXPECTED_MARKDOWN = Path("samples/support_refund_agent/expected/report.md")
@@ -158,7 +158,7 @@ paths:
         """
 version: "0.1"
 project:
-  name: markdown-test
+  name: "**bold** _team_ <tag>"
 agent:
   name: markdown-agent
   declared_purpose:
@@ -186,6 +186,11 @@ policies:
 
     assert "[Click here](https://evil.example)" not in markdown
     assert "\\[Click here\\]\\(https://evil.example\\)" in markdown
+    assert "**bold** _team_ <tag>" not in markdown
+    assert "\\*\\*bold\\*\\* \\_team\\_ \\<tag\\>" in markdown
+    assert _safe_markdown_text("**bold** _underscore_ <tag>") == (
+        "\\*\\*bold\\*\\* \\_underscore\\_ \\<tag\\>"
+    )
 
 
 def test_clean_report_has_affirmative_pass_result(tmp_path):

--- a/tests/test_risk_hints.py
+++ b/tests/test_risk_hints.py
@@ -1,0 +1,148 @@
+from agents_shipgate.config.schema import (
+    AgentConfig,
+    AgentsShipgateManifest,
+    EnvironmentConfig,
+    ProjectConfig,
+    ToolSourceConfig,
+)
+from agents_shipgate.core.models import AuthInfo, Tool
+from agents_shipgate.core.risk_hints import (
+    enrich_tools_with_risk_hints,
+    has_risk_tag,
+    is_effectively_read_only,
+    is_write_tool,
+)
+
+
+def _manifest() -> AgentsShipgateManifest:
+    return AgentsShipgateManifest(
+        version="0.1",
+        project=ProjectConfig(name="test"),
+        agent=AgentConfig(name="agent", declared_purpose=["test"]),
+        environment=EnvironmentConfig(target="local"),
+        tool_sources=[ToolSourceConfig(id="dummy", type="mcp", path="dummy.json")],
+    )
+
+
+def _tool(**kwargs) -> Tool:
+    defaults = {
+        "id": "tool:test",
+        "name": "test",
+        "source_type": "sdk_function",
+        "auth": AuthInfo(),
+    }
+    defaults.update(kwargs)
+    return Tool(**defaults)
+
+
+def _enrich(tool: Tool) -> Tool:
+    return enrich_tools_with_risk_hints(_manifest(), [tool])[0]
+
+
+def test_sdk_keyword_classifier_tags_update_function_as_write():
+    tool = _enrich(_tool(name="update_seat", description="Change a seat assignment."))
+
+    assert is_write_tool(tool), f"expected write tag, got {[h.tag for h in tool.risk_hints]}"
+    assert has_risk_tag(tool, {"write"}, min_confidence="medium")
+
+
+def test_sdk_keyword_classifier_tags_get_function_as_read():
+    tool = _enrich(_tool(name="get_user_profile", description="Look up a user."))
+
+    assert has_risk_tag(tool, {"read_only"}, min_confidence="medium")
+    assert not is_write_tool(tool)
+
+
+def test_get_endpoint_with_infrastructure_keyword_is_effectively_read_only():
+    tool = _enrich(
+        _tool(
+            id="tool:get_v2_kubernetes_clusters",
+            name="get_v2_kubernetes_clusters",
+            description="List all Kubernetes clusters.",
+            source_type="openapi",
+            annotations={"httpMethod": "GET"},
+        )
+    )
+
+    assert has_risk_tag(tool, {"infrastructure_change"}, min_confidence="medium")
+    assert is_effectively_read_only(tool), (
+        "GET listing should be effectively read-only despite the infra keyword"
+    )
+
+
+def test_deployments_token_does_not_match_deploy_keyword():
+    tool = _enrich(
+        _tool(
+            id="tool:get_v2_apps_app_id_deployments",
+            name="get_v2_apps_app_id_deployments",
+            description="List app deployments.",
+            source_type="openapi",
+            annotations={"httpMethod": "GET"},
+        )
+    )
+
+    assert not has_risk_tag(tool, {"infrastructure_change"}), (
+        "GET listing 'deployments' should not be tagged infrastructure_change"
+    )
+
+
+def test_deploy_token_does_match_deploy_keyword():
+    tool = _enrich(
+        _tool(
+            id="tool:post_v2_apps_app_id_deploy",
+            name="post_v2_apps_app_id_deploy",
+            description="Trigger a deploy.",
+            source_type="openapi",
+            annotations={"httpMethod": "POST"},
+        )
+    )
+
+    assert has_risk_tag(tool, {"infrastructure_change"})
+
+
+def test_financial_plural_scope_still_matches():
+    tool = _enrich(
+        _tool(
+            id="tool:create_refund",
+            name="create_refund",
+            description="Issue a refund.",
+            source_type="openapi",
+            annotations={"httpMethod": "POST"},
+            auth=AuthInfo(scopes=["stripe:refunds:write"]),
+        )
+    )
+
+    assert has_risk_tag(tool, {"financial_action"}, min_confidence="medium")
+
+
+def test_email_token_inside_send_email_still_matches():
+    tool = _enrich(
+        _tool(
+            id="tool:send_email",
+            name="send_customer_email",
+            description="Send a customer email notification.",
+            source_type="openapi",
+            annotations={"httpMethod": "POST"},
+        )
+    )
+
+    assert has_risk_tag(tool, {"customer_communication"})
+    assert has_risk_tag(tool, {"external_write"})
+
+
+def test_interview_does_not_falsely_match_view():
+    tool = _enrich(
+        _tool(
+            id="tool:interview_log",
+            name="interview_log",
+            description="Log interview transcripts.",
+            source_type="sdk_function",
+        )
+    )
+
+    read_only_keyword_hints = [
+        hint
+        for hint in tool.risk_hints
+        if hint.tag == "read_only" and hint.source == "sdk_keyword"
+    ]
+    assert not read_only_keyword_hints

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -276,6 +276,23 @@ def test_baseline_save_and_scan_matches_existing_findings(tmp_path):
     )
 
 
+def test_baseline_save_is_idempotent_for_unchanged_findings(tmp_path):
+    baseline_path = tmp_path / "baseline.json"
+    report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="strict",
+    )
+
+    write_baseline(report, baseline_path)
+    first = baseline_path.read_text(encoding="utf-8")
+    write_baseline(report, baseline_path)
+    second = baseline_path.read_text(encoding="utf-8")
+
+    assert first == second
+
+
 def test_baseline_scan_fails_only_on_new_findings(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
@@ -433,7 +450,12 @@ paths:
     {
       "name": "shared.lookup",
       "description": "Look up a shared record from MCP.",
-      "annotations": {"readOnlyHint": true}
+      "annotations": {"readOnlyHint": true},
+      "auth": {
+        "type": "oauth2",
+        "scopes": ["shared:read"]
+      },
+      "owner": "support-platform"
     }
   ]
 }
@@ -471,6 +493,8 @@ tool_sources:
 
     assert report.tool_surface.total_tools == 1
     assert report.tool_inventory[0]["source_type"] == "openapi"
+    assert report.tool_inventory[0]["auth_scopes"] == ["shared:read"]
+    assert report.tool_inventory[0]["owner"] == "support-platform"
     assert any("Duplicate tool name 'shared.lookup'" in warning for warning in report.source_warnings)
 
 


### PR DESCRIPTION
## Summary

This PR addresses the post-v0.2 hardening feedback without changing the published v0.2 check-ID contract.

- Consolidates duplicate schema/auth heuristic constants and derives manifest field typo suggestions from the Pydantic schema.
- Makes baseline saves idempotent when finding content is unchanged and merges duplicate tool-source metadata instead of dropping lower-priority annotations, scopes, owners, and risk hints.
- Merges overlapping OpenAI API policy-rule files with warnings, hardens Markdown escaping, expands SDK static extraction to aliases and `description_override`, and tokenizes risk keywords to reduce substring false positives.
- Adds CI timeouts, SBOM artifact upload, broader discovery skip dirs, and trust-model/docs updates.

## Review Notes

I reviewed the final diff locally and via the GitHub compare API. The PR is 2 commits ahead of `main` and only contains the intended hardening work.

Intentionally deferred for a later breaking/minor release:

- Splitting `SHIP-API-OPERATIONAL-READINESS` into atomic check IDs.
- Removing the legacy top-level `check_severity_overrides` alias.

## Validation

- `python -m ruff check .`
- `python -m compileall -q src tests`
- `python -m pytest --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=75` (`125 passed`, `88.25%` coverage)
- `python -m pip_audit .`
- `rm -rf dist && python -m build && python -m twine check dist/*`