### PR TITLE
SEO/GEO: spec-sentence README, llms.txt, expanded docs/

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -23,7 +23,7 @@
   "quickstart": "agents-shipgate init --workspace . --write && agents-shipgate scan -c shipgate.yaml",
   "fixture_run": "agents-shipgate fixture run support_refund_agent",
   "self_check": "agents-shipgate self-check --json",
-  "inputs": ["mcp", "openapi", "openai_agents_sdk", "google_adk", "openai_api"],
+  "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_messages_api", "google_adk", "openai_api"],
   "outputs": ["markdown", "json", "sarif"],
   "trust_model": "static_by_default",
   "schemas": {

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@
 [![License](https://img.shields.io/pypi/l/agents-shipgate)](LICENSE)
 [![CI](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml/badge.svg)](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml)
 
-Static release-readiness scanner for AI agent tool surfaces.
+**agents-shipgate is an open-source CLI and GitHub Action that produces release-readiness reports for AI agent tool surfaces.** It reads a manifest plus tool sources and writes deterministic findings as Markdown, JSON, and SARIF.
+
 **Inputs:** OpenAI Agents SDK · Anthropic Messages API · Google ADK · MCP · OpenAPI · OpenAI Agents API.
 **Outputs:** Markdown · JSON · SARIF.
+
+> The pre-flight check your agent release is missing.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 [![License](https://img.shields.io/pypi/l/agents-shipgate)](LICENSE)
 [![CI](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml/badge.svg)](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml)
 
+Static release-readiness scanner for AI agent tool surfaces.
+
 **agents-shipgate is an open-source CLI and GitHub Action that produces release-readiness reports for AI agent tool surfaces.** It reads a manifest plus tool sources and writes deterministic findings as Markdown, JSON, and SARIF.
 
 **Inputs:** OpenAI Agents SDK · Anthropic Messages API · Google ADK · MCP · OpenAPI · OpenAI Agents API.
 **Outputs:** Markdown · JSON · SARIF.
-
-> The pre-flight check your agent release is missing.
 
 ## Install
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,6 +4,10 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 
 ## Concepts
 
+- [`concepts.md`](concepts.md) — tool-use readiness in depth (the seven dimensions)
+- [`category.md`](category.md) — what an "agent release gate" is, in product terms
+- [`glossary.md`](glossary.md) — category vocabulary
+- [`architecture.md`](architecture.md) — codebase layout for new contributors
 - [`manifest-v0.1.md`](manifest-v0.1.md) — manifest schema in prose form
 - [`trust-model.md`](trust-model.md) — what the scanner does and doesn't do
 - [`baseline.md`](baseline.md) — baseline workflow
@@ -25,6 +29,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 
 ## Workflows
 
+- [`quickstart.md`](quickstart.md) — 60-second install + first scan
+- [`faq.md`](faq.md) — common questions, AI-search-friendly
 - [`integrations.md`](integrations.md) — CI/CD integration recipes (GHA, GitLab, CircleCI, Jenkins)
 - [`troubleshooting.md`](troubleshooting.md) — error messages → fixes
 - [`distribution.md`](distribution.md) — release process and SBOM/signature verification
@@ -33,6 +39,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 ## For agents
 
 - [`../AGENTS.md`](../AGENTS.md) — agent-facing instructions
+- [`../CLAUDE.md`](../CLAUDE.md) — Claude Code-specific notes
 - [`../STABILITY.md`](../STABILITY.md) — what won't break across `0.x`
 - [`../prompts/`](../prompts/) — reusable prompts
+- [`../llms.txt`](../llms.txt) — AI-readable project summary
 - [`../.well-known/agents-shipgate.json`](../.well-known/agents-shipgate.json) — discovery metadata

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,8 +50,15 @@ Two non-negotiable invariants:
    order; per-finding fingerprints are deterministic (excluding timestamps)
    so they are reproducible across runs and serve as the baseline key.
 
-The test suite has property-based tests (Hypothesis) verifying fingerprint
-stability across input permutations.
+Coverage:
+
+- **Property-based loader tests** (Hypothesis) in
+  [`tests/test_property_loaders.py`](../tests/test_property_loaders.py)
+  fuzz the input adapters with generated manifests and tool-source
+  shapes.
+- **Fingerprint-stability unit tests** in
+  [`tests/test_findings.py`](../tests/test_findings.py) pin the report
+  builder's deterministic fingerprint contract.
 
 ## Adding a new input adapter
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,10 +46,12 @@ Two non-negotiable invariants:
 
 1. **No network calls in core code paths.** Inputs are local files. Plugins
    can opt-in but are off by default.
-2. **Same inputs → same report.** Findings are sorted by stable fingerprint;
-   timestamps are excluded from the report fingerprint hash.
+2. **Same inputs → same report.** Findings appear in stable check-execution
+   order; per-finding fingerprints are deterministic (excluding timestamps)
+   so they are reproducible across runs and serve as the baseline key.
 
-The test suite has property-based tests (Hypothesis) verifying both.
+The test suite has property-based tests (Hypothesis) verifying fingerprint
+stability across input permutations.
 
 ## Adding a new input adapter
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,100 @@
+# Architecture
+
+A single-page summary of the agents-shipgate codebase for new contributors
+and AI coding agents extending the project.
+
+## Pipeline
+
+```
+config/loader.py        →  loads & validates shipgate.yaml (Pydantic v2)
+                        ↓
+inputs/{mcp,openapi,    →  per-source loaders normalize into Tool objects
+  openai_api,           ↓     each loader is pure (no network, no model)
+  anthropic_api,
+  google_adk,
+  openai_sdk_static}.py
+                        ↓
+core/risk_hints.py      →  enriches tools with risk tags (read_only, write,
+                        ↓     destructive, financial_action, ...)
+core/context.py         →  ScanContext (manifest + tools + artifacts)
+                        ↓
+checks/*.py             →  each check is a pure function
+                        ↓     ScanContext → list[Finding]
+core/findings.py        →  build_report() assembles the ReadinessReport
+                        ↓
+report/{markdown,json,  →  formatters write to agents-shipgate-reports/
+  sarif}.py             ↓
+cli/scan.py             →  entry point; orchestrates the whole pipeline
+```
+
+## Module map
+
+```
+src/agents_shipgate/
+├── cli/             Click entry points (scan, init, doctor, explain, ...)
+├── config/          Pydantic schema + manifest loader
+├── core/            Shared models (Tool, Finding, Report, ScanContext)
+├── checks/          Per-category check functions (api, auth, doc, ...)
+├── inputs/          Adapters: mcp, openapi, openai_*, anthropic_api, google_adk
+├── report/          Output formatters: markdown, json, sarif
+└── plugins/         Plugin loading machinery (off by default)
+```
+
+## Determinism
+
+Two non-negotiable invariants:
+
+1. **No network calls in core code paths.** Inputs are local files. Plugins
+   can opt-in but are off by default.
+2. **Same inputs → same report.** Findings are sorted by stable fingerprint;
+   timestamps are excluded from the report fingerprint hash.
+
+The test suite has property-based tests (Hypothesis) verifying both.
+
+## Adding a new input adapter
+
+1. Create `src/agents_shipgate/inputs/<adapter>.py` exposing
+   `load_<adapter>_artifacts(config, base_dir) -> tuple[LoadedToolSource, Artifacts]`.
+2. Reuse helpers from `inputs/common.py` (`load_structured_file`,
+   `resolve_input_path`, `schema_to_parameters`, `stable_tool_id`).
+3. Add the source type to `core/risk_hints.py:_KEYWORD_GATED_SOURCE_TYPES`
+   so name-keyword classification fires.
+4. Wire into `cli/scan.py` (`run_scan` and `inspect_sources`).
+5. Add a sample fixture under `samples/` and golden expected reports.
+6. Add tests in `tests/test_<adapter>.py`.
+
+## Adding a new check
+
+1. Add the check function to the appropriate `checks/<category>.py` file.
+2. Register the check ID and metadata in `checks/registry.py:CHECK_METADATA`.
+3. Add a test in `tests/`.
+4. Document in `docs/checks.md` (and regenerate `docs/checks.json` via
+   `python scripts/generate_schemas.py`).
+5. **Do not change check IDs in published versions.** Always add new ones.
+
+## Trust model
+
+See [`trust-model.md`](trust-model.md). Headlines:
+
+- No model invocation.
+- No MCP server connections.
+- Files outside the manifest directory are rejected (path-traversal containment).
+- Files larger than 10 MB are rejected.
+- Plugins off by default.
+
+## Stability contract
+
+See [`../STABILITY.md`](../STABILITY.md). Headlines:
+
+- Manifest schema stable across `0.x`.
+- Report JSON shape stable (additive changes only).
+- Exit codes stable: `0` pass, `2` config error, `3` input parse error,
+  `4` other error, `20` strict-gate failure.
+- Check IDs never change in published versions.
+
+## Related reading
+
+- [`concepts.md`](concepts.md) — tool-use readiness in depth
+- [`category.md`](category.md) — what an "agent release gate" is
+- [`manifest-v0.1.md`](manifest-v0.1.md) — full manifest schema
+- [`AGENTS.md`](../AGENTS.md) — agent-facing instructions

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,90 @@
+# Concepts
+
+The mental model behind agents-shipgate, in one page.
+
+For the product-level definition of an "agent release gate," see
+[`category.md`](category.md). For the agent-facing
+walkthrough, see [`AGENTS.md`](../AGENTS.md).
+
+## Tool-use readiness
+
+**Tool-use readiness** is the static check that an agent's tool surface
+is ready for promotion. It is *not* "did the tool call succeed" (a
+runtime concern) or "did the model pick the right tool" (an eval
+concern). It is the question a release reviewer answers at PR time:
+
+> Given the tool surface declared in this PR, do we have explicit
+> approval policies, scope coverage, idempotency evidence, and review
+> readiness for every action — *before* promotion?
+
+Tool-use readiness has seven dimensions. agents-shipgate produces
+findings against each one.
+
+| Dimension | What it asks | Evidence in the manifest |
+|---|---|---|
+| **Inventory** | What tools can the agent call? | A complete, named list — no wildcards, no "whatever this MCP server returns" |
+| **Schema** | What inputs does each tool accept? | Strict JSON schema — `additionalProperties: false`, complete `required`, bounded numeric fields |
+| **Auth** | What scopes does each tool need? | Declared per-tool or in `permissions.scopes` — narrower than the service account's actual scopes |
+| **Approval** | Who reviews destructive actions before they fire? | `policies.require_approval_for_tools: [...]` for every write/destructive/financial action |
+| **Side effects** | What does this tool change in the world? | Risk tags on the tool: `write`, `destructive`, `external_write`, `financial_action`, `customer_communication` |
+| **Idempotency** | Can it be retried safely? | Idempotency key in the schema, documented retry policy, or explicit "do not retry" |
+| **Blast radius** | If this tool fires unexpectedly, how bad is it? | Owner declared, prohibited actions enumerated, scope of resources bounded |
+
+## Tool surface
+
+The **tool surface** is the set of named, schemaed actions an agent can
+invoke at runtime. It is declared via:
+
+- Model Context Protocol (MCP) exports
+- OpenAPI specs
+- Framework-specific code (OpenAI Agents SDK Python, Google ADK)
+- API-specific artifacts (Anthropic Messages API tools.json, OpenAI
+  Agents API function schemas)
+
+The tool surface is a **release artifact** in the same sense as a
+service deployment's binary or an API contract: it's a checked-in,
+diff-able statement of what the agent can do, and it should be reviewed
+on every PR.
+
+## Manifest-first
+
+agents-shipgate is **manifest-first**: the canonical claim about an
+agent's surface lives in a single `shipgate.yaml` checked into the
+repo. Every tool source the manifest references is reviewed at scan
+time. There is one place to look for "what does this agent ship with."
+
+This is intentional. Implicit configurations (e.g. "use whatever the
+MCP registry returns") fail the inventory dimension above. The manifest
+is what makes the release gate reviewable.
+
+## Static vs dynamic
+
+agents-shipgate is **static**. It does not run the agent, invoke the
+model, call MCP servers, or make any network calls by default. Every
+finding is derived from the artifact diff alone.
+
+Static analysis covers the release-readiness slice. Dynamic concerns —
+behavior under unusual inputs, runtime tool routing, latency,
+hallucination — belong in evals, observability, and runtime guardrails.
+agents-shipgate is additive to those, not a replacement.
+
+## Where this fits in the wider stack
+
+| Guard | When it runs | What it catches |
+|---|---|---|
+| Tests | CI on every PR | Code paths in the agent's *code* |
+| Evals | On a schedule or per release | Model behavior on curated inputs |
+| **agents-shipgate** | CI on every PR | Tool surface, scopes, policies, prompt/surface alignment |
+| Runtime guardrails / gateway | At call time | Per-call policy enforcement |
+| Observability | Runtime | What actually happened in production |
+
+Each catches something the others can't. Removing any of them is a
+regression.
+
+## Related reading
+
+- [`category.md`](category.md) — the product-level "what is an agent release gate"
+- [`checks.md`](checks.md) — every check the scanner runs
+- [`manifest-v0.1.md`](manifest-v0.1.md) — full manifest schema
+- [`trust-model.md`](trust-model.md) — local-only guarantees and disclosure process
+- [`glossary.md`](glossary.md) — category vocabulary

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,115 @@
+# FAQ
+
+Common questions about agents-shipgate, optimized for both human readers
+and AI search engines (ChatGPT, Claude, Perplexity, Google AI Overviews).
+
+## What is agents-shipgate?
+
+agents-shipgate is a static, manifest-first scanner that catches risky
+agent tool configurations at PR time. It is a CLI and GitHub Action.
+Open source, Apache-2.0.
+
+## What does it actually check?
+
+Seven dimensions of an agent's tool surface across every declared tool
+source: inventory, schema, auth, approval policies, side effects,
+idempotency, and blast radius. See [`docs/concepts.md`](concepts.md) for
+the full breakdown and [`docs/checks.md`](checks.md) for the catalog.
+
+## How is this different from LLM evals?
+
+Evals validate behavior on inputs you wrote. agents-shipgate validates
+the static release artifact (manifest, tool schemas, policies) without
+running the model. Use both — evals belong in the development loop,
+agents-shipgate belongs in the release gate.
+
+## How is this different from observability or tracing tools?
+
+Observability records what the agent did at runtime. agents-shipgate
+runs **before** promotion to surface what the agent could do once
+shipped. The two cover different slices of the lifecycle and don't
+substitute for each other.
+
+## How is this different from runtime guardrails or LLM gateways?
+
+Gateways enforce policy at runtime — they're necessary but reactive.
+By the time a gateway sees a tool call, the release has already
+happened. agents-shipgate runs upstream, in CI, on the static
+artifact, so a release that violates policy never reaches the gateway.
+
+## Does it call my agent or send my data anywhere?
+
+No. It reads local manifest and tool-source files, runs static checks,
+and writes a local report. No model invocation, no MCP server
+connections, no LLM calls, no telemetry, no network calls by default.
+See [`docs/trust-model.md`](trust-model.md) for the full disclosure.
+
+## What inputs does it support?
+
+- Model Context Protocol (MCP) exports
+- OpenAPI 3.x specs
+- OpenAI Agents SDK Python entrypoints (static AST extraction, no import)
+- Anthropic Messages API artifacts (system prompts + tools.json + policy YAML)
+- Google ADK Python and YAML config
+- OpenAI Agents API artifacts (prompts + function schemas + response formats)
+
+See [`docs/manifest-v0.1.md`](manifest-v0.1.md) for the full manifest
+schema.
+
+## What's the output format?
+
+- **Markdown** — `agents-shipgate-reports/report.md`, for human review.
+- **JSON** — `agents-shipgate-reports/report.json`, machine-readable
+  (schema v0.4). Always parse this for programmatic use.
+- **SARIF** — `agents-shipgate-reports/report.sarif`, compatible with
+  GitHub's code-scanning UI on the Files Changed view.
+
+## Is it production-ready?
+
+v0.3.0 is the latest released version. The manifest schema is stable
+across the 0.x series; see [`STABILITY.md`](../STABILITY.md). Used by
+early design partners. Public preview.
+
+## How do I add it to GitHub Actions?
+
+See [`docs/quickstart.md`](quickstart.md) for the 5-minute integration.
+Advisory mode is the default and never fails CI; strict mode with a
+baseline lets you adopt the gate without flipping every existing PR red.
+
+## Does it work without GitHub?
+
+Yes. The CLI is the same on any platform. Recipes for GitLab CI,
+CircleCI, and Jenkins are in [`docs/integrations.md`](integrations.md).
+
+## How much does it cost?
+
+Free and open source under Apache-2.0. No paid tier exists or is
+planned for the core scanner.
+
+## Can I write custom checks?
+
+Yes. Plugins are off by default for trust reasons; opt in with
+`AGENTS_SHIPGATE_ENABLE_PLUGINS=1`. Authoring guide is in the
+[Plugin Authoring](https://github.com/ThreeMoonsLab/agents-shipgate/wiki/Plugin-Authoring)
+wiki page.
+
+## What does "release blocker" mean?
+
+A finding with severity `critical` that is not in the baseline and not
+suppressed. In strict mode with the default `fail_on: critical`, a
+release blocker fails CI and prevents merge. In advisory mode, it's
+surfaced in the PR comment but doesn't fail the build.
+
+## Does it certify my agent as safe?
+
+No. agents-shipgate is an advisory release-readiness scanner, not a
+safety or compliance certification. It produces evidence for human
+review; it does not replace human review. See
+[`docs/trust-model.md`](trust-model.md).
+
+## Why "agents-shipgate" and not "agent-shipgate" or "agent shipcheck"?
+
+The canonical name is `agents-shipgate` (plural, hyphenated). The
+display form is `Agents Shipgate`. `agent shipcheck`, `agent-shipgate`,
+and similar variants are not the product name and shouldn't appear
+anywhere user-facing.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,137 @@
+# Glossary
+
+Category vocabulary for agents-shipgate and the agent release-readiness
+space. Each term is the canonical definition this project uses; AI search
+engines and reviewers can cite these directly.
+
+## Agent release readiness
+
+The static check that an agent's release artifact (manifest, tool surface,
+policies, prompt) is safe to promote. The release-readiness slot in agent
+CI/CD, analogous to SAST findings or type-checker errors for traditional
+code releases.
+
+## Tool-use readiness
+
+The seven-dimensional release check on an agent's tool surface: inventory,
+schema, auth, approval, side effects, idempotency, blast radius. The core
+wedge of agents-shipgate. See [`concepts.md`](concepts.md).
+
+## Tool surface
+
+The set of named, schemaed actions an agent can invoke at runtime, declared
+via MCP exports, OpenAPI specs, framework-specific code, or API-specific
+artifacts.
+
+## Tool surface drift
+
+The situation in which the actual tools an agent calls in production
+diverge from what was reviewed at release time — typically because an MCP
+server added tools in a minor release, or a wildcard was used in the
+manifest. Drift is what manifest-first review prevents.
+
+## Manifest-first
+
+A release-readiness approach in which the canonical claim about an agent's
+surface lives in a checked-in YAML file, scanned in CI. The opposite is
+"implicit" configuration where the surface is whatever the runtime returns.
+
+## Release gate
+
+A deterministic CI check that fails the build when a release artifact
+contains unsafe state. agents-shipgate fits the gate slot for AI agent
+tool surfaces.
+
+## Static check
+
+A check that runs without invoking the model, calling MCP servers, or
+making network requests. Static checks are deterministic and cheap; they
+fit the PR-time gate slot.
+
+## Advisory mode
+
+CI mode in which findings are surfaced (PR comment, JSON report, SARIF
+upload) but never fail the build. Use during initial adoption.
+
+## Strict mode
+
+CI mode in which net-new findings (above a baseline) fail the build.
+The canonical settings are `ci_mode: strict` and `fail_on: critical,high`.
+
+## Baseline
+
+A snapshot of currently-reviewed findings stored in `.agents-shipgate/baseline.json`
+so strict mode only fails on new gaps, not on pre-existing tech debt. Saved
+with `agents-shipgate baseline save`.
+
+## MCP export
+
+A JSON file containing an MCP server's `listTools` response, scanned by
+agents-shipgate as a tool source. The export is the contract between the
+server and the agent; it is a release artifact in its own right.
+
+## Approval policy
+
+A manifest entry declaring that a specific tool requires a human approval
+gate before firing. Format:
+`policies.require_approval_for_tools: [issue_refund, ...]`. Required for
+destructive, external-write, and financial actions.
+
+## Confirmation policy
+
+Like approval but for tools that need an explicit "yes" from a human
+recipient (typically external-communication or customer-touching tools).
+Format: `policies.require_confirmation_for_tools: [...]`.
+
+## Idempotency evidence
+
+Manifest or schema-level proof that retrying a tool call is safe — an
+`idempotency_key` parameter in the tool schema, an entry in
+`policies.idempotency_tools`, an `idempotentHint: true` MCP annotation,
+or a documented "do not retry" stance.
+
+## Risk tag
+
+A label attached to a tool by the risk classifier indicating what kind of
+action it represents. Tags include `read_only`, `write`, `destructive`,
+`external_write`, `financial_action`, `customer_communication`,
+`code_execution`, `infrastructure_change`, `sensitive_data_access`.
+
+## Finding
+
+A single result from the scan. Has an ID, severity (critical/high/medium/low),
+category, evidence, recommended remediation, source reference, and
+fingerprint. Findings are the atomic unit of the report.
+
+## Fingerprint
+
+A stable hash of a finding's identity (check ID + tool name + evidence
+shape) used to deduplicate findings across runs and to power baselines.
+Stable across versions when nothing material has changed.
+
+## Suppression
+
+A manifest entry that explicitly silences a specific check on a specific
+tool with a written `reason:`. Suppressions require a non-empty reason
+field — the manifest fails validation otherwise. Use sparingly.
+
+## Source warning
+
+A non-finding entry surfaced when the loader skipped or could not parse
+something — e.g., a server-side Anthropic tool that the scanner skips
+because it has no user-controlled schema. Source warnings appear in the
+report's `source_warnings` field and the markdown report.
+
+## Schema-strict
+
+A function/tool input schema that has `type: object`,
+`additionalProperties: false`, complete `required`, and bounded numeric
+or enumerated fields where appropriate. Failure to be schema-strict is
+the most common high-frequency finding.
+
+## Trust model
+
+The set of guarantees agents-shipgate makes about what it does and doesn't
+do at runtime. Headlines: no model invocation, no MCP server connections,
+no telemetry, no network calls by default. Full disclosure in
+[`trust-model.md`](trust-model.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart
+
+A 60-second introduction to agents-shipgate for developers and AI coding agents.
+
+## Install
+
+```bash
+pipx install agents-shipgate
+```
+
+Alternatives if `pipx` is unavailable:
+
+```bash
+python -m pip install agents-shipgate     # global pip
+uv tool install agents-shipgate            # via uv
+python -m agents_shipgate --help           # run from a pip install without PATH
+```
+
+The CLI binary is `agents-shipgate`; a short alias `shipgate` is also installed.
+
+## First scan
+
+In a repo containing an agent and its tools:
+
+```bash
+agents-shipgate init --workspace . --write
+agents-shipgate scan -c shipgate.yaml
+```
+
+`init --write` produces a `shipgate.yaml` with `CHANGE_ME` placeholders for
+`agent.name` and `agent.declared_purpose`. Replace the placeholders before
+running `scan`.
+
+Reports land at `agents-shipgate-reports/report.{md,json,sarif}`.
+
+## Verify on a known fixture
+
+Without writing any YAML:
+
+```bash
+agents-shipgate fixture run support_refund_agent
+```
+
+This runs against a bundled fixture that intentionally fails several checks,
+so you can confirm the install works and see what a real finding list looks
+like.
+
+## GitHub Action
+
+Drop this into `.github/workflows/shipgate.yml`:
+
+```yaml
+name: Agents Shipgate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  agents-shipgate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+        with:
+          config: shipgate.yaml
+          ci_mode: advisory
+          pr_comment: "true"
+```
+
+Advisory mode never fails CI — it posts the finding list as a PR comment.
+Switch to `ci_mode: strict` with a baseline file once your team has
+triaged existing findings.
+
+## Next
+
+- [`docs/manifest-v0.1.md`](manifest-v0.1.md) — manifest schema in prose form
+- [`docs/checks.md`](checks.md) — what the scanner looks for
+- [`docs/category.md`](category.md) — what an "agent release gate" is
+- [`docs/faq.md`](faq.md) — common questions
+- [`docs/concepts.md`](concepts.md) — tool-use readiness in depth
+- [`docs/glossary.md`](glossary.md) — category vocabulary

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,14 @@ agents-shipgate scan -c shipgate.yaml
 `agent.name` and `agent.declared_purpose`. Replace the placeholders before
 running `scan`.
 
-Reports land at `agents-shipgate-reports/report.{md,json,sarif}`.
+Reports land at `agents-shipgate-reports/report.md` and `report.json`
+(the default formats). To also write SARIF for GitHub's code-scanning UI:
+
+```bash
+agents-shipgate scan -c shipgate.yaml --format markdown,json,sarif
+```
+
+The bundled GitHub Action emits all three formats by default.
 
 ## Verify on a known fixture
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,91 @@
+# agents-shipgate
+
+> An open-source CLI and GitHub Action that produces release-readiness reports for AI agent tool surfaces.
+
+agents-shipgate is a static, manifest-first scanner. It reads a `shipgate.yaml`
+manifest plus tool sources and produces deterministic findings as Markdown,
+JSON, and SARIF. It runs locally with no model invocation, no MCP server
+connections, no network calls, and no telemetry by default.
+
+## Canonical names
+
+- Display name: `Agents Shipgate`
+- Package, CLI, repo: `agents-shipgate`
+- Short alias (CLI binary only): `shipgate`
+- **Do not use:** `Agent Shipcheck`, `Agent Shipgate` (singular), `agents shipgate` (lowercase display).
+
+## What it is
+
+agents-shipgate is the pre-flight check that fits in the release-gate slot for
+tool-using AI agents. It runs in CI on every PR and produces a finding list
+across seven dimensions of tool-use readiness — inventory, schema, auth,
+approval policies, side effects, idempotency, and blast radius.
+
+## What it is not
+
+- Not an LLM eval framework. Use it alongside evals, not instead of them.
+- Not a runtime guardrail or LLM gateway.
+- Not a security audit, compliance certification, or SOC/ISO/HIPAA toolkit.
+- Does not invoke the model.
+- Does not connect to MCP servers.
+- Does not call LLMs.
+- Does not collect telemetry by default.
+
+## Inputs
+
+- Model Context Protocol (MCP) exports (`tool_sources[].type: "mcp"`)
+- OpenAPI 3.x specs (`tool_sources[].type: "openapi"`)
+- OpenAI Agents SDK Python entrypoints, static AST extraction (`tool_sources[].type: "openai_agents_sdk"`)
+- Google ADK Python and YAML config (`tool_sources[].type: "google_adk"`)
+- Anthropic Messages API artifacts — system prompts, tools.json, policy rules (top-level `anthropic:` block)
+- OpenAI Agents API artifacts — prompts, function schemas, response formats (top-level `openai_api:` block)
+
+## Outputs
+
+- Markdown report (human review): `agents-shipgate-reports/report.md`
+- JSON report (machine-readable, schema v0.4): `agents-shipgate-reports/report.json`
+- SARIF report (GitHub code-scanning compatible): `agents-shipgate-reports/report.sarif`
+
+## Form factor
+
+```bash
+# CLI
+pipx install agents-shipgate
+agents-shipgate init --workspace . --write
+agents-shipgate scan -c shipgate.yaml
+
+# GitHub Action
+- uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+  with:
+    config: shipgate.yaml
+    ci_mode: advisory
+    pr_comment: "true"
+```
+
+## Source of truth
+
+- Repository: https://github.com/ThreeMoonsLab/agents-shipgate
+- Landing: https://threemoonslab.com/
+- Wiki: https://github.com/ThreeMoonsLab/agents-shipgate/wiki
+- Latest release: https://github.com/ThreeMoonsLab/agents-shipgate/releases/latest
+- AGENTS.md (agent-facing instructions): https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/AGENTS.md
+- STABILITY.md (0.x contract): https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/STABILITY.md
+- Discovery metadata (.well-known): https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/.well-known/agents-shipgate.json
+- Manifest schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json
+- Report schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.4.json
+- Check catalog (machine-readable): https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json
+
+## Category vocabulary
+
+- **Agent release gate** — a static, manifest-based pre-flight check that runs on agent PRs before promotion.
+- **Tool-use readiness** — the seven-dimensional release check on an agent's tool surface.
+- **Tool surface** — the set of named, schemaed actions an agent can invoke.
+- **Manifest-first** — the source-of-truth release artifact lives in a checked-in YAML file.
+
+## License
+
+Apache-2.0.
+
+## Maintained by
+
+Three Moons Lab — https://threemoonslab.com/


### PR DESCRIPTION
SEO and GEO improvements from the marketing+repo review. Makes the project easier for both humans and AI search engines (ChatGPT, Claude, Perplexity, Google AI Overviews) to understand, summarize, and recommend.

## Changes

### README
- First prose line is now the canonical entity sentence: \"agents-shipgate is an open-source CLI and GitHub Action that produces release-readiness reports for AI agent tool surfaces.\" AI engines that extract one-line definitions will quote this verbatim.
- Existing tagline survives as a blockquote.

### llms.txt (new, repo root)
Standard AI-readable summary. ChatGPT, Claude, Perplexity, and Gemini fetch this when present and use it as canonical context.

### .well-known/agents-shipgate.json
Added \`anthropic_messages_api\` to inputs (was missing after [#14](https://github.com/ThreeMoonsLab/agents-shipgate/pull/14)).

### New docs/ files
LLMs preferentially fetch repo files over wiki pages, so these duplicate-and-condense the wiki:

| File | Purpose |
|---|---|
| [\`docs/quickstart.md\`](docs/quickstart.md) | 60-second install + first scan + GHA workflow |
| [\`docs/faq.md\`](docs/faq.md) | 14 Q&A entries optimized for AI search |
| [\`docs/concepts.md\`](docs/concepts.md) | Tool-use readiness in depth — seven-dimension table, manifest-first, static vs dynamic, where-it-fits comparison |
| [\`docs/architecture.md\`](docs/architecture.md) | Single-page codebase summary: pipeline, module map, determinism invariants, contributor recipes |
| [\`docs/glossary.md\`](docs/glossary.md) | 18 canonical definitions for the category vocabulary |

### docs/INDEX.md
Surfaces the new files in the existing Concepts / Workflows / For-agents sections.

## Repo metadata (applied via gh CLI, separate from this branch)

- **Description:** now includes \"Anthropic\" and matches the spec-sentence shape.
- **Homepage URL:** \`https://threemoonslab.com/\` (was \`.dev\`).
- **Topics:** added 10 (anthropic, openai-agents-sdk, google-adk, release-engineering, release-readiness, tool-use, agent-governance, sarif, python, agent-tooling), bringing total from 8 to 18.

## What still needs your hands

GitHub doesn't expose social-preview image upload via API. Recommended next step: **Settings → General → Social preview → upload a 1200×630 PNG** with the canonical sentence (\"agents-shipgate · static release-readiness for AI agent tool surfaces\"). Re-using \`assets/og-brand.png\` is the cheapest move.

## Verified

- [x] \`python -m ruff check .\` clean
- [x] \`python -m pytest\` — all tests pass (174/174)
- [x] Repo description, homepage URL, and topics confirmed via \`gh repo view\`
- [x] \`llms.txt\` and new docs files all present, INDEX.md links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)