### PR TITLE
Address PR #14 review: client tools and mixed-manifest false positives

### DIFF
--- a/samples/simple_anthropic_agent/tools/anthropic-tools.json
+++ b/samples/simple_anthropic_agent/tools/anthropic-tools.json
@@ -40,8 +40,8 @@
       }
     },
     {
-      "type": "bash_20250124",
-      "name": "bash"
+      "type": "web_search_20250305",
+      "name": "web_search"
     }
   ]
 }

--- a/src/agents_shipgate/checks/api.py
+++ b/src/agents_shipgate/checks/api.py
@@ -67,11 +67,16 @@ def _function_schema_strictness(context: ScanContext):
 
 def _structured_output_readiness(context: ScanContext):
     # Anthropic config has no first-class response-format artifact in MVP,
-    # so this check stays scoped to the OpenAI Agents API surface.
+    # so this check stays scoped to the OpenAI Agents API surface. Use the
+    # OpenAI-only tool filter so a mixed manifest (anthropic + openai_api)
+    # doesn't list Anthropic tools as high-risk under an OpenAI-shaped
+    # finding.
     artifacts = context.api_artifacts
     if artifacts is None:
         return []
-    high_risk_tools = [tool.name for tool in _api_tools(context) if is_high_risk_tool(tool)]
+    high_risk_tools = [
+        tool.name for tool in _openai_api_tools(context) if is_high_risk_tool(tool)
+    ]
     if not artifacts.response_formats:
         return [
             agent_finding(
@@ -188,13 +193,15 @@ def _prompt_tool_scope_mismatch(context: ScanContext):
 def _operational_readiness(context: ScanContext):
     # The retry / timeout / test-case / output-schema readiness checks key on
     # OpenAI Agents API artifacts. Anthropic MVP doesn't carry equivalent data,
-    # so when only Anthropic artifacts are present these checks intentionally
-    # don't fire — see plan §5.
+    # so we filter to OpenAI tools only — otherwise a mixed manifest would
+    # fire OpenAI-shaped findings against Anthropic tools that have no
+    # response_formats / retry_policy / test_cases / tool_output_schemas
+    # to satisfy. See plan §5.
     artifacts = context.api_artifacts
     if artifacts is None:
         return []
     findings = []
-    api_tools = _api_tools(context)
+    api_tools = _openai_api_tools(context)
     high_risk_tools = [tool for tool in api_tools if is_high_risk_tool(tool)]
     retry_policy = artifacts.retry_policy()
     timeouts = artifacts.timeouts()
@@ -405,8 +412,21 @@ def _broad_free_text(parameter: ToolParameter) -> bool:
 
 
 def _api_tools(context: ScanContext) -> list[Tool]:
+    """Tools backed by an artifact-style adapter (OpenAI Agents API or
+    Anthropic Messages API). Used by checks that apply to both surfaces:
+    function-schema strictness and prompt/tool scope mismatch.
+    """
     return [
         tool
         for tool in context.tools
         if tool.source_type in {"openai_api", "anthropic_api"}
     ]
+
+
+def _openai_api_tools(context: ScanContext) -> list[Tool]:
+    """Tools backed only by the OpenAI Agents API adapter. Used by checks
+    that key on OpenAI-specific artifacts (response_formats, retry_policy,
+    test_cases, tool_output_schemas) — these have no Anthropic equivalent
+    in the v0.4 MVP and would produce false positives on Anthropic tools.
+    """
+    return [tool for tool in context.tools if tool.source_type == "openai_api"]

--- a/src/agents_shipgate/inputs/anthropic_api.py
+++ b/src/agents_shipgate/inputs/anthropic_api.py
@@ -22,10 +22,17 @@ Anthropic-specific differences from the OpenAI loader:
   :data:`agents_shipgate.inputs.common.CONVENTIONAL_TOOL_NAME_RE`). Violations
   are warnings, not errors — the static linter surfaces the issue without
   blocking the load.
-- Server-side built-in tool types (``computer_*``, ``bash_*``,
-  ``web_search``, ``text_editor_*``, ...) have no user-controlled
+- Server-side Anthropic tools (``web_search_*``, ``code_execution_*``)
+  execute on Anthropic infrastructure and have no user-controlled
   ``input_schema``. We skip them with a warning rather than emitting noisy
   schema findings on a managed tool the user cannot fix.
+- Client-side Anthropic tools (``bash_*``, ``text_editor_*``, ``computer_*``,
+  ``memory_*``) execute inside the user's application code and ARE in scope
+  for static release-readiness review. We inventory them as
+  ``source_type='anthropic_api'`` tools, attach explicit risk hints (e.g.
+  ``bash`` -> destructive + write + code_execution), and let the existing
+  framework-agnostic checks (approval policy, auth scopes, owner, etc.)
+  fire normally. See https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference
 
 Public docs: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
 """
@@ -39,7 +46,12 @@ from typing import Any
 
 from agents_shipgate.config.schema import AnthropicConfig, ArtifactPathConfig
 from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.core.models import AnthropicArtifacts, LoadedToolSource, Tool
+from agents_shipgate.core.models import (
+    AnthropicArtifacts,
+    LoadedToolSource,
+    Tool,
+    ToolRiskHint,
+)
 from agents_shipgate.inputs.common import (
     load_structured_file,
     load_text_file,
@@ -53,6 +65,44 @@ PROMPT_SUFFIXES = {".md", ".markdown", ".txt"}
 # Per https://docs.anthropic.com/en/docs/build-with-claude/tool-use the tool
 # name must match this regex. Surface a warning when it doesn't.
 _ANTHROPIC_TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+# Anthropic server-side tool type prefixes. These tools execute on Anthropic
+# infrastructure (sandboxed search, sandboxed code interpreter) and have no
+# user-controlled schema; static checks against `input_schema` would fire
+# spurious findings on a managed surface the user cannot remediate.
+_ANTHROPIC_SERVER_TOOL_PREFIXES: tuple[str, ...] = (
+    "web_search_",
+    "code_execution_",
+)
+
+# Anthropic client-side tool type prefixes mapped to known risk tags. Client
+# tools execute inside the user's application code, so static
+# release-readiness checks ARE relevant: a `bash` tool needs an approval
+# policy, a `computer` tool needs auth scopes, etc. Risk tags are
+# pre-populated here because the keyword classifier alone would miss most of
+# these names (e.g. "computer", "memory", "str_replace_editor").
+_ANTHROPIC_CLIENT_TOOL_RISK_TAGS: dict[str, tuple[str, ...]] = {
+    "bash_": ("code_execution", "destructive", "write"),
+    "text_editor_": ("destructive", "write"),
+    "computer_": ("code_execution", "destructive", "write"),
+    "memory_": ("write",),
+}
+
+
+def _classify_anthropic_typed_tool(tool_type: str) -> tuple[str, tuple[str, ...]]:
+    """Classify a typed Anthropic tool definition.
+
+    Returns ``(category, risk_tags)`` where ``category`` is one of
+    ``"server"``, ``"client"``, or ``"unknown"`` and ``risk_tags`` is the
+    pre-populated tag list for client tools (empty for server/unknown).
+    """
+    for prefix in _ANTHROPIC_SERVER_TOOL_PREFIXES:
+        if tool_type.startswith(prefix):
+            return "server", ()
+    for prefix, tags in _ANTHROPIC_CLIENT_TOOL_RISK_TAGS.items():
+        if tool_type.startswith(prefix):
+            return "client", tags
+    return "unknown", ()
 
 
 def load_anthropic_artifacts(
@@ -209,17 +259,42 @@ def _tool_from_anthropic_definition(
         return None
 
     tool_type = data.get("type")
+    typed_client_risk_tags: tuple[str, ...] = ()
+    typed_client_kind: str | None = None
     if isinstance(tool_type, str) and tool_type != "custom":
-        # Server-side / built-in Anthropic tool. Schema is managed by Anthropic
-        # and is not user-controlled, so static checks against an
-        # `input_schema` would fire spurious findings on something the user
-        # cannot remediate. Per the plan, skip with a warning.
-        skipped_server_tools.append({"name": name, "type": tool_type, "source_ref": source_ref})
-        warnings.append(
-            f"Anthropic server-side tool {name!r} ({tool_type!r}) at {source_ref} skipped; "
-            "managed Anthropic tools have no user-controlled schema."
-        )
-        return None
+        category, risk_tag_seed = _classify_anthropic_typed_tool(tool_type)
+        if category == "server":
+            # Anthropic-managed server tool (web_search, code_execution).
+            # Schema is sandboxed on Anthropic's side; the user cannot
+            # influence behavior, so static checks would be spurious.
+            skipped_server_tools.append(
+                {"name": name, "type": tool_type, "source_ref": source_ref}
+            )
+            warnings.append(
+                f"Anthropic server-side tool {name!r} ({tool_type!r}) at {source_ref} skipped; "
+                "managed Anthropic tools have no user-controlled schema."
+            )
+            return None
+        if category == "unknown":
+            # Forward-compat: a typed tool we don't yet classify. We skip
+            # with an explicit warning so the user can either declare it
+            # under `type: "custom"` (loaded as a normal tool) or wait for
+            # adapter support. This avoids silently dropping high-risk
+            # tools when Anthropic introduces a new type prefix.
+            skipped_server_tools.append(
+                {"name": name, "type": tool_type, "source_ref": source_ref}
+            )
+            warnings.append(
+                f"Anthropic tool {name!r} at {source_ref} declares unrecognized "
+                f"type {tool_type!r}; skipping. If this is a custom tool, omit "
+                "`type` or set it to \"custom\" so the static checks can review it."
+            )
+            return None
+        # Client tool: executes in the user's application code. We inventory
+        # it with pre-populated risk tags so framework-agnostic checks
+        # (approval, auth scope, owner, idempotency, ...) can fire correctly.
+        typed_client_risk_tags = risk_tag_seed
+        typed_client_kind = tool_type
 
     if "input_schema" not in data and "parameters" in data:
         warnings.append(
@@ -249,6 +324,20 @@ def _tool_from_anthropic_definition(
     annotations: dict[str, Any] = {"anthropicTool": True}
     if cache_control is not None:
         annotations["anthropicCacheControl"] = cache_control
+    if typed_client_kind is not None:
+        annotations["anthropicClientTool"] = True
+        annotations["anthropicToolType"] = typed_client_kind
+
+    risk_hints: list[ToolRiskHint] = []
+    for tag in typed_client_risk_tags:
+        risk_hints.append(
+            ToolRiskHint(
+                tag=tag,
+                source="anthropic_client_tool_type",
+                confidence="high",
+                evidence={"anthropic_tool_type": typed_client_kind},
+            )
+        )
 
     return Tool(
         id=stable_tool_id(name),
@@ -260,6 +349,7 @@ def _tool_from_anthropic_definition(
         input_schema=input_schema,
         parameters=schema_to_parameters(input_schema),
         annotations=annotations,
+        risk_hints=risk_hints,
         extraction_confidence="high",
         extraction={"method": "anthropic_api_artifact", "confidence": "high"},
     )

--- a/tests/test_anthropic_api.py
+++ b/tests/test_anthropic_api.py
@@ -81,16 +81,17 @@ def test_anthropic_loader_warns_on_invalid_tool_name(tmp_path):
     assert any("violates the documented" in w for w in artifacts.warnings)
 
 
-def test_anthropic_loader_skips_server_side_tool_types_with_warning(tmp_path):
+def test_anthropic_loader_skips_anthropic_managed_server_tools(tmp_path):
+    """Server-side Anthropic tools (web_search, code_execution) are
+    sandboxed on Anthropic infrastructure and have no user-controlled
+    schema; static checks against them would be unactionable."""
     tools = tmp_path / "tools.json"
     tools.write_text(
         """
 {
   "tools": [
-    {"type": "computer_20250124", "name": "computer"},
-    {"type": "bash_20250124", "name": "bash"},
     {"type": "web_search_20250305", "name": "web_search"},
-    {"type": "text_editor_20250124", "name": "str_replace_editor"},
+    {"type": "code_execution_20250522", "name": "code_execution"},
     {
       "name": "list_records",
       "description": "List records the agent can read.",
@@ -108,8 +109,239 @@ def test_anthropic_loader_skips_server_side_tool_types_with_warning(tmp_path):
     assert source is not None
     assert {tool.name for tool in source.tools} == {"list_records"}
     skipped_names = {entry["name"] for entry in artifacts.skipped_server_tools}
-    assert skipped_names == {"computer", "bash", "web_search", "str_replace_editor"}
+    assert skipped_names == {"web_search", "code_execution"}
     assert any("server-side tool" in w for w in artifacts.warnings)
+
+
+def test_anthropic_loader_inventories_client_tools_with_risk_hints(tmp_path):
+    """Anthropic client tools (bash, text_editor, computer, memory) execute
+    in the user's application code and ARE in scope for static review.
+    They are inventoried with pre-populated risk hints so the
+    framework-agnostic checks (approval, auth scope, owner, idempotency)
+    fire correctly — a manifest enabling bash should not silently produce
+    zero actionable findings beyond a warning."""
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        """
+{
+  "tools": [
+    {"type": "bash_20250124", "name": "bash"},
+    {"type": "text_editor_20250124", "name": "str_replace_editor"},
+    {"type": "computer_20250124", "name": "computer"},
+    {"type": "memory_20250818", "name": "memory"}
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    assert artifacts is not None
+    # All four are loaded — none skipped.
+    assert artifacts.skipped_server_tools == []
+    by_name = {tool.name: tool for tool in source.tools}
+    assert set(by_name) == {"bash", "str_replace_editor", "computer", "memory"}
+
+    # Each carries the type info on the tool annotations.
+    assert by_name["bash"].annotations["anthropicClientTool"] is True
+    assert by_name["bash"].annotations["anthropicToolType"] == "bash_20250124"
+
+    # Risk hints are pre-populated at high confidence per the type prefix.
+    bash_tags = {hint.tag for hint in by_name["bash"].risk_hints}
+    assert {"code_execution", "destructive", "write"} <= bash_tags
+
+    editor_tags = {hint.tag for hint in by_name["str_replace_editor"].risk_hints}
+    assert {"destructive", "write"} <= editor_tags
+
+    computer_tags = {hint.tag for hint in by_name["computer"].risk_hints}
+    assert {"code_execution", "destructive", "write"} <= computer_tags
+
+    memory_tags = {hint.tag for hint in by_name["memory"].risk_hints}
+    assert {"write"} <= memory_tags
+
+    # The hints are sourced from the typed-tool classifier so the evidence
+    # carries the specific Anthropic type for traceability.
+    bash_hint_sources = {hint.source for hint in by_name["bash"].risk_hints}
+    assert "anthropic_client_tool_type" in bash_hint_sources
+
+
+def test_anthropic_loader_skips_unknown_typed_tools_with_warning(tmp_path):
+    """Forward-compat: a typed Anthropic tool we don't classify yet is
+    skipped with an explicit warning so the user can either declare it as
+    `type: "custom"` or wait for adapter support — never silently dropped."""
+    tools = tmp_path / "tools.json"
+    tools.write_text(
+        '[{"type": "future_anthropic_tool_20990101", "name": "future_thing"}]',
+        encoding="utf-8",
+    )
+    config = AnthropicConfig(tools=[ArtifactPathConfig(path="tools.json")])
+
+    source, artifacts = load_anthropic_artifacts(config, tmp_path)
+
+    assert source is not None
+    assert source.tools == []
+    assert any("unrecognized type" in w for w in artifacts.warnings)
+    assert {entry["name"] for entry in artifacts.skipped_server_tools} == {"future_thing"}
+
+
+def test_anthropic_client_tool_fires_high_risk_release_findings(tmp_path):
+    """End-to-end: a manifest declaring `bash_20250124` with no approval
+    policy must NOT silently pass; it should fire SHIP-POLICY-APPROVAL-MISSING
+    and SHIP-AUTH-MISSING-SCOPE just like any other write-shaped tool."""
+    (tmp_path / "prompt.md").write_text(
+        "You are a coding assistant that runs shell commands.", encoding="utf-8"
+    )
+    (tmp_path / "tools.json").write_text(
+        '[{"type": "bash_20250124", "name": "bash"}]',
+        encoding="utf-8",
+    )
+    (tmp_path / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: anthropic-bash-agent
+agent:
+  name: bash-agent
+  declared_purpose:
+    - run bash commands
+environment:
+  target: production_like
+anthropic:
+  prompt_files:
+    - prompt.md
+  tools:
+    - path: tools.json
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=tmp_path / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    bash_findings = {
+        finding.check_id
+        for finding in report.findings
+        if finding.tool_name == "bash" and not finding.suppressed
+    }
+    assert "SHIP-POLICY-APPROVAL-MISSING" in bash_findings
+    assert "SHIP-AUTH-MISSING-SCOPE" in bash_findings
+    # The bash tool should be in the inventory (not skipped).
+    inventory_names = {
+        (tool.name if hasattr(tool, "name") else tool["name"])
+        for tool in report.tool_inventory
+    }
+    assert "bash" in inventory_names
+
+
+def test_anthropic_tools_do_not_fire_openai_only_checks_in_mixed_manifest(tmp_path):
+    """Regression test for PR #14 review P2: when a manifest declares both
+    openai_api and anthropic blocks, the OpenAI-only checks
+    (structured-output-readiness, retry, timeout, test-cases,
+    tool-output-schema, retry-without-idempotency) must filter to OpenAI
+    tools — Anthropic tools have no equivalent artifacts and would
+    otherwise produce false-positive findings."""
+    (tmp_path / "openai_prompt.md").write_text("OpenAI prompt.", encoding="utf-8")
+    (tmp_path / "openai-tools.json").write_text(
+        """
+[
+  {
+    "type": "function",
+    "name": "openai_only_tool",
+    "description": "Returns customer status.",
+    "strict": true,
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {"id": {"type": "string"}},
+      "required": ["id"]
+    }
+  }
+]
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "anthropic-tools.json").write_text(
+        """
+[
+  {
+    "name": "create_refund",
+    "description": "Creates a refund (financial action).",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "amount": {"type": "number"},
+        "payment_id": {"type": "string"}
+      },
+      "required": ["amount", "payment_id"]
+    }
+  }
+]
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: mixed-anthropic-openai
+agent:
+  name: mixed-agent
+  declared_purpose:
+    - look up customer status
+    - issue refunds
+environment:
+  target: production_like
+openai_api:
+  prompt_files:
+    - openai_prompt.md
+  tools:
+    - path: openai-tools.json
+anthropic:
+  tools:
+    - path: anthropic-tools.json
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=tmp_path / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    # Anthropic create_refund must NOT appear under any OpenAI-shaped finding.
+    openai_only_check_ids = {
+        "SHIP-API-RETRY-POLICY-MISSING",
+        "SHIP-API-TIMEOUT-MISSING",
+        "SHIP-API-TEST-CASES-MISSING",
+        "SHIP-API-TOOL-OUTPUT-SCHEMA-MISSING",
+        "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY",
+    }
+    for finding in report.findings:
+        if (
+            finding.check_id in openai_only_check_ids
+            and finding.tool_name == "create_refund"
+        ):
+            raise AssertionError(
+                f"OpenAI-only check {finding.check_id} fired on Anthropic tool create_refund"
+            )
+
+    # Specifically: the agent-level structured-output-readiness finding
+    # (when fired) must not list Anthropic tools in high_risk_tools.
+    for finding in report.findings:
+        if finding.check_id == "SHIP-API-STRUCTURED-OUTPUT-READINESS":
+            high_risk = finding.evidence.get("high_risk_tools") or []
+            assert "create_refund" not in high_risk, (
+                "Anthropic create_refund leaked into OpenAI structured-output finding"
+            )
 
 
 def test_anthropic_loader_warns_on_openai_style_function_wrapper(tmp_path):


### PR DESCRIPTION
Stacked on top of [#14](https://github.com/ThreeMoonsLab/agents-shipgate/pull/14). Addresses two bugs surfaced in code review.

## P1 · Do not drop Anthropic client tools from inventory

Per Anthropic's [tool reference](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference), `bash_*`, `text_editor_*`, `computer_*`, and `memory_*` are **client tools** — they execute inside the user's application code, not on Anthropic infrastructure. The original adapter skipped them along with the (genuinely server-side) `web_search_*` and `code_execution_*`, which meant a manifest enabling Bash or computer-use produced **zero actionable findings beyond a warning**.

### Fix

`inputs/anthropic_api.py` now distinguishes three categories:

| Category | Type prefixes | Behavior |
|---|---|---|
| Server-side | `web_search_`, `code_execution_` | Skip with warning (unchanged) |
| Client-side | `bash_`, `text_editor_`, `computer_`, `memory_` | **Inventory** as `anthropic_api` tools with pre-populated risk hints |
| Unknown | anything else with a non-`custom` `type` | Skip with cautionary warning explaining how to declare manually |

Risk hints are pre-populated at high confidence sourced from `anthropic_client_tool_type`:
- `bash_*`, `computer_*` → `code_execution`, `destructive`, `write`
- `text_editor_*` → `destructive`, `write`
- `memory_*` → `write`

### Real-world smoke

A manifest declaring `bash_20250124` (no approval policy) now fires:

```
[critical] SHIP-POLICY-APPROVAL-MISSING            bash
[high    ] SHIP-AUTH-MISSING-SCOPE                 bash
[high    ] SHIP-POLICY-CONFIRMATION-MISSING        bash
[high    ] SHIP-SIDEFX-IDEMPOTENCY-MISSING         bash
[high    ] SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING   bash
[high    ] SHIP-API-FUNCTION-SCHEMA-STRICTNESS     bash
```

Same for `computer` and `str_replace_editor`. `memory` (write-only, not destructive) fires the auth + schema-strictness findings without the destructive-only critical. `web_search` and `code_execution` are still skipped with warnings — unchanged.

## P2 · Mixed OpenAI/Anthropic manifests produce OpenAI false positives

`_api_tools()` was generalized to include both surfaces, but `_structured_output_readiness` and `_operational_readiness` use it to decide which tools count as "high-risk for OpenAI-only checks." When a manifest had both `openai_api:` and `anthropic:` blocks, an Anthropic tool like `create_refund` ended up listed under OpenAI-shaped findings (`SHIP-API-STRUCTURED-OUTPUT-READINESS`, `RETRY-POLICY-MISSING`, `TIMEOUT-MISSING`, `TEST-CASES-MISSING`, `TOOL-OUTPUT-SCHEMA-MISSING`, `RETRY-WITHOUT-IDEMPOTENCY`) — none of which apply to Anthropic, since Anthropic MVP carries no equivalent artifacts.

### Fix

Added `_openai_api_tools(context)` helper and routed the OpenAI-only checks through it. Shared checks (`_function_schema_strictness`, `_prompt_tool_scope_mismatch`) keep using `_api_tools()` since they apply to both surfaces with appropriate per-tool gating already in place (e.g. `missing_strict_true` is OpenAI-only).

## Test plan

- [x] `python -m ruff check .` clean
- [x] `python -m pytest` — 174/174 pass (170 existing + 4 new)
- [x] New tests:
  - `test_anthropic_loader_skips_anthropic_managed_server_tools` — renamed from `skips_server_side_tool_types_with_warning`, scoped to true server tools (`web_search_*`, `code_execution_*`)
  - `test_anthropic_loader_inventories_client_tools_with_risk_hints` — verifies bash/computer/text_editor/memory load with correct risk-tag seeds
  - `test_anthropic_loader_skips_unknown_typed_tools_with_warning` — forward-compat
  - `test_anthropic_client_tool_fires_high_risk_release_findings` — end-to-end on a bash-only manifest
  - `test_anthropic_tools_do_not_fire_openai_only_checks_in_mixed_manifest` — regression test for P2
- [x] Real-world smoke on `samples/simple_anthropic_agent` (fixture updated to use `web_search_20250305` for the skipped-server demo since `bash` is now correctly inventoried)
- [x] `agents-shipgate doctor` still reports `skipped_server_tool_count: 1` for the sample fixture
- [x] No new check IDs introduced; PR #14's "zero new check IDs" guarantee preserved

Sources used: [PR #14](https://github.com/ThreeMoonsLab/agents-shipgate/pull/14), [Anthropic Tool reference](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)