### PR TITLE
[codex] Prepare v0.4 release readiness fixes

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -3,7 +3,7 @@
   "name": "agents-shipgate",
   "display_name": "Agents Shipgate",
   "tagline": "Static release-readiness scanner for AI agent tool surfaces",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "publisher": {
     "name": "Three Moons Lab",
@@ -11,7 +11,7 @@
   },
   "package": {
     "pypi": "agents-shipgate",
-    "github_action": "ThreeMoonsLab/agents-shipgate@v0.3.0",
+    "github_action": "ThreeMoonsLab/agents-shipgate@v0.4.0",
     "github_repo": "ThreeMoonsLab/agents-shipgate"
   },
   "install": {
@@ -23,12 +23,12 @@
   "quickstart": "agents-shipgate init --workspace . --write && agents-shipgate scan -c shipgate.yaml",
   "fixture_run": "agents-shipgate fixture run support_refund_agent",
   "self_check": "agents-shipgate self-check --json",
-  "inputs": ["mcp", "openapi", "openai_agents_sdk", "google_adk", "openai_api"],
+  "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_messages_api", "google_adk", "openai_api"],
   "outputs": ["markdown", "json", "sarif"],
   "trust_model": "static_by_default",
   "schemas": {
     "manifest": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json",
-    "report": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.3.json",
+    "report": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.4.json",
     "checks_catalog": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json"
   },
   "agent_instructions": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/AGENTS.md",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Always parse `agents-shipgate-reports/report.json`, not the markdown. Stable fie
 - `baseline.{matched_count, new_count, resolved_count}`
 - `tool_inventory[]`
 
-The full schema is at [`docs/report-schema.v0.3.json`](docs/report-schema.v0.3.json) and what's-stable is documented in [STABILITY.md](STABILITY.md).
+The full schema is at [`docs/report-schema.v0.4.json`](docs/report-schema.v0.4.json) and what's-stable is documented in [STABILITY.md](STABILITY.md).
 
 ### Task 3 · Suppress a finding with a reason
 
@@ -183,7 +183,7 @@ Returns the full `CheckMetadata` with `id`, `category`, `default_severity`, `des
 | What | Path | Stable |
 |---|---|---|
 | Manifest schema | [`docs/manifest-v0.1.json`](docs/manifest-v0.1.json) | `0.1` |
-| Report schema | [`docs/report-schema.v0.3.json`](docs/report-schema.v0.3.json) | `0.3` |
+| Report schema | [`docs/report-schema.v0.4.json`](docs/report-schema.v0.4.json) | `0.4` |
 | Check catalog | [`docs/checks.json`](docs/checks.json) | regenerated each release |
 | Anti-patterns (what NOT to write) | [`samples/_anti_patterns/`](samples/_anti_patterns/) | reference |
 | Minimal manifest example | [`docs/manifest-v0.1.example.minimal.yaml`](docs/manifest-v0.1.example.minimal.yaml) | reference |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 0.4.0 - Unreleased
+## 0.4.0 - 2026-04-27
 
 - Added declarative YAML policy packs with manifest, CLI, report, SARIF, and GitHub Action support.
 - Split `SHIP-API-OPERATIONAL-READINESS` into atomic OpenAI API operational readiness check IDs.
+- Kept `SHIP-API-OPERATIONAL-READINESS` as a deprecated compatibility alias for suppressions, severity overrides, baseline matching, and check metadata.
 - Removed the legacy top-level `check_severity_overrides` alias; use `checks.severity_overrides`.
 - Added report schema v0.4 with `loaded_policy_packs` and stabilized Google ADK warnings in the framework surface.
 - Added an internal framework adapter seam and documented runtime inventory as design-only.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Static release-readiness scanner for AI agent tool surfaces.
 ```bash
 pipx install agents-shipgate
 # or in CI:
-# - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+# - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
 ```
 
 ## 60-second run
@@ -56,7 +56,7 @@ Agents Shipgate is designed to be agent-friendly. If you're a coding agent (Clau
 - **[`AGENTS.md`](AGENTS.md)** — canonical agent-facing instructions: install, run, common tasks, JSON-mode flags, error semantics
 - **[`STABILITY.md`](STABILITY.md)** — what won't break across `0.x` versions
 - **[`prompts/`](prompts/)** — reusable prompts for common workflows
-- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.3.json`](docs/report-schema.v0.3.json)** — JSON Schemas for live editor validation
+- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.4.json`](docs/report-schema.v0.4.json)** — JSON Schemas for live editor validation
 - **[`docs/checks.json`](docs/checks.json)** — machine-readable check catalog
 
 Every command has a `--json` form. Errors emit a structured `next_action` line on stderr when `AGENTS_SHIPGATE_AGENT_MODE=1`.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -121,7 +121,7 @@ If you need stability guarantees beyond what's listed here, please open an issue
 
 We follow [SemVer](https://semver.org/) loosely:
 
-- **Patch** (`0.3.x`): bug fixes only. No new features, no breaking changes.
+- **Patch** (`0.4.x`): bug fixes only. No new features, no breaking changes.
 - **Minor** (`0.x.0`): new features (new checks, new input loaders, new flags). Adheres to this contract.
 - **Major** (`1.0.0`): may break the contract. Will be announced with a migration guide.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,7 +13,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`checks.md`](checks.md) — full check catalog (human-readable)
 - [`checks.json`](checks.json) — machine-readable check catalog (regenerated each release)
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
-- [`report-schema.v0.3.json`](report-schema.v0.3.json) — JSON Schema for `report.json`
+- [`report-schema.v0.4.json`](report-schema.v0.4.json) — JSON Schema for `report.json`
 - [`category.md`](category.md) — what an "agent release gate" is, in product terms
 
 ## Examples

--- a/docs/checks.json
+++ b/docs/checks.json
@@ -100,6 +100,19 @@
     },
     {
       "category": "api",
+      "default_severity": "medium",
+      "description": "Deprecated compatibility alias for the v0.3 OpenAI API operational readiness bundle.",
+      "docs_url": "docs/checks.md#ship-api-operational-readiness",
+      "evidence_fields": [
+        "legacy_check_id"
+      ],
+      "fires_when": "Not emitted by v0.4 scans; matching configuration expands to the v0.4 atomic OpenAI API operational readiness checks.",
+      "id": "SHIP-API-OPERATIONAL-READINESS",
+      "rationale": "v0.4 emits atomic OpenAI API readiness check IDs, but this ID remains available for existing suppressions, severity overrides, baselines, SARIF consumers, and explain/list-checks workflows during the deprecation window.",
+      "recommendation": "Migrate suppressions, severity overrides, and baselines to the specific v0.4 SHIP-API-* readiness check IDs."
+    },
+    {
+      "category": "api",
       "default_severity": "high",
       "description": "Prompt scope contradicts enabled OpenAI API tools.",
       "docs_url": "docs/checks.md#ship-api-prompt-tool-scope-mismatch",

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -59,6 +59,7 @@ baseline summary and do not fail CI.
 | `SHIP-API-RETRY-WITHOUT-IDEMPOTENCY` | high | A risky OpenAI API write tool may be retried without idempotency evidence. |
 | `SHIP-API-TRACE-APPROVAL-MISSING` | medium | A trace sample shows a policy-controlled tool call without approval. |
 | `SHIP-API-TRACE-CONFIRMATION-MISSING` | medium | A trace sample shows a policy-controlled tool call without confirmation. |
+| `SHIP-API-OPERATIONAL-READINESS` | medium | Deprecated v0.3 compatibility alias for the v0.4 atomic OpenAI API operational readiness checks. |
 | `SHIP-ADK-DYNAMIC-TOOLSET-NOT-ENUMERABLE` | high | A Google ADK toolset cannot be statically enumerated and no explicit inventory is declared. |
 | `SHIP-ADK-MCP-TOOLSET-UNFILTERED` | high/medium | A Google ADK `McpToolset` has no static `tool_filter`. |
 | `SHIP-ADK-FUNCTION-TOOL-METADATA-MISSING` | medium | A Google ADK function/config tool lacks static description or parameter metadata. |
@@ -173,9 +174,18 @@ policy, missing timeouts, missing test cases, non-idempotent high-risk tools
 with retry evidence, missing success/failure tool-output modeling, and trace
 samples that show required approval or confirmation missing.
 
-The old bundled check ID is intentionally not kept as an alias. Update v0.3
-suppressions and baselines that referenced `SHIP-API-OPERATIONAL-READINESS` to
-the specific v0.4 ID that now represents the condition.
+The old bundled check ID remains as a deprecated compatibility alias through at
+least one minor release. v0.4 does not emit new findings with
+`SHIP-API-OPERATIONAL-READINESS`, but existing suppressions, severity overrides,
+baseline entries, `explain`, `list-checks`, and stale-suppression validation
+continue to recognize it. New configs should use the specific v0.4 ID that
+represents the condition.
+
+### SHIP-API-OPERATIONAL-READINESS
+
+Deprecated compatibility alias for the v0.3 OpenAI API operational readiness
+bundle. Migrate suppressions, severity overrides, and baselines to the specific
+v0.4 `SHIP-API-*` readiness checks when you touch the config.
 
 ### SHIP-ADK-DYNAMIC-TOOLSET-NOT-ENUMERABLE
 

--- a/examples/github-actions/01-advisory-pr-comment.yml
+++ b/examples/github-actions/01-advisory-pr-comment.yml
@@ -16,8 +16,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.3.0'
+          shipgate_version: '0.4.0'

--- a/examples/github-actions/02-strict-on-critical.yml
+++ b/examples/github-actions/02-strict-on-critical.yml
@@ -16,9 +16,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
         with:
           ci_mode: strict
           fail_on: critical
           pr_comment: 'true'
-          shipgate_version: '0.3.0'
+          shipgate_version: '0.4.0'

--- a/examples/github-actions/03-strict-with-baseline.yml
+++ b/examples/github-actions/03-strict-with-baseline.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
         with:
           ci_mode: strict
           fail_on: critical,high
           baseline: .agents-shipgate/baseline.json
           pr_comment: 'true'
-          shipgate_version: '0.3.0'
+          shipgate_version: '0.4.0'

--- a/examples/github-actions/04-multi-config-workspace.yml
+++ b/examples/github-actions/04-multi-config-workspace.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: pip install --quiet agents-shipgate==0.3.0
+      - run: pip install --quiet agents-shipgate==0.4.0
       - run: |
           agents-shipgate scan \
             --workspace . \

--- a/examples/github-actions/05-sarif-to-code-scanning.yml
+++ b/examples/github-actions/05-sarif-to-code-scanning.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+        uses: ThreeMoonsLab/agents-shipgate@v0.4.0
         with:
           ci_mode: advisory
           formats: markdown,json,sarif
           pr_comment: 'true'
-          shipgate_version: '0.3.0'
+          shipgate_version: '0.4.0'
       - if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/examples/github-actions/06-on-tool-source-changes.yml
+++ b/examples/github-actions/06-on-tool-source-changes.yml
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.3.0'
+          shipgate_version: '0.4.0'

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -29,9 +29,9 @@ Configure per-job, never repo-wide.
 For reproducible CI, pin both the action and the underlying CLI:
 
 ```yaml
-- uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+- uses: ThreeMoonsLab/agents-shipgate@v0.4.0
   with:
-    shipgate_version: "0.3.0"
+    shipgate_version: "0.4.0"
 ```
 
 When `shipgate_version` is empty the action installs the CLI from the action source — convenient on `@main`, less reproducible.
@@ -42,7 +42,7 @@ Useful for downstream steps:
 
 ```yaml
 - id: shipgate
-  uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+  uses: ThreeMoonsLab/agents-shipgate@v0.4.0
 
 - if: steps.shipgate.outputs.critical_count != '0'
   run: echo "Action this!"

--- a/prompts/stabilize-strict-mode.md
+++ b/prompts/stabilize-strict-mode.md
@@ -37,7 +37,7 @@ The user has Agents Shipgate running in **advisory** mode and wants to graduate 
 
 5. **Update the CI workflow.** Replace the existing advisory step with strict + baseline. Use [`examples/github-actions/03-strict-with-baseline.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/03-strict-with-baseline.yml) as the template:
    ```yaml
-   - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+   - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
      with:
        ci_mode: strict
        fail_on: critical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "agents-shipgate"
 version = "0.4.0"
-description = "Static release-readiness scanner for AI agent tool surfaces (MCP, OpenAPI, OpenAI Agents SDK, Google ADK). CLI + GitHub Action."
+description = "Static release-readiness scanner for AI agent tool surfaces (MCP, OpenAPI, OpenAI Agents SDK, Anthropic Messages API, Google ADK). CLI + GitHub Action."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
@@ -95,6 +95,11 @@ packages = ["src/agents_shipgate"]
 "samples" = "agents_shipgate/_fixtures"
 "AGENTS.md" = "agents_shipgate/_meta/AGENTS.md"
 "STABILITY.md" = "agents_shipgate/_meta/STABILITY.md"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.hypothesis",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/agents_shipgate/checks/registry.py
+++ b/src/agents_shipgate/checks/registry.py
@@ -18,6 +18,7 @@ from agents_shipgate.checks import (
     schema,
     side_effects,
 )
+from agents_shipgate.core.check_ids import known_check_ids_with_legacy
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.models import CheckMetadata, Finding
 
@@ -64,6 +65,7 @@ CHECK_METADATA: list[CheckMetadata] = [
     CheckMetadata(id="SHIP-API-RETRY-WITHOUT-IDEMPOTENCY", category="api", default_severity="high", description="OpenAI API write tool may be retried without idempotency evidence.", rationale="Retries against non-idempotent writes can duplicate financial, destructive, or external side effects.", fires_when="Retry policy is declared and a risky write tool lacks idempotency evidence.", evidence_fields=["retry_policy", "risk_tags"], recommendation="Add idempotency evidence for retried risky OpenAI API tools or avoid retrying those side effects."),
     CheckMetadata(id="SHIP-API-TRACE-APPROVAL-MISSING", category="api", default_severity="medium", description="OpenAI API trace sample shows a policy-controlled tool without approval.", rationale="Trace samples should demonstrate approval behavior for tools that require approval.", fires_when="A trace sample marks approved=false for a tool with approval policy evidence.", evidence_fields=["tool_name", "approved"], recommendation="Require approval before calling policy-controlled OpenAI API tools."),
     CheckMetadata(id="SHIP-API-TRACE-CONFIRMATION-MISSING", category="api", default_severity="medium", description="OpenAI API trace sample shows a policy-controlled tool without confirmation.", rationale="Trace samples should demonstrate explicit confirmation for tools that require confirmation.", fires_when="A trace sample marks confirmed=false for a tool with confirmation policy evidence.", evidence_fields=["tool_name", "confirmed"], recommendation="Require explicit confirmation before calling policy-controlled OpenAI API tools."),
+    CheckMetadata(id="SHIP-API-OPERATIONAL-READINESS", category="api", default_severity="medium", description="Deprecated compatibility alias for the v0.3 OpenAI API operational readiness bundle.", rationale="v0.4 emits atomic OpenAI API readiness check IDs, but this ID remains available for existing suppressions, severity overrides, baselines, SARIF consumers, and explain/list-checks workflows during the deprecation window.", fires_when="Not emitted by v0.4 scans; matching configuration expands to the v0.4 atomic OpenAI API operational readiness checks.", evidence_fields=["legacy_check_id"], recommendation="Migrate suppressions, severity overrides, and baselines to the specific v0.4 SHIP-API-* readiness check IDs."),
     CheckMetadata(id="SHIP-ADK-DYNAMIC-TOOLSET-NOT-ENUMERABLE", category="adk", default_severity="high", description="Google ADK toolset cannot be statically enumerated.", rationale="Release review needs an explicit tool inventory; ADK MCP/OpenAPI toolsets may resolve tools dynamically at runtime.", fires_when="A Google ADK toolset is dynamic or unresolved and no explicit MCP/OpenAPI/tool inventory input is declared.", evidence_fields=["toolset", "explicit_inventory"], recommendation="Provide explicit MCP/OpenAPI/tool inventory inputs for dynamic ADK toolsets."),
     CheckMetadata(id="SHIP-ADK-MCP-TOOLSET-UNFILTERED", category="adk", default_severity="high", description="Google ADK McpToolset lacks a static tool filter.", rationale="Unfiltered MCP toolsets can expose more tools than reviewers expect.", fires_when="A Google ADK McpToolset has no static tool_filter.", evidence_fields=["source_ref", "agent_name", "inventory_path"], recommendation="Declare a tool_filter and provide a local MCP tool inventory."),
     CheckMetadata(id="SHIP-ADK-FUNCTION-TOOL-METADATA-MISSING", category="adk", default_severity="medium", description="Google ADK function tool lacks static metadata.", rationale="Static review depends on descriptions and parameter schemas because user ADK code is not imported.", fires_when="A Google ADK function/config tool lacks description or parameter metadata.", evidence_fields=["missing", "source_type"], recommendation="Add docstrings, annotations, or explicit local inventory metadata."),
@@ -100,10 +102,12 @@ def run_checks(
     findings.extend(
         manifest_consistency.run(
             context,
-            known_check_ids={
-                *(metadata.id for metadata in CHECK_METADATA),
-                *(extra_known_check_ids or set()),
-            },
+            known_check_ids=known_check_ids_with_legacy(
+                {
+                    *(metadata.id for metadata in CHECK_METADATA),
+                    *(extra_known_check_ids or set()),
+                }
+            ),
         )
     )
     return findings

--- a/src/agents_shipgate/core/baseline.py
+++ b/src/agents_shipgate/core/baseline.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from agents_shipgate.core.check_ids import expands_to_check_id
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import BaselineSummary, Finding, ReadinessReport, Severity
 
@@ -83,6 +84,7 @@ def apply_baseline(
         finding.fingerprint for finding in baseline.findings if finding.fingerprint
     }
     current_active_fingerprints: set[str] = set()
+    matched_legacy_fingerprints: set[str] = set()
     matched = 0
     new = 0
     for finding in findings:
@@ -95,6 +97,10 @@ def apply_baseline(
         if fingerprint in baseline_fingerprints:
             finding.baseline_status = "matched"
             matched += 1
+        elif legacy_match := _legacy_baseline_match(finding, baseline.findings):
+            finding.baseline_status = "matched"
+            matched += 1
+            matched_legacy_fingerprints.add(legacy_match.fingerprint)
         else:
             finding.baseline_status = "new"
             new += 1
@@ -102,12 +108,31 @@ def apply_baseline(
         path=display_path,
         matched_count=matched,
         new_count=new,
-        resolved_count=len(baseline_fingerprints - current_active_fingerprints),
+        resolved_count=len(
+            baseline_fingerprints
+            - current_active_fingerprints
+            - matched_legacy_fingerprints
+        ),
     )
 
 
 def _active_findings(findings: list[Finding]) -> list[Finding]:
     return [finding for finding in findings if not finding.suppressed]
+
+
+def _legacy_baseline_match(
+    finding: Finding, baseline_findings: list[BaselineFinding]
+) -> BaselineFinding | None:
+    for baseline_finding in baseline_findings:
+        if not expands_to_check_id(baseline_finding.check_id, finding.check_id):
+            continue
+        if (
+            baseline_finding.tool_name is not None
+            and baseline_finding.tool_name != finding.tool_name
+        ):
+            continue
+        return baseline_finding
+    return None
 
 
 def _utc_now() -> str:

--- a/src/agents_shipgate/core/check_ids.py
+++ b/src/agents_shipgate/core/check_ids.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+LEGACY_CHECK_ID_ALIASES: dict[str, tuple[str, ...]] = {
+    "SHIP-API-OPERATIONAL-READINESS": (
+        "SHIP-API-RETRY-POLICY-MISSING",
+        "SHIP-API-TIMEOUT-MISSING",
+        "SHIP-API-TEST-CASES-MISSING",
+        "SHIP-API-TOOL-OUTPUT-SCHEMA-MISSING",
+        "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY",
+        "SHIP-API-TRACE-APPROVAL-MISSING",
+        "SHIP-API-TRACE-CONFIRMATION-MISSING",
+    ),
+}
+
+
+def expands_to_check_id(configured_check_id: str, emitted_check_id: str) -> bool:
+    """Return whether a configured check id should match an emitted finding."""
+    return (
+        configured_check_id == emitted_check_id
+        or emitted_check_id in LEGACY_CHECK_ID_ALIASES.get(configured_check_id, ())
+    )
+
+
+def known_check_ids_with_legacy(check_ids: Iterable[str]) -> set[str]:
+    return {*check_ids, *LEGACY_CHECK_ID_ALIASES}

--- a/src/agents_shipgate/core/findings.py
+++ b/src/agents_shipgate/core/findings.py
@@ -5,6 +5,7 @@ import json
 from collections import Counter, defaultdict
 
 from agents_shipgate.config.schema import AgentsShipgateManifest, SuppressionConfig
+from agents_shipgate.core.check_ids import expands_to_check_id
 from agents_shipgate.core.models import (
     BaselineSummary,
     Finding,
@@ -51,7 +52,7 @@ def apply_severity_overrides(
     findings: list[Finding], overrides: dict[str, Severity]
 ) -> list[Finding]:
     for finding in findings:
-        override = overrides.get(finding.check_id)
+        override = _severity_override_for_check(finding.check_id, overrides)
         if override:
             # Keep this audit field out of fingerprinting so overrides can be
             # applied before or after ID assignment without changing identity.
@@ -171,7 +172,7 @@ def _matching_suppression(
     finding: Finding, suppressions: list[SuppressionConfig]
 ) -> SuppressionConfig | None:
     for suppression in suppressions:
-        if suppression.check_id != finding.check_id:
+        if not expands_to_check_id(suppression.check_id, finding.check_id):
             continue
         if not suppression.tool:
             return suppression
@@ -182,6 +183,17 @@ def _matching_suppression(
         }
         if suppression.tool in possible_tools:
             return suppression
+    return None
+
+
+def _severity_override_for_check(
+    check_id: str, overrides: dict[str, Severity]
+) -> Severity | None:
+    if override := overrides.get(check_id):
+        return override
+    for configured_check_id, override in overrides.items():
+        if expands_to_check_id(configured_check_id, check_id):
+            return override
     return None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,8 @@ def test_cli_list_checks_outputs_catalog():
     assert result.exit_code == 0
     assert "SHIP-POLICY-APPROVAL-MISSING" in result.output
     assert "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY" in result.output
-    assert "SHIP-API-OPERATIONAL-READINESS" not in result.output
+    assert "SHIP-API-OPERATIONAL-READINESS" in result.output
+    assert "Deprecated compatibility alias" in result.output
 
 
 def test_cli_version_outputs_version():
@@ -165,6 +166,13 @@ def test_cli_explain_outputs_atomic_api_check_details():
     assert result.exit_code == 0
     assert "Default severity: high" in result.output
     assert "OpenAI API write tool may be retried without idempotency evidence." in result.output
+
+
+def test_cli_explain_outputs_legacy_compatibility_alias():
+    result = runner.invoke(app, ["explain", "SHIP-API-OPERATIONAL-READINESS"])
+
+    assert result.exit_code == 0
+    assert "Deprecated compatibility alias" in result.output
 
 
 def test_cli_explain_unknown_check_suggests_close_match():

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -1,4 +1,5 @@
 from agents_shipgate.config.schema import SuppressionConfig
+from agents_shipgate.core.baseline import BaselineFile, BaselineFinding, apply_baseline
 from agents_shipgate.core.findings import (
     apply_severity_overrides,
     apply_suppressions,
@@ -33,6 +34,80 @@ def test_apply_suppressions_matches_tool_name_and_preserves_reason():
 
     assert finding.suppressed is True
     assert finding.suppression_reason == "Intentional free-form search."
+
+
+def test_legacy_api_operational_readiness_suppression_matches_split_check():
+    finding = Finding(
+        check_id="SHIP-API-TIMEOUT-MISSING",
+        title="OpenAI API flow lacks timeout metadata",
+        severity="medium",
+        category="api",
+        recommendation="Declare timeouts.",
+    )
+
+    apply_suppressions(
+        [finding],
+        [
+            SuppressionConfig(
+                check_id="SHIP-API-OPERATIONAL-READINESS",
+                reason="Accepted existing v0.3 operational-readiness finding.",
+            )
+        ],
+    )
+
+    assert finding.suppressed is True
+    assert (
+        finding.suppression_reason
+        == "Accepted existing v0.3 operational-readiness finding."
+    )
+
+
+def test_legacy_api_operational_readiness_severity_override_matches_split_check():
+    finding = Finding(
+        check_id="SHIP-API-RETRY-POLICY-MISSING",
+        title="OpenAI API flow lacks retry policy metadata",
+        severity="medium",
+        category="api",
+        recommendation="Declare retry policy.",
+    )
+
+    apply_severity_overrides(
+        [finding],
+        {"SHIP-API-OPERATIONAL-READINESS": "high"},
+    )
+
+    assert finding.severity == "high"
+    assert finding.evidence["default_severity"] == "medium"
+
+
+def test_legacy_api_operational_readiness_baseline_matches_split_check():
+    finding = Finding(
+        check_id="SHIP-API-TEST-CASES-MISSING",
+        title="OpenAI API flow lacks test case metadata",
+        severity="medium",
+        category="api",
+        recommendation="Add test cases.",
+        fingerprint="fp_current",
+    )
+    baseline = BaselineFile(
+        created_at="2026-04-26T00:00:00Z",
+        source_report_run_id="run_v03",
+        findings=[
+            BaselineFinding(
+                fingerprint="fp_legacy",
+                check_id="SHIP-API-OPERATIONAL-READINESS",
+                severity="medium",
+                title="OpenAI API operational readiness evidence is incomplete",
+            )
+        ],
+    )
+
+    summary = apply_baseline([finding], baseline, display_path="baseline.json")
+
+    assert finding.baseline_status == "matched"
+    assert summary.matched_count == 1
+    assert summary.new_count == 0
+    assert summary.resolved_count == 0
 
 
 def test_finding_ids_are_stable_across_ordering():

--- a/tests/test_manifest_consistency.py
+++ b/tests/test_manifest_consistency.py
@@ -115,6 +115,8 @@ checks:
     - check_id: SHIP-DOC-MISSING-DESCRIPTION
       tool: support.lookup
       reason: "covered by internal docs"
+    - check_id: SHIP-API-OPERATIONAL-READINESS
+      reason: "legacy v0.3 compatibility alias"
 """,
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary

Addresses the v0.4 release-readiness findings from the repo review:

- Keeps `SHIP-API-OPERATIONAL-READINESS` as a deprecated compatibility alias for existing suppressions, severity overrides, baseline matching, stale-suppression validation, `list-checks`, and `explain`.
- Updates v0.4 public release metadata, discovery metadata, docs, examples, schema references, and changelog date.
- Excludes local Hypothesis cache data from source distributions.
- Regenerates `docs/checks.json` and adds regression coverage for the legacy alias behavior.

## Root Cause

The v0.4 branch had already moved to atomic OpenAI API readiness check IDs and report schema v0.4, but release-facing metadata still advertised v0.3 in several places. The old bundled check ID had also been removed outright, which conflicted with the published check-ID stability contract.

## Validation

- `python -m ruff check .`
- `python -m pytest tests/test_findings.py tests/test_cli.py tests/test_manifest_consistency.py tests/test_reports.py`
- `python -m pytest`
- `PYTHONPATH=src python -m agents_shipgate self-check --json`
- `python -m build --outdir /tmp/agents-shipgate-dist-pr-20260427`
- `python -m twine check /tmp/agents-shipgate-dist-pr-20260427/*`
- Verified rebuilt sdist contains no `.hypothesis` entries.
- `python -m compileall -q src tests`
- `python -m pytest --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=75`
- `python -m pip_audit .`
- Installed the rebuilt wheel into a clean venv and ran `agents-shipgate self-check --json` successfully.