### PR TITLE
Add Anthropic Messages API adapter (MVP)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aid
 
 ## What this project is
 
-Static release-readiness scanner for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Google ADK Python/config files) and produces deterministic findings.
+Static release-readiness scanner for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files) and produces deterministic findings.
 
-- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Google ADK
+- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK
 - **Outputs:** Markdown · JSON · SARIF
 - **Trust:** Static-by-default. No agent execution, tool calls, LLM calls, or network access.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![CI](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml/badge.svg)](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml)
 
 Static release-readiness scanner for AI agent tool surfaces.
-**Inputs:** OpenAI Agents SDK · Google ADK · MCP · OpenAPI · OpenAI Agents API.
+**Inputs:** OpenAI Agents SDK · Anthropic Messages API · Google ADK · MCP · OpenAPI · OpenAI Agents API.
 **Outputs:** Markdown · JSON · SARIF.
 
 ## Install

--- a/docs/manifest-v0.1.json
+++ b/docs/manifest-v0.1.json
@@ -116,6 +116,34 @@
       "title": "AgentSdkConfig",
       "type": "object"
     },
+    "AnthropicConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "policy_rules": {
+          "items": {
+            "$ref": "#/$defs/ArtifactPathConfig"
+          },
+          "title": "Policy Rules",
+          "type": "array"
+        },
+        "prompt_files": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Prompt Files",
+          "type": "array"
+        },
+        "tools": {
+          "items": {
+            "$ref": "#/$defs/ArtifactPathConfig"
+          },
+          "title": "Tools",
+          "type": "array"
+        }
+      },
+      "title": "AnthropicConfig",
+      "type": "object"
+    },
     "ArtifactPathConfig": {
       "additionalProperties": false,
       "properties": {
@@ -763,6 +791,17 @@
   "properties": {
     "agent": {
       "$ref": "#/$defs/AgentConfig"
+    },
+    "anthropic": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AnthropicConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     },
     "checks": {
       "$ref": "#/$defs/ChecksConfig"

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -187,6 +187,51 @@ tool_output_schemas:
 
 Trace samples are JSON arrays or JSONL with simple normalized fields such as `tool_name`, `approved`, `confirmed`, `success`, and `error`. Unsupported raw logs produce source warnings rather than blockers.
 
+## Anthropic Messages API Artifacts
+
+`anthropic` is for agents built on the Anthropic Messages API tool-use surface (https://docs.anthropic.com/en/docs/build-with-claude/tool-use). It is local-only: Agents Shipgate reads files and never calls Anthropic APIs.
+
+Supported fields:
+
+```yaml
+anthropic:
+  prompt_files:
+    - prompts/support_refund.md
+
+  tools:
+    - path: tools/anthropic-tools.json
+
+  policy_rules:
+    - path: policies/anthropic-policy.yaml
+```
+
+Anthropic tool definitions are flat objects (no OpenAI-style `function` wrapper):
+
+```json
+{
+  "tools": [
+    {
+      "name": "create_refund",
+      "description": "Create a refund for a customer payment.",
+      "input_schema": {
+        "type": "object",
+        "properties": {"payment_id": {"type": "string"}},
+        "required": ["payment_id"]
+      },
+      "cache_control": {"type": "ephemeral"}
+    }
+  ]
+}
+```
+
+Tool names are validated against Anthropic's documented regex `^[a-zA-Z0-9_-]{1,64}$`; violations surface as source warnings (the static linter does not block). Server-side built-in tool types (`type: "computer_*"`, `"bash_*"`, `"web_search*"`, `"text_editor_*"`) have no user-controlled `input_schema` and are skipped with a warning so checks like `SHIP-DOC-MISSING-DESCRIPTION` and `SHIP-SCHEMA-MISSING-BOUNDS` do not fire on managed schemas the user cannot fix.
+
+`cache_control` values are captured verbatim into `tool.annotations.anthropicCacheControl`. They have no influence on risk classification in v0.4.
+
+`policy_rules` files share the same shape as the OpenAI Agents API policy file (`approval_required`, `confirmation_required`, `idempotency_required`). They feed `SHIP-POLICY-APPROVAL-MISSING`, `SHIP-POLICY-CONFIRMATION-MISSING`, and `SHIP-SIDEFX-IDEMPOTENCY-MISSING` checks alongside the manifest's top-level `policies` block.
+
+The framework-agnostic checks (`SHIP-INVENTORY-*`, `SHIP-DOC-*`, `SHIP-SCHEMA-*`, `SHIP-AUTH-*`, `SHIP-SCOPE-*`, `SHIP-POLICY-*`, `SHIP-SIDEFX-*`, `SHIP-MANIFEST-*`) all fire on Anthropic tools without any extra configuration. From the `SHIP-API-*` family, `SHIP-API-FUNCTION-SCHEMA-STRICTNESS` and `SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH` apply; the others key on OpenAI-specific data (response formats, retry policy, trace samples) and intentionally do not fire on Anthropic-only manifests. No new `SHIP-ANTHROPIC-*` check IDs are introduced.
+
 ## MCP Tools JSON Contract
 
 Preferred shape:

--- a/samples/simple_anthropic_agent/policies/anthropic-policy.yaml
+++ b/samples/simple_anthropic_agent/policies/anthropic-policy.yaml
@@ -1,0 +1,4 @@
+approval_required:
+  - create_refund
+confirmation_required:
+  - send_customer_email

--- a/samples/simple_anthropic_agent/prompts/support_refund.md
+++ b/samples/simple_anthropic_agent/prompts/support_refund.md
@@ -1,0 +1,3 @@
+You are a support refund assistant.
+
+You should only advise the support representative and prepare a draft response. Do not take action on the customer's account.

--- a/samples/simple_anthropic_agent/shipgate.yaml
+++ b/samples/simple_anthropic_agent/shipgate.yaml
@@ -1,0 +1,33 @@
+version: "0.1"
+
+project:
+  name: simple-anthropic-agent
+  owner: support-platform
+
+agent:
+  name: anthropic-refund-assistant
+  prohibited_actions:
+    - issue refund without approval
+    - send customer email without confirmation
+
+environment:
+  target: production_like
+
+anthropic:
+  prompt_files:
+    - prompts/support_refund.md
+
+  tools:
+    - path: tools/anthropic-tools.json
+
+  policy_rules:
+    - path: policies/anthropic-policy.yaml
+
+ci:
+  mode: advisory
+
+output:
+  directory: agents-shipgate-reports
+  formats:
+    - markdown
+    - json

--- a/samples/simple_anthropic_agent/tools/anthropic-tools.json
+++ b/samples/simple_anthropic_agent/tools/anthropic-tools.json
@@ -1,0 +1,47 @@
+{
+  "tools": [
+    {
+      "name": "create_refund",
+      "description": "Create a refund for a customer payment.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "payment_id": {
+            "type": "string",
+            "description": "Payment identifier."
+          },
+          "amount": {
+            "type": "number",
+            "description": "Refund amount."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Free-form refund reason."
+          }
+        },
+        "required": ["payment_id"]
+      },
+      "cache_control": {"type": "ephemeral"}
+    },
+    {
+      "name": "get_help_article",
+      "description": "Fetch a help-center article by slug for the support agent to reference.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Help-center article slug."
+          }
+        },
+        "required": ["slug"]
+      }
+    },
+    {
+      "type": "bash_20250124",
+      "name": "bash"
+    }
+  ]
+}

--- a/samples/simple_anthropic_agent/tools/anthropic-tools.json
+++ b/samples/simple_anthropic_agent/tools/anthropic-tools.json
@@ -40,8 +40,8 @@
       }
     },
     {
-      "type": "bash_20250124",
-      "name": "bash"
+      "type": "web_search_20250305",
+      "name": "web_search"
     }
   ]
 }

--- a/src/agents_shipgate/checks/api.py
+++ b/src/agents_shipgate/checks/api.py
@@ -29,7 +29,7 @@ CONFIRMATION_PROMPT_TERMS = ("confirm", "confirmation", "explicit consent", "ask
 
 
 def run(context: ScanContext):
-    if context.api_artifacts is None:
+    if context.api_artifacts is None and context.anthropic_artifacts is None:
         return []
     findings = []
     findings.extend(_function_schema_strictness(context))
@@ -66,6 +66,8 @@ def _function_schema_strictness(context: ScanContext):
 
 
 def _structured_output_readiness(context: ScanContext):
+    # Anthropic config has no first-class response-format artifact in MVP,
+    # so this check stays scoped to the OpenAI Agents API surface.
     artifacts = context.api_artifacts
     if artifacts is None:
         return []
@@ -118,10 +120,17 @@ def _structured_output_readiness(context: ScanContext):
 
 
 def _prompt_tool_scope_mismatch(context: ScanContext):
-    artifacts = context.api_artifacts
-    if artifacts is None or not artifacts.prompt_text:
+    prompt_segments: list[str] = []
+    if context.api_artifacts is not None and context.api_artifacts.prompt_text:
+        prompt_segments.append(context.api_artifacts.prompt_text)
+    if (
+        context.anthropic_artifacts is not None
+        and context.anthropic_artifacts.prompt_text
+    ):
+        prompt_segments.append(context.anthropic_artifacts.prompt_text)
+    if not prompt_segments:
         return []
-    prompt = artifacts.prompt_text.lower()
+    prompt = "\n\n".join(prompt_segments).lower()
     api_tools = _api_tools(context)
     write_or_high_risk = [
         tool for tool in api_tools if is_write_tool(tool) or is_high_risk_tool(tool)
@@ -177,6 +186,10 @@ def _prompt_tool_scope_mismatch(context: ScanContext):
 
 
 def _operational_readiness(context: ScanContext):
+    # The retry / timeout / test-case / output-schema readiness checks key on
+    # OpenAI Agents API artifacts. Anthropic MVP doesn't carry equivalent data,
+    # so when only Anthropic artifacts are present these checks intentionally
+    # don't fire — see plan §5.
     artifacts = context.api_artifacts
     if artifacts is None:
         return []
@@ -313,7 +326,10 @@ def _function_schema_issues(tool: Tool) -> list[str]:
     schema = tool.input_schema
     if not schema:
         return ["missing_parameters_schema"]
-    if tool.annotations.get("openaiStrict") is not True:
+    # `strict: true` is OpenAI-specific. Anthropic Messages API has no such
+    # field, so emitting `missing_strict_true` for Anthropic tools would be
+    # an unfixable false positive.
+    if tool.source_type == "openai_api" and tool.annotations.get("openaiStrict") is not True:
         issues.append("missing_strict_true")
     if schema.get("type") != "object":
         issues.append("parameters_schema_not_object")
@@ -389,4 +405,8 @@ def _broad_free_text(parameter: ToolParameter) -> bool:
 
 
 def _api_tools(context: ScanContext) -> list[Tool]:
-    return [tool for tool in context.tools if tool.source_type == "openai_api"]
+    return [
+        tool
+        for tool in context.tools
+        if tool.source_type in {"openai_api", "anthropic_api"}
+    ]

--- a/src/agents_shipgate/checks/api.py
+++ b/src/agents_shipgate/checks/api.py
@@ -67,11 +67,16 @@ def _function_schema_strictness(context: ScanContext):
 
 def _structured_output_readiness(context: ScanContext):
     # Anthropic config has no first-class response-format artifact in MVP,
-    # so this check stays scoped to the OpenAI Agents API surface.
+    # so this check stays scoped to the OpenAI Agents API surface. Use the
+    # OpenAI-only tool filter so a mixed manifest (anthropic + openai_api)
+    # doesn't list Anthropic tools as high-risk under an OpenAI-shaped
+    # finding.
     artifacts = context.api_artifacts
     if artifacts is None:
         return []
-    high_risk_tools = [tool.name for tool in _api_tools(context) if is_high_risk_tool(tool)]
+    high_risk_tools = [
+        tool.name for tool in _openai_api_tools(context) if is_high_risk_tool(tool)
+    ]
     if not artifacts.response_formats:
         return [
             agent_finding(
@@ -188,13 +193,15 @@ def _prompt_tool_scope_mismatch(context: ScanContext):
 def _operational_readiness(context: ScanContext):
     # The retry / timeout / test-case / output-schema readiness checks key on
     # OpenAI Agents API artifacts. Anthropic MVP doesn't carry equivalent data,
-    # so when only Anthropic artifacts are present these checks intentionally
-    # don't fire — see plan §5.
+    # so we filter to OpenAI tools only — otherwise a mixed manifest would
+    # fire OpenAI-shaped findings against Anthropic tools that have no
+    # response_formats / retry_policy / test_cases / tool_output_schemas
+    # to satisfy. See plan §5.
     artifacts = context.api_artifacts
     if artifacts is None:
         return []
     findings = []
-    api_tools = _api_tools(context)
+    api_tools = _openai_api_tools(context)
     high_risk_tools = [tool for tool in api_tools if is_high_risk_tool(tool)]
     retry_policy = artifacts.retry_policy()
     timeouts = artifacts.timeouts()
@@ -405,8 +412,21 @@ def _broad_free_text(parameter: ToolParameter) -> bool:
 
 
 def _api_tools(context: ScanContext) -> list[Tool]:
+    """Tools backed by an artifact-style adapter (OpenAI Agents API or
+    Anthropic Messages API). Used by checks that apply to both surfaces:
+    function-schema strictness and prompt/tool scope mismatch.
+    """
     return [
         tool
         for tool in context.tools
         if tool.source_type in {"openai_api", "anthropic_api"}
     ]
+
+
+def _openai_api_tools(context: ScanContext) -> list[Tool]:
+    """Tools backed only by the OpenAI Agents API adapter. Used by checks
+    that key on OpenAI-specific artifacts (response_formats, retry_policy,
+    test_cases, tool_output_schemas) — these have no Anthropic equivalent
+    in the v0.4 MVP and would produce false positives on Anthropic tools.
+    """
+    return [tool for tool in context.tools if tool.source_type == "openai_api"]

--- a/src/agents_shipgate/checks/policy.py
+++ b/src/agents_shipgate/checks/policy.py
@@ -25,6 +25,9 @@ def run(context: ScanContext):
     if context.api_artifacts:
         approval_tools.update(context.api_artifacts.approval_tools())
         confirmation_tools.update(context.api_artifacts.confirmation_tools())
+    if context.anthropic_artifacts:
+        approval_tools.update(context.anthropic_artifacts.approval_tools())
+        confirmation_tools.update(context.anthropic_artifacts.confirmation_tools())
     for tool in context.tools:
         if is_effectively_read_only(tool):
             continue

--- a/src/agents_shipgate/checks/side_effects.py
+++ b/src/agents_shipgate/checks/side_effects.py
@@ -15,6 +15,8 @@ def run(context: ScanContext):
     policy_tools = set(context.manifest.policies.idempotency_tools())
     if context.api_artifacts:
         policy_tools.update(context.api_artifacts.idempotency_tools())
+    if context.anthropic_artifacts:
+        policy_tools.update(context.anthropic_artifacts.idempotency_tools())
     for tool in context.tools:
         if is_effectively_read_only(tool):
             continue

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -22,6 +22,7 @@ from agents_shipgate.core.findings import (
 )
 from agents_shipgate.core.models import (
     Agent,
+    AnthropicArtifacts,
     GoogleAdkArtifacts,
     LoadedToolSource,
     OpenAIApiArtifacts,
@@ -30,6 +31,7 @@ from agents_shipgate.core.models import (
     parse_severity,
 )
 from agents_shipgate.core.risk_hints import enrich_tools_with_risk_hints
+from agents_shipgate.inputs.anthropic_api import load_anthropic_artifacts
 from agents_shipgate.inputs.frameworks import load_framework_artifacts
 from agents_shipgate.inputs.mcp import load_mcp_tools
 from agents_shipgate.inputs.openai_api import load_openai_api_artifacts
@@ -80,6 +82,11 @@ def run_scan(
     api_source, api_artifacts = load_openai_api_artifacts(manifest.openai_api, base_dir)
     if api_source:
         loaded_sources.append(api_source)
+    anthropic_source, anthropic_artifacts = load_anthropic_artifacts(
+        manifest.anthropic, base_dir
+    )
+    if anthropic_source:
+        loaded_sources.append(anthropic_source)
     logger.debug(
         "loaded sources",
         extra={
@@ -121,13 +128,14 @@ def run_scan(
             ]
         },
     )
-    agent = _build_agent(manifest, tools, api_artifacts, adk_artifacts)
+    agent = _build_agent(manifest, tools, api_artifacts, anthropic_artifacts, adk_artifacts)
     context = ScanContext(
         manifest=manifest,
         agent=agent,
         tools=tools,
         config_path=config_path.resolve(),
         api_artifacts=api_artifacts,
+        anthropic_artifacts=anthropic_artifacts,
         adk_artifacts=adk_artifacts,
     )
     loaded_plugins: list[dict[str, str | None]] = []
@@ -161,12 +169,16 @@ def run_scan(
 
     out_dir = (base_dir / manifest.output.directory).resolve()
     generated_paths = _planned_generated_paths(out_dir, manifest.output.formats)
+    anthropic_surface = (
+        anthropic_artifacts.surface_summary() if anthropic_artifacts else None
+    )
     report = build_report(
         run_id=_run_id(
             manifest,
             tools,
             findings,
             api_surface=api_artifacts.surface_summary() if api_artifacts else None,
+            anthropic_surface=anthropic_surface,
             frameworks=_frameworks_surface(adk_artifacts),
         ),
         manifest=manifest,
@@ -182,6 +194,7 @@ def run_scan(
         loaded_plugins=loaded_plugins,
         source_warnings=warnings,
         api_surface=api_artifacts.surface_summary() if api_artifacts else None,
+        anthropic_surface=anthropic_surface,
         frameworks=_frameworks_surface(adk_artifacts),
         baseline=baseline_summary,
     )
@@ -205,6 +218,11 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
     api_source, api_artifacts = load_openai_api_artifacts(manifest.openai_api, base_dir)
     if api_source:
         loaded_sources.append(api_source)
+    anthropic_source, anthropic_artifacts = load_anthropic_artifacts(
+        manifest.anthropic, base_dir
+    )
+    if anthropic_source:
+        loaded_sources.append(anthropic_source)
     tools, duplicate_warnings = _flatten_and_deduplicate_tools(loaded_sources)
     warnings = [warning for loaded in loaded_sources for warning in loaded.warnings]
     warnings.extend(duplicate_warnings)
@@ -228,6 +246,9 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
             for source in loaded_sources
         ],
         "api_surface": api_artifacts.surface_summary() if api_artifacts else None,
+        "anthropic_surface": (
+            anthropic_artifacts.surface_summary() if anthropic_artifacts else None
+        ),
         "frameworks": _frameworks_surface(adk_artifacts),
         "policy_packs": [pack.model_dump(mode="json") for pack in policy_packs.loaded],
         "baseline": _default_baseline_status(base_dir),
@@ -292,8 +313,12 @@ def _flatten_and_deduplicate_tools(
 
 
 def _source_priority(tool: Tool) -> int:
+    # Anthropic and OpenAI artifacts are equally authoritative; on duplicate
+    # tool names across them the first-loaded entry wins (OpenAI is loaded
+    # first in run_scan), and a `Duplicate tool name` warning surfaces.
     return {
         "openai_api": 40,
+        "anthropic_api": 40,
         "openapi": 30,
         "google_adk_inventory": 25,
         "mcp": 20,
@@ -343,6 +368,7 @@ def _build_agent(
     manifest,
     tools: list[Tool],
     api_artifacts: OpenAIApiArtifacts | None = None,
+    anthropic_artifacts: AnthropicArtifacts | None = None,
     adk_artifacts: GoogleAdkArtifacts | None = None,
 ) -> Agent:
     sdk = manifest.agent.sdk
@@ -352,6 +378,14 @@ def _build_agent(
     if not instructions_preview and api_artifacts and api_artifacts.prompt_text:
         instructions_preview = api_artifacts.prompt_text[:500]
         instruction_source = "openai_api_prompt_files"
+        instruction_confidence = "high"
+    if (
+        not instructions_preview
+        and anthropic_artifacts
+        and anthropic_artifacts.prompt_text
+    ):
+        instructions_preview = anthropic_artifacts.prompt_text[:500]
+        instruction_source = "anthropic_prompt_files"
         instruction_confidence = "high"
     if not instructions_preview and adk_artifacts:
         adk_instruction = _first_adk_instruction_preview(adk_artifacts)
@@ -430,6 +464,7 @@ def _run_id(
     tools: list[Tool],
     findings,
     api_surface: dict[str, object] | None = None,
+    anthropic_surface: dict[str, object] | None = None,
     frameworks: dict[str, object] | None = None,
 ) -> str:
     payload = {
@@ -446,6 +481,7 @@ def _run_id(
             for finding in findings
         ],
         "api_surface": api_surface,
+        "anthropic_surface": anthropic_surface,
         "frameworks": frameworks or {},
     }
     digest = hashlib.sha256(

--- a/src/agents_shipgate/config/schema.py
+++ b/src/agents_shipgate/config/schema.py
@@ -162,6 +162,39 @@ class OpenAIApiConfig(BaseModel):
         raise TypeError("model_config must be a string path or object with path")
 
 
+class AnthropicConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    prompt_files: list[str] = Field(default_factory=list)
+    tools: list[ArtifactPathConfig] = Field(default_factory=list)
+    policy_rules: list[ArtifactPathConfig] = Field(default_factory=list)
+
+    @field_validator("prompt_files", mode="before")
+    @classmethod
+    def parse_prompt_files(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise TypeError("prompt_files must be a list")
+        files: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                files.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("path"), str):
+                files.append(item["path"])
+            else:
+                raise TypeError("prompt_files entries must be strings or objects with path")
+        return files
+
+    @field_validator("tools", "policy_rules", mode="before")
+    @classmethod
+    def parse_artifacts(cls, value: Any) -> list[ArtifactPathConfig]:
+        return _parse_artifact_entries(value)
+
+    def has_inputs(self) -> bool:
+        return any([self.prompt_files, self.tools, self.policy_rules])
+
+
 class GoogleAdkConfig(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
@@ -349,6 +382,7 @@ class AgentsShipgateManifest(BaseModel):
     environment: EnvironmentConfig
     tool_sources: list[ToolSourceConfig] = Field(default_factory=list)
     openai_api: OpenAIApiConfig | None = None
+    anthropic: AnthropicConfig | None = None
     google_adk: GoogleAdkConfig | None = None
     policies: PoliciesConfig = Field(default_factory=PoliciesConfig)
     permissions: PermissionsConfig = Field(default_factory=PermissionsConfig)
@@ -364,17 +398,26 @@ class AgentsShipgateManifest(BaseModel):
             or self.google_adk is not None
             and self.google_adk.has_inputs()
         )
-        if not self.tool_sources and self.openai_api is None and not has_google_adk:
-            raise ValueError("At least one of tool_sources or openai_api, or google_adk is required")
+        has_anthropic = self.anthropic is not None and self.anthropic.has_inputs()
+        if (
+            not self.tool_sources
+            and self.openai_api is None
+            and not has_anthropic
+            and not has_google_adk
+        ):
+            raise ValueError(
+                "At least one of tool_sources, openai_api, anthropic, or google_adk is required"
+            )
         if (
             not self.agent.declared_purpose
             and not self.agent.instructions_preview
             and not (self.openai_api and self.openai_api.prompt_files)
+            and not (self.anthropic and self.anthropic.prompt_files)
             and not has_google_adk
         ):
             raise ValueError(
                 "agent.declared_purpose, agent.instructions_preview, "
-                "or openai_api.prompt_files is required"
+                "openai_api.prompt_files, or anthropic.prompt_files is required"
             )
         return self
 

--- a/src/agents_shipgate/core/context.py
+++ b/src/agents_shipgate/core/context.py
@@ -4,7 +4,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from agents_shipgate.config.schema import AgentsShipgateManifest
-from agents_shipgate.core.models import Agent, GoogleAdkArtifacts, OpenAIApiArtifacts, Tool
+from agents_shipgate.core.models import (
+    Agent,
+    AnthropicArtifacts,
+    GoogleAdkArtifacts,
+    OpenAIApiArtifacts,
+    Tool,
+)
 
 
 @dataclass
@@ -14,4 +20,5 @@ class ScanContext:
     tools: list[Tool]
     config_path: Path
     api_artifacts: OpenAIApiArtifacts | None = None
+    anthropic_artifacts: AnthropicArtifacts | None = None
     adk_artifacts: GoogleAdkArtifacts | None = None

--- a/src/agents_shipgate/core/findings.py
+++ b/src/agents_shipgate/core/findings.py
@@ -142,6 +142,7 @@ def build_report(
     loaded_plugins: list[dict[str, object]] | None = None,
     source_warnings: list[str] | None = None,
     api_surface: dict[str, object] | None = None,
+    anthropic_surface: dict[str, object] | None = None,
     frameworks: dict[str, object] | None = None,
     baseline: BaselineSummary | None = None,
 ) -> ReadinessReport:
@@ -153,6 +154,7 @@ def build_report(
         summary=summarize_findings(findings, tools),
         tool_surface=summarize_tool_surface(tools),
         api_surface=api_surface,
+        anthropic_surface=anthropic_surface,
         frameworks=frameworks or {},
         baseline=baseline,
         findings=findings,

--- a/src/agents_shipgate/core/models.py
+++ b/src/agents_shipgate/core/models.py
@@ -226,6 +226,65 @@ class OpenAIApiArtifacts(BaseModel):
         }
 
 
+class AnthropicArtifacts(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    prompt_files: list[str] = Field(default_factory=list)
+    prompt_text: str | None = None
+    tool_files: list[str] = Field(default_factory=list)
+    policy_rule_files: list[str] = Field(default_factory=list)
+    policy_rules: dict[str, Any] = Field(default_factory=dict)
+    skipped_server_tools: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    # Mirror OpenAIApiArtifacts so checks/api.py can consume either artifact
+    # source via the same helpers without branching.
+    def approval_tools(self) -> set[str]:
+        return set(_string_list(self.policy_rules.get("approval_required")))
+
+    def confirmation_tools(self) -> set[str]:
+        return set(_string_list(self.policy_rules.get("confirmation_required")))
+
+    def idempotency_tools(self) -> set[str]:
+        return set(_string_list(self.policy_rules.get("idempotency_required")))
+
+    def retry_policy(self) -> dict[str, Any]:
+        value = self.policy_rules.get("retry_policy")
+        return value if isinstance(value, dict) else {}
+
+    def timeouts(self) -> dict[str, Any]:
+        value = self.policy_rules.get("timeouts")
+        return value if isinstance(value, dict) else {}
+
+    def tool_output_schemas(self) -> dict[str, Any]:
+        value = self.policy_rules.get("tool_output_schemas")
+        return value if isinstance(value, dict) else {}
+
+    @property
+    def response_formats(self) -> list[Any]:
+        # Anthropic has no first-class response-format object in the
+        # documented Messages API surface; expose an empty list so the
+        # OpenAI-shaped readiness checks early-return cleanly when the
+        # only artifact present is an Anthropic one.
+        return []
+
+    @property
+    def test_cases(self) -> list[Any]:
+        return []
+
+    @property
+    def trace_samples(self) -> list[Any]:
+        return []
+
+    def surface_summary(self) -> dict[str, Any]:
+        return {
+            "prompt_file_count": len(self.prompt_files),
+            "tool_file_count": len(self.tool_files),
+            "policy_rule_count": len(self.policy_rule_files),
+            "skipped_server_tool_count": len(self.skipped_server_tools),
+        }
+
+
 class GoogleAdkToolset(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -301,6 +360,7 @@ class ReadinessReport(BaseModel):
     summary: ReportSummary
     tool_surface: ToolSurfaceSummary
     api_surface: dict[str, Any] | None = None
+    anthropic_surface: dict[str, Any] | None = None
     frameworks: dict[str, Any] = Field(default_factory=dict)
     baseline: BaselineSummary | None = None
     findings: list[Finding] = Field(default_factory=list)

--- a/src/agents_shipgate/core/risk_hints.py
+++ b/src/agents_shipgate/core/risk_hints.py
@@ -84,7 +84,7 @@ INFRASTRUCTURE_KEYWORDS = {
     "terraform",
 }
 
-_KEYWORD_GATED_SOURCE_TYPES = {"openai_api", "sdk_function"}
+_KEYWORD_GATED_SOURCE_TYPES = {"openai_api", "anthropic_api", "sdk_function"}
 
 
 def enrich_tools_with_risk_hints(
@@ -165,6 +165,8 @@ def _add_automatic_hints(tool: Tool) -> None:
     keyword_source = (
         "openai_api_keyword"
         if tool.source_type == "openai_api"
+        else "anthropic_api_keyword"
+        if tool.source_type == "anthropic_api"
         else "sdk_keyword"
         if tool.source_type == "sdk_function"
         else "keyword"

--- a/src/agents_shipgate/inputs/anthropic_api.py
+++ b/src/agents_shipgate/inputs/anthropic_api.py
@@ -22,10 +22,17 @@ Anthropic-specific differences from the OpenAI loader:
   :data:`agents_shipgate.inputs.common.CONVENTIONAL_TOOL_NAME_RE`). Violations
   are warnings, not errors — the static linter surfaces the issue without
   blocking the load.
-- Server-side built-in tool types (``computer_*``, ``bash_*``,
-  ``web_search``, ``text_editor_*``, ...) have no user-controlled
+- Server-side Anthropic tools (``web_search_*``, ``code_execution_*``)
+  execute on Anthropic infrastructure and have no user-controlled
   ``input_schema``. We skip them with a warning rather than emitting noisy
   schema findings on a managed tool the user cannot fix.
+- Client-side Anthropic tools (``bash_*``, ``text_editor_*``, ``computer_*``,
+  ``memory_*``) execute inside the user's application code and ARE in scope
+  for static release-readiness review. We inventory them as
+  ``source_type='anthropic_api'`` tools, attach explicit risk hints (e.g.
+  ``bash`` -> destructive + write + code_execution), and let the existing
+  framework-agnostic checks (approval policy, auth scopes, owner, etc.)
+  fire normally. See https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference
 
 Public docs: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
 """
@@ -39,7 +46,12 @@ from typing import Any
 
 from agents_shipgate.config.schema import AnthropicConfig, ArtifactPathConfig
 from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.core.models import AnthropicArtifacts, LoadedToolSource, Tool
+from agents_shipgate.core.models import (
+    AnthropicArtifacts,
+    LoadedToolSource,
+    Tool,
+    ToolRiskHint,
+)
 from agents_shipgate.inputs.common import (
     load_structured_file,
     load_text_file,
@@ -53,6 +65,44 @@ PROMPT_SUFFIXES = {".md", ".markdown", ".txt"}
 # Per https://docs.anthropic.com/en/docs/build-with-claude/tool-use the tool
 # name must match this regex. Surface a warning when it doesn't.
 _ANTHROPIC_TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+# Anthropic server-side tool type prefixes. These tools execute on Anthropic
+# infrastructure (sandboxed search, sandboxed code interpreter) and have no
+# user-controlled schema; static checks against `input_schema` would fire
+# spurious findings on a managed surface the user cannot remediate.
+_ANTHROPIC_SERVER_TOOL_PREFIXES: tuple[str, ...] = (
+    "web_search_",
+    "code_execution_",
+)
+
+# Anthropic client-side tool type prefixes mapped to known risk tags. Client
+# tools execute inside the user's application code, so static
+# release-readiness checks ARE relevant: a `bash` tool needs an approval
+# policy, a `computer` tool needs auth scopes, etc. Risk tags are
+# pre-populated here because the keyword classifier alone would miss most of
+# these names (e.g. "computer", "memory", "str_replace_editor").
+_ANTHROPIC_CLIENT_TOOL_RISK_TAGS: dict[str, tuple[str, ...]] = {
+    "bash_": ("code_execution", "destructive", "write"),
+    "text_editor_": ("destructive", "write"),
+    "computer_": ("code_execution", "destructive", "write"),
+    "memory_": ("write",),
+}
+
+
+def _classify_anthropic_typed_tool(tool_type: str) -> tuple[str, tuple[str, ...]]:
+    """Classify a typed Anthropic tool definition.
+
+    Returns ``(category, risk_tags)`` where ``category`` is one of
+    ``"server"``, ``"client"``, or ``"unknown"`` and ``risk_tags`` is the
+    pre-populated tag list for client tools (empty for server/unknown).
+    """
+    for prefix in _ANTHROPIC_SERVER_TOOL_PREFIXES:
+        if tool_type.startswith(prefix):
+            return "server", ()
+    for prefix, tags in _ANTHROPIC_CLIENT_TOOL_RISK_TAGS.items():
+        if tool_type.startswith(prefix):
+            return "client", tags
+    return "unknown", ()
 
 
 def load_anthropic_artifacts(
@@ -209,17 +259,42 @@ def _tool_from_anthropic_definition(
         return None
 
     tool_type = data.get("type")
+    typed_client_risk_tags: tuple[str, ...] = ()
+    typed_client_kind: str | None = None
     if isinstance(tool_type, str) and tool_type != "custom":
-        # Server-side / built-in Anthropic tool. Schema is managed by Anthropic
-        # and is not user-controlled, so static checks against an
-        # `input_schema` would fire spurious findings on something the user
-        # cannot remediate. Per the plan, skip with a warning.
-        skipped_server_tools.append({"name": name, "type": tool_type, "source_ref": source_ref})
-        warnings.append(
-            f"Anthropic server-side tool {name!r} ({tool_type!r}) at {source_ref} skipped; "
-            "managed Anthropic tools have no user-controlled schema."
-        )
-        return None
+        category, risk_tag_seed = _classify_anthropic_typed_tool(tool_type)
+        if category == "server":
+            # Anthropic-managed server tool (web_search, code_execution).
+            # Schema is sandboxed on Anthropic's side; the user cannot
+            # influence behavior, so static checks would be spurious.
+            skipped_server_tools.append(
+                {"name": name, "type": tool_type, "source_ref": source_ref}
+            )
+            warnings.append(
+                f"Anthropic server-side tool {name!r} ({tool_type!r}) at {source_ref} skipped; "
+                "managed Anthropic tools have no user-controlled schema."
+            )
+            return None
+        if category == "unknown":
+            # Forward-compat: a typed tool we don't yet classify. We skip
+            # with an explicit warning so the user can either declare it
+            # under `type: "custom"` (loaded as a normal tool) or wait for
+            # adapter support. This avoids silently dropping high-risk
+            # tools when Anthropic introduces a new type prefix.
+            skipped_server_tools.append(
+                {"name": name, "type": tool_type, "source_ref": source_ref}
+            )
+            warnings.append(
+                f"Anthropic tool {name!r} at {source_ref} declares unrecognized "
+                f"type {tool_type!r}; skipping. If this is a custom tool, omit "
+                "`type` or set it to \"custom\" so the static checks can review it."
+            )
+            return None
+        # Client tool: executes in the user's application code. We inventory
+        # it with pre-populated risk tags so framework-agnostic checks
+        # (approval, auth scope, owner, idempotency, ...) can fire correctly.
+        typed_client_risk_tags = risk_tag_seed
+        typed_client_kind = tool_type
 
     if "input_schema" not in data and "parameters" in data:
         warnings.append(
@@ -249,6 +324,20 @@ def _tool_from_anthropic_definition(
     annotations: dict[str, Any] = {"anthropicTool": True}
     if cache_control is not None:
         annotations["anthropicCacheControl"] = cache_control
+    if typed_client_kind is not None:
+        annotations["anthropicClientTool"] = True
+        annotations["anthropicToolType"] = typed_client_kind
+
+    risk_hints: list[ToolRiskHint] = []
+    for tag in typed_client_risk_tags:
+        risk_hints.append(
+            ToolRiskHint(
+                tag=tag,
+                source="anthropic_client_tool_type",
+                confidence="high",
+                evidence={"anthropic_tool_type": typed_client_kind},
+            )
+        )
 
     return Tool(
         id=stable_tool_id(name),
@@ -260,6 +349,7 @@ def _tool_from_anthropic_definition(
         input_schema=input_schema,
         parameters=schema_to_parameters(input_schema),
         annotations=annotations,
+        risk_hints=risk_hints,
         extraction_confidence="high",
         extraction={"method": "anthropic_api_artifact", "confidence": "high"},
     )

--- a/src/agents_shipgate/inputs/anthropic_api.py
+++ b/src/agents_shipgate/inputs/anthropic_api.py
@@ -1,0 +1,276 @@
+"""Loader for Anthropic Messages API tool-use artifacts.
+
+The MVP surface (per the plan) is intentionally narrow:
+
+- ``prompt_files`` — markdown / text system prompts. Concatenated into
+  ``AnthropicArtifacts.prompt_text``.
+- ``tools`` — JSON files containing a Messages API ``tools`` array
+  (``[{name, description, input_schema, ...}, ...]``). Each entry becomes
+  a normalized :class:`Tool` with ``source_type='anthropic_api'``.
+- ``policy_rules`` — YAML / JSON files merged into
+  ``AnthropicArtifacts.policy_rules`` so framework-agnostic policy checks
+  pick up Anthropic-side approval / confirmation / idempotency lists.
+
+Anthropic-specific differences from the OpenAI loader:
+
+- Tool definitions are flat ``{name, description, input_schema}`` — there is
+  no ``function`` wrapper.
+- The schema field is ``input_schema``, not ``parameters``. We read only
+  ``input_schema`` and warn if a hand-converted OpenAI shape is detected.
+- Tool names are validated against Anthropic's documented regex
+  ``^[a-zA-Z0-9_-]{1,64}$`` (stricter than the shared
+  :data:`agents_shipgate.inputs.common.CONVENTIONAL_TOOL_NAME_RE`). Violations
+  are warnings, not errors — the static linter surfaces the issue without
+  blocking the load.
+- Server-side built-in tool types (``computer_*``, ``bash_*``,
+  ``web_search``, ``text_editor_*``, ...) have no user-controlled
+  ``input_schema``. We skip them with a warning rather than emitting noisy
+  schema findings on a managed tool the user cannot fix.
+
+Public docs: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from agents_shipgate.config.schema import AnthropicConfig, ArtifactPathConfig
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.models import AnthropicArtifacts, LoadedToolSource, Tool
+from agents_shipgate.inputs.common import (
+    load_structured_file,
+    load_text_file,
+    resolve_input_path,
+    schema_to_parameters,
+    stable_tool_id,
+)
+
+PROMPT_SUFFIXES = {".md", ".markdown", ".txt"}
+
+# Per https://docs.anthropic.com/en/docs/build-with-claude/tool-use the tool
+# name must match this regex. Surface a warning when it doesn't.
+_ANTHROPIC_TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+def load_anthropic_artifacts(
+    config: AnthropicConfig | None, base_dir: Path
+) -> tuple[LoadedToolSource | None, AnthropicArtifacts | None]:
+    if config is None:
+        return None, None
+
+    artifacts = AnthropicArtifacts()
+    tools: list[Tool] = []
+
+    for prompt_path in config.prompt_files:
+        prompt = _resolve(base_dir, prompt_path)
+        if prompt.suffix.lower() not in PROMPT_SUFFIXES:
+            artifacts.warnings.append(
+                f"Anthropic prompt file {prompt_path!r} is not markdown/text; "
+                "loaded as UTF-8 text."
+            )
+        text = load_text_file(prompt)
+        artifacts.prompt_files.append(_display_path(prompt, base_dir))
+        artifacts.prompt_text = "\n\n".join(
+            item for item in [artifacts.prompt_text, text] if item
+        )
+
+    for tool_ref in config.tools:
+        data = _load_required_or_optional(tool_ref, base_dir, artifacts.warnings, "tools")
+        if data is None:
+            continue
+        artifacts.tool_files.append(
+            _display_path(_resolve(base_dir, tool_ref.path), base_dir)
+        )
+        for index, item in enumerate(_tool_items(data)):
+            tool = _tool_from_anthropic_definition(
+                item,
+                source_ref=f"{tool_ref.path}#{index}",
+                warnings=artifacts.warnings,
+                skipped_server_tools=artifacts.skipped_server_tools,
+            )
+            if tool:
+                tools.append(tool)
+
+    for policy_ref in config.policy_rules:
+        data = _load_required_or_optional(
+            policy_ref, base_dir, artifacts.warnings, "policy_rules"
+        )
+        if data is None:
+            continue
+        if not isinstance(data, dict):
+            raise InputParseError(
+                f"Anthropic policy_rules file must contain an object: {policy_ref.path}"
+            )
+        artifacts.policy_rule_files.append(
+            _display_path(_resolve(base_dir, policy_ref.path), base_dir)
+        )
+        _merge_policy_rules(
+            artifacts.policy_rules,
+            data,
+            source_ref=policy_ref.path,
+            warnings=artifacts.warnings,
+        )
+
+    return (
+        LoadedToolSource(
+            source_id="anthropic",
+            source_type="anthropic_api",
+            tools=tools,
+            warnings=artifacts.warnings,
+        ),
+        artifacts,
+    )
+
+
+def _load_required_or_optional(
+    ref: ArtifactPathConfig,
+    base_dir: Path,
+    warnings: list[str],
+    kind: str,
+) -> Any | None:
+    path = _resolve(base_dir, ref.path)
+    try:
+        return load_structured_file(path)
+    except InputParseError:
+        if not ref.optional:
+            raise
+        warnings.append(f"Optional Anthropic {kind} artifact {ref.path!r} failed to load.")
+        return None
+
+
+def _merge_policy_rules(
+    target: dict[str, Any],
+    incoming: dict[str, Any],
+    *,
+    source_ref: str,
+    warnings: list[str],
+) -> None:
+    for key, value in incoming.items():
+        if key not in target:
+            target[key] = value
+            continue
+        warnings.append(
+            f"Anthropic policy_rules key {key!r} from {source_ref!r} overlaps an earlier policy file; merging values."
+        )
+        target[key] = _merge_policy_value(target[key], value)
+
+
+def _merge_policy_value(existing: Any, incoming: Any) -> Any:
+    if isinstance(existing, list) and isinstance(incoming, list):
+        return _merge_list_values(existing, incoming)
+    if isinstance(existing, dict) and isinstance(incoming, dict):
+        return {**existing, **incoming}
+    return incoming
+
+
+def _merge_list_values(existing: list[Any], incoming: list[Any]) -> list[Any]:
+    merged: list[Any] = []
+    seen: set[str] = set()
+    for item in [*existing, *incoming]:
+        marker = json.dumps(item, sort_keys=True, default=str)
+        if marker in seen:
+            continue
+        merged.append(item)
+        seen.add(marker)
+    return merged
+
+
+def _tool_items(data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if isinstance(data, dict):
+        tools = data.get("tools")
+        if isinstance(tools, list):
+            return [item for item in tools if isinstance(item, dict)]
+        return [data]
+    raise InputParseError("Anthropic tools artifact must be an object or list")
+
+
+def _tool_from_anthropic_definition(
+    data: dict[str, Any],
+    *,
+    source_ref: str,
+    warnings: list[str],
+    skipped_server_tools: list[dict[str, Any]],
+) -> Tool | None:
+    if "function" in data and isinstance(data.get("function"), dict):
+        warnings.append(
+            f"Anthropic tool definition at {source_ref} contains a 'function' wrapper "
+            "(OpenAI-style nesting); Anthropic Messages API tools are flat. Skipping."
+        )
+        return None
+
+    name = data.get("name")
+    if not isinstance(name, str) or not name.strip():
+        warnings.append(f"Skipping Anthropic tool without name at {source_ref}.")
+        return None
+
+    tool_type = data.get("type")
+    if isinstance(tool_type, str) and tool_type != "custom":
+        # Server-side / built-in Anthropic tool. Schema is managed by Anthropic
+        # and is not user-controlled, so static checks against an
+        # `input_schema` would fire spurious findings on something the user
+        # cannot remediate. Per the plan, skip with a warning.
+        skipped_server_tools.append({"name": name, "type": tool_type, "source_ref": source_ref})
+        warnings.append(
+            f"Anthropic server-side tool {name!r} ({tool_type!r}) at {source_ref} skipped; "
+            "managed Anthropic tools have no user-controlled schema."
+        )
+        return None
+
+    if "input_schema" not in data and "parameters" in data:
+        warnings.append(
+            f"Anthropic tool {name!r} at {source_ref} uses 'parameters' instead of "
+            "'input_schema'; this looks like an OpenAI-converted definition. Skipping."
+        )
+        return None
+
+    input_schema = data.get("input_schema")
+    if input_schema is None:
+        input_schema = {}
+    if not isinstance(input_schema, dict):
+        warnings.append(
+            f"Skipping Anthropic tool {name!r} at {source_ref}; input_schema is not an object."
+        )
+        return None
+
+    description = data.get("description")
+    cache_control = data.get("cache_control")
+
+    if not _ANTHROPIC_TOOL_NAME_RE.fullmatch(name):
+        warnings.append(
+            f"Anthropic tool name {name!r} at {source_ref} violates the documented "
+            "regex ^[a-zA-Z0-9_-]{1,64}$; runtime requests will be rejected."
+        )
+
+    annotations: dict[str, Any] = {"anthropicTool": True}
+    if cache_control is not None:
+        annotations["anthropicCacheControl"] = cache_control
+
+    return Tool(
+        id=stable_tool_id(name),
+        name=name,
+        description=description if isinstance(description, str) else None,
+        source_type="anthropic_api",
+        source_id="anthropic",
+        source_ref=source_ref,
+        input_schema=input_schema,
+        parameters=schema_to_parameters(input_schema),
+        annotations=annotations,
+        extraction_confidence="high",
+        extraction={"method": "anthropic_api_artifact", "confidence": "high"},
+    )
+
+
+def _resolve(base_dir: Path, value: str) -> Path:
+    return resolve_input_path(base_dir, value)
+
+
+def _display_path(path: Path, base_dir: Path) -> str:
+    try:
+        return path.resolve().relative_to(base_dir.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/tests/test_anthropic_api.py
+++ b/tests/test_anthropic_api.py
@@ -1,0 +1,218 @@
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.cli.scan import inspect_sources, run_scan
+from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.config.schema import (
+    AnthropicConfig,
+    ArtifactPathConfig,
+)
+from agents_shipgate.core.errors import ConfigError
+from agents_shipgate.inputs.anthropic_api import load_anthropic_artifacts
+
+SAMPLE = Path("samples/simple_anthropic_agent/shipgate.yaml")
+
+
+def test_anthropic_only_manifest_is_valid_and_prompt_files_satisfy_scope_text():
+    manifest = load_manifest(SAMPLE)
+
+    assert manifest.tool_sources == []
+    assert manifest.openai_api is None
+    assert manifest.anthropic is not None
+    assert manifest.anthropic.prompt_files == ["prompts/support_refund.md"]
+    # No declared_purpose / instructions_preview is present; the
+    # anthropic.prompt_files entry must satisfy the scope-text validator.
+
+
+def test_manifest_requires_tool_sources_or_openai_api_or_anthropic_or_google_adk(tmp_path):
+    manifest_path = tmp_path / "shipgate.yaml"
+    manifest_path.write_text(
+        """
+version: "0.1"
+project:
+  name: invalid
+agent:
+  name: invalid-agent
+  declared_purpose:
+    - test
+environment:
+  target: local
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigError, match="tool_sources, openai_api, anthropic"):
+        load_manifest(manifest_path)
+
+
+def test_anthropic_loader_normalizes_input_schema_into_tool_parameters():
+    manifest = load_manifest(SAMPLE)
+    source, artifacts = load_anthropic_artifacts(manifest.anthropic, SAMPLE.parent)
+
+    assert source is not None
+    assert artifacts is not None
+    assert source.source_type == "anthropic_api"
+    names = {tool.name for tool in source.tools}
+    assert names == {"create_refund", "get_help_article"}
+
+    create_refund = next(tool for tool in source.tools if tool.name == "create_refund")
+    assert create_refund.source_type == "anthropic_api"
+    assert create_refund.extraction_confidence == "high"
+    assert create_refund.input_schema["type"] == "object"
+    parameter_names = {parameter.name for parameter in create_refund.parameters}
+    assert parameter_names == {"payment_id", "amount", "reason"}
+
+
+def test_anthropic_loader_warns_on_invalid_tool_name(tmp_path):
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        '[{"name": "bad.name.with.dots", "description": "Long enough description to be valid.", '
+        '"input_schema": {"type": "object", "properties": {}}}]',
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    # Tool still loads — it's a warning, not an error.
+    assert {tool.name for tool in source.tools} == {"bad.name.with.dots"}
+    assert any("violates the documented" in w for w in artifacts.warnings)
+
+
+def test_anthropic_loader_skips_server_side_tool_types_with_warning(tmp_path):
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        """
+{
+  "tools": [
+    {"type": "computer_20250124", "name": "computer"},
+    {"type": "bash_20250124", "name": "bash"},
+    {"type": "web_search_20250305", "name": "web_search"},
+    {"type": "text_editor_20250124", "name": "str_replace_editor"},
+    {
+      "name": "list_records",
+      "description": "List records the agent can read.",
+      "input_schema": {"type": "object", "properties": {}}
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    assert {tool.name for tool in source.tools} == {"list_records"}
+    skipped_names = {entry["name"] for entry in artifacts.skipped_server_tools}
+    assert skipped_names == {"computer", "bash", "web_search", "str_replace_editor"}
+    assert any("server-side tool" in w for w in artifacts.warnings)
+
+
+def test_anthropic_loader_warns_on_openai_style_function_wrapper(tmp_path):
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        """
+[{
+  "type": "function",
+  "function": {
+    "name": "create_refund",
+    "description": "Create a refund.",
+    "parameters": {"type": "object", "properties": {}}
+  }
+}]
+""",
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    assert source.tools == []
+    assert any("'function' wrapper" in w for w in artifacts.warnings)
+
+
+def test_anthropic_loader_warns_when_definition_uses_parameters_not_input_schema(tmp_path):
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        """
+[{
+  "name": "create_refund",
+  "description": "Create a refund.",
+  "parameters": {"type": "object", "properties": {}}
+}]
+""",
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    assert source.tools == []
+    assert any("'parameters' instead of 'input_schema'" in w for w in artifacts.warnings)
+
+
+def test_anthropic_loader_captures_cache_control_annotation_verbatim():
+    manifest = load_manifest(SAMPLE)
+    source, _ = load_anthropic_artifacts(manifest.anthropic, SAMPLE.parent)
+
+    create_refund = next(tool for tool in source.tools if tool.name == "create_refund")
+    assert create_refund.annotations.get("anthropicTool") is True
+    assert create_refund.annotations.get("anthropicCacheControl") == {"type": "ephemeral"}
+
+
+def test_anthropic_scan_runs_existing_framework_agnostic_checks(tmp_path):
+    report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    fingerprints = {finding.check_id for finding in report.findings if not finding.suppressed}
+    # Existing framework-agnostic + generalized SHIP-API-* checks fire on
+    # Anthropic tools without any new check IDs.
+    assert "SHIP-API-FUNCTION-SCHEMA-STRICTNESS" in fingerprints
+    assert "SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH" in fingerprints
+    assert "SHIP-AUTH-MISSING-SCOPE" in fingerprints
+    assert "SHIP-SCHEMA-MISSING-BOUNDS" in fingerprints
+    assert "SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING" in fingerprints
+    # Approval is satisfied by anthropic.policy_rules so the check should NOT fire.
+    assert "SHIP-POLICY-APPROVAL-MISSING" not in fingerprints
+    # No new check IDs introduced by Anthropic support.
+    assert not any(check_id.startswith("SHIP-ANTHROPIC-") for check_id in fingerprints)
+
+
+def test_anthropic_function_strictness_does_not_emit_missing_strict_true():
+    """OpenAI's `strict: true` field is not part of Anthropic's Messages API,
+    so the function-schema-strictness check must not list it as an issue
+    for Anthropic tools."""
+    report, _ = run_scan(
+        config_path=SAMPLE,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    strictness_findings = [
+        finding
+        for finding in report.findings
+        if finding.check_id == "SHIP-API-FUNCTION-SCHEMA-STRICTNESS"
+        and finding.tool_name == "create_refund"
+    ]
+    assert strictness_findings, "create_refund should still flag schema strictness"
+    issues = strictness_findings[0].evidence.get("issues") or []
+    assert "missing_strict_true" not in issues
+
+
+def test_doctor_includes_anthropic_surface():
+    payload = inspect_sources(config_path=SAMPLE)
+
+    assert payload["anthropic_surface"] is not None
+    assert payload["anthropic_surface"]["tool_file_count"] == 1
+    assert payload["anthropic_surface"]["prompt_file_count"] == 1
+    assert payload["anthropic_surface"]["policy_rule_count"] == 1
+    assert payload["anthropic_surface"]["skipped_server_tool_count"] == 1

--- a/tests/test_anthropic_api.py
+++ b/tests/test_anthropic_api.py
@@ -81,16 +81,17 @@ def test_anthropic_loader_warns_on_invalid_tool_name(tmp_path):
     assert any("violates the documented" in w for w in artifacts.warnings)
 
 
-def test_anthropic_loader_skips_server_side_tool_types_with_warning(tmp_path):
+def test_anthropic_loader_skips_anthropic_managed_server_tools(tmp_path):
+    """Server-side Anthropic tools (web_search, code_execution) are
+    sandboxed on Anthropic infrastructure and have no user-controlled
+    schema; static checks against them would be unactionable."""
     tools = tmp_path / "tools.json"
     tools.write_text(
         """
 {
   "tools": [
-    {"type": "computer_20250124", "name": "computer"},
-    {"type": "bash_20250124", "name": "bash"},
     {"type": "web_search_20250305", "name": "web_search"},
-    {"type": "text_editor_20250124", "name": "str_replace_editor"},
+    {"type": "code_execution_20250522", "name": "code_execution"},
     {
       "name": "list_records",
       "description": "List records the agent can read.",
@@ -108,8 +109,239 @@ def test_anthropic_loader_skips_server_side_tool_types_with_warning(tmp_path):
     assert source is not None
     assert {tool.name for tool in source.tools} == {"list_records"}
     skipped_names = {entry["name"] for entry in artifacts.skipped_server_tools}
-    assert skipped_names == {"computer", "bash", "web_search", "str_replace_editor"}
+    assert skipped_names == {"web_search", "code_execution"}
     assert any("server-side tool" in w for w in artifacts.warnings)
+
+
+def test_anthropic_loader_inventories_client_tools_with_risk_hints(tmp_path):
+    """Anthropic client tools (bash, text_editor, computer, memory) execute
+    in the user's application code and ARE in scope for static review.
+    They are inventoried with pre-populated risk hints so the
+    framework-agnostic checks (approval, auth scope, owner, idempotency)
+    fire correctly — a manifest enabling bash should not silently produce
+    zero actionable findings beyond a warning."""
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        """
+{
+  "tools": [
+    {"type": "bash_20250124", "name": "bash"},
+    {"type": "text_editor_20250124", "name": "str_replace_editor"},
+    {"type": "computer_20250124", "name": "computer"},
+    {"type": "memory_20250818", "name": "memory"}
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    assert artifacts is not None
+    # All four are loaded — none skipped.
+    assert artifacts.skipped_server_tools == []
+    by_name = {tool.name: tool for tool in source.tools}
+    assert set(by_name) == {"bash", "str_replace_editor", "computer", "memory"}
+
+    # Each carries the type info on the tool annotations.
+    assert by_name["bash"].annotations["anthropicClientTool"] is True
+    assert by_name["bash"].annotations["anthropicToolType"] == "bash_20250124"
+
+    # Risk hints are pre-populated at high confidence per the type prefix.
+    bash_tags = {hint.tag for hint in by_name["bash"].risk_hints}
+    assert {"code_execution", "destructive", "write"} <= bash_tags
+
+    editor_tags = {hint.tag for hint in by_name["str_replace_editor"].risk_hints}
+    assert {"destructive", "write"} <= editor_tags
+
+    computer_tags = {hint.tag for hint in by_name["computer"].risk_hints}
+    assert {"code_execution", "destructive", "write"} <= computer_tags
+
+    memory_tags = {hint.tag for hint in by_name["memory"].risk_hints}
+    assert {"write"} <= memory_tags
+
+    # The hints are sourced from the typed-tool classifier so the evidence
+    # carries the specific Anthropic type for traceability.
+    bash_hint_sources = {hint.source for hint in by_name["bash"].risk_hints}
+    assert "anthropic_client_tool_type" in bash_hint_sources
+
+
+def test_anthropic_loader_skips_unknown_typed_tools_with_warning(tmp_path):
+    """Forward-compat: a typed Anthropic tool we don't classify yet is
+    skipped with an explicit warning so the user can either declare it as
+    `type: "custom"` or wait for adapter support — never silently dropped."""
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        '[{"type": "future_anthropic_tool_20990101", "name": "future_thing"}]',
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    assert source.tools == []
+    assert any("unrecognized type" in w for w in artifacts.warnings)
+    assert {entry["name"] for entry in artifacts.skipped_server_tools} == {"future_thing"}
+
+
+def test_anthropic_client_tool_fires_high_risk_release_findings(tmp_path):
+    """End-to-end: a manifest declaring `bash_20250124` with no approval
+    policy must NOT silently pass; it should fire SHIP-POLICY-APPROVAL-MISSING
+    and SHIP-AUTH-MISSING-SCOPE just like any other write-shaped tool."""
+    (tmp_path / "prompt.md").write_text(
+        "You are a coding assistant that runs shell commands.", encoding="utf-8"
+    )
+    (tmp_path / "tools.json").write_text(
+        '[{"type": "bash_20250124", "name": "bash"}]',
+        encoding="utf-8",
+    )
+    (tmp_path / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: anthropic-bash-agent
+agent:
+  name: bash-agent
+  declared_purpose:
+    - run bash commands
+environment:
+  target: production_like
+anthropic:
+  prompt_files:
+    - prompt.md
+  tools:
+    - path: tools.json
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=tmp_path / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    bash_findings = {
+        finding.check_id
+        for finding in report.findings
+        if finding.tool_name == "bash" and not finding.suppressed
+    }
+    assert "SHIP-POLICY-APPROVAL-MISSING" in bash_findings
+    assert "SHIP-AUTH-MISSING-SCOPE" in bash_findings
+    # The bash tool should be in the inventory (not skipped).
+    inventory_names = {
+        (tool.name if hasattr(tool, "name") else tool["name"])
+        for tool in report.tool_inventory
+    }
+    assert "bash" in inventory_names
+
+
+def test_anthropic_tools_do_not_fire_openai_only_checks_in_mixed_manifest(tmp_path):
+    """Regression test for PR #14 review P2: when a manifest declares both
+    openai_api and anthropic blocks, the OpenAI-only checks
+    (structured-output-readiness, retry, timeout, test-cases,
+    tool-output-schema, retry-without-idempotency) must filter to OpenAI
+    tools — Anthropic tools have no equivalent artifacts and would
+    otherwise produce false-positive findings."""
+    (tmp_path / "openai_prompt.md").write_text("OpenAI prompt.", encoding="utf-8")
+    (tmp_path / "openai-tools.json").write_text(
+        """
+[
+  {
+    "type": "function",
+    "name": "openai_only_tool",
+    "description": "Returns customer status.",
+    "strict": true,
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {"id": {"type": "string"}},
+      "required": ["id"]
+    }
+  }
+]
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "anthropic-tools.json").write_text(
+        """
+[
+  {
+    "name": "create_refund",
+    "description": "Creates a refund (financial action).",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "amount": {"type": "number"},
+        "payment_id": {"type": "string"}
+      },
+      "required": ["amount", "payment_id"]
+    }
+  }
+]
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: mixed-anthropic-openai
+agent:
+  name: mixed-agent
+  declared_purpose:
+    - look up customer status
+    - issue refunds
+environment:
+  target: production_like
+openai_api:
+  prompt_files:
+    - openai_prompt.md
+  tools:
+    - path: openai-tools.json
+anthropic:
+  tools:
+    - path: anthropic-tools.json
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=tmp_path / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    # Anthropic create_refund must NOT appear under any OpenAI-shaped finding.
+    openai_only_check_ids = {
+        "SHIP-API-RETRY-POLICY-MISSING",
+        "SHIP-API-TIMEOUT-MISSING",
+        "SHIP-API-TEST-CASES-MISSING",
+        "SHIP-API-TOOL-OUTPUT-SCHEMA-MISSING",
+        "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY",
+    }
+    for finding in report.findings:
+        if (
+            finding.check_id in openai_only_check_ids
+            and finding.tool_name == "create_refund"
+        ):
+            raise AssertionError(
+                f"OpenAI-only check {finding.check_id} fired on Anthropic tool create_refund"
+            )
+
+    # Specifically: the agent-level structured-output-readiness finding
+    # (when fired) must not list Anthropic tools in high_risk_tools.
+    for finding in report.findings:
+        if finding.check_id == "SHIP-API-STRUCTURED-OUTPUT-READINESS":
+            high_risk = finding.evidence.get("high_risk_tools") or []
+            assert "create_refund" not in high_risk, (
+                "Anthropic create_refund leaked into OpenAI structured-output finding"
+            )
 
 
 def test_anthropic_loader_warns_on_openai_style_function_wrapper(tmp_path):

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -36,7 +36,7 @@ environment:
         encoding="utf-8",
     )
 
-    with pytest.raises(ConfigError, match="tool_sources or openai_api"):
+    with pytest.raises(ConfigError, match="tool_sources, openai_api"):
         load_manifest(manifest_path)
 
 


### PR DESCRIPTION
## Summary

- Adds first-class support for the **Anthropic Messages API tool-use** shape, reaching feature parity with the existing OpenAI Agents API surface for prompt + tool + policy artifacts.
- **Zero new check IDs** — generalizes existing framework-agnostic and `SHIP-API-*` checks so an Anthropic agent gets the same release-readiness audit an OpenAI Agents API agent gets today.
- Strict MVP scope: top-level `anthropic:` block with three fields (`prompt_files`, `tools`, `policy_rules`). No Claude Code project-layout ingestion, no Claude Agent SDK static extraction, no trace ingestion — those are explicit Phase-2 items.

## Manifest

```yaml
version: "0.1"
project: { name: refund-assistant }
agent:
  name: refund-assistant
  declared_purpose: [issue customer refunds]
environment: { target: production_like }
anthropic:
  prompt_files: [prompts/system.md]
  tools:
    - path: tools/anthropic-tools.json
  policy_rules:
    - path: policies/anthropic-policy.yaml
```

## Anthropic-specific behavior

- **Tool name validator**: enforces Anthropic's documented regex `^[a-zA-Z0-9_-]{1,64}$` (stricter than the shared regex which allows `.` and 128 chars). Warning, not error.
- **`input_schema` only**: warns if a tool definition uses OpenAI-style `parameters`, treating it as a likely hand-conversion.
- **No `function` wrapper**: warns if a tool has a top-level `function` key.
- **Server-side built-in tools** (`computer_*`, `bash_*`, `web_search`, `text_editor_*`): **skipped with warning**, not loaded into the tool inventory.
- **`cache_control`**: captured verbatim into `annotations[\"anthropicCacheControl\"]`. No risk-classification influence in MVP.
- **No `strict` field**: the `SHIP-API-FUNCTION-SCHEMA-STRICTNESS` check still fires, but `missing_strict_true` is gated to OpenAI tools only.

## Wire-in changes

- `config/schema.py` — `AnthropicConfig`, `AgentsShipgateManifest.anthropic`, scope-text + at-least-one-source validator extensions.
- `core/models.py` — `AnthropicArtifacts` (mirrors `OpenAIApiArtifacts` helpers), `ReadinessReport.anthropic_surface`.
- `core/context.py` — `ScanContext.anthropic_artifacts`.
- `inputs/anthropic_api.py` — new loader (lift-and-shift from `openai_api.py` with the four Anthropic-specific differences above).
- `core/risk_hints.py` — extend `_KEYWORD_GATED_SOURCE_TYPES` so write/read keyword classification fires on Anthropic tools.
- `checks/api.py` — generalize the early-return guard and `_api_tools` filter; gate `missing_strict_true`.
- `checks/policy.py`, `checks/side_effects.py` — consult `anthropic_artifacts` for approval, confirmation, and idempotency policy rules.
- `cli/scan.py` — load Anthropic artifacts in `run_scan` and `inspect_sources`; extend `_build_agent` prompt fallback chain; include Anthropic in `_run_id` payload and `_source_priority` (40, same as OpenAI; first-wins on collision).
- `samples/simple_anthropic_agent/` — fixture with one write-shaped custom tool, one read-shaped custom tool, and one `bash_20250124` server-side built-in to exercise the skip path.
- `docs/manifest-v0.1.md` — new \"Anthropic Messages API Artifacts\" section.
- `docs/manifest-v0.1.json` — regenerated via `scripts/generate_schemas.py`.
- `AGENTS.md` + `README.md` — Inputs lines updated to include \"Anthropic Messages API\".

## Out of scope (Phase 2)

- `tool_sources[].type: \"anthropic\"` (only top-level block supported)
- Claude Agent SDK static AST extraction
- Claude Code project-layout ingestion (`.claude/agents/`, `.claude/hooks/`, `.mcp.json`, `settings.json`)
- Anthropic trace ingestion
- `model_config`, `response_formats`, `function_schemas`, `test_cases`, `trace_samples` config fields
- `SHIP-ANTHROPIC-*` check IDs
- `cache_control` semantic checks (capture only)

## Test plan

- [x] `python -m ruff check .` clean
- [x] `python -m pytest` — 170/170 pass (159 existing + 11 new)
- [x] Schema regen via `scripts/generate_schemas.py` — `docs/manifest-v0.1.json` updated, no other drift
- [x] End-to-end smoke test on `samples/simple_anthropic_agent/`:
  - Server-side `bash_20250124` correctly skipped with warning, not in `tool_inventory`
  - `create_refund` classified as `write + financial_action` via keyword hints
  - `get_help_article` classified as read-only
  - Approval check satisfied by `anthropic.policy_rules`
  - 7 high + 1 medium findings, all from generalized framework-agnostic + `SHIP-API-*` checks
- [x] Stability contract preserved: no existing check IDs renamed, no existing JSON fields removed; `anthropic_surface` is additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)