### PR TITLE
Document the canonical naming convention (Agents Shipgate / agents-shipgate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,26 @@ Static release-readiness scanner for AI agent tool surfaces. Reads `shipgate.yam
 
 ---
 
+## Naming (canonical)
+
+Use exactly one form depending on context. Mixing them in user-visible copy is an adoption cost.
+
+| Form | When to use |
+|---|---|
+| **Agents Shipgate** | Display name. Prose, headings, marketing copy, social cards, slide titles, blog posts. |
+| **`agents-shipgate`** | Package, CLI binary, repo, GitHub Action, PyPI distribution name, env-var prefix (`AGENTS_SHIPGATE_*`), import path (`agents_shipgate`). Always lowercase, kebab-case. |
+| **`shipgate`** | Short alias for the CLI binary only. Acceptable in shell snippets where brevity helps; never as the project name. |
+
+Do **not** use any of: `Agent Shipgate` (singular), `Agent Shipcheck`, `agents shipgate` (display lowercase), `Agents-Shipgate` (display kebab). When in doubt: prose → `Agents Shipgate`; code → `agents-shipgate`.
+
+The canonical tagline is:
+
+> Static release-readiness scanner for AI agent tool surfaces.
+
+This single sentence is the source of truth for the GitHub repo description, [README.md](README.md), the [wiki Home page](https://github.com/ThreeMoonsLab/agents-shipgate/wiki/Home), and the marketing site `<meta name="description">`. Keep them in sync.
+
+---
+
 ## Install (canonical)
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,7 @@
 # Roadmap
 
+> **Naming.** This project is **Agents Shipgate** (display name) / `agents-shipgate` (package, CLI, repo). See [`AGENTS.md` § Naming (canonical)](AGENTS.md#naming-canonical) for the full convention.
+
 ## v0.2
 
 - Improve onboarding with `agents-shipgate init`, `doctor`, and richer examples.


### PR DESCRIPTION
## Summary

Adds an authoritative **Naming (canonical)** section to `AGENTS.md` and a one-line pointer at the top of `ROADMAP.md` so the convention is reachable from every top-level doc.

The repo, CLI, AGENTS.md, README, and CHANGELOG already use the canonical forms — this PR documents them so they stop drifting and so coding agents have a single place to look up "what do I call this thing in code vs prose."

## The convention

| Form | When to use |
|---|---|
| **Agents Shipgate** | Display name. Prose, headings, marketing copy, social cards, slide titles. |
| **`agents-shipgate`** | Package, CLI binary, repo, GitHub Action, PyPI distribution name, env-var prefix (`AGENTS_SHIPGATE_*`), import path (`agents_shipgate`). |
| **`shipgate`** | Short alias for the CLI binary only. Never the project name. |

Disallowed: `Agent Shipgate` (singular), `Agent Shipcheck`, `agents shipgate` (display lowercase), `Agents-Shipgate` (display kebab).

## Canonical tagline

> Static release-readiness scanner for AI agent tool surfaces.

Source-of-truth for the GitHub repo description, README, wiki Home page, and the marketing site `<meta name="description">`.

## What also landed in this naming pass (out-of-band of this PR)

- GitHub repo description for `agents-shipgate` updated (was stale "Agent release gate" framing).
- GitHub repo description for `web` updated (was empty).
- Wiki Home tagline aligned (was "Manifest-first…" → "Static…").

## Test plan

- [ ] `grep -ni "shipcheck" .` returns nothing
- [ ] `grep -ni "agent shipgate" .` returns nothing (singular form should be absent)
- [ ] AGENTS.md anchor `#naming-canonical` resolves cleanly when linked from ROADMAP.md
- [ ] Wiki Home and AGENTS.md taglines now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)