### PR TITLE
Implement v0.5.0 framework adapters and CI recipes

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -3,7 +3,7 @@
   "name": "agents-shipgate",
   "display_name": "Agents Shipgate",
   "tagline": "Static release-readiness scanner for AI agent tool surfaces",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "publisher": {
     "name": "Three Moons Lab",
@@ -11,7 +11,7 @@
   },
   "package": {
     "pypi": "agents-shipgate",
-    "github_action": "ThreeMoonsLab/agents-shipgate@v0.4.0",
+    "github_action": "ThreeMoonsLab/agents-shipgate@v0.5.0",
     "github_repo": "ThreeMoonsLab/agents-shipgate"
   },
   "install": {
@@ -23,12 +23,12 @@
   "quickstart": "agents-shipgate init --workspace . --write && agents-shipgate scan -c shipgate.yaml",
   "fixture_run": "agents-shipgate fixture run support_refund_agent",
   "self_check": "agents-shipgate self-check --json",
-  "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_messages_api", "google_adk", "openai_api"],
+  "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_messages_api", "google_adk", "langchain", "crewai", "openai_api"],
   "outputs": ["markdown", "json", "sarif"],
   "trust_model": "static_by_default",
   "schemas": {
     "manifest": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json",
-    "report": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.4.json",
+    "report": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.5.json",
     "checks_catalog": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json"
   },
   "agent_instructions": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/AGENTS.md",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aid
 
 ## What this project is
 
-Static release-readiness scanner for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files) and produces deterministic findings.
+Static release-readiness scanner for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files) and produces deterministic findings.
 
-- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK
+- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI
 - **Outputs:** Markdown · JSON · SARIF
 - **Trust:** Static-by-default. No agent execution, tool calls, LLM calls, or network access.
 
@@ -101,7 +101,7 @@ Config error: Config file not found: missing.yaml
 
 Use it when the user is:
 
-- Writing or modifying an AI agent that calls tools (MCP servers, OpenAPI APIs, `@function_tool`-decorated Python, Google ADK)
+- Writing or modifying an AI agent that calls tools (MCP servers, OpenAPI APIs, `@function_tool`-decorated Python, Google ADK, LangChain/LangGraph, CrewAI)
 - Adding a new tool, scope, or policy to an existing agent
 - Preparing an agent for production promotion
 - Wiring a release gate into PR CI
@@ -137,7 +137,7 @@ Always parse `agents-shipgate-reports/report.json`, not the markdown. Stable fie
 - `baseline.{matched_count, new_count, resolved_count}`
 - `tool_inventory[]`
 
-The full schema is at [`docs/report-schema.v0.4.json`](docs/report-schema.v0.4.json) and what's-stable is documented in [STABILITY.md](STABILITY.md).
+The full schema is at [`docs/report-schema.v0.5.json`](docs/report-schema.v0.5.json) and what's-stable is documented in [STABILITY.md](STABILITY.md).
 
 ### Task 3 · Suppress a finding with a reason
 
@@ -183,7 +183,7 @@ Returns the full `CheckMetadata` with `id`, `category`, `default_severity`, `des
 | What | Path | Stable |
 |---|---|---|
 | Manifest schema | [`docs/manifest-v0.1.json`](docs/manifest-v0.1.json) | `0.1` |
-| Report schema | [`docs/report-schema.v0.4.json`](docs/report-schema.v0.4.json) | `0.4` |
+| Report schema | [`docs/report-schema.v0.5.json`](docs/report-schema.v0.5.json) | `0.5` |
 | Check catalog | [`docs/checks.json`](docs/checks.json) | regenerated each release |
 | Anti-patterns (what NOT to write) | [`samples/_anti_patterns/`](samples/_anti_patterns/) | reference |
 | Minimal manifest example | [`docs/manifest-v0.1.example.minimal.yaml`](docs/manifest-v0.1.example.minimal.yaml) | reference |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   examples.
 - Added report schema v0.5 for additive LangChain/CrewAI framework fields.
 - Added a framework adapter checklist for future static framework support.
+- Deduplicated `source_warnings`; baselines from 0.4.x may report a small
+  number of resolved warning entries on first run after upgrade.
 
 ## 0.4.0 - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.0 - 2026-04-28
+
+- Added static LangChain/LangGraph and CrewAI Python adapters with manifest
+  source types, supplemental inventories, framework report blocks, fixtures,
+  and self-check coverage.
+- Added framework-specific checks for dynamic LangChain/CrewAI tool surfaces
+  and missing function-tool metadata.
+- Promoted GitLab CI and CircleCI to first-class integration recipes with
+  advisory, strict baseline, artifact, multi-config, and tool-source trigger
+  examples.
+- Added report schema v0.5 for additive LangChain/CrewAI framework fields.
+- Added a framework adapter checklist for future static framework support.
+
 ## 0.4.0 - 2026-04-27
 
 - Added declarative YAML policy packs with manifest, CLI, report, SARIF, and GitHub Action support.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Static release-readiness scanner for AI agent tool surfaces.
 
 **agents-shipgate is an open-source CLI and GitHub Action that produces release-readiness reports for AI agent tool surfaces.** It reads a manifest plus tool sources and writes deterministic findings as Markdown, JSON, and SARIF.
 
-**Inputs:** OpenAI Agents SDK · Anthropic Messages API · Google ADK · MCP · OpenAPI · OpenAI Agents API.
+**Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · OpenAI Agents API.
 **Outputs:** Markdown · JSON · SARIF.
 
 ## Install
@@ -25,7 +25,7 @@ Static release-readiness scanner for AI agent tool surfaces.
 ```bash
 pipx install agents-shipgate
 # or in CI:
-# - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+# - uses: ThreeMoonsLab/agents-shipgate@v0.5.0
 ```
 
 ## 60-second run
@@ -59,7 +59,7 @@ Agents Shipgate is designed to be agent-friendly. If you're a coding agent (Clau
 - **[`AGENTS.md`](AGENTS.md)** — canonical agent-facing instructions: install, run, common tasks, JSON-mode flags, error semantics
 - **[`STABILITY.md`](STABILITY.md)** — what won't break across `0.x` versions
 - **[`prompts/`](prompts/)** — reusable prompts for common workflows
-- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.4.json`](docs/report-schema.v0.4.json)** — JSON Schemas for live editor validation
+- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.5.json`](docs/report-schema.v0.5.json)** — JSON Schemas for live editor validation
 - **[`docs/checks.json`](docs/checks.json)** — machine-readable check catalog
 
 Every command has a `--json` form. Errors emit a structured `next_action` line on stderr when `AGENTS_SHIPGATE_AGENT_MODE=1`.
@@ -134,6 +134,8 @@ Try the bundled fixture:
 agents-shipgate scan --config samples/support_refund_agent/shipgate.yaml
 agents-shipgate scan --config samples/simple_openai_api_agent/shipgate.yaml
 agents-shipgate scan --config samples/google_adk_agent/shipgate.yaml
+agents-shipgate scan --config samples/simple_langchain_agent/shipgate.yaml
+agents-shipgate scan --config samples/simple_crewai_agent/shipgate.yaml
 agents-shipgate scan --config samples/clean_read_only_agent/shipgate.yaml
 ```
 
@@ -199,6 +201,33 @@ google_adk:
 
 Dynamic ADK toolsets produce warnings or findings unless you provide explicit MCP, OpenAPI, or local tool inventory inputs.
 
+## LangChain And CrewAI
+
+v0.5 adds static Python extraction for LangChain/LangGraph and CrewAI. The
+adapters parse Python AST only; they do not import framework packages or user
+modules.
+
+```yaml
+tool_sources:
+  - id: langchain_agent
+    type: langchain
+    path: agent.py
+  - id: crewai_agent
+    type: crewai
+    path: crew.py
+```
+
+For dynamic or prebuilt tool surfaces, provide explicit local inventory files:
+
+```yaml
+langchain:
+  tool_inventories:
+    - inventories/langchain-tools.json
+crewai:
+  tool_inventories:
+    - inventories/crewai-tools.json
+```
+
 ## Policy Packs
 
 v0.4 adds local declarative YAML policy packs for organization-specific release
@@ -229,8 +258,8 @@ Agents Shipgate is a static, manifest-first scanner. It is intentionally narrow:
 - It does not run agents, call tools, invoke LLMs, or verify model availability.
 - It does not verify runtime behavior, latency, prompt quality, or routing decisions.
 - It does not replace dynamic security testing or human security review of the underlying systems.
-- It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, simple OpenAI API artifacts, optional SDK AST metadata, and static Google ADK inputs; tools that are not declared or statically discoverable are not scanned.
-- The manifest remains `version: "0.1"` in v0.4 so existing configs keep working. Reports add `report_schema_version: "0.4"` while preserving the v0.1 payload keys.
+- It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, simple OpenAI API artifacts, optional SDK AST metadata, and static Google ADK/LangChain/CrewAI inputs; tools that are not declared or statically discoverable are not scanned.
+- The manifest remains `version: "0.1"` in v0.5 so existing configs keep working. Reports add `report_schema_version: "0.5"` while preserving the v0.1 payload keys.
 
 See [ROADMAP.md](ROADMAP.md) for what is planned next.
 
@@ -259,7 +288,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: agents-shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+        uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           config: shipgate.yaml
           ci_mode: advisory
@@ -287,7 +316,7 @@ If hosted dashboards, SSO, org-wide baselines, approval workflows, or trace-base
 - [Check catalog](docs/checks.md)
 - [Policy packs](docs/policy-packs.md)
 - [Baseline workflow](docs/baseline.md)
-- [JSON report schema v0.4](docs/report-schema.v0.4.json)
+- [JSON report schema v0.5](docs/report-schema.v0.5.json)
 - [Trust model](docs/trust-model.md)
 - [Runtime inventory design note](docs/runtime-inventory.md)
 - [Troubleshooting](docs/troubleshooting.md)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Dynamic ADK toolsets produce warnings or findings unless you provide explicit MC
 
 v0.5 adds static Python extraction for LangChain/LangGraph and CrewAI. The
 adapters parse Python AST only; they do not import framework packages or user
-modules.
+modules. The supported LangChain/LangGraph patterns target LangChain Core
+0.3+, LangChain 1.x `create_agent`, and LangGraph 0.2+ source shapes.
 
 ```yaml
 tool_sources:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Naming.** This project is **Agents Shipgate** (display name) / `agents-shipgate` (package, CLI, repo). See [`AGENTS.md` § Naming (canonical)](AGENTS.md#naming-canonical) for the full convention.
 
-Agents Shipgate is currently in the `0.4.x` line. The `v0.2` through `v0.4`
+Agents Shipgate is currently in the `0.5.x` line. The `v0.2` through `v0.4`
 items are complete and retained here as release history. Active public planning
 starts at `v0.5.0`.
 
@@ -46,16 +46,33 @@ starts at `v0.5.0`.
 
 ## Open
 
-### v0.5.0 Cross-Platform CI And Agent Platform Coverage
+### v0.5.0 LangChain/CrewAI And Focused CI
 
-Goal: make Agents Shipgate easy to adopt across major CI systems and major agent
-development platforms while preserving the default static trust model.
+Goal: add static Python coverage for LangChain/LangGraph and CrewAI, and make
+GitLab CI plus CircleCI first-class CI targets while preserving the default
+static trust model.
 
 - Promote GitLab CI and CircleCI from examples to first-class integration recipes:
   - documented strict/advisory gating;
   - baseline artifact handling;
   - SARIF or native security report guidance where supported;
   - copy-pasteable workflows for monorepos and multi-manifest scans.
+- Expand agent-platform coverage beyond the current MCP, OpenAPI, OpenAI Agents SDK, Anthropic Messages API, and Google ADK surfaces:
+  - LangGraph / LangChain tool definitions;
+  - CrewAI agents and tools.
+- Add a framework adapter checklist so new platform support is consistent:
+  - static extraction only by default;
+  - no agent execution, model call, tool call, network call, or MCP connection;
+  - deterministic tool inventory normalization;
+  - source warnings for dynamic or unresolved tools;
+  - framework surface summary in JSON, Markdown, and SARIF-compatible metadata.
+- Bump the additive report schema to `report_schema_version: "0.5"` while
+  keeping manifest `version: "0.1"`.
+
+### v0.5.1 Cross-Platform CI Expansion
+
+Goal: broaden CI documentation after the v0.5.0 adapter work lands.
+
 - Add or harden recipes for additional CI platforms:
   - Jenkins;
   - Buildkite;
@@ -63,20 +80,6 @@ development platforms while preserving the default static trust model.
   - Bitbucket Pipelines;
   - local pre-commit / pre-push usage;
   - generic POSIX shell integration for unsupported CI systems.
-- Expand agent-platform coverage beyond the current MCP, OpenAPI, OpenAI Agents SDK, Anthropic Messages API, and Google ADK surfaces:
-  - LangGraph / LangChain tool definitions;
-  - CrewAI agents and tools;
-  - AutoGen multi-agent tool surfaces;
-  - Semantic Kernel plugins/functions;
-  - LlamaIndex tools and workflows;
-  - TypeScript/JavaScript agent frameworks where static extraction is practical;
-  - additional Google ADK language surfaces after the Python adapter remains stable.
-- Add a framework adapter checklist so new platform support is consistent:
-  - static extraction only by default;
-  - no agent execution, model call, tool call, network call, or MCP connection;
-  - deterministic tool inventory normalization;
-  - source warnings for dynamic or unresolved tools;
-  - framework surface summary in JSON, Markdown, and SARIF-compatible metadata.
 - Improve cross-platform release-gate documentation:
   - reference architecture for advisory-to-strict rollout;
   - baseline management across CI providers;
@@ -85,6 +88,12 @@ development platforms while preserving the default static trust model.
 
 ### Later Candidates
 
+- Expand agent-platform coverage beyond the v0.5.0 framework adapters:
+  - AutoGen multi-agent tool surfaces;
+  - Semantic Kernel plugins/functions;
+  - LlamaIndex tools and workflows;
+  - TypeScript/JavaScript agent frameworks where static extraction is practical;
+  - additional Google ADK language surfaces after the Python adapter remains stable.
 - Optional trust-gated runtime inventory export as an explicit command, separate from default static CI.
 - Container image distribution if the image has CI coverage, security scanning, and release signing.
 - Homebrew or other package-manager distribution if CLI usage warrants it.
@@ -92,8 +101,8 @@ development platforms while preserving the default static trust model.
 
 ## Google ADK Support Principles
 
-ADK support must preserve the default trust model: no `adk run`, `adk web`,
-`adk eval`, MCP connection, tool call, model call, or network call by default.
+ADK support is read-only by default: local file parsing only; no `adk run`,
+`adk web`, `adk eval`, MCP connection, tool call, model call, or network call.
 ADK callbacks and plugins are static guardrail evidence only, not proof of
 runtime enforcement. Dynamic toolsets must produce warnings or findings unless
 the user provides explicit MCP, OpenAPI, or tool inventory inputs.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -121,7 +121,7 @@ If you need stability guarantees beyond what's listed here, please open an issue
 
 We follow [SemVer](https://semver.org/) loosely:
 
-- **Patch** (`0.4.x`): bug fixes only. No new features, no breaking changes.
+- **Patch** (`0.5.x`): bug fixes only. No new features, no breaking changes.
 - **Minor** (`0.x.0`): new features (new checks, new input loaders, new flags). Adheres to this contract.
 - **Major** (`1.0.0`): may break the contract. Will be announced with a migration guide.
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
   baseline_mode:
     required: false
     default: new-findings
-    description: Baseline comparison mode. v0.4 supports new-findings.
+    description: "Baseline comparison mode. Supported value: new-findings."
   policy_packs:
     required: false
     default: ""

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,13 +11,14 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`manifest-v0.1.md`](manifest-v0.1.md) — manifest schema in prose form
 - [`trust-model.md`](trust-model.md) — what the scanner does and doesn't do
 - [`baseline.md`](baseline.md) — baseline workflow
+- [`framework-adapter-checklist.md`](framework-adapter-checklist.md) — checklist for adding static framework adapters
 
 ## Reference
 
 - [`checks.md`](checks.md) — full check catalog (human-readable)
 - [`checks.json`](checks.json) — machine-readable check catalog (regenerated each release)
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
-- [`report-schema.v0.4.json`](report-schema.v0.4.json) — JSON Schema for `report.json`
+- [`report-schema.v0.5.json`](report-schema.v0.5.json) — JSON Schema for `report.json`
 - [`category.md`](category.md) — what an "agent release gate" is, in product terms
 
 ## Examples
@@ -31,7 +32,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 
 - [`quickstart.md`](quickstart.md) — 60-second install + first scan
 - [`faq.md`](faq.md) — common questions, AI-search-friendly
-- [`integrations.md`](integrations.md) — CI/CD integration recipes (GHA, GitLab, CircleCI, Jenkins)
+- [`integrations.md`](integrations.md) — CI/CD integration recipes (GitHub Actions, GitLab CI, CircleCI, Jenkins snippet)
 - [`troubleshooting.md`](troubleshooting.md) — error messages → fixes
 - [`distribution.md`](distribution.md) — release process and SBOM/signature verification
 - [`decisions.md`](decisions.md) — architectural decisions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,8 @@ inputs/{mcp,openapi,    →  per-source loaders normalize into Tool objects
   openai_api,           ↓     each loader is pure (no network, no model)
   anthropic_api,
   google_adk,
+  langchain,
+  crewai,
   openai_sdk_static}.py
                         ↓
 core/risk_hints.py      →  enriches tools with risk tags (read_only, write,
@@ -35,7 +37,8 @@ src/agents_shipgate/
 ├── config/          Pydantic schema + manifest loader
 ├── core/            Shared models (Tool, Finding, Report, ScanContext)
 ├── checks/          Per-category check functions (api, auth, doc, ...)
-├── inputs/          Adapters: mcp, openapi, openai_*, anthropic_api, google_adk
+├── inputs/          Adapters: mcp, openapi, openai_*, anthropic_api,
+│                   google_adk, langchain, crewai
 ├── report/          Output formatters: markdown, json, sarif
 └── plugins/         Plugin loading machinery (off by default)
 ```
@@ -71,6 +74,8 @@ Coverage:
 4. Wire into `cli/scan.py` (`run_scan` and `inspect_sources`).
 5. Add a sample fixture under `samples/` and golden expected reports.
 6. Add tests in `tests/test_<adapter>.py`.
+7. For framework adapters, follow
+   [`framework-adapter-checklist.md`](framework-adapter-checklist.md).
 
 ## Adding a new check
 

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -37,7 +37,7 @@ fail CI.
 
 Reports keep the v0.1 payload contract and add baseline fields:
 
-- `report_schema_version: "0.4"` in v0.4 reports
+- `report_schema_version: "0.5"` in v0.5 reports
 - `baseline.path`
 - `baseline.matched_count`
 - `baseline.new_count`

--- a/docs/checks.json
+++ b/docs/checks.json
@@ -288,6 +288,34 @@
       "recommendation": "Use narrower tool scopes."
     },
     {
+      "category": "crewai",
+      "default_severity": "high",
+      "description": "CrewAI tool surface cannot be statically enumerated.",
+      "docs_url": "docs/checks.md#ship-crewai-dynamic-tool-surface-not-enumerable",
+      "evidence_fields": [
+        "surface",
+        "explicit_inventory"
+      ],
+      "fires_when": "A CrewAI agent tool binding is dynamic or unresolved and no explicit local inventory is declared.",
+      "id": "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
+      "rationale": "CrewAI exposes ad hoc agent-bound tool lists rather than a consistent toolset abstraction, so the check names the broader tool surface instead of ADK's toolset.",
+      "recommendation": "Provide explicit MCP-style tool inventory metadata for dynamic CrewAI tool lists."
+    },
+    {
+      "category": "crewai",
+      "default_severity": "medium",
+      "description": "CrewAI function tool lacks static metadata.",
+      "docs_url": "docs/checks.md#ship-crewai-function-tool-metadata-missing",
+      "evidence_fields": [
+        "missing",
+        "source_type"
+      ],
+      "fires_when": "A CrewAI @tool or BaseTool class lacks description or parameter metadata.",
+      "id": "SHIP-CREWAI-FUNCTION-TOOL-METADATA-MISSING",
+      "rationale": "Static review depends on descriptions and parameter schemas because user CrewAI code is not imported.",
+      "recommendation": "Add docstrings, descriptions, type annotations, args_schema, or explicit local inventory metadata."
+    },
+    {
       "category": "security",
       "default_severity": "medium",
       "description": "Tool description contains instruction-override-like language.",
@@ -379,6 +407,34 @@
       "id": "SHIP-INVENTORY-WILDCARD-TOOLS",
       "rationale": "Wildcard tools make review and least-privilege reasoning impossible.",
       "recommendation": "Replace wildcard exposure with an explicit allowlist."
+    },
+    {
+      "category": "langchain",
+      "default_severity": "high",
+      "description": "LangChain tool surface cannot be statically enumerated.",
+      "docs_url": "docs/checks.md#ship-langchain-dynamic-tool-surface-not-enumerable",
+      "evidence_fields": [
+        "surface",
+        "explicit_inventory"
+      ],
+      "fires_when": "A LangChain or LangGraph tool binding is dynamic or unresolved and no explicit local inventory is declared.",
+      "id": "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
+      "rationale": "LangChain and LangGraph expose ad hoc tool lists and agent-bound tools rather than a consistent toolset abstraction, so the check names the broader tool surface instead of ADK's toolset.",
+      "recommendation": "Provide explicit MCP-style tool inventory metadata for dynamic LangChain tool lists."
+    },
+    {
+      "category": "langchain",
+      "default_severity": "medium",
+      "description": "LangChain function tool lacks static metadata.",
+      "docs_url": "docs/checks.md#ship-langchain-function-tool-metadata-missing",
+      "evidence_fields": [
+        "missing",
+        "source_type"
+      ],
+      "fires_when": "A LangChain @tool or StructuredTool lacks description or parameter metadata.",
+      "id": "SHIP-LANGCHAIN-FUNCTION-TOOL-METADATA-MISSING",
+      "rationale": "Static review depends on descriptions and parameter schemas because user LangChain code is not imported.",
+      "recommendation": "Add docstrings, descriptions, type annotations, args_schema, or explicit local inventory metadata."
     },
     {
       "category": "manifest",

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -66,6 +66,10 @@ baseline summary and do not fail CI.
 | `SHIP-ADK-LONGRUNNING-CONTRACT-MISSING` | high | A Google ADK long-running tool lacks operation-id and status/progress contract evidence. |
 | `SHIP-ADK-GUARDRAIL-EVIDENCE-MISSING` | high | High-risk Google ADK tools lack callback/plugin or policy guardrail evidence. |
 | `SHIP-ADK-EVAL-COVERAGE-MISSING` | medium | Production-like Google ADK inputs are present without declared eval files. |
+| `SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE` | high | A LangChain/LangGraph tool surface cannot be statically enumerated and no explicit inventory is declared. |
+| `SHIP-LANGCHAIN-FUNCTION-TOOL-METADATA-MISSING` | medium | A LangChain/LangGraph function tool lacks static description or parameter metadata. |
+| `SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE` | high | A CrewAI tool surface cannot be statically enumerated and no explicit inventory is declared. |
+| `SHIP-CREWAI-FUNCTION-TOOL-METADATA-MISSING` | medium | A CrewAI function/class tool lacks static description or parameter metadata. |
 | `SHIP-MANIFEST-STALE-SUPPRESSION` | medium | A suppression references a missing check ID or missing tool. |
 | `SHIP-MANIFEST-STALE-POLICY` | medium | An approval, confirmation, or idempotency policy references a missing tool. |
 | `SHIP-MANIFEST-STALE-RISK-OVERRIDE` | medium | A risk override references a missing tool. |
@@ -224,6 +228,35 @@ Google ADK inputs target `production_like` or `production` without declared eval
 files. Add eval artifacts that cover expected responses and tool-use
 trajectories.
 
+### SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE
+
+A LangChain/LangGraph tool list, binding, or graph node could not be enumerated
+statically. Provide an explicit local inventory when tools are produced by
+factories, comprehensions, loop-built lists, unresolved imports, or other
+runtime-only code. This ID uses `TOOL-SURFACE` instead of ADK's `TOOLSET`
+because LangChain exposes ad hoc tool lists and model/graph bindings rather
+than a consistent toolset abstraction.
+
+### SHIP-LANGCHAIN-FUNCTION-TOOL-METADATA-MISSING
+
+A LangChain/LangGraph `@tool` function or `StructuredTool.from_function(...)`
+surface lacks a static description or parameter metadata. Add docstrings,
+function annotations, or same-file Pydantic `args_schema` metadata.
+
+### SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE
+
+A CrewAI agent or crew tool surface could not be enumerated statically. Provide
+an explicit local inventory when tools are produced by factories,
+comprehensions, loop-built lists, unresolved imports, or other runtime-only
+code. This ID uses `TOOL-SURFACE` instead of ADK's `TOOLSET` because CrewAI
+agents bind ad hoc tool lists rather than a consistent toolset abstraction.
+
+### SHIP-CREWAI-FUNCTION-TOOL-METADATA-MISSING
+
+A CrewAI `@tool` function or `BaseTool` subclass lacks a static description or
+parameter metadata. Add descriptions, `_run` annotations, or same-file Pydantic
+`args_schema` metadata.
+
 ### SHIP-MANIFEST-STALE-SUPPRESSION
 
 A suppression references an unknown check ID or a tool that is not loaded in the
@@ -317,3 +350,17 @@ The ADK extractor does not import user modules, run `adk`, connect to MCP
 servers, fetch OpenAPI specs over the network, call tools, or call models.
 Dynamic ADK toolsets produce source warnings and one ADK finding per unresolved
 toolset unless explicit local MCP/OpenAPI/tool inventory inputs are provided.
+
+## LangChain And CrewAI Static Extraction
+
+LangChain/LangGraph and CrewAI extraction are optional static enrichment.
+Agents Shipgate detects supported Python tool definitions, wrappers, agent
+bindings, and local inventory files where those values are statically knowable.
+
+The extractors do not import user modules, import framework packages, run
+agents, run graphs, run crews, connect to MCP servers, fetch specs over the
+network, call tools, call models, or execute framework subprocesses. Dynamic
+tool surfaces produce source warnings and framework findings unless explicit
+local tool inventory inputs are provided. CrewAI prebuilt `crewai_tools.*Tool()`
+references are emitted as low-confidence stubs and warnings; they do not by
+themselves produce the dynamic-tools finding.

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -356,6 +356,8 @@ toolset unless explicit local MCP/OpenAPI/tool inventory inputs are provided.
 LangChain/LangGraph and CrewAI extraction are optional static enrichment.
 Agents Shipgate detects supported Python tool definitions, wrappers, agent
 bindings, and local inventory files where those values are statically knowable.
+CrewAI `BaseTool` class metadata may use literal strings or Pydantic-style
+`Field(default="...")` assignments for `name` and `description`.
 
 The extractors do not import user modules, import framework packages, run
 agents, run graphs, run crews, connect to MCP servers, fetch specs over the

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -37,7 +37,7 @@ invoke at runtime. It is declared via:
 
 - Model Context Protocol (MCP) exports
 - OpenAPI specs
-- Framework-specific code (OpenAI Agents SDK Python, Google ADK)
+- Framework-specific code (OpenAI Agents SDK Python, Google ADK, LangChain/LangGraph, CrewAI)
 - API-specific artifacts (Anthropic Messages API tools.json, OpenAI
   Agents API function schemas)
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,7 +5,7 @@ These items require release infrastructure, registry credentials, domains, or Gi
 ## Package Channels
 
 - Publish `agents-shipgate` to PyPI.
-- Publish a pinned GitHub Action release tag such as `v0.4.0`.
+- Publish a pinned GitHub Action release tag such as `v0.5.0`.
 - Evaluate a container image later only if it has an exercised build-and-test path.
 - Evaluate Homebrew once CLI usage warrants it.
 
@@ -38,4 +38,4 @@ release tag.
 The repository keeps a root `action.yml` for GitHub Marketplace publication and
 a minimal `.github/workflows/ci.yml` for project validation plus a tag-triggered
 release workflow. The action remains a composite action; there is no Docker
-action entrypoint in v0.4.
+action entrypoint in v0.5.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -51,6 +51,8 @@ See [`docs/trust-model.md`](trust-model.md) for the full disclosure.
 - OpenAI Agents SDK Python entrypoints (static AST extraction, no import)
 - Anthropic Messages API artifacts (system prompts + tools.json + policy YAML)
 - Google ADK Python and YAML config
+- LangChain/LangGraph Python entrypoints
+- CrewAI Python entrypoints
 - OpenAI Agents API artifacts (prompts + function schemas + response formats)
 
 See [`docs/manifest-v0.1.md`](manifest-v0.1.md) for the full manifest
@@ -60,13 +62,13 @@ schema.
 
 - **Markdown** — `agents-shipgate-reports/report.md`, for human review.
 - **JSON** — `agents-shipgate-reports/report.json`, machine-readable
-  (schema v0.4). Always parse this for programmatic use.
+  (schema v0.5). Always parse this for programmatic use.
 - **SARIF** — `agents-shipgate-reports/report.sarif`, compatible with
   GitHub's code-scanning UI on the Files Changed view.
 
 ## Is it production-ready?
 
-v0.3.0 is the latest released version. The manifest schema is stable
+v0.5.0 is the latest released version. The manifest schema is stable
 across the 0.x series; see [`STABILITY.md`](../STABILITY.md). Used by
 early design partners. Public preview.
 
@@ -78,8 +80,9 @@ baseline lets you adopt the gate without flipping every existing PR red.
 
 ## Does it work without GitHub?
 
-Yes. The CLI is the same on any platform. Recipes for GitLab CI,
-CircleCI, and Jenkins are in [`docs/integrations.md`](integrations.md).
+Yes. The CLI is the same on any platform. First-class recipes for GitLab CI
+and CircleCI are in [`docs/integrations.md`](integrations.md); Jenkins remains
+available as a lightweight snippet.
 
 ## How much does it cost?
 

--- a/docs/framework-adapter-checklist.md
+++ b/docs/framework-adapter-checklist.md
@@ -1,0 +1,86 @@
+# Framework Adapter Checklist
+
+Use this checklist when adding or changing a framework adapter. Framework
+support must stay consistent with the default Agents Shipgate trust model:
+static file parsing only, no imports, no agent execution, no tool calls, no
+model calls, no MCP connections, and no network access.
+
+## Static Extraction
+
+- Parse Python with `ast.parse` or parse declarative config with safe structured
+  loaders only.
+- Never use `import`, `exec`, `eval`, framework CLIs, subprocess execution, or
+  package runtime APIs to discover tools.
+- Reuse `inputs/common.py` for path containment, size limits, structured-file
+  parsing, schema conversion, and stable tool IDs.
+- Keep file processing deterministic: manifest references in declared order,
+  supplemental discovered files sorted by resolved path, and AST objects in
+  source order.
+
+## Tool Normalization
+
+- Normalize each enumerated callable surface into `core.models.Tool`.
+- Use source types that describe both framework and confidence source, such as
+  `langchain_function`, `crewai_class_tool`, or `<framework>_inventory`.
+- Preserve descriptions, parameter schemas, auth scopes, annotations, owners,
+  and risk hints when they are statically knowable.
+- Generate stable names and IDs so finding fingerprints and baselines are
+  reproducible.
+
+## Confidence
+
+- Set high confidence for explicit inventories and direct static function/class
+  tools with names, descriptions, and schemas.
+- Set medium confidence for static framework wrappers when some metadata is
+  inferred.
+- Set low confidence for prebuilt/config stubs whose runtime schema cannot be
+  fully known from local source.
+- Let `SHIP-INVENTORY-LOW-CONFIDENCE-PRODUCTION-SURFACE` cover production
+  exposure of low-confidence tools instead of duplicating that condition in a
+  framework-specific check.
+
+## Source Priority
+
+- Explicit local framework inventories should outrank static extraction.
+- Static custom function/class tools should outrank low-confidence prebuilt or
+  config stubs.
+- Register new source types in the scan merge priority table before relying on
+  duplicate-name resolution.
+
+## Dynamic Surfaces
+
+- Emit source warnings for dynamic or unresolved tool surfaces, including
+  factory calls, loop-built lists, comprehensions, unresolved imports, and
+  external schema classes that cannot be inspected safely.
+- Add framework-specific findings only when static extraction cannot enumerate
+  the surface and no explicit inventory resolves it.
+- Keep warning ordering stable, normally by `(source_ref, line, message)`.
+
+## Report Surface
+
+- Add a typed artifact model to `ScanContext`, following the
+  `google_adk_artifacts` pattern.
+- Add an additive `frameworks.<framework>` report block with count fields and
+  warnings.
+- Update Markdown rendering through the generic framework renderer instead of
+  adding copy-paste branches.
+- Bump `report_schema_version` only for additive report fields, and keep
+  manifest `version: "0.1"` unless the manifest schema itself changes.
+
+## Tests And Fixtures
+
+- Add focused unit tests for each supported source shape and each dynamic
+  warning/finding path.
+- Include a fixture whose top-level Python code would fail if imported.
+- Add a sample under `samples/` with golden `report.md` and `report.json`.
+- Add the fixture to `agents-shipgate self-check --json` when it is part of the
+  supported install surface.
+- Regenerate `docs/manifest-v0.1.json` and `docs/checks.json` with
+  `python scripts/generate_schemas.py` after schema or check metadata changes.
+
+## Documentation
+
+- Document the manifest form, supported static patterns, unsupported dynamic
+  patterns, trust boundary, source priorities, and remediation path through
+  explicit inventories.
+- Add check catalog entries for every new `SHIP-*` ID.

--- a/docs/framework-adapter-checklist.md
+++ b/docs/framework-adapter-checklist.md
@@ -13,6 +13,9 @@ model calls, no MCP connections, and no network access.
   package runtime APIs to discover tools.
 - Reuse `inputs/common.py` for path containment, size limits, structured-file
   parsing, schema conversion, and stable tool IDs.
+- For Python framework adapters, reuse `inputs/_python_framework.py` for
+  source loading, inventory wrapping, AST ordering, duplicate handling, and
+  shared `Tool` construction before adding framework-specific extraction logic.
 - Keep file processing deterministic: manifest references in declared order,
   supplemental discovered files sorted by resolved path, and AST objects in
   source order.
@@ -83,4 +86,6 @@ model calls, no MCP connections, and no network access.
 - Document the manifest form, supported static patterns, unsupported dynamic
   patterns, trust boundary, source priorities, and remediation path through
   explicit inventories.
+- Document the tested framework version range so users can map unsupported
+  source shapes to version churn instead of scanner failure.
 - Add check catalog entries for every new `SHIP-*` ID.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: agents-shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+        uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           config: shipgate.yaml
           ci_mode: advisory
@@ -88,28 +88,56 @@ AGENTS_SHIPGATE_LOG_FORMAT=json agents-shipgate scan --config shipgate.yaml --ve
 
 ## GitLab CI
 
+First-class GitLab CI recipes live in [`../examples/gitlab-ci/`](../examples/gitlab-ci/):
+
+- advisory rollout;
+- strict mode with a baseline;
+- SARIF-or-artifact retention;
+- monorepo multi-config scans;
+- tool-source-change triggers.
+
 ```yaml
 agents-shipgate:
+  stage: test
   image: python:3.12
   script:
-    - python -m pip install agents-shipgate
-    - agents-shipgate scan --config shipgate.yaml --ci-mode advisory
+    - python -m pip install "agents-shipgate==0.5.0"
+    - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
+    when: always
+    expire_in: 1 week
     paths:
       - agents-shipgate-reports/
 ```
 
+GitLab SARIF report ingestion is tier/version dependent. Always retain
+`agents-shipgate-reports/` as path artifacts; enable `artifacts:reports:sarif`
+only where your GitLab instance supports it.
+
 ## CircleCI
 
+First-class CircleCI recipes live in [`../examples/circleci/`](../examples/circleci/):
+
+- advisory rollout;
+- strict mode with a baseline;
+- SARIF artifact retention;
+- monorepo multi-config scans;
+- tool-source-change triggers.
+
 ```yaml
+version: 2.1
+
 jobs:
   agents-shipgate:
     docker:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install agents-shipgate
-      - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory
+      - run: python -m pip install "agents-shipgate==0.5.0"
+      - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
+      - store_artifacts:
+          path: agents-shipgate-reports
+          destination: agents-shipgate-reports
 ```
 
 ## Jenkins

--- a/docs/manifest-v0.1.example.full.yaml
+++ b/docs/manifest-v0.1.example.full.yaml
@@ -42,6 +42,14 @@ tool_sources:
     type: openai_agents_sdk
     path: agent.py
     optional: true
+  - id: langchain_agent
+    type: langchain
+    path: agents/langchain_agent.py
+    optional: true
+  - id: crewai_agent
+    type: crewai
+    path: agents/crew.py
+    optional: true
 
 openai_api:
   prompt_files:
@@ -54,6 +62,14 @@ openai_api:
       downstream_critical_fields: [decision, refund_amount]
   test_cases:
     - path: tests/refund_cases.json
+
+langchain:
+  tool_inventories:
+    - inventories/langchain-tools.json
+
+crewai:
+  tool_inventories:
+    - inventories/crewai-tools.json
 
 permissions:
   scopes:

--- a/docs/manifest-v0.1.example.full.yaml
+++ b/docs/manifest-v0.1.example.full.yaml
@@ -65,11 +65,11 @@ openai_api:
 
 langchain:
   tool_inventories:
-    - inventories/langchain-tools.json
+    - path: inventories/langchain-tools.json
 
 crewai:
   tool_inventories:
-    - inventories/crewai-tools.json
+    - path: inventories/crewai-tools.json
 
 permissions:
   scopes:
@@ -83,7 +83,7 @@ policies:
     - tool: issue_refund
       reason: financial action
   require_confirmation_for_tools:
-    - send_customer_email
+    - tool: send_customer_email
   require_idempotency_for_tools:
     - tool: issue_refund
       reason: avoid double refunds on retry

--- a/docs/manifest-v0.1.example.minimal.yaml
+++ b/docs/manifest-v0.1.example.minimal.yaml
@@ -17,5 +17,5 @@ environment:
 
 tool_sources:
   - id: tools                # any stable identifier
-    type: mcp                # mcp | openapi | openai_agents_sdk | google_adk
+    type: mcp                # mcp | openapi | openai_agents_sdk | google_adk | langchain | crewai
     path: mcp_tools.json     # relative to this manifest's directory

--- a/docs/manifest-v0.1.json
+++ b/docs/manifest-v0.1.json
@@ -251,6 +251,27 @@
       "title": "CiConfig",
       "type": "object"
     },
+    "CrewAiConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "python_entrypoints": {
+          "items": {
+            "$ref": "#/$defs/ArtifactPathConfig"
+          },
+          "title": "Python Entrypoints",
+          "type": "array"
+        },
+        "tool_inventories": {
+          "items": {
+            "$ref": "#/$defs/ArtifactPathConfig"
+          },
+          "title": "Tool Inventories",
+          "type": "array"
+        }
+      },
+      "title": "CrewAiConfig",
+      "type": "object"
+    },
     "EnvironmentConfig": {
       "additionalProperties": false,
       "properties": {
@@ -335,6 +356,27 @@
         }
       },
       "title": "GoogleAdkConfig",
+      "type": "object"
+    },
+    "LangChainConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "python_entrypoints": {
+          "items": {
+            "$ref": "#/$defs/ArtifactPathConfig"
+          },
+          "title": "Python Entrypoints",
+          "type": "array"
+        },
+        "tool_inventories": {
+          "items": {
+            "$ref": "#/$defs/ArtifactPathConfig"
+          },
+          "title": "Tool Inventories",
+          "type": "array"
+        }
+      },
+      "title": "LangChainConfig",
       "type": "object"
     },
     "NamedArtifactPathConfig": {
@@ -770,7 +812,9 @@
             "mcp",
             "openapi",
             "openai_agents_sdk",
-            "google_adk"
+            "google_adk",
+            "langchain",
+            "crewai"
           ],
           "title": "Type",
           "type": "string"
@@ -809,6 +853,17 @@
     "ci": {
       "$ref": "#/$defs/CiConfig"
     },
+    "crewai": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CrewAiConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
     "environment": {
       "$ref": "#/$defs/EnvironmentConfig"
     },
@@ -816,6 +871,17 @@
       "anyOf": [
         {
           "$ref": "#/$defs/GoogleAdkConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "langchain": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LangChainConfig"
         },
         {
           "type": "null"

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -4,9 +4,10 @@
 
 A manifest is valid when it declares at least one of:
 
-- `tool_sources` for MCP, OpenAPI, optional OpenAI Agents SDK metadata, or Google ADK static metadata.
+- `tool_sources` for MCP, OpenAPI, optional OpenAI Agents SDK metadata, Google ADK static metadata, LangChain/LangGraph Python, or CrewAI Python.
 - `openai_api` for simple OpenAI API apps that use prompt files, OpenAI tool schemas, and structured output schemas directly.
 - `google_adk` for explicit Google ADK Agent Config, eval, trace, or inventory artifacts.
+- `langchain` and `crewai` for supplemental Python entrypoints and explicit local tool inventories.
 
 Agent scope text can come from `agent.declared_purpose`, `agent.instructions_preview`, or `openai_api.prompt_files`.
 
@@ -68,8 +69,10 @@ openai_api:
 - `mcp`: local exported MCP tools JSON.
 - `openai_agents_sdk`: optional static Python AST extraction.
 - `google_adk`: static Google ADK Python entrypoint or Agent Config YAML.
+- `langchain`: static LangChain/LangGraph Python entrypoint.
+- `crewai`: static CrewAI Python entrypoint.
 
-When two sources declare the same tool name, Agents Shipgate keeps the higher-fidelity source, merges non-schema metadata such as annotations, auth scopes, risk hints, and owner, and emits a source warning. Current precedence is OpenAI API artifacts, then OpenAPI, then Google ADK inventories, then MCP JSON, then SDK/ADK static extraction.
+When two sources declare the same tool name, Agents Shipgate keeps the higher-fidelity source, merges non-schema metadata such as annotations, auth scopes, risk hints, and owner, and emits a source warning. Current precedence is OpenAI API artifacts, then OpenAPI, then Google ADK/LangChain/CrewAI inventories, then MCP JSON, then SDK/ADK/LangChain/CrewAI static extraction. Low-confidence framework stubs rank below static custom function/class tools.
 
 ## Google ADK Artifacts
 
@@ -119,6 +122,60 @@ Module-relative expressions such as `Path(__file__).parent / "spec.yaml"` or
 assignment-then-read patterns may be reported as dynamic. In those cases,
 declare the same spec or MCP inventory explicitly in `tool_sources` or
 `google_adk.tool_inventories`.
+
+## LangChain And CrewAI Artifacts
+
+LangChain/LangGraph and CrewAI support is local-only and static-only. Agents
+Shipgate parses Python AST and does not import framework packages, call models,
+run crews/graphs/agents, connect to MCP servers, call tools, or execute
+subprocesses.
+
+Prefer declaring primary framework entrypoints in `tool_sources` so the scanned
+surface is visible beside MCP and OpenAPI inputs. Use the top-level
+`langchain` and `crewai` blocks for supplemental batch entrypoints or explicit
+local MCP-style inventories that document dynamic or prebuilt runtime tool
+surfaces.
+
+```yaml
+tool_sources:
+  - id: support_langchain
+    type: langchain
+    path: agents/langchain_agent.py
+  - id: support_crewai
+    type: crewai
+    path: agents/support_crew.py
+
+langchain:
+  python_entrypoints:
+    - agents/graph.py
+  tool_inventories:
+    - inventories/langchain-tools.json
+
+crewai:
+  python_entrypoints:
+    - agents/crew.py
+  tool_inventories:
+    - inventories/crewai-tools.json
+```
+
+Supported static LangChain/LangGraph signals:
+
+- `@tool` decorators from `langchain.tools` and `langchain_core.tools`, including aliases.
+- `StructuredTool.from_function(...)`.
+- Static tool lists passed to `create_agent`, `create_react_agent`, `ToolNode`, and `bind_tools`.
+- Same-file Pydantic `args_schema` classes with simple annotated fields and `Field(...)` descriptions.
+
+Supported static CrewAI signals:
+
+- `@tool` decorators from `crewai.tools`, including aliases.
+- `BaseTool` subclasses with `name`, `description`, `_run`, and same-file `args_schema`.
+- Static `Agent(..., tools=[...])` and `Crew(...)` references.
+- `crewai_tools.*Tool()` prebuilt references as low-confidence stubs plus source warnings.
+
+Dynamic framework tool surfaces such as `tools=get_tools()`, list
+comprehensions, loop-built lists, unresolved imported toolkits, or unresolved
+external schema classes remain visible as source warnings and framework
+findings unless an explicit local inventory resolves the surface.
 
 ## OpenAI API Artifacts
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           config: shipgate.yaml
           ci_mode: advisory

--- a/docs/report-schema.v0.5.json
+++ b/docs/report-schema.v0.5.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ThreeMoonsLab/agents-shipgate/docs/report-schema.v0.5.json",
+  "title": "Agents Shipgate Readiness Report v0.5",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "report_schema_version",
+    "run_id",
+    "project",
+    "agent",
+    "environment",
+    "summary",
+    "tool_surface",
+    "frameworks",
+    "findings",
+    "recommended_actions",
+    "generated_reports",
+    "loaded_policy_packs",
+    "loaded_plugins",
+    "tool_inventory",
+    "source_warnings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1"
+    },
+    "report_schema_version": {
+      "const": "0.5"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "project": {
+      "type": "object"
+    },
+    "agent": {
+      "type": "object"
+    },
+    "environment": {
+      "type": "object"
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "status",
+        "critical_count",
+        "high_count",
+        "medium_count",
+        "low_count",
+        "info_count",
+        "suppressed_count",
+        "human_review_recommended",
+        "evidence_coverage"
+      ],
+      "additionalProperties": true
+    },
+    "baseline": {
+      "type": ["object", "null"],
+      "required": ["path", "matched_count", "new_count", "resolved_count"],
+      "additionalProperties": true
+    },
+    "tool_surface": {
+      "type": "object"
+    },
+    "api_surface": {
+      "type": ["object", "null"]
+    },
+    "frameworks": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "google_adk": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "python_entrypoint_count",
+            "agent_config_count",
+            "agent_count",
+            "function_tool_count",
+            "long_running_tool_count",
+            "toolset_count",
+            "dynamic_toolset_count",
+            "callback_count",
+            "plugin_count",
+            "sub_agent_count",
+            "eval_file_count",
+            "trace_sample_count",
+            "tool_inventory_file_count",
+            "warnings"
+          ]
+        },
+        "langchain": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "python_entrypoint_count",
+            "function_tool_count",
+            "structured_tool_count",
+            "tool_node_count",
+            "agent_tool_binding_count",
+            "dynamic_tool_surface_count",
+            "tool_inventory_file_count",
+            "warnings"
+          ]
+        },
+        "crewai": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "python_entrypoint_count",
+            "agent_count",
+            "crew_count",
+            "function_tool_count",
+            "class_tool_count",
+            "prebuilt_tool_count",
+            "dynamic_tool_surface_count",
+            "tool_inventory_file_count",
+            "warnings"
+          ]
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "fingerprint",
+          "check_id",
+          "title",
+          "severity",
+          "category",
+          "evidence",
+          "confidence",
+          "recommendation",
+          "suppressed",
+          "baseline_status"
+        ],
+        "additionalProperties": true
+      }
+    },
+    "recommended_actions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "generated_reports": {
+      "type": "object"
+    },
+    "loaded_policy_packs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "path", "rule_count"],
+        "additionalProperties": true
+      }
+    },
+    "loaded_plugins": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "value", "distribution", "version", "check_id"],
+        "additionalProperties": true
+      }
+    },
+    "tool_inventory": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "source_type", "risk_tags", "auth_scopes", "confidence"],
+        "additionalProperties": true
+      }
+    },
+    "source_warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/runtime-inventory.md
+++ b/docs/runtime-inventory.md
@@ -1,6 +1,6 @@
 # Runtime Inventory Design Note
 
-Runtime inventory remains design-only in v0.4. Agents Shipgate does not ship a
+Runtime inventory remains design-only in v0.5. Agents Shipgate does not ship a
 runtime inventory command, does not run agents, and does not connect to MCP
 servers by default.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,8 +69,9 @@ evidence.
 
 Static OpenAPI spec resolution covers simple literal-path idioms such as
 `Path("spec.yaml").read_text()` and `open("spec.yaml").read()`. Module-relative
-patterns such as `Path(__file__).parent / "spec.yaml"` are treated as dynamic in
-v0.4. Declare those specs under `tool_sources` or provide a local inventory
+patterns such as `Path(__file__).parent / "spec.yaml"` are treated as dynamic
+by the static extractor. Declare those specs under `tool_sources` or provide a
+local inventory
 artifact when you want them resolved by the scanner.
 
 ## A Finding Is Intentional

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -26,6 +26,7 @@ By default Agents Shipgate does not:
 - OpenAI Agents SDK enrichment uses `ast.parse` only. It does not import or execute Python modules.
 - `openai_api` artifacts are local prompt, JSON, YAML, or JSONL files. Agents Shipgate parses them locally and does not call OpenAI APIs, validate model availability, estimate pricing, or execute traces.
 - Google ADK support is static-only. Agents Shipgate parses Python AST and Agent Config YAML, but does not import ADK code, run `adk run`, run `adk web`, run `adk eval`, connect to MCP servers, call tools, call models, or fetch remote specs by default.
+- LangChain/LangGraph and CrewAI support is static-only. Agents Shipgate parses Python AST, but does not import framework packages, run graphs, crews, or agents, call models, call tools, execute `exec`/`eval`, connect to MCP servers, shell out to framework subprocesses, or make network calls.
 - ADK callbacks and plugins are recorded as static guardrail evidence only. They are not proof that runtime enforcement is correct.
 - Declarative policy packs are local YAML data. They do not import Python,
   execute code, connect to services, or weaken the default no-execution model.

--- a/examples/circleci/01-advisory.yml
+++ b/examples/circleci/01-advisory.yml
@@ -1,0 +1,18 @@
+version: 2.1
+
+jobs:
+  agents-shipgate:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run: python -m pip install "agents-shipgate==0.5.0"
+      - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
+      - store_artifacts:
+          path: agents-shipgate-reports
+          destination: agents-shipgate-reports
+
+workflows:
+  agents-shipgate:
+    jobs:
+      - agents-shipgate

--- a/examples/circleci/02-strict-with-baseline.yml
+++ b/examples/circleci/02-strict-with-baseline.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+jobs:
+  agents-shipgate:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run: python -m pip install "agents-shipgate==0.5.0"
+      - run:
+          name: Agents Shipgate strict scan
+          command: >
+            agents-shipgate scan
+            --config shipgate.yaml
+            --ci-mode strict
+            --fail-on critical,high
+            --baseline .agents-shipgate/baseline.json
+            --format markdown,json,sarif
+      - store_artifacts:
+          path: agents-shipgate-reports
+          destination: agents-shipgate-reports
+
+workflows:
+  agents-shipgate:
+    jobs:
+      - agents-shipgate

--- a/examples/circleci/03-sarif-artifact-retention.yml
+++ b/examples/circleci/03-sarif-artifact-retention.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+jobs:
+  agents-shipgate:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run: python -m pip install "agents-shipgate==0.5.0"
+      - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
+      - store_artifacts:
+          path: agents-shipgate-reports/report.sarif
+          destination: agents-shipgate/report.sarif
+      - store_artifacts:
+          path: agents-shipgate-reports
+          destination: agents-shipgate-reports
+
+workflows:
+  agents-shipgate:
+    jobs:
+      - agents-shipgate

--- a/examples/circleci/04-multi-config-workspace.yml
+++ b/examples/circleci/04-multi-config-workspace.yml
@@ -1,0 +1,25 @@
+version: 2.1
+
+jobs:
+  agents-shipgate:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run: python -m pip install "agents-shipgate==0.5.0"
+      - run:
+          name: Agents Shipgate workspace scan
+          command: >
+            agents-shipgate scan
+            --workspace .
+            --ci-mode advisory
+            --format markdown,json,sarif
+            --out agents-shipgate-reports
+      - store_artifacts:
+          path: agents-shipgate-reports
+          destination: agents-shipgate-reports
+
+workflows:
+  agents-shipgate:
+    jobs:
+      - agents-shipgate

--- a/examples/circleci/05-on-tool-source-changes.yml
+++ b/examples/circleci/05-on-tool-source-changes.yml
@@ -1,0 +1,33 @@
+version: 2.1
+
+jobs:
+  agents-shipgate:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run: python -m pip install "agents-shipgate==0.5.0"
+      - run:
+          name: Run only when tool sources changed
+          command: |
+            changed="$(git diff --name-only origin/main...HEAD -- \
+              'shipgate.yaml' \
+              '**/shipgate.yaml' \
+              '**/*.openapi.yaml' \
+              '**/*.openapi.yml' \
+              '**/*openapi*.json' \
+              '**/*mcp*.json' \
+              '**/*.py')"
+            if [ -z "${changed}" ]; then
+              echo "No Agents Shipgate inputs changed; skipping scan."
+              exit 0
+            fi
+            agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
+      - store_artifacts:
+          path: agents-shipgate-reports
+          destination: agents-shipgate-reports
+
+workflows:
+  agents-shipgate:
+    jobs:
+      - agents-shipgate

--- a/examples/circleci/README.md
+++ b/examples/circleci/README.md
@@ -1,0 +1,14 @@
+# CircleCI examples
+
+Copy one of these files to `.circleci/config.yml` or merge the job into an
+existing CircleCI config. Each job installs `agents-shipgate`, writes reports
+under `agents-shipgate-reports/`, and stores the directory as CircleCI
+artifacts.
+
+| File | When to use |
+| --- | --- |
+| `01-advisory.yml` | First rollout. Reports findings but does not block. |
+| `02-strict-with-baseline.yml` | Fail only on new critical/high findings after saving a baseline. |
+| `03-sarif-artifact-retention.yml` | Generate Markdown, JSON, and SARIF reports as artifacts. |
+| `04-multi-config-workspace.yml` | Monorepo with multiple `shipgate.yaml` files. |
+| `05-on-tool-source-changes.yml` | Skip the scan when the manifest/tool surface did not change. |

--- a/examples/github-actions/01-advisory-pr-comment.yml
+++ b/examples/github-actions/01-advisory-pr-comment.yml
@@ -16,8 +16,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.4.0'
+          shipgate_version: '0.5.0'

--- a/examples/github-actions/02-strict-on-critical.yml
+++ b/examples/github-actions/02-strict-on-critical.yml
@@ -16,9 +16,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           ci_mode: strict
           fail_on: critical
           pr_comment: 'true'
-          shipgate_version: '0.4.0'
+          shipgate_version: '0.5.0'

--- a/examples/github-actions/03-strict-with-baseline.yml
+++ b/examples/github-actions/03-strict-with-baseline.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           ci_mode: strict
           fail_on: critical,high
           baseline: .agents-shipgate/baseline.json
           pr_comment: 'true'
-          shipgate_version: '0.4.0'
+          shipgate_version: '0.5.0'

--- a/examples/github-actions/04-multi-config-workspace.yml
+++ b/examples/github-actions/04-multi-config-workspace.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: pip install --quiet agents-shipgate==0.4.0
+      - run: pip install --quiet agents-shipgate==0.5.0
       - run: |
           agents-shipgate scan \
             --workspace . \

--- a/examples/github-actions/05-sarif-to-code-scanning.yml
+++ b/examples/github-actions/05-sarif-to-code-scanning.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+        uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           ci_mode: advisory
           formats: markdown,json,sarif
           pr_comment: 'true'
-          shipgate_version: '0.4.0'
+          shipgate_version: '0.5.0'
       - if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/examples/github-actions/06-on-tool-source-changes.yml
+++ b/examples/github-actions/06-on-tool-source-changes.yml
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.5.0
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.4.0'
+          shipgate_version: '0.5.0'

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -29,9 +29,9 @@ Configure per-job, never repo-wide.
 For reproducible CI, pin both the action and the underlying CLI:
 
 ```yaml
-- uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+- uses: ThreeMoonsLab/agents-shipgate@v0.5.0
   with:
-    shipgate_version: "0.4.0"
+    shipgate_version: "0.5.0"
 ```
 
 When `shipgate_version` is empty the action installs the CLI from the action source — convenient on `@main`, less reproducible.
@@ -42,7 +42,7 @@ Useful for downstream steps:
 
 ```yaml
 - id: shipgate
-  uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+  uses: ThreeMoonsLab/agents-shipgate@v0.5.0
 
 - if: steps.shipgate.outputs.critical_count != '0'
   run: echo "Action this!"

--- a/examples/gitlab-ci/01-advisory.yml
+++ b/examples/gitlab-ci/01-advisory.yml
@@ -1,0 +1,14 @@
+stages:
+  - test
+
+agents_shipgate:
+  stage: test
+  image: python:3.12
+  script:
+    - python -m pip install "agents-shipgate==0.5.0"
+    - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - agents-shipgate-reports/

--- a/examples/gitlab-ci/02-strict-with-baseline.yml
+++ b/examples/gitlab-ci/02-strict-with-baseline.yml
@@ -1,0 +1,20 @@
+stages:
+  - test
+
+agents_shipgate:
+  stage: test
+  image: python:3.12
+  script:
+    - python -m pip install "agents-shipgate==0.5.0"
+    - >
+      agents-shipgate scan
+      --config shipgate.yaml
+      --ci-mode strict
+      --fail-on critical,high
+      --baseline .agents-shipgate/baseline.json
+      --format markdown,json,sarif
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - agents-shipgate-reports/

--- a/examples/gitlab-ci/03-sarif-or-artifact.yml
+++ b/examples/gitlab-ci/03-sarif-or-artifact.yml
@@ -1,0 +1,17 @@
+stages:
+  - test
+
+agents_shipgate:
+  stage: test
+  image: python:3.12
+  script:
+    - python -m pip install "agents-shipgate==0.5.0"
+    - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - agents-shipgate-reports/
+    # Enable this on GitLab instances that support SARIF report ingestion.
+    # reports:
+    #   sarif: agents-shipgate-reports/report.sarif

--- a/examples/gitlab-ci/04-multi-config-workspace.yml
+++ b/examples/gitlab-ci/04-multi-config-workspace.yml
@@ -1,0 +1,19 @@
+stages:
+  - test
+
+agents_shipgate:
+  stage: test
+  image: python:3.12
+  script:
+    - python -m pip install "agents-shipgate==0.5.0"
+    - >
+      agents-shipgate scan
+      --workspace .
+      --ci-mode advisory
+      --format markdown,json,sarif
+      --out agents-shipgate-reports
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - agents-shipgate-reports/

--- a/examples/gitlab-ci/05-on-tool-source-changes.yml
+++ b/examples/gitlab-ci/05-on-tool-source-changes.yml
@@ -1,0 +1,23 @@
+stages:
+  - test
+
+agents_shipgate:
+  stage: test
+  image: python:3.12
+  rules:
+    - changes:
+        - shipgate.yaml
+        - "**/shipgate.yaml"
+        - "**/*.openapi.yaml"
+        - "**/*.openapi.yml"
+        - "**/*openapi*.json"
+        - "**/*mcp*.json"
+        - "**/*.py"
+  script:
+    - python -m pip install "agents-shipgate==0.5.0"
+    - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - agents-shipgate-reports/

--- a/examples/gitlab-ci/README.md
+++ b/examples/gitlab-ci/README.md
@@ -1,0 +1,17 @@
+# GitLab CI examples
+
+Copy one of these files into `.gitlab-ci.yml` or include the job in an existing
+pipeline. Each job installs `agents-shipgate`, writes reports under
+`agents-shipgate-reports/`, and keeps those reports as artifacts.
+
+| File | When to use |
+| --- | --- |
+| `01-advisory.yml` | First rollout. Reports findings but does not block merge requests. |
+| `02-strict-with-baseline.yml` | Fail only on new critical/high findings after saving a baseline. |
+| `03-sarif-or-artifact.yml` | Generate SARIF and retain all reports as artifacts. |
+| `04-multi-config-workspace.yml` | Monorepo with multiple `shipgate.yaml` files. |
+| `05-on-tool-source-changes.yml` | Run only when manifests or tool sources change. |
+
+GitLab SARIF report ingestion is tier/version dependent. These examples always
+retain `agents-shipgate-reports/` as path artifacts; enable
+`artifacts:reports:sarif` only where your GitLab instance supports it.

--- a/llms.txt
+++ b/llms.txt
@@ -37,13 +37,15 @@ approval policies, side effects, idempotency, and blast radius.
 - OpenAPI 3.x specs (`tool_sources[].type: "openapi"`)
 - OpenAI Agents SDK Python entrypoints, static AST extraction (`tool_sources[].type: "openai_agents_sdk"`)
 - Google ADK Python and YAML config (`tool_sources[].type: "google_adk"`)
+- LangChain/LangGraph Python entrypoints (`tool_sources[].type: "langchain"`)
+- CrewAI Python entrypoints (`tool_sources[].type: "crewai"`)
 - Anthropic Messages API artifacts — system prompts, tools.json, policy rules (top-level `anthropic:` block)
 - OpenAI Agents API artifacts — prompts, function schemas, response formats (top-level `openai_api:` block)
 
 ## Outputs
 
 - Markdown report (human review): `agents-shipgate-reports/report.md`
-- JSON report (machine-readable, schema v0.4): `agents-shipgate-reports/report.json`
+- JSON report (machine-readable, schema v0.5): `agents-shipgate-reports/report.json`
 - SARIF report (GitHub code-scanning compatible): `agents-shipgate-reports/report.sarif`
 
 ## Form factor
@@ -55,7 +57,7 @@ agents-shipgate init --workspace . --write
 agents-shipgate scan -c shipgate.yaml
 
 # GitHub Action
-- uses: ThreeMoonsLab/agents-shipgate@v0.3.0
+- uses: ThreeMoonsLab/agents-shipgate@v0.5.0
   with:
     config: shipgate.yaml
     ci_mode: advisory
@@ -72,7 +74,7 @@ agents-shipgate scan -c shipgate.yaml
 - STABILITY.md (0.x contract): https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/STABILITY.md
 - Discovery metadata (.well-known): https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/.well-known/agents-shipgate.json
 - Manifest schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json
-- Report schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.4.json
+- Report schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.5.json
 - Check catalog (machine-readable): https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json
 
 ## Category vocabulary

--- a/prompts/stabilize-strict-mode.md
+++ b/prompts/stabilize-strict-mode.md
@@ -37,7 +37,7 @@ The user has Agents Shipgate running in **advisory** mode and wants to graduate 
 
 5. **Update the CI workflow.** Replace the existing advisory step with strict + baseline. Use [`examples/github-actions/03-strict-with-baseline.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/03-strict-with-baseline.yml) as the template:
    ```yaml
-   - uses: ThreeMoonsLab/agents-shipgate@v0.4.0
+   - uses: ThreeMoonsLab/agents-shipgate@v0.5.0
      with:
        ci_mode: strict
        fail_on: critical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agents-shipgate"
-version = "0.4.0"
-description = "Static release-readiness scanner for AI agent tool surfaces (MCP, OpenAPI, OpenAI Agents SDK, Anthropic Messages API, Google ADK). CLI + GitHub Action."
+version = "0.5.0"
+description = "Static release-readiness scanner for AI agent tool surfaces (MCP, OpenAPI, OpenAI Agents SDK, Anthropic Messages API, Google ADK, LangChain, CrewAI). CLI + GitHub Action."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
@@ -87,6 +87,8 @@ policy = "agents_shipgate.checks.policy:run"
 side_effects = "agents_shipgate.checks.side_effects:run"
 api = "agents_shipgate.checks.api:run"
 adk = "agents_shipgate.checks.adk:run"
+langchain = "agents_shipgate.checks.langchain:run"
+crewai = "agents_shipgate.checks.crewai:run"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agents_shipgate"]

--- a/samples/simple_crewai_agent/crew.py
+++ b/samples/simple_crewai_agent/crew.py
@@ -1,0 +1,38 @@
+from crewai import Agent, Crew
+from crewai.tools import BaseTool, tool
+from crewai_tools import FileReadTool
+from pydantic import BaseModel, Field
+
+raise RuntimeError("agents-shipgate must parse this file without importing it")
+
+
+class CaseLookupInput(BaseModel):
+    case_id: str = Field(..., description="Support case identifier.")
+
+
+@tool("summarize_case")
+def summarize_case(case_id: str) -> dict:
+    """Summarize read-only support case metadata for reviewer context."""
+    return {"case_id": case_id, "summary": "Customer asked about refund timing."}
+
+
+class CaseLookupTool(BaseTool):
+    name: str = "lookup_case"
+    description: str = "Look up read-only metadata for an existing support case."
+    args_schema = CaseLookupInput
+
+    def _run(self, case_id: str) -> dict:
+        return {"case_id": case_id, "status": "open"}
+
+
+file_tool = FileReadTool()
+case_lookup_tool = CaseLookupTool()
+
+researcher = Agent(
+    role="Support case reader",
+    goal="Review support case metadata without changing customer records",
+    backstory="Reviews existing support evidence for release-readiness examples.",
+    tools=[summarize_case, case_lookup_tool, file_tool],
+)
+
+crew = Crew(agents=[researcher])

--- a/samples/simple_crewai_agent/expected/report.json
+++ b/samples/simple_crewai_agent/expected/report.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "0.1",
+  "report_schema_version": "0.5",
+  "run_id": "agents_shipgate_1c4577c21998a147",
+  "project": {
+    "name": "simple-crewai-agent"
+  },
+  "agent": {
+    "id": "agent:simple-crewai-agent/support-case-crew",
+    "name": "support-case-crew",
+    "source": {
+      "source": "manifest"
+    },
+    "instructions": {
+      "value_preview": null,
+      "source": "dynamic_unknown",
+      "confidence": "medium"
+    },
+    "declared_purpose": [
+      "look up and summarize read-only support case metadata"
+    ],
+    "prohibited_actions": [],
+    "tools": [
+      "summarize_case",
+      "lookup_case",
+      "FileReadTool"
+    ],
+    "handoffs": [],
+    "guardrails": {
+      "input": "unknown",
+      "output": "unknown",
+      "tool": "unknown",
+      "source": "unknown"
+    },
+    "extraction": {
+      "method": "config_assisted",
+      "confidence": "medium",
+      "missing_fields": [
+        "runtime_traces"
+      ],
+      "dynamic_fields": []
+    }
+  },
+  "environment": {
+    "target": "local"
+  },
+  "summary": {
+    "status": "human_review_recommended",
+    "critical_count": 0,
+    "high_count": 0,
+    "medium_count": 0,
+    "low_count": 0,
+    "info_count": 0,
+    "suppressed_count": 0,
+    "human_review_recommended": true,
+    "evidence_coverage": "mixed"
+  },
+  "tool_surface": {
+    "total_tools": 3,
+    "high_risk_tools": 0,
+    "sources": {
+      "crewai_class_tool": 1,
+      "crewai_function": 1,
+      "crewai_prebuilt_tool": 1
+    },
+    "wildcard_tools": 0,
+    "missing_descriptions": 0
+  },
+  "api_surface": null,
+  "anthropic_surface": null,
+  "frameworks": {
+    "crewai": {
+      "python_entrypoint_count": 1,
+      "agent_count": 1,
+      "crew_count": 1,
+      "function_tool_count": 1,
+      "class_tool_count": 1,
+      "prebuilt_tool_count": 1,
+      "dynamic_tool_surface_count": 0,
+      "tool_inventory_file_count": 0,
+      "warnings": [
+        "CrewAI prebuilt tool 'FileReadTool' at crew.py:28 was recorded as low-confidence metadata; provide an explicit inventory for full review."
+      ]
+    }
+  },
+  "baseline": null,
+  "findings": [],
+  "recommended_actions": [],
+  "generated_reports": {
+    "markdown": "expected/report.md",
+    "json": "expected/report.json"
+  },
+  "loaded_policy_packs": [],
+  "loaded_plugins": [],
+  "tool_inventory": [
+    {
+      "name": "FileReadTool",
+      "source_type": "crewai_prebuilt_tool",
+      "source_ref": "crew.py",
+      "risk_tags": [],
+      "risk_tag_confidence": {},
+      "auth_scopes": [],
+      "owner": null,
+      "confidence": "low"
+    },
+    {
+      "name": "lookup_case",
+      "source_type": "crewai_class_tool",
+      "source_ref": "crew.py",
+      "risk_tags": [
+        "read_only"
+      ],
+      "risk_tag_confidence": {
+        "read_only": "medium"
+      },
+      "auth_scopes": [],
+      "owner": null,
+      "confidence": "medium"
+    },
+    {
+      "name": "summarize_case",
+      "source_type": "crewai_function",
+      "source_ref": "crew.py",
+      "risk_tags": [],
+      "risk_tag_confidence": {},
+      "auth_scopes": [],
+      "owner": null,
+      "confidence": "medium"
+    }
+  ],
+  "source_warnings": [
+    "CrewAI prebuilt tool 'FileReadTool' at crew.py:28 was recorded as low-confidence metadata; provide an explicit inventory for full review."
+  ]
+}

--- a/samples/simple_crewai_agent/expected/report.md
+++ b/samples/simple_crewai_agent/expected/report.md
@@ -1,0 +1,67 @@
+# Agents Shipgate Report
+
+Project: simple-crewai-agent
+Agent: support-case-crew
+Target: local
+
+Result: PASS - no static findings across 3 tools.
+Status: Human review recommended
+Critical: 0
+High: 0
+Medium: 0
+Low: 0
+Suppressed: 0
+Evidence coverage: mixed
+Human review: recommended
+
+## Top Findings
+
+No critical or high findings.
+
+## Recommended Next Actions
+
+No action required from static findings.
+
+## Source Warnings
+
+- CrewAI prebuilt tool 'FileReadTool' at crew.py:28 was recorded as low-confidence metadata; provide an explicit inventory for full review.
+
+## Tool Surface Summary
+
+- Total tools: 3
+- High-risk tools: 0
+- Wildcard tools: 0
+- Missing descriptions: 0
+- Sources: crewai_class_tool=1, crewai_function=1, crewai_prebuilt_tool=1
+
+## CrewAI Surface Summary
+
+- Python entrypoints: 1
+- Agents: 1
+- Crews: 1
+- Function tools: 1
+- Class tools: 1
+- Prebuilt tools: 1
+- Dynamic or unresolved tool surfaces: 0
+- Tool inventory files: 0
+
+CrewAI warnings:
+
+- CrewAI prebuilt tool 'FileReadTool' at crew.py:28 was recorded as low-confidence metadata; provide an explicit inventory for full review.
+
+## Findings By Category
+
+No findings.
+
+## Appendix: Normalized Tool Inventory
+
+| Tool | Source | Risk Tags | Risk Confidence | Auth Scopes | Owner |
+| --- | --- | --- | --- | --- | --- |
+| FileReadTool | crewai\_prebuilt\_tool | \- | \- | \- | \- |
+| lookup\_case | crewai\_class\_tool | read\_only | read\_only=medium | \- | \- |
+| summarize\_case | crewai\_function | \- | \- | \- | \- |
+
+
+## Disclaimer
+
+Agents Shipgate is an advisory release-readiness scanner. It does not certify agent safety or compliance. Findings are based on static configuration, declared policies, tool schemas, and optional SDK metadata. Runtime behavior, actual tool routing, and output interpretation are not verified.

--- a/samples/simple_crewai_agent/shipgate.yaml
+++ b/samples/simple_crewai_agent/shipgate.yaml
@@ -1,0 +1,17 @@
+version: "0.1"
+
+project:
+  name: simple-crewai-agent
+
+agent:
+  name: support-case-crew
+  declared_purpose:
+    - look up and summarize read-only support case metadata
+
+environment:
+  target: local
+
+tool_sources:
+  - id: crewai_agent
+    type: crewai
+    path: crew.py

--- a/samples/simple_langchain_agent/agent.py
+++ b/samples/simple_langchain_agent/agent.py
@@ -1,0 +1,30 @@
+from langchain.agents import create_agent
+from langchain.tools import tool
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+raise RuntimeError("agents-shipgate must parse this file without importing it")
+
+
+class LookupInput(BaseModel):
+    case_id: str = Field(..., description="Support case identifier.")
+
+
+@tool(args_schema=LookupInput)
+def lookup_case(case_id: str) -> dict:
+    """Look up read-only metadata for an existing support case."""
+    return {"case_id": case_id, "status": "open"}
+
+
+def summarize_case(case_id: str) -> dict:
+    """Summarize read-only support case metadata for reviewer context."""
+    return {"case_id": case_id, "summary": "Customer asked about refund timing."}
+
+
+summary_tool = StructuredTool.from_function(
+    func=summarize_case,
+    name="summarize_case",
+    description="Summarize read-only support case metadata for reviewer context.",
+)
+
+agent = create_agent(model=None, tools=[lookup_case, summary_tool])

--- a/samples/simple_langchain_agent/expected/report.json
+++ b/samples/simple_langchain_agent/expected/report.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "0.1",
+  "report_schema_version": "0.5",
+  "run_id": "agents_shipgate_09ab0114a3ecb63a",
+  "project": {
+    "name": "simple-langchain-agent"
+  },
+  "agent": {
+    "id": "agent:simple-langchain-agent/support-case-reader",
+    "name": "support-case-reader",
+    "source": {
+      "source": "manifest"
+    },
+    "instructions": {
+      "value_preview": null,
+      "source": "dynamic_unknown",
+      "confidence": "medium"
+    },
+    "declared_purpose": [
+      "look up and summarize read-only support case metadata"
+    ],
+    "prohibited_actions": [],
+    "tools": [
+      "lookup_case",
+      "summarize_case"
+    ],
+    "handoffs": [],
+    "guardrails": {
+      "input": "unknown",
+      "output": "unknown",
+      "tool": "unknown",
+      "source": "unknown"
+    },
+    "extraction": {
+      "method": "config_assisted",
+      "confidence": "medium",
+      "missing_fields": [
+        "runtime_traces"
+      ],
+      "dynamic_fields": []
+    }
+  },
+  "environment": {
+    "target": "local"
+  },
+  "summary": {
+    "status": "human_review_recommended",
+    "critical_count": 0,
+    "high_count": 0,
+    "medium_count": 0,
+    "low_count": 0,
+    "info_count": 0,
+    "suppressed_count": 0,
+    "human_review_recommended": true,
+    "evidence_coverage": "mixed"
+  },
+  "tool_surface": {
+    "total_tools": 2,
+    "high_risk_tools": 0,
+    "sources": {
+      "langchain_function": 1,
+      "langchain_structured_tool": 1
+    },
+    "wildcard_tools": 0,
+    "missing_descriptions": 0
+  },
+  "api_surface": null,
+  "anthropic_surface": null,
+  "frameworks": {
+    "langchain": {
+      "python_entrypoint_count": 1,
+      "function_tool_count": 1,
+      "structured_tool_count": 1,
+      "tool_node_count": 0,
+      "agent_tool_binding_count": 1,
+      "dynamic_tool_surface_count": 0,
+      "tool_inventory_file_count": 0,
+      "warnings": []
+    }
+  },
+  "baseline": null,
+  "findings": [],
+  "recommended_actions": [],
+  "generated_reports": {
+    "markdown": "expected/report.md",
+    "json": "expected/report.json"
+  },
+  "loaded_policy_packs": [],
+  "loaded_plugins": [],
+  "tool_inventory": [
+    {
+      "name": "lookup_case",
+      "source_type": "langchain_function",
+      "source_ref": "agent.py",
+      "risk_tags": [
+        "read_only"
+      ],
+      "risk_tag_confidence": {
+        "read_only": "medium"
+      },
+      "auth_scopes": [],
+      "owner": null,
+      "confidence": "medium"
+    },
+    {
+      "name": "summarize_case",
+      "source_type": "langchain_structured_tool",
+      "source_ref": "agent.py",
+      "risk_tags": [],
+      "risk_tag_confidence": {},
+      "auth_scopes": [],
+      "owner": null,
+      "confidence": "medium"
+    }
+  ],
+  "source_warnings": []
+}

--- a/samples/simple_langchain_agent/expected/report.md
+++ b/samples/simple_langchain_agent/expected/report.md
@@ -1,0 +1,57 @@
+# Agents Shipgate Report
+
+Project: simple-langchain-agent
+Agent: support-case-reader
+Target: local
+
+Result: PASS - no static findings across 2 tools.
+Status: Human review recommended
+Critical: 0
+High: 0
+Medium: 0
+Low: 0
+Suppressed: 0
+Evidence coverage: mixed
+Human review: recommended
+
+## Top Findings
+
+No critical or high findings.
+
+## Recommended Next Actions
+
+No action required from static findings.
+
+## Tool Surface Summary
+
+- Total tools: 2
+- High-risk tools: 0
+- Wildcard tools: 0
+- Missing descriptions: 0
+- Sources: langchain_function=1, langchain_structured_tool=1
+
+## LangChain Surface Summary
+
+- Python entrypoints: 1
+- Function tools: 1
+- Structured tools: 1
+- Tool nodes: 0
+- Agent tool bindings: 1
+- Dynamic or unresolved tool surfaces: 0
+- Tool inventory files: 0
+
+## Findings By Category
+
+No findings.
+
+## Appendix: Normalized Tool Inventory
+
+| Tool | Source | Risk Tags | Risk Confidence | Auth Scopes | Owner |
+| --- | --- | --- | --- | --- | --- |
+| lookup\_case | langchain\_function | read\_only | read\_only=medium | \- | \- |
+| summarize\_case | langchain\_structured\_tool | \- | \- | \- | \- |
+
+
+## Disclaimer
+
+Agents Shipgate is an advisory release-readiness scanner. It does not certify agent safety or compliance. Findings are based on static configuration, declared policies, tool schemas, and optional SDK metadata. Runtime behavior, actual tool routing, and output interpretation are not verified.

--- a/samples/simple_langchain_agent/shipgate.yaml
+++ b/samples/simple_langchain_agent/shipgate.yaml
@@ -1,0 +1,17 @@
+version: "0.1"
+
+project:
+  name: simple-langchain-agent
+
+agent:
+  name: support-case-reader
+  declared_purpose:
+    - look up and summarize read-only support case metadata
+
+environment:
+  target: local
+
+tool_sources:
+  - id: langchain_agent
+    type: langchain
+    path: agent.py

--- a/samples/simple_openai_api_agent/expected/report.json
+++ b/samples/simple_openai_api_agent/expected/report.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.4",
-  "run_id": "agents_shipgate_abbe19ac5c15d475",
+  "report_schema_version": "0.5",
+  "run_id": "agents_shipgate_d07e1421099084ae",
   "project": {
     "name": "simple-openai-api-agent",
     "owner": "support-platform"
@@ -74,6 +74,7 @@
     "trace_sample_count": 1,
     "policy_rule_count": 1
   },
+  "anthropic_surface": null,
   "frameworks": {},
   "baseline": null,
   "findings": [

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.4",
-  "run_id": "agents_shipgate_42a625b68c0df0a8",
+  "report_schema_version": "0.5",
+  "run_id": "agents_shipgate_3716da0eb0ec2fad",
   "project": {
     "name": "support-refund-agent",
     "owner": "support-platform",
@@ -87,6 +87,7 @@
     "missing_descriptions": 0
   },
   "api_surface": null,
+  "anthropic_surface": null,
   "frameworks": {},
   "baseline": null,
   "findings": [

--- a/src/agents_shipgate/__init__.py
+++ b/src/agents_shipgate/__init__.py
@@ -1,3 +1,3 @@
 """Agents Shipgate package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/agents_shipgate/checks/crewai.py
+++ b/src/agents_shipgate/checks/crewai.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from agents_shipgate.checks.base import agent_finding, tool_finding
+from agents_shipgate.core.context import ScanContext
+
+
+def run(context: ScanContext):
+    artifacts = context.crewai_artifacts
+    if not artifacts:
+        return []
+
+    findings = []
+    if not artifacts.tool_inventory_files:
+        for surface in artifacts.dynamic_tool_surfaces:
+            findings.append(
+                agent_finding(
+                    check_id="SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
+                    title="CrewAI tool surface cannot be statically enumerated",
+                    severity="high",
+                    category="crewai",
+                    evidence={
+                        "surface": surface,
+                        "explicit_inventory": False,
+                    },
+                    confidence="medium",
+                    recommendation=(
+                        "Provide explicit MCP-style tool inventory metadata for dynamic "
+                        "CrewAI tool lists before release review."
+                    ),
+                    context=context,
+                )
+            )
+
+    for tool in context.tools:
+        if tool.source_type not in {"crewai_function", "crewai_class_tool"}:
+            continue
+        missing = []
+        if not (tool.description or "").strip():
+            missing.append("description")
+        if not tool.parameters and not tool.input_schema.get("properties"):
+            missing.append("parameters")
+        if not missing:
+            continue
+        findings.append(
+            tool_finding(
+                tool=tool,
+                check_id="SHIP-CREWAI-FUNCTION-TOOL-METADATA-MISSING",
+                title=f"{tool.name} lacks static CrewAI function-tool metadata",
+                severity="medium",
+                category="crewai",
+                evidence={"missing": missing, "source_type": tool.source_type},
+                confidence="high",
+                recommendation=(
+                    "Add a docstring, description, type annotations, args_schema, or "
+                    f"explicit local inventory metadata for CrewAI tool {tool.name}."
+                ),
+                context=context,
+            )
+        )
+
+    return findings

--- a/src/agents_shipgate/checks/langchain.py
+++ b/src/agents_shipgate/checks/langchain.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from agents_shipgate.checks.base import agent_finding, tool_finding
+from agents_shipgate.core.context import ScanContext
+
+
+def run(context: ScanContext):
+    artifacts = context.langchain_artifacts
+    if not artifacts:
+        return []
+
+    findings = []
+    if not artifacts.tool_inventory_files:
+        for surface in artifacts.dynamic_tool_surfaces:
+            findings.append(
+                agent_finding(
+                    check_id="SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
+                    title="LangChain tool surface cannot be statically enumerated",
+                    severity="high",
+                    category="langchain",
+                    evidence={
+                        "surface": surface,
+                        "explicit_inventory": False,
+                    },
+                    confidence="medium",
+                    recommendation=(
+                        "Provide explicit MCP-style tool inventory metadata for dynamic "
+                        "LangChain or LangGraph tool lists before release review."
+                    ),
+                    context=context,
+                )
+            )
+
+    for tool in context.tools:
+        if tool.source_type not in {"langchain_function", "langchain_structured_tool"}:
+            continue
+        missing = []
+        if not (tool.description or "").strip():
+            missing.append("description")
+        if not tool.parameters and not tool.input_schema.get("properties"):
+            missing.append("parameters")
+        if not missing:
+            continue
+        findings.append(
+            tool_finding(
+                tool=tool,
+                check_id="SHIP-LANGCHAIN-FUNCTION-TOOL-METADATA-MISSING",
+                title=f"{tool.name} lacks static LangChain function-tool metadata",
+                severity="medium",
+                category="langchain",
+                evidence={"missing": missing, "source_type": tool.source_type},
+                confidence="high",
+                recommendation=(
+                    "Add a docstring, description, type annotations, args_schema, or "
+                    f"explicit local inventory metadata for LangChain tool {tool.name}."
+                ),
+                context=context,
+            )
+        )
+
+    return findings

--- a/src/agents_shipgate/checks/registry.py
+++ b/src/agents_shipgate/checks/registry.py
@@ -10,8 +10,10 @@ from agents_shipgate.checks import (
     adk,
     api,
     auth,
+    crewai,
     documentation,
     inventory,
+    langchain,
     manifest_consistency,
     manifest_scope,
     policy,
@@ -32,6 +34,8 @@ BUILTIN_CHECKS: list[Callable[[ScanContext], list[Finding]]] = [
     side_effects.run,
     api.run,
     adk.run,
+    langchain.run,
+    crewai.run,
 ]
 
 
@@ -72,6 +76,10 @@ CHECK_METADATA: list[CheckMetadata] = [
     CheckMetadata(id="SHIP-ADK-LONGRUNNING-CONTRACT-MISSING", category="adk", default_severity="high", description="Google ADK long-running tool lacks an operation contract.", rationale="Long-running tools need explicit status and operation-id semantics for safe continuation.", fires_when="A LongRunningFunctionTool lacks structured status/progress and operation id output evidence.", evidence_fields=["output_schema"], recommendation="Document operation id, status/progress fields, and completion behavior."),
     CheckMetadata(id="SHIP-ADK-GUARDRAIL-EVIDENCE-MISSING", category="adk", default_severity="high", description="High-risk Google ADK tools lack static guardrail evidence.", rationale="Callbacks and plugins are the static ADK surface where release reviewers can see guardrail intent.", fires_when="High-risk ADK tools are present without callbacks, plugins, or equivalent manifest policy evidence.", evidence_fields=["tools"], recommendation="Attach ADK callbacks/plugins or manifest policies that document guardrails."),
     CheckMetadata(id="SHIP-ADK-EVAL-COVERAGE-MISSING", category="adk", default_severity="medium", description="Google ADK eval coverage is not declared.", rationale="ADK releases should include response and tool-trajectory eval evidence before promotion.", fires_when="Google ADK inputs target production_like or production and no eval files are declared.", evidence_fields=["agent_count", "eval_file_count"], recommendation="Declare ADK eval files for expected responses and tool-use trajectories."),
+    CheckMetadata(id="SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE", category="langchain", default_severity="high", description="LangChain tool surface cannot be statically enumerated.", rationale="LangChain and LangGraph expose ad hoc tool lists and agent-bound tools rather than a consistent toolset abstraction, so the check names the broader tool surface instead of ADK's toolset.", fires_when="A LangChain or LangGraph tool binding is dynamic or unresolved and no explicit local inventory is declared.", evidence_fields=["surface", "explicit_inventory"], recommendation="Provide explicit MCP-style tool inventory metadata for dynamic LangChain tool lists."),
+    CheckMetadata(id="SHIP-LANGCHAIN-FUNCTION-TOOL-METADATA-MISSING", category="langchain", default_severity="medium", description="LangChain function tool lacks static metadata.", rationale="Static review depends on descriptions and parameter schemas because user LangChain code is not imported.", fires_when="A LangChain @tool or StructuredTool lacks description or parameter metadata.", evidence_fields=["missing", "source_type"], recommendation="Add docstrings, descriptions, type annotations, args_schema, or explicit local inventory metadata."),
+    CheckMetadata(id="SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE", category="crewai", default_severity="high", description="CrewAI tool surface cannot be statically enumerated.", rationale="CrewAI exposes ad hoc agent-bound tool lists rather than a consistent toolset abstraction, so the check names the broader tool surface instead of ADK's toolset.", fires_when="A CrewAI agent tool binding is dynamic or unresolved and no explicit local inventory is declared.", evidence_fields=["surface", "explicit_inventory"], recommendation="Provide explicit MCP-style tool inventory metadata for dynamic CrewAI tool lists."),
+    CheckMetadata(id="SHIP-CREWAI-FUNCTION-TOOL-METADATA-MISSING", category="crewai", default_severity="medium", description="CrewAI function tool lacks static metadata.", rationale="Static review depends on descriptions and parameter schemas because user CrewAI code is not imported.", fires_when="A CrewAI @tool or BaseTool class lacks description or parameter metadata.", evidence_fields=["missing", "source_type"], recommendation="Add docstrings, descriptions, type annotations, args_schema, or explicit local inventory metadata."),
     CheckMetadata(id="SHIP-MANIFEST-STALE-SUPPRESSION", category="manifest", default_severity="medium", description="A suppression references a missing check or tool.", rationale="Stale suppressions hide intent and make release review harder to audit.", fires_when="checks.ignore contains an unknown check_id or a tool name that is not loaded.", evidence_fields=["check_id", "tool", "issues"], recommendation="Remove stale suppressions or update them to current check IDs and tool names."),
     CheckMetadata(id="SHIP-MANIFEST-STALE-POLICY", category="manifest", default_severity="medium", description="A policy references a missing tool.", rationale="Approval, confirmation, and idempotency policies should map to the actual release surface.", fires_when="A policy entry names a tool that is not loaded.", evidence_fields=["policy", "tool"], recommendation="Remove stale policy entries or update them to current tool names."),
     CheckMetadata(id="SHIP-MANIFEST-STALE-RISK-OVERRIDE", category="manifest", default_severity="medium", description="A risk override references a missing tool.", rationale="Risk overrides should not outlive the tool they describe.", fires_when="risk_overrides.tools contains a tool that is not loaded.", evidence_fields=["tool"], recommendation="Remove stale risk overrides or update them to current tool names."),

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -408,6 +408,25 @@ def doctor(
                 f"dynamic_toolsets={adk_surface.get('dynamic_toolset_count', 0)}, "
                 f"eval_files={adk_surface.get('eval_file_count', 0)}"
             )
+        if isinstance(frameworks, dict) and frameworks.get("langchain"):
+            langchain_surface = frameworks["langchain"]
+            typer.echo(
+                "LangChain artifacts: "
+                f"functions={langchain_surface.get('function_tool_count', 0)}, "
+                f"structured_tools={langchain_surface.get('structured_tool_count', 0)}, "
+                f"tool_nodes={langchain_surface.get('tool_node_count', 0)}, "
+                f"dynamic_surfaces={langchain_surface.get('dynamic_tool_surface_count', 0)}"
+            )
+        if isinstance(frameworks, dict) and frameworks.get("crewai"):
+            crewai_surface = frameworks["crewai"]
+            typer.echo(
+                "CrewAI artifacts: "
+                f"agents={crewai_surface.get('agent_count', 0)}, "
+                f"functions={crewai_surface.get('function_tool_count', 0)}, "
+                f"class_tools={crewai_surface.get('class_tool_count', 0)}, "
+                f"prebuilt_tools={crewai_surface.get('prebuilt_tool_count', 0)}, "
+                f"dynamic_surfaces={crewai_surface.get('dynamic_tool_surface_count', 0)}"
+            )
         if payload.get("baseline"):
             baseline = payload["baseline"]
             typer.echo(

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -23,7 +23,9 @@ from agents_shipgate.core.findings import (
 from agents_shipgate.core.models import (
     Agent,
     AnthropicArtifacts,
+    CrewAiArtifacts,
     GoogleAdkArtifacts,
+    LangChainArtifacts,
     LoadedToolSource,
     OpenAIApiArtifacts,
     ReadinessReport,
@@ -78,6 +80,8 @@ def run_scan(
     loaded_sources = _load_sources(manifest, base_dir, verbose=verbose)
     framework_result = load_framework_artifacts(manifest, base_dir)
     adk_artifacts = framework_result.adk_artifacts
+    langchain_artifacts = framework_result.langchain_artifacts
+    crewai_artifacts = framework_result.crewai_artifacts
     loaded_sources.extend(framework_result.loaded_sources)
     api_source, api_artifacts = load_openai_api_artifacts(manifest.openai_api, base_dir)
     if api_source:
@@ -102,12 +106,17 @@ def run_scan(
     warnings.extend(duplicate_warnings)
     if adk_artifacts:
         warnings.extend(adk_artifacts.warnings)
+    if langchain_artifacts:
+        warnings.extend(langchain_artifacts.warnings)
+    if crewai_artifacts:
+        warnings.extend(crewai_artifacts.warnings)
     policy_packs = load_policy_packs(
         manifest,
         base_dir,
         cli_policy_packs=policy_pack_paths,
     )
     warnings.extend(policy_packs.warnings)
+    warnings = list(dict.fromkeys(warnings))
     tools = enrich_tools_with_risk_hints(manifest, tools)
     logger.debug(
         "risk hints generated",
@@ -128,7 +137,13 @@ def run_scan(
             ]
         },
     )
-    agent = _build_agent(manifest, tools, api_artifacts, anthropic_artifacts, adk_artifacts)
+    agent = _build_agent(
+        manifest,
+        tools,
+        api_artifacts,
+        anthropic_artifacts,
+        adk_artifacts,
+    )
     context = ScanContext(
         manifest=manifest,
         agent=agent,
@@ -137,6 +152,8 @@ def run_scan(
         api_artifacts=api_artifacts,
         anthropic_artifacts=anthropic_artifacts,
         adk_artifacts=adk_artifacts,
+        langchain_artifacts=langchain_artifacts,
+        crewai_artifacts=crewai_artifacts,
     )
     loaded_plugins: list[dict[str, str | None]] = []
     findings = run_checks(
@@ -172,6 +189,11 @@ def run_scan(
     anthropic_surface = (
         anthropic_artifacts.surface_summary() if anthropic_artifacts else None
     )
+    frameworks_surface = _frameworks_surface(
+        adk_artifacts,
+        langchain_artifacts,
+        crewai_artifacts,
+    )
     report = build_report(
         run_id=_run_id(
             manifest,
@@ -179,7 +201,7 @@ def run_scan(
             findings,
             api_surface=api_artifacts.surface_summary() if api_artifacts else None,
             anthropic_surface=anthropic_surface,
-            frameworks=_frameworks_surface(adk_artifacts),
+            frameworks=frameworks_surface,
         ),
         manifest=manifest,
         agent=agent.model_dump(exclude_none=True),
@@ -195,7 +217,7 @@ def run_scan(
         source_warnings=warnings,
         api_surface=api_artifacts.surface_summary() if api_artifacts else None,
         anthropic_surface=anthropic_surface,
-        frameworks=_frameworks_surface(adk_artifacts),
+        frameworks=frameworks_surface,
         baseline=baseline_summary,
     )
     _write_reports(report, generated_paths, manifest.output.formats)
@@ -214,6 +236,8 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
     loaded_sources = _load_sources(manifest, base_dir, verbose=verbose)
     framework_result = load_framework_artifacts(manifest, base_dir)
     adk_artifacts = framework_result.adk_artifacts
+    langchain_artifacts = framework_result.langchain_artifacts
+    crewai_artifacts = framework_result.crewai_artifacts
     loaded_sources.extend(framework_result.loaded_sources)
     api_source, api_artifacts = load_openai_api_artifacts(manifest.openai_api, base_dir)
     if api_source:
@@ -228,8 +252,13 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
     warnings.extend(duplicate_warnings)
     if adk_artifacts:
         warnings.extend(adk_artifacts.warnings)
+    if langchain_artifacts:
+        warnings.extend(langchain_artifacts.warnings)
+    if crewai_artifacts:
+        warnings.extend(crewai_artifacts.warnings)
     policy_packs = load_policy_packs(manifest, base_dir)
     warnings.extend(policy_packs.warnings)
+    warnings = list(dict.fromkeys(warnings))
     return {
         "project": manifest.project.name,
         "agent": manifest.agent.name,
@@ -249,7 +278,11 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
         "anthropic_surface": (
             anthropic_artifacts.surface_summary() if anthropic_artifacts else None
         ),
-        "frameworks": _frameworks_surface(adk_artifacts),
+        "frameworks": _frameworks_surface(
+            adk_artifacts,
+            langchain_artifacts,
+            crewai_artifacts,
+        ),
         "policy_packs": [pack.model_dump(mode="json") for pack in policy_packs.loaded],
         "baseline": _default_baseline_status(base_dir),
         "warnings": warnings,
@@ -268,6 +301,9 @@ def _load_sources(manifest, base_dir: Path, *, verbose: bool) -> list[LoadedTool
                 loaded.append(load_openai_sdk_static_tools(source, manifest, base_dir))
             elif source.type == "google_adk":
                 # Google ADK sources are loaded with framework artifacts below.
+                continue
+            elif source.type in {"langchain", "crewai"}:
+                # Framework sources are loaded with framework artifacts below.
                 continue
         except InputParseError:
             if source.optional:
@@ -321,10 +357,17 @@ def _source_priority(tool: Tool) -> int:
         "anthropic_api": 40,
         "openapi": 30,
         "google_adk_inventory": 25,
+        "langchain_inventory": 25,
+        "crewai_inventory": 25,
         "mcp": 20,
         "google_adk_function": 10,
+        "langchain_function": 10,
+        "langchain_structured_tool": 10,
+        "crewai_function": 10,
+        "crewai_class_tool": 10,
         "sdk_function": 10,
         "google_adk_config": 5,
+        "crewai_prebuilt_tool": 5,
     }.get(tool.source_type, 0)
 
 
@@ -492,10 +535,17 @@ def _run_id(
 
 def _frameworks_surface(
     adk_artifacts: GoogleAdkArtifacts | None,
+    langchain_artifacts: LangChainArtifacts | None = None,
+    crewai_artifacts: CrewAiArtifacts | None = None,
 ) -> dict[str, object]:
-    if not adk_artifacts:
-        return {}
-    return {"google_adk": adk_artifacts.surface_summary()}
+    surface: dict[str, object] = {}
+    if adk_artifacts:
+        surface["google_adk"] = adk_artifacts.surface_summary()
+    if langchain_artifacts:
+        surface["langchain"] = langchain_artifacts.surface_summary()
+    if crewai_artifacts:
+        surface["crewai"] = crewai_artifacts.surface_summary()
+    return surface
 
 
 def _default_baseline_status(base_dir: Path) -> dict[str, object]:

--- a/src/agents_shipgate/cli/self_check.py
+++ b/src/agents_shipgate/cli/self_check.py
@@ -29,6 +29,8 @@ _DEFAULT_FIXTURES = (
     "clean_read_only_agent",
     "support_refund_agent",
     "google_adk_agent",
+    "simple_langchain_agent",
+    "simple_crewai_agent",
 )
 
 

--- a/src/agents_shipgate/config/schema.py
+++ b/src/agents_shipgate/config/schema.py
@@ -50,7 +50,14 @@ class ToolSourceConfig(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
     id: str
-    type: Literal["mcp", "openapi", "openai_agents_sdk", "google_adk"]
+    type: Literal[
+        "mcp",
+        "openapi",
+        "openai_agents_sdk",
+        "google_adk",
+        "langchain",
+        "crewai",
+    ]
     path: str | None = None
     trust: str | None = None
     mode: str | None = None
@@ -58,7 +65,7 @@ class ToolSourceConfig(BaseModel):
 
     @model_validator(mode="after")
     def require_path_when_needed(self) -> ToolSourceConfig:
-        if self.type in {"mcp", "openapi", "google_adk"} and not self.path:
+        if self.type in {"mcp", "openapi", "google_adk", "langchain", "crewai"} and not self.path:
             raise ValueError(f"tool source {self.id!r} requires path")
         return self
 
@@ -228,6 +235,36 @@ class GoogleAdkConfig(BaseModel):
         )
 
 
+class LangChainConfig(BaseModel):
+    model_config = STRICT_MODEL_CONFIG
+
+    python_entrypoints: list[ArtifactPathConfig] = Field(default_factory=list)
+    tool_inventories: list[ArtifactPathConfig] = Field(default_factory=list)
+
+    @field_validator("python_entrypoints", "tool_inventories", mode="before")
+    @classmethod
+    def parse_artifacts(cls, value: Any) -> list[ArtifactPathConfig]:
+        return _parse_artifact_entries(value)
+
+    def has_inputs(self) -> bool:
+        return any([self.python_entrypoints, self.tool_inventories])
+
+
+class CrewAiConfig(BaseModel):
+    model_config = STRICT_MODEL_CONFIG
+
+    python_entrypoints: list[ArtifactPathConfig] = Field(default_factory=list)
+    tool_inventories: list[ArtifactPathConfig] = Field(default_factory=list)
+
+    @field_validator("python_entrypoints", "tool_inventories", mode="before")
+    @classmethod
+    def parse_artifacts(cls, value: Any) -> list[ArtifactPathConfig]:
+        return _parse_artifact_entries(value)
+
+    def has_inputs(self) -> bool:
+        return any([self.python_entrypoints, self.tool_inventories])
+
+
 class PolicyToolEntry(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
@@ -384,6 +421,8 @@ class AgentsShipgateManifest(BaseModel):
     openai_api: OpenAIApiConfig | None = None
     anthropic: AnthropicConfig | None = None
     google_adk: GoogleAdkConfig | None = None
+    langchain: LangChainConfig | None = None
+    crewai: CrewAiConfig | None = None
     policies: PoliciesConfig = Field(default_factory=PoliciesConfig)
     permissions: PermissionsConfig = Field(default_factory=PermissionsConfig)
     risk_overrides: RiskOverridesConfig = Field(default_factory=RiskOverridesConfig)
@@ -398,15 +437,28 @@ class AgentsShipgateManifest(BaseModel):
             or self.google_adk is not None
             and self.google_adk.has_inputs()
         )
+        has_langchain = (
+            any(source.type == "langchain" for source in self.tool_sources)
+            or self.langchain is not None
+            and self.langchain.has_inputs()
+        )
+        has_crewai = (
+            any(source.type == "crewai" for source in self.tool_sources)
+            or self.crewai is not None
+            and self.crewai.has_inputs()
+        )
         has_anthropic = self.anthropic is not None and self.anthropic.has_inputs()
         if (
             not self.tool_sources
             and self.openai_api is None
             and not has_anthropic
             and not has_google_adk
+            and not has_langchain
+            and not has_crewai
         ):
             raise ValueError(
-                "At least one of tool_sources, openai_api, anthropic, or google_adk is required"
+                "At least one of tool_sources, openai_api, anthropic, google_adk, "
+                "langchain, or crewai is required"
             )
         if (
             not self.agent.declared_purpose
@@ -414,10 +466,13 @@ class AgentsShipgateManifest(BaseModel):
             and not (self.openai_api and self.openai_api.prompt_files)
             and not (self.anthropic and self.anthropic.prompt_files)
             and not has_google_adk
+            and not has_langchain
+            and not has_crewai
         ):
             raise ValueError(
                 "agent.declared_purpose, agent.instructions_preview, "
-                "openai_api.prompt_files, or anthropic.prompt_files is required"
+                "openai_api.prompt_files, anthropic.prompt_files, or framework "
+                "inputs are required"
             )
         return self
 

--- a/src/agents_shipgate/core/context.py
+++ b/src/agents_shipgate/core/context.py
@@ -7,7 +7,9 @@ from agents_shipgate.config.schema import AgentsShipgateManifest
 from agents_shipgate.core.models import (
     Agent,
     AnthropicArtifacts,
+    CrewAiArtifacts,
     GoogleAdkArtifacts,
+    LangChainArtifacts,
     OpenAIApiArtifacts,
     Tool,
 )
@@ -22,3 +24,5 @@ class ScanContext:
     api_artifacts: OpenAIApiArtifacts | None = None
     anthropic_artifacts: AnthropicArtifacts | None = None
     adk_artifacts: GoogleAdkArtifacts | None = None
+    langchain_artifacts: LangChainArtifacts | None = None
+    crewai_artifacts: CrewAiArtifacts | None = None

--- a/src/agents_shipgate/core/models.py
+++ b/src/agents_shipgate/core/models.py
@@ -340,6 +340,58 @@ class GoogleAdkArtifacts(BaseModel):
         }
 
 
+class LangChainArtifacts(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    python_entrypoints: list[str] = Field(default_factory=list)
+    tool_inventory_files: list[str] = Field(default_factory=list)
+    function_tools: list[dict[str, Any]] = Field(default_factory=list)
+    structured_tools: list[dict[str, Any]] = Field(default_factory=list)
+    tool_nodes: list[dict[str, Any]] = Field(default_factory=list)
+    agent_bindings: list[dict[str, Any]] = Field(default_factory=list)
+    dynamic_tool_surfaces: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    def surface_summary(self) -> dict[str, Any]:
+        return {
+            "python_entrypoint_count": len(self.python_entrypoints),
+            "function_tool_count": len(self.function_tools),
+            "structured_tool_count": len(self.structured_tools),
+            "tool_node_count": len(self.tool_nodes),
+            "agent_tool_binding_count": len(self.agent_bindings),
+            "dynamic_tool_surface_count": len(self.dynamic_tool_surfaces),
+            "tool_inventory_file_count": len(self.tool_inventory_files),
+            "warnings": self.warnings,
+        }
+
+
+class CrewAiArtifacts(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    python_entrypoints: list[str] = Field(default_factory=list)
+    tool_inventory_files: list[str] = Field(default_factory=list)
+    agents: list[dict[str, Any]] = Field(default_factory=list)
+    crews: list[dict[str, Any]] = Field(default_factory=list)
+    function_tools: list[dict[str, Any]] = Field(default_factory=list)
+    class_tools: list[dict[str, Any]] = Field(default_factory=list)
+    prebuilt_tools: list[dict[str, Any]] = Field(default_factory=list)
+    dynamic_tool_surfaces: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    def surface_summary(self) -> dict[str, Any]:
+        return {
+            "python_entrypoint_count": len(self.python_entrypoints),
+            "agent_count": len(self.agents),
+            "crew_count": len(self.crews),
+            "function_tool_count": len(self.function_tools),
+            "class_tool_count": len(self.class_tools),
+            "prebuilt_tool_count": len(self.prebuilt_tools),
+            "dynamic_tool_surface_count": len(self.dynamic_tool_surfaces),
+            "tool_inventory_file_count": len(self.tool_inventory_files),
+            "warnings": self.warnings,
+        }
+
+
 class LoadedPolicyPack(BaseModel):
     id: str
     name: str
@@ -352,7 +404,7 @@ class ReadinessReport(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     schema_version: str = "0.1"
-    report_schema_version: str = "0.4"
+    report_schema_version: str = "0.5"
     run_id: str
     project: dict[str, Any]
     agent: dict[str, Any]

--- a/src/agents_shipgate/core/risk_hints.py
+++ b/src/agents_shipgate/core/risk_hints.py
@@ -84,7 +84,15 @@ INFRASTRUCTURE_KEYWORDS = {
     "terraform",
 }
 
-_KEYWORD_GATED_SOURCE_TYPES = {"openai_api", "anthropic_api", "sdk_function"}
+_KEYWORD_GATED_SOURCE_TYPES = {
+    "openai_api",
+    "anthropic_api",
+    "sdk_function",
+    "langchain_function",
+    "langchain_structured_tool",
+    "crewai_function",
+    "crewai_class_tool",
+}
 
 
 def enrich_tools_with_risk_hints(

--- a/src/agents_shipgate/inputs/_python_framework.py
+++ b/src/agents_shipgate/inputs/_python_framework.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+from agents_shipgate.config.schema import ArtifactPathConfig, ToolSourceConfig
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool
+from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id
+from agents_shipgate.inputs.mcp import load_mcp_tools
+from agents_shipgate.inputs.python_static import (
+    display_path,
+    function_output_schema,
+    function_signature,
+    parse_python_file,
+)
+
+ExtractorFactory = Callable[[ast.Module, str, str, Any], Any]
+
+
+def load_python_framework_sources(
+    *,
+    source_refs: Iterable[ToolSourceConfig],
+    config: Any,
+    base_dir: Path,
+    framework_type: str,
+    framework_label: str,
+    inventory_source_type: str,
+    inventory_annotation: str,
+    artifacts: Any,
+    extractor_factory: ExtractorFactory,
+) -> list[LoadedToolSource]:
+    loaded_sources: list[LoadedToolSource] = []
+    for source in source_refs:
+        try:
+            loaded_sources.extend(
+                _load_framework_source(
+                    source,
+                    base_dir,
+                    framework_label=framework_label,
+                    framework_type=framework_type,
+                    artifacts=artifacts,
+                    extractor_factory=extractor_factory,
+                )
+            )
+        except InputParseError:
+            if not source.optional:
+                raise
+            warning = f"Optional {framework_label} source {source.id!r} failed to load."
+            artifacts.warnings.append(warning)
+            loaded_sources.append(
+                LoadedToolSource(
+                    source_id=source.id,
+                    source_type=framework_type,
+                    warnings=[warning],
+                )
+            )
+
+    if config:
+        for entrypoint in config.python_entrypoints:
+            loaded_sources.extend(
+                _load_python_ref(
+                    entrypoint,
+                    base_dir,
+                    source_id=f"{framework_type}:{entrypoint.path}",
+                    framework_label=framework_label,
+                    framework_type=framework_type,
+                    artifacts=artifacts,
+                    extractor_factory=extractor_factory,
+                )
+            )
+        for inventory in config.tool_inventories:
+            loaded = _load_inventory_ref(
+                inventory,
+                base_dir,
+                source_id=f"{inventory_source_type}:{inventory.path}",
+                framework_label=framework_label,
+                inventory_source_type=inventory_source_type,
+                inventory_annotation=inventory_annotation,
+                artifacts=artifacts,
+            )
+            if loaded:
+                loaded_sources.append(loaded)
+
+    artifacts.warnings = sorted(dict.fromkeys(artifacts.warnings))
+    artifacts.dynamic_tool_surfaces = sorted(
+        artifacts.dynamic_tool_surfaces,
+        key=lambda item: (
+            str(item.get("source_ref") or ""),
+            int(item.get("line") or 0),
+            str(item.get("reason") or ""),
+        ),
+    )
+    return loaded_sources
+
+
+def _load_framework_source(
+    source: ToolSourceConfig,
+    base_dir: Path,
+    *,
+    framework_label: str,
+    framework_type: str,
+    artifacts: Any,
+    extractor_factory: ExtractorFactory,
+) -> list[LoadedToolSource]:
+    assert source.path is not None
+    ref = ArtifactPathConfig(path=source.path, optional=source.optional)
+    path = resolve_existing_path(ref, base_dir)
+    if path.is_dir():
+        python_files = sorted(path.glob("*.py"))
+        if not python_files:
+            raise InputParseError(f"{framework_label} source directory has no Python files: {path}")
+        loaded: list[LoadedToolSource] = []
+        for python_file in python_files:
+            loaded.extend(
+                load_python_path(
+                    python_file,
+                    base_dir,
+                    source_id=source.id,
+                    framework_label=framework_label,
+                    framework_type=framework_type,
+                    artifacts=artifacts,
+                    extractor_factory=extractor_factory,
+                )
+            )
+        return loaded
+    if path.suffix.lower() != ".py":
+        raise InputParseError(f"{framework_label} source must be a Python file or directory: {path}")
+    return load_python_path(
+        path,
+        base_dir,
+        source_id=source.id,
+        framework_label=framework_label,
+        framework_type=framework_type,
+        artifacts=artifacts,
+        extractor_factory=extractor_factory,
+    )
+
+
+def _load_python_ref(
+    ref: ArtifactPathConfig,
+    base_dir: Path,
+    *,
+    source_id: str,
+    framework_label: str,
+    framework_type: str,
+    artifacts: Any,
+    extractor_factory: ExtractorFactory,
+) -> list[LoadedToolSource]:
+    try:
+        path = resolve_existing_path(ref, base_dir)
+    except InputParseError:
+        if not ref.optional:
+            raise
+        artifacts.warnings.append(
+            f"Optional {framework_label} Python entrypoint {ref.path!r} failed to load."
+        )
+        return []
+    return load_python_path(
+        path,
+        base_dir,
+        source_id=source_id,
+        framework_label=framework_label,
+        framework_type=framework_type,
+        artifacts=artifacts,
+        extractor_factory=extractor_factory,
+    )
+
+
+def load_python_path(
+    path: Path,
+    base_dir: Path,
+    *,
+    source_id: str,
+    framework_label: str,
+    framework_type: str,
+    artifacts: Any,
+    extractor_factory: ExtractorFactory,
+) -> list[LoadedToolSource]:
+    if path.is_dir():
+        loaded: list[LoadedToolSource] = []
+        for python_file in sorted(path.glob("*.py")):
+            loaded.extend(
+                load_python_path(
+                    python_file,
+                    base_dir,
+                    source_id=source_id,
+                    framework_label=framework_label,
+                    framework_type=framework_type,
+                    artifacts=artifacts,
+                    extractor_factory=extractor_factory,
+                )
+            )
+        return loaded
+    tree = parse_python_file(path, label=framework_label)
+    display = display_path(path, base_dir)
+    artifacts.python_entrypoints.append(display)
+    extractor = extractor_factory(tree, source_id, display, artifacts)
+    tools, warnings = extractor.extract()
+    return [
+        LoadedToolSource(
+            source_id=source_id,
+            source_type=framework_type,
+            tools=tools,
+            warnings=warnings,
+        )
+    ]
+
+
+def _load_inventory_ref(
+    ref: ArtifactPathConfig,
+    base_dir: Path,
+    *,
+    source_id: str,
+    framework_label: str,
+    inventory_source_type: str,
+    inventory_annotation: str,
+    artifacts: Any,
+) -> LoadedToolSource | None:
+    source = ToolSourceConfig(id=source_id, type="mcp", path=ref.path, optional=ref.optional)
+    try:
+        loaded = load_mcp_tools(source, base_dir)
+    except InputParseError:
+        if not ref.optional:
+            raise
+        artifacts.warnings.append(
+            f"Optional {framework_label} tool inventory {ref.path!r} failed to load."
+        )
+        return None
+    artifacts.tool_inventory_files.append(display_path(resolve_input_path(base_dir, ref.path), base_dir))
+    tools: list[Tool] = []
+    for original in loaded.tools:
+        tool = original.model_copy(deep=True)
+        tool.source_type = inventory_source_type
+        tool.annotations[inventory_annotation] = True
+        tool.extraction_confidence = "high"
+        tool.extraction["confidence"] = "high"
+        tools.append(tool)
+    return LoadedToolSource(
+        source_id=source_id,
+        source_type=inventory_source_type,
+        tools=tools,
+        warnings=loaded.warnings,
+    )
+
+
+def framework_function_tool(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    *,
+    framework: str,
+    auth_source: str,
+    name: str,
+    description: str | None,
+    input_schema: dict[str, Any],
+    parameters: list[Any],
+    source_id: str,
+    source_ref: str,
+    source_type: str,
+    extraction_method: str,
+) -> Tool:
+    return Tool(
+        id=stable_tool_id(name),
+        name=name,
+        description=description,
+        source_type=source_type,
+        source_id=source_id,
+        source_ref=source_ref,
+        source_location=f"{source_ref}:{node.lineno}",
+        input_schema=input_schema,
+        output_schema=function_output_schema(node),
+        parameters=parameters,
+        function_signature=function_signature(name, parameters, node),
+        annotations={"framework": framework},
+        auth=AuthInfo(source=auth_source),
+        extraction_confidence="medium",
+        extraction={"method": extraction_method, "confidence": "medium"},
+    )
+
+
+def assignment_call(node: ast.Assign | ast.AnnAssign) -> ast.Call | None:
+    value = assignment_value(node)
+    return value if isinstance(value, ast.Call) else None
+
+
+def assignment_value(node: ast.AST | None) -> ast.AST | None:
+    if isinstance(node, ast.Assign | ast.AnnAssign):
+        return node.value
+    return node
+
+
+def assignment_target(node: ast.Assign | ast.AnnAssign) -> str | None:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                return target.id
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def ordered_nodes(tree: ast.AST, node_types: tuple[type[Any], ...]) -> list[Any]:
+    return sorted(
+        (node for node in ast.walk(tree) if isinstance(node, node_types)),
+        key=lambda node: (getattr(node, "lineno", 0), getattr(node, "col_offset", 0)),
+    )
+
+
+def unique_tools(tools: Iterable[Tool]) -> list[Tool]:
+    unique: list[Tool] = []
+    seen: set[tuple[str, str | None]] = set()
+    for tool in tools:
+        key = (tool.name, tool.source_location)
+        if key in seen:
+            continue
+        unique.append(tool)
+        seen.add(key)
+    return unique
+
+
+def dynamic_reason(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return f"unresolved tool reference {node.id!r}"
+    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
+        return "tool list is built by a comprehension"
+    if isinstance(node, ast.Call):
+        return "tool list comes from a runtime call"
+    if isinstance(node, ast.List | ast.Tuple):
+        return "tool list contains unresolved or inline tool expressions"
+    return f"unsupported static tool expression {type(node).__name__}"
+
+
+def source_line(location: str | None) -> int | None:
+    if not location or ":" not in location:
+        return None
+    try:
+        return int(location.rsplit(":", 1)[1])
+    except ValueError:
+        return None
+
+
+def resolve_existing_path(ref: ArtifactPathConfig, base_dir: Path) -> Path:
+    path = resolve_input_path(base_dir, ref.path)
+    if not path.exists():
+        raise InputParseError(f"Input file not found: {path}")
+    return path

--- a/src/agents_shipgate/inputs/crewai.py
+++ b/src/agents_shipgate/inputs/crewai.py
@@ -1,0 +1,607 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from agents_shipgate.config.schema import (
+    AgentsShipgateManifest,
+    ArtifactPathConfig,
+    ToolSourceConfig,
+)
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.models import AuthInfo, CrewAiArtifacts, LoadedToolSource, Tool
+from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id, tool_name_warning
+from agents_shipgate.inputs.mcp import load_mcp_tools
+from agents_shipgate.inputs.python_static import (
+    display_path,
+    dotted_name,
+    first_string_arg,
+    function_input_schema,
+    function_output_schema,
+    function_parameters,
+    function_signature,
+    keyword,
+    keyword_name,
+    keyword_string,
+    last_name,
+    literal_string,
+    parse_python_file,
+    pydantic_model_schemas,
+)
+
+TOOL_DECORATOR_MODULES = {"crewai.tools"}
+
+
+def load_crewai_artifacts(
+    manifest: AgentsShipgateManifest,
+    base_dir: Path,
+) -> tuple[list[LoadedToolSource], CrewAiArtifacts | None]:
+    source_refs = [source for source in manifest.tool_sources if source.type == "crewai"]
+    config = manifest.crewai
+    if not source_refs and (config is None or not config.has_inputs()):
+        return [], None
+
+    artifacts = CrewAiArtifacts()
+    loaded_sources: list[LoadedToolSource] = []
+    for source in source_refs:
+        try:
+            loaded_sources.extend(_load_crewai_source(source, base_dir, artifacts))
+        except InputParseError:
+            if not source.optional:
+                raise
+            warning = f"Optional CrewAI source {source.id!r} failed to load."
+            artifacts.warnings.append(warning)
+            loaded_sources.append(
+                LoadedToolSource(source_id=source.id, source_type="crewai", warnings=[warning])
+            )
+
+    if config:
+        for entrypoint in config.python_entrypoints:
+            loaded_sources.extend(
+                _load_python_ref(
+                    entrypoint,
+                    base_dir,
+                    source_id=f"crewai:{entrypoint.path}",
+                    artifacts=artifacts,
+                )
+            )
+        for inventory in config.tool_inventories:
+            loaded = _load_inventory_ref(
+                inventory,
+                base_dir,
+                source_id=f"crewai_inventory:{inventory.path}",
+                artifacts=artifacts,
+            )
+            if loaded:
+                loaded_sources.append(loaded)
+
+    artifacts.warnings = sorted(dict.fromkeys(artifacts.warnings))
+    artifacts.dynamic_tool_surfaces = sorted(
+        artifacts.dynamic_tool_surfaces,
+        key=lambda item: (
+            str(item.get("source_ref") or ""),
+            int(item.get("line") or 0),
+            str(item.get("reason") or ""),
+        ),
+    )
+    return loaded_sources, artifacts
+
+
+def _load_crewai_source(
+    source: ToolSourceConfig,
+    base_dir: Path,
+    artifacts: CrewAiArtifacts,
+) -> list[LoadedToolSource]:
+    assert source.path is not None
+    ref = ArtifactPathConfig(path=source.path, optional=source.optional)
+    path = _resolve_existing_path(ref, base_dir)
+    if path.is_dir():
+        python_files = sorted(path.glob("*.py"))
+        if not python_files:
+            raise InputParseError(f"CrewAI source directory has no Python files: {path}")
+        loaded: list[LoadedToolSource] = []
+        for python_file in python_files:
+            loaded.extend(_load_python_path(python_file, base_dir, source.id, source.path, artifacts))
+        return loaded
+    if path.suffix.lower() != ".py":
+        raise InputParseError(f"CrewAI source must be a Python file or directory: {path}")
+    return _load_python_path(path, base_dir, source.id, source.path, artifacts)
+
+
+def _load_python_ref(
+    ref: ArtifactPathConfig,
+    base_dir: Path,
+    *,
+    source_id: str,
+    artifacts: CrewAiArtifacts,
+) -> list[LoadedToolSource]:
+    try:
+        path = _resolve_existing_path(ref, base_dir)
+    except InputParseError:
+        if not ref.optional:
+            raise
+        artifacts.warnings.append(f"Optional CrewAI Python entrypoint {ref.path!r} failed to load.")
+        return []
+    return _load_python_path(path, base_dir, source_id, ref.path, artifacts)
+
+
+def _load_python_path(
+    path: Path,
+    base_dir: Path,
+    source_id: str,
+    source_ref: str,
+    artifacts: CrewAiArtifacts,
+) -> list[LoadedToolSource]:
+    if path.is_dir():
+        loaded: list[LoadedToolSource] = []
+        for python_file in sorted(path.glob("*.py")):
+            loaded.extend(_load_python_path(python_file, base_dir, source_id, source_ref, artifacts))
+        return loaded
+    tree = parse_python_file(path, label="CrewAI")
+    display = display_path(path, base_dir)
+    artifacts.python_entrypoints.append(display)
+    extractor = _CrewAiExtractor(tree, source_id, display, artifacts)
+    tools, warnings = extractor.extract()
+    return [
+        LoadedToolSource(
+            source_id=source_id,
+            source_type="crewai",
+            tools=tools,
+            warnings=warnings,
+        )
+    ]
+
+
+def _load_inventory_ref(
+    ref: ArtifactPathConfig,
+    base_dir: Path,
+    *,
+    source_id: str,
+    artifacts: CrewAiArtifacts,
+) -> LoadedToolSource | None:
+    source = ToolSourceConfig(id=source_id, type="mcp", path=ref.path, optional=ref.optional)
+    try:
+        loaded = load_mcp_tools(source, base_dir)
+    except InputParseError:
+        if not ref.optional:
+            raise
+        artifacts.warnings.append(f"Optional CrewAI tool inventory {ref.path!r} failed to load.")
+        return None
+    artifacts.tool_inventory_files.append(display_path(resolve_input_path(base_dir, ref.path), base_dir))
+    loaded.source_type = "crewai_inventory"
+    for tool in loaded.tools:
+        tool.source_type = "crewai_inventory"
+        tool.annotations["crewai_inventory"] = True
+        tool.extraction_confidence = "high"
+        tool.extraction["confidence"] = "high"
+    return loaded
+
+
+class _CrewAiExtractor:
+    def __init__(
+        self,
+        tree: ast.Module,
+        source_id: str,
+        source_ref: str,
+        artifacts: CrewAiArtifacts,
+    ) -> None:
+        self.tree = tree
+        self.source_id = source_id
+        self.source_ref = source_ref
+        self.artifacts = artifacts
+        self.schemas = pydantic_model_schemas(tree)
+        self.tool_decorators = self._tool_decorator_names()
+        self.prebuilt_names = self._prebuilt_tool_names()
+        self.tool_vars: dict[str, Tool] = {}
+        self.list_vars: dict[str, list[str] | None] = {}
+        self.agent_vars: set[str] = set()
+        self.warnings: list[str] = []
+
+    def extract(self) -> tuple[list[Tool], list[str]]:
+        for node in _ordered_nodes(self.tree, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            self._record_decorated_tool(node)
+        for node in _ordered_nodes(self.tree, (ast.ClassDef,)):
+            self._record_class_tool(node)
+        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+            self._record_prebuilt_tool(node)
+        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+            self._record_list_assignment(node)
+        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+            self._record_agent_assignment(node)
+        for call in _ordered_nodes(self.tree, (ast.Call,)):
+            self._record_agent_or_crew(call)
+        warnings = sorted(dict.fromkeys(self.warnings))
+        self.artifacts.warnings.extend(warnings)
+        return _unique_tools(self.tool_vars.values()), warnings
+
+    def _tool_decorator_names(self) -> set[str]:
+        names = {"tool", "crewai.tools.tool"}
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ImportFrom) and node.module in TOOL_DECORATOR_MODULES:
+                for alias in node.names:
+                    if alias.name == "tool":
+                        names.add(alias.asname or alias.name)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in TOOL_DECORATOR_MODULES:
+                        names.add(f"{alias.asname or alias.name}.tool")
+        return names
+
+    def _prebuilt_tool_names(self) -> set[str]:
+        names: set[str] = set()
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "crewai_tools":
+                for alias in node.names:
+                    if alias.name.endswith("Tool"):
+                        names.add(alias.asname or alias.name)
+        return names
+
+    def _record_decorated_tool(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        decorator = self._tool_decorator(node)
+        if decorator is None:
+            return
+        tool_name = _decorator_tool_name(decorator) or node.name
+        input_schema, parameters = function_input_schema(
+            node,
+            schema=self._schema_for_call(decorator, getattr(decorator, "lineno", node.lineno)),
+        )
+        description = ast.get_docstring(node)
+        tool = _function_tool(
+            node,
+            name=tool_name,
+            description=description,
+            input_schema=input_schema,
+            parameters=parameters,
+            source_id=self.source_id,
+            source_ref=self.source_ref,
+            source_type="crewai_function",
+            extraction_method="crewai_tool_decorator_ast",
+        )
+        self._add_tool(node.name, tool, "function_tools")
+
+    def _tool_decorator(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.Call | ast.Name | None:
+        for decorator in node.decorator_list:
+            name = dotted_name(decorator.func) if isinstance(decorator, ast.Call) else dotted_name(decorator)
+            if name in self.tool_decorators:
+                return decorator
+        return None
+
+    def _record_class_tool(self, node: ast.ClassDef) -> None:
+        if not any(last_name(base) == "BaseTool" for base in node.bases):
+            return
+        name = _class_string_attr(node, "name") or node.name
+        description = _class_string_attr(node, "description") or ast.get_docstring(node)
+        schema_name = _class_name_attr(node, "args_schema")
+        schema = self.schemas.get(schema_name or "")
+        if schema_name and schema is None:
+            self._dynamic(
+                "args_schema",
+                node.lineno,
+                f"args_schema {schema_name!r} is not defined in the same file",
+            )
+        run_method = _class_method(node, "_run") or _class_method(node, "run")
+        if run_method:
+            input_schema, parameters = function_input_schema(run_method, schema=schema)
+            output_schema = function_output_schema(run_method)
+            signature = function_signature(name, parameters, run_method)
+        else:
+            input_schema = schema or {"type": "object", "properties": {}, "required": []}
+            parameters = function_parameters(node) if isinstance(node, ast.FunctionDef) else []
+            output_schema = {}
+            signature = f"{name}()"
+        tool = Tool(
+            id=stable_tool_id(name),
+            name=name,
+            description=description,
+            source_type="crewai_class_tool",
+            source_id=self.source_id,
+            source_ref=self.source_ref,
+            source_location=f"{self.source_ref}:{node.lineno}",
+            input_schema=input_schema,
+            output_schema=output_schema,
+            parameters=parameters,
+            function_signature=signature,
+            annotations={"framework": "crewai"},
+            auth=AuthInfo(source="crewai_static"),
+            extraction_confidence="medium",
+            extraction={"method": "crewai_base_tool_ast", "confidence": "medium"},
+        )
+        self._add_tool(node.name, tool, "class_tools")
+
+    def _record_prebuilt_tool(self, node: ast.Assign | ast.AnnAssign) -> None:
+        target = _assignment_target(node)
+        call = _assignment_call(node)
+        if target is None or call is None:
+            return
+        class_name = last_name(call.func)
+        if class_name in self.tool_vars and self.tool_vars[class_name].source_type == "crewai_class_tool":
+            self.tool_vars[target] = self.tool_vars[class_name]
+            return
+        if not self._is_prebuilt_tool_call(call):
+            return
+        name = last_name(call.func) or target
+        tool = self._prebuilt_tool(name, call.lineno)
+        self._add_tool(target, tool, "prebuilt_tools")
+        self.warnings.append(
+            f"CrewAI prebuilt tool {name!r} at {self.source_ref}:{call.lineno} "
+            "was recorded as low-confidence metadata; provide an explicit inventory "
+            "for full review."
+        )
+
+    def _record_list_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
+        target = _assignment_target(node)
+        value = _assignment_value(node)
+        if target is None or value is None:
+            return
+        names = self._resolve_tool_names(value)
+        if names is not None:
+            self.list_vars[target] = names
+        elif isinstance(value, ast.List | ast.Tuple):
+            self.list_vars[target] = None
+
+    def _record_agent_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
+        target = _assignment_target(node)
+        call = _assignment_call(node)
+        if target is None or call is None or last_name(call.func) != "Agent":
+            return
+        self.agent_vars.add(target)
+
+    def _record_agent_or_crew(self, call: ast.Call) -> None:
+        call_kind = last_name(call.func)
+        if call_kind == "Agent":
+            tools_expr = keyword(call, "tools")
+            names = self._resolve_tool_names(tools_expr) if tools_expr is not None else []
+            record = {"source_ref": self.source_ref, "line": call.lineno, "tools": names or []}
+            self.artifacts.agents.append(record)
+            if tools_expr is not None and names is None:
+                self._dynamic("agent", call.lineno, _dynamic_reason(tools_expr))
+        elif call_kind == "Crew":
+            agents_expr = keyword(call, "agents")
+            agents = _resolve_names(agents_expr) if agents_expr is not None else []
+            self.artifacts.crews.append(
+                {"source_ref": self.source_ref, "line": call.lineno, "agents": agents or []}
+            )
+
+    def _resolve_tool_names(self, node: ast.AST | None) -> list[str] | None:
+        if node is None:
+            return []
+        if isinstance(node, ast.Name):
+            if node.id in self.list_vars:
+                return self.list_vars[node.id]
+            if node.id in self.tool_vars:
+                return [self.tool_vars[node.id].name]
+            return None
+        if isinstance(node, ast.List | ast.Tuple):
+            names: list[str] = []
+            for element in node.elts:
+                if isinstance(element, ast.Name) and element.id in self.tool_vars:
+                    names.append(self.tool_vars[element.id].name)
+                    continue
+                if isinstance(element, ast.Call) and self._is_prebuilt_tool_call(element):
+                    name = last_name(element.func) or "CrewAI prebuilt tool"
+                    inline_name = f"{name}@{element.lineno}"
+                    tool = self._prebuilt_tool(name, element.lineno)
+                    self.tool_vars[inline_name] = tool
+                    self.artifacts.prebuilt_tools.append(
+                        {"name": tool.name, "source_ref": self.source_ref, "line": element.lineno}
+                    )
+                    self.warnings.append(
+                        f"CrewAI prebuilt tool {name!r} at {self.source_ref}:{element.lineno} "
+                        "was recorded as low-confidence metadata; provide an explicit "
+                        "inventory for full review."
+                    )
+                    names.append(name)
+                    continue
+                return None
+            return names
+        return None
+
+    def _is_prebuilt_tool_call(self, call: ast.Call) -> bool:
+        name = dotted_name(call.func) or ""
+        return (
+            name in self.prebuilt_names
+            or name.startswith("crewai_tools.")
+            or last_name(call.func) in self.prebuilt_names
+        )
+
+    def _schema_for_call(self, call: ast.Call | ast.Name, line: int) -> dict[str, Any] | None:
+        if not isinstance(call, ast.Call):
+            return None
+        schema_name = keyword_name(call, "args_schema")
+        if not schema_name:
+            return None
+        schema = self.schemas.get(schema_name)
+        if schema is None:
+            self._dynamic(
+                "args_schema",
+                line,
+                f"args_schema {schema_name!r} is not defined in the same file",
+            )
+        return schema
+
+    def _prebuilt_tool(self, name: str, line: int) -> Tool:
+        return Tool(
+            id=stable_tool_id(name),
+            name=name,
+            description=(
+                f"CrewAI prebuilt tool {name}. Static reference only; provide an "
+                "explicit inventory for full metadata."
+            ),
+            source_type="crewai_prebuilt_tool",
+            source_id=self.source_id,
+            source_ref=self.source_ref,
+            source_location=f"{self.source_ref}:{line}",
+            annotations={"framework": "crewai", "prebuilt_tool": True},
+            auth=AuthInfo(source="crewai_static"),
+            extraction_confidence="low",
+            extraction={"method": "crewai_prebuilt_tool_reference", "confidence": "low"},
+        )
+
+    def _add_tool(self, variable_name: str, tool: Tool, artifact_field: str) -> None:
+        if warning := tool_name_warning(tool.name):
+            self.warnings.append(warning)
+        self.tool_vars[variable_name] = tool
+        getattr(self.artifacts, artifact_field).append(
+            {"name": tool.name, "source_ref": self.source_ref, "line": _line(tool.source_location)}
+        )
+
+    def _dynamic(self, kind: str, line: int, reason: str) -> None:
+        surface = {"kind": kind, "source_ref": self.source_ref, "line": line, "reason": reason}
+        self.artifacts.dynamic_tool_surfaces.append(surface)
+        self.warnings.append(
+            f"CrewAI {kind} at {self.source_ref}:{line} has dynamic tool surface: {reason}."
+        )
+
+
+def _function_tool(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    *,
+    name: str,
+    description: str | None,
+    input_schema: dict[str, Any],
+    parameters: list[Any],
+    source_id: str,
+    source_ref: str,
+    source_type: str,
+    extraction_method: str,
+) -> Tool:
+    return Tool(
+        id=stable_tool_id(name),
+        name=name,
+        description=description,
+        source_type=source_type,
+        source_id=source_id,
+        source_ref=source_ref,
+        source_location=f"{source_ref}:{node.lineno}",
+        input_schema=input_schema,
+        output_schema=function_output_schema(node),
+        parameters=parameters,
+        function_signature=function_signature(name, parameters, node),
+        annotations={"framework": "crewai"},
+        auth=AuthInfo(source="crewai_static"),
+        extraction_confidence="medium",
+        extraction={"method": extraction_method, "confidence": "medium"},
+    )
+
+
+def _decorator_tool_name(decorator: ast.Call | ast.Name) -> str | None:
+    if isinstance(decorator, ast.Call):
+        return first_string_arg(decorator) or keyword_string(decorator, "name")
+    return None
+
+
+def _class_string_attr(node: ast.ClassDef, attr_name: str) -> str | None:
+    for statement in node.body:
+        target = _simple_assignment_name(statement)
+        if target != attr_name:
+            continue
+        if value := literal_string(_assignment_value(statement)):
+            return value
+    return None
+
+
+def _class_name_attr(node: ast.ClassDef, attr_name: str) -> str | None:
+    for statement in node.body:
+        target = _simple_assignment_name(statement)
+        if target == attr_name:
+            return dotted_name(_assignment_value(statement))
+    return None
+
+
+def _class_method(node: ast.ClassDef, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for statement in node.body:
+        if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef) and statement.name == name:
+            return statement
+    return None
+
+
+def _simple_assignment_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                return target.id
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def _assignment_call(node: ast.Assign | ast.AnnAssign) -> ast.Call | None:
+    value = _assignment_value(node)
+    return value if isinstance(value, ast.Call) else None
+
+
+def _assignment_value(node: ast.AST | None) -> ast.AST | None:
+    if isinstance(node, ast.Assign | ast.AnnAssign):
+        return node.value
+    return node
+
+
+def _assignment_target(node: ast.Assign | ast.AnnAssign) -> str | None:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                return target.id
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def _ordered_nodes(tree: ast.AST, node_types: tuple[type[Any], ...]) -> list[Any]:
+    return sorted(
+        (node for node in ast.walk(tree) if isinstance(node, node_types)),
+        key=lambda node: (getattr(node, "lineno", 0), getattr(node, "col_offset", 0)),
+    )
+
+
+def _resolve_names(node: ast.AST | None) -> list[str] | None:
+    if isinstance(node, ast.List | ast.Tuple):
+        names: list[str] = []
+        for element in node.elts:
+            if not isinstance(element, ast.Name):
+                return None
+            names.append(element.id)
+        return names
+    if isinstance(node, ast.Name):
+        return [node.id]
+    return None
+
+
+def _unique_tools(tools: Any) -> list[Tool]:
+    unique: list[Tool] = []
+    seen: set[tuple[str, str | None]] = set()
+    for tool in tools:
+        key = (tool.name, tool.source_location)
+        if key in seen:
+            continue
+        unique.append(tool)
+        seen.add(key)
+    return unique
+
+
+def _dynamic_reason(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return f"unresolved tool reference {node.id!r}"
+    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
+        return "tool list is built by a comprehension"
+    if isinstance(node, ast.Call):
+        return "tool list comes from a runtime call"
+    if isinstance(node, ast.List | ast.Tuple):
+        return "tool list contains unresolved or inline tool expressions"
+    return f"unsupported static tool expression {type(node).__name__}"
+
+
+def _line(location: str | None) -> int | None:
+    if not location or ":" not in location:
+        return None
+    try:
+        return int(location.rsplit(":", 1)[1])
+    except ValueError:
+        return None
+
+
+def _resolve_existing_path(ref: ArtifactPathConfig, base_dir: Path) -> Path:
+    path = resolve_input_path(base_dir, ref.path)
+    if not path.exists():
+        raise InputParseError(f"Input file not found: {path}")
+    return path

--- a/src/agents_shipgate/inputs/crewai.py
+++ b/src/agents_shipgate/inputs/crewai.py
@@ -4,18 +4,23 @@ import ast
 from pathlib import Path
 from typing import Any
 
-from agents_shipgate.config.schema import (
-    AgentsShipgateManifest,
-    ArtifactPathConfig,
-    ToolSourceConfig,
-)
-from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.config.schema import AgentsShipgateManifest
 from agents_shipgate.core.models import AuthInfo, CrewAiArtifacts, LoadedToolSource, Tool
-from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id, tool_name_warning
-from agents_shipgate.inputs.mcp import load_mcp_tools
+from agents_shipgate.inputs._python_framework import (
+    assignment_call,
+    assignment_target,
+    assignment_value,
+    dynamic_reason,
+    framework_function_tool,
+    load_python_framework_sources,
+    ordered_nodes,
+    source_line,
+    unique_tools,
+)
+from agents_shipgate.inputs.common import stable_tool_id, tool_name_warning
 from agents_shipgate.inputs.python_static import (
-    display_path,
     dotted_name,
+    field_default_string,
     first_string_arg,
     function_input_schema,
     function_output_schema,
@@ -26,7 +31,6 @@ from agents_shipgate.inputs.python_static import (
     keyword_string,
     last_name,
     literal_string,
-    parse_python_file,
     pydantic_model_schemas,
 )
 
@@ -43,139 +47,18 @@ def load_crewai_artifacts(
         return [], None
 
     artifacts = CrewAiArtifacts()
-    loaded_sources: list[LoadedToolSource] = []
-    for source in source_refs:
-        try:
-            loaded_sources.extend(_load_crewai_source(source, base_dir, artifacts))
-        except InputParseError:
-            if not source.optional:
-                raise
-            warning = f"Optional CrewAI source {source.id!r} failed to load."
-            artifacts.warnings.append(warning)
-            loaded_sources.append(
-                LoadedToolSource(source_id=source.id, source_type="crewai", warnings=[warning])
-            )
-
-    if config:
-        for entrypoint in config.python_entrypoints:
-            loaded_sources.extend(
-                _load_python_ref(
-                    entrypoint,
-                    base_dir,
-                    source_id=f"crewai:{entrypoint.path}",
-                    artifacts=artifacts,
-                )
-            )
-        for inventory in config.tool_inventories:
-            loaded = _load_inventory_ref(
-                inventory,
-                base_dir,
-                source_id=f"crewai_inventory:{inventory.path}",
-                artifacts=artifacts,
-            )
-            if loaded:
-                loaded_sources.append(loaded)
-
-    artifacts.warnings = sorted(dict.fromkeys(artifacts.warnings))
-    artifacts.dynamic_tool_surfaces = sorted(
-        artifacts.dynamic_tool_surfaces,
-        key=lambda item: (
-            str(item.get("source_ref") or ""),
-            int(item.get("line") or 0),
-            str(item.get("reason") or ""),
-        ),
+    loaded_sources = load_python_framework_sources(
+        source_refs=source_refs,
+        config=config,
+        base_dir=base_dir,
+        framework_type="crewai",
+        framework_label="CrewAI",
+        inventory_source_type="crewai_inventory",
+        inventory_annotation="crewai_inventory",
+        artifacts=artifacts,
+        extractor_factory=_CrewAiExtractor,
     )
     return loaded_sources, artifacts
-
-
-def _load_crewai_source(
-    source: ToolSourceConfig,
-    base_dir: Path,
-    artifacts: CrewAiArtifacts,
-) -> list[LoadedToolSource]:
-    assert source.path is not None
-    ref = ArtifactPathConfig(path=source.path, optional=source.optional)
-    path = _resolve_existing_path(ref, base_dir)
-    if path.is_dir():
-        python_files = sorted(path.glob("*.py"))
-        if not python_files:
-            raise InputParseError(f"CrewAI source directory has no Python files: {path}")
-        loaded: list[LoadedToolSource] = []
-        for python_file in python_files:
-            loaded.extend(_load_python_path(python_file, base_dir, source.id, source.path, artifacts))
-        return loaded
-    if path.suffix.lower() != ".py":
-        raise InputParseError(f"CrewAI source must be a Python file or directory: {path}")
-    return _load_python_path(path, base_dir, source.id, source.path, artifacts)
-
-
-def _load_python_ref(
-    ref: ArtifactPathConfig,
-    base_dir: Path,
-    *,
-    source_id: str,
-    artifacts: CrewAiArtifacts,
-) -> list[LoadedToolSource]:
-    try:
-        path = _resolve_existing_path(ref, base_dir)
-    except InputParseError:
-        if not ref.optional:
-            raise
-        artifacts.warnings.append(f"Optional CrewAI Python entrypoint {ref.path!r} failed to load.")
-        return []
-    return _load_python_path(path, base_dir, source_id, ref.path, artifacts)
-
-
-def _load_python_path(
-    path: Path,
-    base_dir: Path,
-    source_id: str,
-    source_ref: str,
-    artifacts: CrewAiArtifacts,
-) -> list[LoadedToolSource]:
-    if path.is_dir():
-        loaded: list[LoadedToolSource] = []
-        for python_file in sorted(path.glob("*.py")):
-            loaded.extend(_load_python_path(python_file, base_dir, source_id, source_ref, artifacts))
-        return loaded
-    tree = parse_python_file(path, label="CrewAI")
-    display = display_path(path, base_dir)
-    artifacts.python_entrypoints.append(display)
-    extractor = _CrewAiExtractor(tree, source_id, display, artifacts)
-    tools, warnings = extractor.extract()
-    return [
-        LoadedToolSource(
-            source_id=source_id,
-            source_type="crewai",
-            tools=tools,
-            warnings=warnings,
-        )
-    ]
-
-
-def _load_inventory_ref(
-    ref: ArtifactPathConfig,
-    base_dir: Path,
-    *,
-    source_id: str,
-    artifacts: CrewAiArtifacts,
-) -> LoadedToolSource | None:
-    source = ToolSourceConfig(id=source_id, type="mcp", path=ref.path, optional=ref.optional)
-    try:
-        loaded = load_mcp_tools(source, base_dir)
-    except InputParseError:
-        if not ref.optional:
-            raise
-        artifacts.warnings.append(f"Optional CrewAI tool inventory {ref.path!r} failed to load.")
-        return None
-    artifacts.tool_inventory_files.append(display_path(resolve_input_path(base_dir, ref.path), base_dir))
-    loaded.source_type = "crewai_inventory"
-    for tool in loaded.tools:
-        tool.source_type = "crewai_inventory"
-        tool.annotations["crewai_inventory"] = True
-        tool.extraction_confidence = "high"
-        tool.extraction["confidence"] = "high"
-    return loaded
 
 
 class _CrewAiExtractor:
@@ -194,26 +77,27 @@ class _CrewAiExtractor:
         self.tool_decorators = self._tool_decorator_names()
         self.prebuilt_names = self._prebuilt_tool_names()
         self.tool_vars: dict[str, Tool] = {}
+        self.discovered_tools: list[Tool] = []
         self.list_vars: dict[str, list[str] | None] = {}
         self.agent_vars: set[str] = set()
         self.warnings: list[str] = []
 
     def extract(self) -> tuple[list[Tool], list[str]]:
-        for node in _ordered_nodes(self.tree, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        for node in ordered_nodes(self.tree, (ast.FunctionDef, ast.AsyncFunctionDef)):
             self._record_decorated_tool(node)
-        for node in _ordered_nodes(self.tree, (ast.ClassDef,)):
+        for node in ordered_nodes(self.tree, (ast.ClassDef,)):
             self._record_class_tool(node)
-        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+        for node in ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
             self._record_prebuilt_tool(node)
-        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+        for node in ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
             self._record_list_assignment(node)
-        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+        for node in ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
             self._record_agent_assignment(node)
-        for call in _ordered_nodes(self.tree, (ast.Call,)):
+        for call in ordered_nodes(self.tree, (ast.Call,)):
             self._record_agent_or_crew(call)
         warnings = sorted(dict.fromkeys(self.warnings))
         self.artifacts.warnings.extend(warnings)
-        return _unique_tools(self.tool_vars.values()), warnings
+        return unique_tools(self.discovered_tools), warnings
 
     def _tool_decorator_names(self) -> set[str]:
         names = {"tool", "crewai.tools.tool"}
@@ -310,8 +194,8 @@ class _CrewAiExtractor:
         self._add_tool(node.name, tool, "class_tools")
 
     def _record_prebuilt_tool(self, node: ast.Assign | ast.AnnAssign) -> None:
-        target = _assignment_target(node)
-        call = _assignment_call(node)
+        target = assignment_target(node)
+        call = assignment_call(node)
         if target is None or call is None:
             return
         class_name = last_name(call.func)
@@ -330,8 +214,8 @@ class _CrewAiExtractor:
         )
 
     def _record_list_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
-        target = _assignment_target(node)
-        value = _assignment_value(node)
+        target = assignment_target(node)
+        value = assignment_value(node)
         if target is None or value is None:
             return
         names = self._resolve_tool_names(value)
@@ -341,8 +225,8 @@ class _CrewAiExtractor:
             self.list_vars[target] = None
 
     def _record_agent_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
-        target = _assignment_target(node)
-        call = _assignment_call(node)
+        target = assignment_target(node)
+        call = assignment_call(node)
         if target is None or call is None or last_name(call.func) != "Agent":
             return
         self.agent_vars.add(target)
@@ -355,7 +239,7 @@ class _CrewAiExtractor:
             record = {"source_ref": self.source_ref, "line": call.lineno, "tools": names or []}
             self.artifacts.agents.append(record)
             if tools_expr is not None and names is None:
-                self._dynamic("agent", call.lineno, _dynamic_reason(tools_expr))
+                self._dynamic("agent", call.lineno, dynamic_reason(tools_expr))
         elif call_kind == "Crew":
             agents_expr = keyword(call, "agents")
             agents = _resolve_names(agents_expr) if agents_expr is not None else []
@@ -383,6 +267,9 @@ class _CrewAiExtractor:
                     inline_name = f"{name}@{element.lineno}"
                     tool = self._prebuilt_tool(name, element.lineno)
                     self.tool_vars[inline_name] = tool
+                    self.discovered_tools.append(tool)
+                    # Record every inline occurrence for counts; warning text is
+                    # deduped later so repeated prebuilt uses do not spam reports.
                     self.artifacts.prebuilt_tools.append(
                         {"name": tool.name, "source_ref": self.source_ref, "line": element.lineno}
                     )
@@ -441,9 +328,20 @@ class _CrewAiExtractor:
     def _add_tool(self, variable_name: str, tool: Tool, artifact_field: str) -> None:
         if warning := tool_name_warning(tool.name):
             self.warnings.append(warning)
+        existing = self.tool_vars.get(variable_name)
+        if existing and existing.source_location != tool.source_location:
+            self._dynamic(
+                "tool_shadowing",
+                source_line(tool.source_location) or 0,
+                (
+                    f"tool variable {variable_name!r} is reassigned from "
+                    f"{existing.name!r} to {tool.name!r}"
+                ),
+            )
         self.tool_vars[variable_name] = tool
+        self.discovered_tools.append(tool)
         getattr(self.artifacts, artifact_field).append(
-            {"name": tool.name, "source_ref": self.source_ref, "line": _line(tool.source_location)}
+            {"name": tool.name, "source_ref": self.source_ref, "line": source_line(tool.source_location)}
         )
 
     def _dynamic(self, kind: str, line: int, reason: str) -> None:
@@ -466,22 +364,18 @@ def _function_tool(
     source_type: str,
     extraction_method: str,
 ) -> Tool:
-    return Tool(
-        id=stable_tool_id(name),
+    return framework_function_tool(
+        node,
+        framework="crewai",
+        auth_source="crewai_static",
         name=name,
         description=description,
-        source_type=source_type,
+        input_schema=input_schema,
+        parameters=parameters,
         source_id=source_id,
         source_ref=source_ref,
-        source_location=f"{source_ref}:{node.lineno}",
-        input_schema=input_schema,
-        output_schema=function_output_schema(node),
-        parameters=parameters,
-        function_signature=function_signature(name, parameters, node),
-        annotations={"framework": "crewai"},
-        auth=AuthInfo(source="crewai_static"),
-        extraction_confidence="medium",
-        extraction={"method": extraction_method, "confidence": "medium"},
+        source_type=source_type,
+        extraction_method=extraction_method,
     )
 
 
@@ -496,7 +390,10 @@ def _class_string_attr(node: ast.ClassDef, attr_name: str) -> str | None:
         target = _simple_assignment_name(statement)
         if target != attr_name:
             continue
-        if value := literal_string(_assignment_value(statement)):
+        value_node = assignment_value(statement)
+        if value := literal_string(value_node):
+            return value
+        if value := field_default_string(value_node):
             return value
     return None
 
@@ -505,7 +402,7 @@ def _class_name_attr(node: ast.ClassDef, attr_name: str) -> str | None:
     for statement in node.body:
         target = _simple_assignment_name(statement)
         if target == attr_name:
-            return dotted_name(_assignment_value(statement))
+            return dotted_name(assignment_value(statement))
     return None
 
 
@@ -526,34 +423,6 @@ def _simple_assignment_name(node: ast.AST) -> str | None:
     return None
 
 
-def _assignment_call(node: ast.Assign | ast.AnnAssign) -> ast.Call | None:
-    value = _assignment_value(node)
-    return value if isinstance(value, ast.Call) else None
-
-
-def _assignment_value(node: ast.AST | None) -> ast.AST | None:
-    if isinstance(node, ast.Assign | ast.AnnAssign):
-        return node.value
-    return node
-
-
-def _assignment_target(node: ast.Assign | ast.AnnAssign) -> str | None:
-    if isinstance(node, ast.Assign):
-        for target in node.targets:
-            if isinstance(target, ast.Name):
-                return target.id
-    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-        return node.target.id
-    return None
-
-
-def _ordered_nodes(tree: ast.AST, node_types: tuple[type[Any], ...]) -> list[Any]:
-    return sorted(
-        (node for node in ast.walk(tree) if isinstance(node, node_types)),
-        key=lambda node: (getattr(node, "lineno", 0), getattr(node, "col_offset", 0)),
-    )
-
-
 def _resolve_names(node: ast.AST | None) -> list[str] | None:
     if isinstance(node, ast.List | ast.Tuple):
         names: list[str] = []
@@ -565,43 +434,3 @@ def _resolve_names(node: ast.AST | None) -> list[str] | None:
     if isinstance(node, ast.Name):
         return [node.id]
     return None
-
-
-def _unique_tools(tools: Any) -> list[Tool]:
-    unique: list[Tool] = []
-    seen: set[tuple[str, str | None]] = set()
-    for tool in tools:
-        key = (tool.name, tool.source_location)
-        if key in seen:
-            continue
-        unique.append(tool)
-        seen.add(key)
-    return unique
-
-
-def _dynamic_reason(node: ast.AST) -> str:
-    if isinstance(node, ast.Name):
-        return f"unresolved tool reference {node.id!r}"
-    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
-        return "tool list is built by a comprehension"
-    if isinstance(node, ast.Call):
-        return "tool list comes from a runtime call"
-    if isinstance(node, ast.List | ast.Tuple):
-        return "tool list contains unresolved or inline tool expressions"
-    return f"unsupported static tool expression {type(node).__name__}"
-
-
-def _line(location: str | None) -> int | None:
-    if not location or ":" not in location:
-        return None
-    try:
-        return int(location.rsplit(":", 1)[1])
-    except ValueError:
-        return None
-
-
-def _resolve_existing_path(ref: ArtifactPathConfig, base_dir: Path) -> Path:
-    path = resolve_input_path(base_dir, ref.path)
-    if not path.exists():
-        raise InputParseError(f"Input file not found: {path}")
-    return path

--- a/src/agents_shipgate/inputs/frameworks.py
+++ b/src/agents_shipgate/inputs/frameworks.py
@@ -4,14 +4,23 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from agents_shipgate.config.schema import AgentsShipgateManifest
-from agents_shipgate.core.models import GoogleAdkArtifacts, LoadedToolSource
+from agents_shipgate.core.models import (
+    CrewAiArtifacts,
+    GoogleAdkArtifacts,
+    LangChainArtifacts,
+    LoadedToolSource,
+)
+from agents_shipgate.inputs.crewai import load_crewai_artifacts
 from agents_shipgate.inputs.google_adk import load_google_adk_artifacts
+from agents_shipgate.inputs.langchain import load_langchain_artifacts
 
 
 @dataclass(frozen=True)
 class FrameworkLoadResult:
     loaded_sources: list[LoadedToolSource]
     adk_artifacts: GoogleAdkArtifacts | None = None
+    langchain_artifacts: LangChainArtifacts | None = None
+    crewai_artifacts: CrewAiArtifacts | None = None
 
 
 def load_framework_artifacts(
@@ -19,4 +28,11 @@ def load_framework_artifacts(
     base_dir: Path,
 ) -> FrameworkLoadResult:
     adk_sources, adk_artifacts = load_google_adk_artifacts(manifest, base_dir)
-    return FrameworkLoadResult(loaded_sources=adk_sources, adk_artifacts=adk_artifacts)
+    langchain_sources, langchain_artifacts = load_langchain_artifacts(manifest, base_dir)
+    crewai_sources, crewai_artifacts = load_crewai_artifacts(manifest, base_dir)
+    return FrameworkLoadResult(
+        loaded_sources=[*adk_sources, *langchain_sources, *crewai_sources],
+        adk_artifacts=adk_artifacts,
+        langchain_artifacts=langchain_artifacts,
+        crewai_artifacts=crewai_artifacts,
+    )

--- a/src/agents_shipgate/inputs/langchain.py
+++ b/src/agents_shipgate/inputs/langchain.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from agents_shipgate.config.schema import (
+    AgentsShipgateManifest,
+    ArtifactPathConfig,
+    ToolSourceConfig,
+)
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.models import AuthInfo, LangChainArtifacts, LoadedToolSource, Tool
+from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id, tool_name_warning
+from agents_shipgate.inputs.mcp import load_mcp_tools
+from agents_shipgate.inputs.python_static import (
+    display_path,
+    dotted_name,
+    first_string_arg,
+    function_input_schema,
+    function_output_schema,
+    function_signature,
+    keyword,
+    keyword_name,
+    keyword_string,
+    last_name,
+    parse_python_file,
+    pydantic_model_schemas,
+)
+
+TOOL_DECORATOR_MODULES = {"langchain.tools", "langchain_core.tools"}
+STRUCTURED_TOOL_NAMES = {
+    "StructuredTool",
+    "langchain.tools.StructuredTool",
+    "langchain_core.tools.StructuredTool",
+}
+AGENT_BINDING_CALLS = {"create_agent", "create_react_agent"}
+
+
+def load_langchain_artifacts(
+    manifest: AgentsShipgateManifest,
+    base_dir: Path,
+) -> tuple[list[LoadedToolSource], LangChainArtifacts | None]:
+    source_refs = [source for source in manifest.tool_sources if source.type == "langchain"]
+    config = manifest.langchain
+    if not source_refs and (config is None or not config.has_inputs()):
+        return [], None
+
+    artifacts = LangChainArtifacts()
+    loaded_sources: list[LoadedToolSource] = []
+    for source in source_refs:
+        try:
+            loaded_sources.extend(_load_langchain_source(source, base_dir, artifacts))
+        except InputParseError:
+            if not source.optional:
+                raise
+            warning = f"Optional LangChain source {source.id!r} failed to load."
+            artifacts.warnings.append(warning)
+            loaded_sources.append(
+                LoadedToolSource(source_id=source.id, source_type="langchain", warnings=[warning])
+            )
+
+    if config:
+        for entrypoint in config.python_entrypoints:
+            loaded_sources.extend(
+                _load_python_ref(
+                    entrypoint,
+                    base_dir,
+                    source_id=f"langchain:{entrypoint.path}",
+                    artifacts=artifacts,
+                )
+            )
+        for inventory in config.tool_inventories:
+            loaded = _load_inventory_ref(
+                inventory,
+                base_dir,
+                source_id=f"langchain_inventory:{inventory.path}",
+                artifacts=artifacts,
+            )
+            if loaded:
+                loaded_sources.append(loaded)
+
+    artifacts.warnings = sorted(dict.fromkeys(artifacts.warnings))
+    artifacts.dynamic_tool_surfaces = sorted(
+        artifacts.dynamic_tool_surfaces,
+        key=lambda item: (str(item.get("source_ref") or ""), int(item.get("line") or 0), str(item.get("reason") or "")),
+    )
+    return loaded_sources, artifacts
+
+
+def _load_langchain_source(
+    source: ToolSourceConfig,
+    base_dir: Path,
+    artifacts: LangChainArtifacts,
+) -> list[LoadedToolSource]:
+    assert source.path is not None
+    ref = ArtifactPathConfig(path=source.path, optional=source.optional)
+    path = _resolve_existing_path(ref, base_dir)
+    if path.is_dir():
+        python_files = sorted(path.glob("*.py"))
+        if not python_files:
+            raise InputParseError(f"LangChain source directory has no Python files: {path}")
+        loaded: list[LoadedToolSource] = []
+        for python_file in python_files:
+            loaded.extend(_load_python_path(python_file, base_dir, source.id, source.path, artifacts))
+        return loaded
+    if path.suffix.lower() != ".py":
+        raise InputParseError(f"LangChain source must be a Python file or directory: {path}")
+    return _load_python_path(path, base_dir, source.id, source.path, artifacts)
+
+
+def _load_python_ref(
+    ref: ArtifactPathConfig,
+    base_dir: Path,
+    *,
+    source_id: str,
+    artifacts: LangChainArtifacts,
+) -> list[LoadedToolSource]:
+    try:
+        path = _resolve_existing_path(ref, base_dir)
+    except InputParseError:
+        if not ref.optional:
+            raise
+        artifacts.warnings.append(f"Optional LangChain Python entrypoint {ref.path!r} failed to load.")
+        return []
+    return _load_python_path(path, base_dir, source_id, ref.path, artifacts)
+
+
+def _load_python_path(
+    path: Path,
+    base_dir: Path,
+    source_id: str,
+    source_ref: str,
+    artifacts: LangChainArtifacts,
+) -> list[LoadedToolSource]:
+    if path.is_dir():
+        loaded: list[LoadedToolSource] = []
+        for python_file in sorted(path.glob("*.py")):
+            loaded.extend(_load_python_path(python_file, base_dir, source_id, source_ref, artifacts))
+        return loaded
+    tree = parse_python_file(path, label="LangChain")
+    display = display_path(path, base_dir)
+    artifacts.python_entrypoints.append(display)
+    extractor = _LangChainExtractor(tree, source_id, display, artifacts)
+    tools, warnings = extractor.extract()
+    return [
+        LoadedToolSource(
+            source_id=source_id,
+            source_type="langchain",
+            tools=tools,
+            warnings=warnings,
+        )
+    ]
+
+
+def _load_inventory_ref(
+    ref: ArtifactPathConfig,
+    base_dir: Path,
+    *,
+    source_id: str,
+    artifacts: LangChainArtifacts,
+) -> LoadedToolSource | None:
+    source = ToolSourceConfig(id=source_id, type="mcp", path=ref.path, optional=ref.optional)
+    try:
+        loaded = load_mcp_tools(source, base_dir)
+    except InputParseError:
+        if not ref.optional:
+            raise
+        artifacts.warnings.append(f"Optional LangChain tool inventory {ref.path!r} failed to load.")
+        return None
+    artifacts.tool_inventory_files.append(display_path(resolve_input_path(base_dir, ref.path), base_dir))
+    loaded.source_type = "langchain_inventory"
+    for tool in loaded.tools:
+        tool.source_type = "langchain_inventory"
+        tool.annotations["langchain_inventory"] = True
+        tool.extraction_confidence = "high"
+        tool.extraction["confidence"] = "high"
+    return loaded
+
+
+class _LangChainExtractor:
+    def __init__(
+        self,
+        tree: ast.Module,
+        source_id: str,
+        source_ref: str,
+        artifacts: LangChainArtifacts,
+    ) -> None:
+        self.tree = tree
+        self.source_id = source_id
+        self.source_ref = source_ref
+        self.artifacts = artifacts
+        self.schemas = pydantic_model_schemas(tree)
+        self.functions = {
+            node.name: node
+            for node in _ordered_nodes(tree, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.tool_decorators = self._tool_decorator_names()
+        self.tool_vars: dict[str, Tool] = {}
+        self.list_vars: dict[str, list[str] | None] = {}
+        self.warnings: list[str] = []
+
+    def extract(self) -> tuple[list[Tool], list[str]]:
+        for node in _ordered_nodes(self.tree, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            self._record_decorated_tool(node)
+        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+            self._record_structured_tool(node)
+        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+            self._record_list_assignment(node)
+        for call in _ordered_nodes(self.tree, (ast.Call,)):
+            self._record_tool_surface(call)
+        warnings = sorted(dict.fromkeys(self.warnings))
+        self.artifacts.warnings.extend(warnings)
+        return _unique_tools(self.tool_vars.values()), warnings
+
+    def _tool_decorator_names(self) -> set[str]:
+        names = {"tool", "langchain.tools.tool", "langchain_core.tools.tool"}
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ImportFrom) and node.module in TOOL_DECORATOR_MODULES:
+                for alias in node.names:
+                    if alias.name == "tool":
+                        names.add(alias.asname or alias.name)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in TOOL_DECORATOR_MODULES:
+                        names.add(f"{alias.asname or alias.name}.tool")
+        return names
+
+    def _record_decorated_tool(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        decorator = self._tool_decorator(node)
+        if decorator is None:
+            return
+        tool_name = _decorator_tool_name(decorator) or node.name
+        args_schema = self._schema_for_call(decorator, getattr(decorator, "lineno", node.lineno))
+        input_schema, parameters = function_input_schema(node, schema=args_schema)
+        description = _decorator_description(decorator) or ast.get_docstring(node)
+        tool = _function_tool(
+            node,
+            name=tool_name,
+            description=description,
+            input_schema=input_schema,
+            parameters=parameters,
+            source_id=self.source_id,
+            source_ref=self.source_ref,
+            source_type="langchain_function",
+            extraction_method="langchain_tool_decorator_ast",
+        )
+        self._add_tool(node.name, tool, "function_tools")
+
+    def _tool_decorator(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.Call | ast.Name | None:
+        for decorator in node.decorator_list:
+            name = dotted_name(decorator.func) if isinstance(decorator, ast.Call) else dotted_name(decorator)
+            if name in self.tool_decorators:
+                return decorator
+        return None
+
+    def _record_structured_tool(self, node: ast.Assign | ast.AnnAssign) -> None:
+        call = _assignment_call(node)
+        if call is None or last_name(call.func) != "from_function":
+            return
+        owner_name = dotted_name(call.func)
+        if not owner_name or not any(owner_name.startswith(name) for name in STRUCTURED_TOOL_NAMES):
+            return
+        function_name = keyword_name(call, "func") or (dotted_name(call.args[0]) if call.args else None)
+        function = self.functions.get(function_name or "")
+        if function is None:
+            self._dynamic(
+                "structured_tool",
+                getattr(call, "lineno", 0),
+                f"StructuredTool.from_function references unresolved function {function_name!r}",
+            )
+            return
+        tool_name = keyword_string(call, "name") or function.name
+        args_schema = self._schema_for_call(call, call.lineno)
+        input_schema, parameters = function_input_schema(function, schema=args_schema)
+        description = keyword_string(call, "description") or ast.get_docstring(function)
+        tool = _function_tool(
+            function,
+            name=tool_name,
+            description=description,
+            input_schema=input_schema,
+            parameters=parameters,
+            source_id=self.source_id,
+            source_ref=self.source_ref,
+            source_type="langchain_structured_tool",
+            extraction_method="langchain_structured_tool_ast",
+        )
+        target = _assignment_target(node) or tool_name
+        self._add_tool(target, tool, "structured_tools")
+
+    def _record_list_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
+        target = _assignment_target(node)
+        value = _assignment_value(node)
+        if target is None or value is None:
+            return
+        names = self._resolve_tool_names(value)
+        if names is not None:
+            self.list_vars[target] = names
+        elif isinstance(value, ast.List | ast.Tuple):
+            self.list_vars[target] = None
+
+    def _record_tool_surface(self, call: ast.Call) -> None:
+        call_kind = last_name(call.func)
+        if call_kind in AGENT_BINDING_CALLS:
+            tools_expr = keyword(call, "tools")
+            if tools_expr is None and len(call.args) > 1:
+                tools_expr = call.args[1]
+            self._record_binding("agent", call, tools_expr)
+        elif call_kind == "ToolNode":
+            self._record_binding("tool_node", call, call.args[0] if call.args else None)
+        elif isinstance(call.func, ast.Attribute) and call.func.attr == "bind_tools":
+            self._record_binding("bind_tools", call, call.args[0] if call.args else keyword(call, "tools"))
+
+    def _record_binding(self, kind: str, call: ast.Call, tools_expr: ast.AST | None) -> None:
+        if tools_expr is None:
+            return
+        names = self._resolve_tool_names(tools_expr)
+        if names is None:
+            self._dynamic(kind, call.lineno, _dynamic_reason(tools_expr))
+            return
+        record = {"source_ref": self.source_ref, "line": call.lineno, "tools": names}
+        if kind == "tool_node":
+            self.artifacts.tool_nodes.append(record)
+        else:
+            record["kind"] = kind
+            self.artifacts.agent_bindings.append(record)
+
+    def _resolve_tool_names(self, node: ast.AST) -> list[str] | None:
+        if isinstance(node, ast.Name):
+            if node.id in self.list_vars:
+                return self.list_vars[node.id]
+            if node.id in self.tool_vars:
+                return [self.tool_vars[node.id].name]
+            return None
+        if isinstance(node, ast.List | ast.Tuple):
+            names: list[str] = []
+            for element in node.elts:
+                if not isinstance(element, ast.Name) or element.id not in self.tool_vars:
+                    return None
+                names.append(self.tool_vars[element.id].name)
+            return names
+        return None
+
+    def _schema_for_call(self, call: ast.Call | ast.Name, line: int) -> dict[str, Any] | None:
+        if not isinstance(call, ast.Call):
+            return None
+        schema_name = keyword_name(call, "args_schema")
+        if not schema_name:
+            return None
+        schema = self.schemas.get(schema_name)
+        if schema is None:
+            self._dynamic(
+                "args_schema",
+                line,
+                f"args_schema {schema_name!r} is not defined in the same file",
+            )
+        return schema
+
+    def _add_tool(self, variable_name: str, tool: Tool, artifact_field: str) -> None:
+        if warning := tool_name_warning(tool.name):
+            self.warnings.append(warning)
+        self.tool_vars[variable_name] = tool
+        getattr(self.artifacts, artifact_field).append(
+            {"name": tool.name, "source_ref": self.source_ref, "line": _line(tool.source_location)}
+        )
+
+    def _dynamic(self, kind: str, line: int, reason: str) -> None:
+        surface = {"kind": kind, "source_ref": self.source_ref, "line": line, "reason": reason}
+        self.artifacts.dynamic_tool_surfaces.append(surface)
+        self.warnings.append(
+            f"LangChain {kind} at {self.source_ref}:{line} has dynamic tool surface: {reason}."
+        )
+
+
+def _function_tool(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    *,
+    name: str,
+    description: str | None,
+    input_schema: dict[str, Any],
+    parameters: list[Any],
+    source_id: str,
+    source_ref: str,
+    source_type: str,
+    extraction_method: str,
+) -> Tool:
+    return Tool(
+        id=stable_tool_id(name),
+        name=name,
+        description=description,
+        source_type=source_type,
+        source_id=source_id,
+        source_ref=source_ref,
+        source_location=f"{source_ref}:{node.lineno}",
+        input_schema=input_schema,
+        output_schema=function_output_schema(node),
+        parameters=parameters,
+        function_signature=function_signature(name, parameters, node),
+        annotations={"framework": "langchain"},
+        auth=AuthInfo(source="langchain_static"),
+        extraction_confidence="medium",
+        extraction={"method": extraction_method, "confidence": "medium"},
+    )
+
+
+def _decorator_tool_name(decorator: ast.Call | ast.Name) -> str | None:
+    if isinstance(decorator, ast.Call):
+        return first_string_arg(decorator) or keyword_string(decorator, "name")
+    return None
+
+
+def _decorator_description(decorator: ast.Call | ast.Name) -> str | None:
+    return keyword_string(decorator, "description") if isinstance(decorator, ast.Call) else None
+
+
+def _assignment_call(node: ast.Assign | ast.AnnAssign) -> ast.Call | None:
+    value = _assignment_value(node)
+    return value if isinstance(value, ast.Call) else None
+
+
+def _assignment_value(node: ast.Assign | ast.AnnAssign) -> ast.AST | None:
+    return node.value if isinstance(node, ast.Assign | ast.AnnAssign) else None
+
+
+def _assignment_target(node: ast.Assign | ast.AnnAssign) -> str | None:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                return target.id
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def _ordered_nodes(tree: ast.AST, node_types: tuple[type[Any], ...]) -> list[Any]:
+    return sorted(
+        (node for node in ast.walk(tree) if isinstance(node, node_types)),
+        key=lambda node: (getattr(node, "lineno", 0), getattr(node, "col_offset", 0)),
+    )
+
+
+def _unique_tools(tools: Any) -> list[Tool]:
+    unique: list[Tool] = []
+    seen: set[tuple[str, str | None]] = set()
+    for tool in tools:
+        key = (tool.name, tool.source_location)
+        if key in seen:
+            continue
+        unique.append(tool)
+        seen.add(key)
+    return unique
+
+
+def _dynamic_reason(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return f"unresolved tool reference {node.id!r}"
+    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
+        return "tool list is built by a comprehension"
+    if isinstance(node, ast.Call):
+        return "tool list comes from a runtime call"
+    if isinstance(node, ast.List | ast.Tuple):
+        return "tool list contains unresolved or inline tool expressions"
+    return f"unsupported static tool expression {type(node).__name__}"
+
+
+def _line(location: str | None) -> int | None:
+    if not location or ":" not in location:
+        return None
+    try:
+        return int(location.rsplit(":", 1)[1])
+    except ValueError:
+        return None
+
+
+def _resolve_existing_path(ref: ArtifactPathConfig, base_dir: Path) -> Path:
+    path = resolve_input_path(base_dir, ref.path)
+    if not path.exists():
+        raise InputParseError(f"Input file not found: {path}")
+    return path

--- a/src/agents_shipgate/inputs/langchain.py
+++ b/src/agents_shipgate/inputs/langchain.py
@@ -4,27 +4,28 @@ import ast
 from pathlib import Path
 from typing import Any
 
-from agents_shipgate.config.schema import (
-    AgentsShipgateManifest,
-    ArtifactPathConfig,
-    ToolSourceConfig,
+from agents_shipgate.config.schema import AgentsShipgateManifest
+from agents_shipgate.core.models import LangChainArtifacts, LoadedToolSource, Tool
+from agents_shipgate.inputs._python_framework import (
+    assignment_call,
+    assignment_target,
+    assignment_value,
+    dynamic_reason,
+    framework_function_tool,
+    load_python_framework_sources,
+    ordered_nodes,
+    source_line,
+    unique_tools,
 )
-from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.core.models import AuthInfo, LangChainArtifacts, LoadedToolSource, Tool
-from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id, tool_name_warning
-from agents_shipgate.inputs.mcp import load_mcp_tools
+from agents_shipgate.inputs.common import tool_name_warning
 from agents_shipgate.inputs.python_static import (
-    display_path,
     dotted_name,
     first_string_arg,
     function_input_schema,
-    function_output_schema,
-    function_signature,
     keyword,
     keyword_name,
     keyword_string,
     last_name,
-    parse_python_file,
     pydantic_model_schemas,
 )
 
@@ -47,135 +48,18 @@ def load_langchain_artifacts(
         return [], None
 
     artifacts = LangChainArtifacts()
-    loaded_sources: list[LoadedToolSource] = []
-    for source in source_refs:
-        try:
-            loaded_sources.extend(_load_langchain_source(source, base_dir, artifacts))
-        except InputParseError:
-            if not source.optional:
-                raise
-            warning = f"Optional LangChain source {source.id!r} failed to load."
-            artifacts.warnings.append(warning)
-            loaded_sources.append(
-                LoadedToolSource(source_id=source.id, source_type="langchain", warnings=[warning])
-            )
-
-    if config:
-        for entrypoint in config.python_entrypoints:
-            loaded_sources.extend(
-                _load_python_ref(
-                    entrypoint,
-                    base_dir,
-                    source_id=f"langchain:{entrypoint.path}",
-                    artifacts=artifacts,
-                )
-            )
-        for inventory in config.tool_inventories:
-            loaded = _load_inventory_ref(
-                inventory,
-                base_dir,
-                source_id=f"langchain_inventory:{inventory.path}",
-                artifacts=artifacts,
-            )
-            if loaded:
-                loaded_sources.append(loaded)
-
-    artifacts.warnings = sorted(dict.fromkeys(artifacts.warnings))
-    artifacts.dynamic_tool_surfaces = sorted(
-        artifacts.dynamic_tool_surfaces,
-        key=lambda item: (str(item.get("source_ref") or ""), int(item.get("line") or 0), str(item.get("reason") or "")),
+    loaded_sources = load_python_framework_sources(
+        source_refs=source_refs,
+        config=config,
+        base_dir=base_dir,
+        framework_type="langchain",
+        framework_label="LangChain",
+        inventory_source_type="langchain_inventory",
+        inventory_annotation="langchain_inventory",
+        artifacts=artifacts,
+        extractor_factory=_LangChainExtractor,
     )
     return loaded_sources, artifacts
-
-
-def _load_langchain_source(
-    source: ToolSourceConfig,
-    base_dir: Path,
-    artifacts: LangChainArtifacts,
-) -> list[LoadedToolSource]:
-    assert source.path is not None
-    ref = ArtifactPathConfig(path=source.path, optional=source.optional)
-    path = _resolve_existing_path(ref, base_dir)
-    if path.is_dir():
-        python_files = sorted(path.glob("*.py"))
-        if not python_files:
-            raise InputParseError(f"LangChain source directory has no Python files: {path}")
-        loaded: list[LoadedToolSource] = []
-        for python_file in python_files:
-            loaded.extend(_load_python_path(python_file, base_dir, source.id, source.path, artifacts))
-        return loaded
-    if path.suffix.lower() != ".py":
-        raise InputParseError(f"LangChain source must be a Python file or directory: {path}")
-    return _load_python_path(path, base_dir, source.id, source.path, artifacts)
-
-
-def _load_python_ref(
-    ref: ArtifactPathConfig,
-    base_dir: Path,
-    *,
-    source_id: str,
-    artifacts: LangChainArtifacts,
-) -> list[LoadedToolSource]:
-    try:
-        path = _resolve_existing_path(ref, base_dir)
-    except InputParseError:
-        if not ref.optional:
-            raise
-        artifacts.warnings.append(f"Optional LangChain Python entrypoint {ref.path!r} failed to load.")
-        return []
-    return _load_python_path(path, base_dir, source_id, ref.path, artifacts)
-
-
-def _load_python_path(
-    path: Path,
-    base_dir: Path,
-    source_id: str,
-    source_ref: str,
-    artifacts: LangChainArtifacts,
-) -> list[LoadedToolSource]:
-    if path.is_dir():
-        loaded: list[LoadedToolSource] = []
-        for python_file in sorted(path.glob("*.py")):
-            loaded.extend(_load_python_path(python_file, base_dir, source_id, source_ref, artifacts))
-        return loaded
-    tree = parse_python_file(path, label="LangChain")
-    display = display_path(path, base_dir)
-    artifacts.python_entrypoints.append(display)
-    extractor = _LangChainExtractor(tree, source_id, display, artifacts)
-    tools, warnings = extractor.extract()
-    return [
-        LoadedToolSource(
-            source_id=source_id,
-            source_type="langchain",
-            tools=tools,
-            warnings=warnings,
-        )
-    ]
-
-
-def _load_inventory_ref(
-    ref: ArtifactPathConfig,
-    base_dir: Path,
-    *,
-    source_id: str,
-    artifacts: LangChainArtifacts,
-) -> LoadedToolSource | None:
-    source = ToolSourceConfig(id=source_id, type="mcp", path=ref.path, optional=ref.optional)
-    try:
-        loaded = load_mcp_tools(source, base_dir)
-    except InputParseError:
-        if not ref.optional:
-            raise
-        artifacts.warnings.append(f"Optional LangChain tool inventory {ref.path!r} failed to load.")
-        return None
-    artifacts.tool_inventory_files.append(display_path(resolve_input_path(base_dir, ref.path), base_dir))
-    loaded.source_type = "langchain_inventory"
-    for tool in loaded.tools:
-        tool.source_type = "langchain_inventory"
-        tool.annotations["langchain_inventory"] = True
-        tool.extraction_confidence = "high"
-        tool.extraction["confidence"] = "high"
-    return loaded
 
 
 class _LangChainExtractor:
@@ -193,25 +77,26 @@ class _LangChainExtractor:
         self.schemas = pydantic_model_schemas(tree)
         self.functions = {
             node.name: node
-            for node in _ordered_nodes(tree, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for node in ordered_nodes(tree, (ast.FunctionDef, ast.AsyncFunctionDef))
         }
         self.tool_decorators = self._tool_decorator_names()
         self.tool_vars: dict[str, Tool] = {}
+        self.discovered_tools: list[Tool] = []
         self.list_vars: dict[str, list[str] | None] = {}
         self.warnings: list[str] = []
 
     def extract(self) -> tuple[list[Tool], list[str]]:
-        for node in _ordered_nodes(self.tree, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        for node in ordered_nodes(self.tree, (ast.FunctionDef, ast.AsyncFunctionDef)):
             self._record_decorated_tool(node)
-        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+        for node in ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
             self._record_structured_tool(node)
-        for node in _ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
+        for node in ordered_nodes(self.tree, (ast.Assign, ast.AnnAssign)):
             self._record_list_assignment(node)
-        for call in _ordered_nodes(self.tree, (ast.Call,)):
+        for call in ordered_nodes(self.tree, (ast.Call,)):
             self._record_tool_surface(call)
         warnings = sorted(dict.fromkeys(self.warnings))
         self.artifacts.warnings.extend(warnings)
-        return _unique_tools(self.tool_vars.values()), warnings
+        return unique_tools(self.discovered_tools), warnings
 
     def _tool_decorator_names(self) -> set[str]:
         names = {"tool", "langchain.tools.tool", "langchain_core.tools.tool"}
@@ -255,7 +140,7 @@ class _LangChainExtractor:
         return None
 
     def _record_structured_tool(self, node: ast.Assign | ast.AnnAssign) -> None:
-        call = _assignment_call(node)
+        call = assignment_call(node)
         if call is None or last_name(call.func) != "from_function":
             return
         owner_name = dotted_name(call.func)
@@ -285,12 +170,12 @@ class _LangChainExtractor:
             source_type="langchain_structured_tool",
             extraction_method="langchain_structured_tool_ast",
         )
-        target = _assignment_target(node) or tool_name
+        target = assignment_target(node) or tool_name
         self._add_tool(target, tool, "structured_tools")
 
     def _record_list_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
-        target = _assignment_target(node)
-        value = _assignment_value(node)
+        target = assignment_target(node)
+        value = assignment_value(node)
         if target is None or value is None:
             return
         names = self._resolve_tool_names(value)
@@ -316,7 +201,7 @@ class _LangChainExtractor:
             return
         names = self._resolve_tool_names(tools_expr)
         if names is None:
-            self._dynamic(kind, call.lineno, _dynamic_reason(tools_expr))
+            self._dynamic(kind, call.lineno, dynamic_reason(tools_expr))
             return
         record = {"source_ref": self.source_ref, "line": call.lineno, "tools": names}
         if kind == "tool_node":
@@ -359,9 +244,20 @@ class _LangChainExtractor:
     def _add_tool(self, variable_name: str, tool: Tool, artifact_field: str) -> None:
         if warning := tool_name_warning(tool.name):
             self.warnings.append(warning)
+        existing = self.tool_vars.get(variable_name)
+        if existing and existing.source_location != tool.source_location:
+            self._dynamic(
+                "tool_shadowing",
+                source_line(tool.source_location) or 0,
+                (
+                    f"tool variable {variable_name!r} is reassigned from "
+                    f"{existing.name!r} to {tool.name!r}"
+                ),
+            )
         self.tool_vars[variable_name] = tool
+        self.discovered_tools.append(tool)
         getattr(self.artifacts, artifact_field).append(
-            {"name": tool.name, "source_ref": self.source_ref, "line": _line(tool.source_location)}
+            {"name": tool.name, "source_ref": self.source_ref, "line": source_line(tool.source_location)}
         )
 
     def _dynamic(self, kind: str, line: int, reason: str) -> None:
@@ -384,22 +280,18 @@ def _function_tool(
     source_type: str,
     extraction_method: str,
 ) -> Tool:
-    return Tool(
-        id=stable_tool_id(name),
+    return framework_function_tool(
+        node,
+        framework="langchain",
+        auth_source="langchain_static",
         name=name,
         description=description,
-        source_type=source_type,
+        input_schema=input_schema,
+        parameters=parameters,
         source_id=source_id,
         source_ref=source_ref,
-        source_location=f"{source_ref}:{node.lineno}",
-        input_schema=input_schema,
-        output_schema=function_output_schema(node),
-        parameters=parameters,
-        function_signature=function_signature(name, parameters, node),
-        annotations={"framework": "langchain"},
-        auth=AuthInfo(source="langchain_static"),
-        extraction_confidence="medium",
-        extraction={"method": extraction_method, "confidence": "medium"},
+        source_type=source_type,
+        extraction_method=extraction_method,
     )
 
 
@@ -411,69 +303,3 @@ def _decorator_tool_name(decorator: ast.Call | ast.Name) -> str | None:
 
 def _decorator_description(decorator: ast.Call | ast.Name) -> str | None:
     return keyword_string(decorator, "description") if isinstance(decorator, ast.Call) else None
-
-
-def _assignment_call(node: ast.Assign | ast.AnnAssign) -> ast.Call | None:
-    value = _assignment_value(node)
-    return value if isinstance(value, ast.Call) else None
-
-
-def _assignment_value(node: ast.Assign | ast.AnnAssign) -> ast.AST | None:
-    return node.value if isinstance(node, ast.Assign | ast.AnnAssign) else None
-
-
-def _assignment_target(node: ast.Assign | ast.AnnAssign) -> str | None:
-    if isinstance(node, ast.Assign):
-        for target in node.targets:
-            if isinstance(target, ast.Name):
-                return target.id
-    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-        return node.target.id
-    return None
-
-
-def _ordered_nodes(tree: ast.AST, node_types: tuple[type[Any], ...]) -> list[Any]:
-    return sorted(
-        (node for node in ast.walk(tree) if isinstance(node, node_types)),
-        key=lambda node: (getattr(node, "lineno", 0), getattr(node, "col_offset", 0)),
-    )
-
-
-def _unique_tools(tools: Any) -> list[Tool]:
-    unique: list[Tool] = []
-    seen: set[tuple[str, str | None]] = set()
-    for tool in tools:
-        key = (tool.name, tool.source_location)
-        if key in seen:
-            continue
-        unique.append(tool)
-        seen.add(key)
-    return unique
-
-
-def _dynamic_reason(node: ast.AST) -> str:
-    if isinstance(node, ast.Name):
-        return f"unresolved tool reference {node.id!r}"
-    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
-        return "tool list is built by a comprehension"
-    if isinstance(node, ast.Call):
-        return "tool list comes from a runtime call"
-    if isinstance(node, ast.List | ast.Tuple):
-        return "tool list contains unresolved or inline tool expressions"
-    return f"unsupported static tool expression {type(node).__name__}"
-
-
-def _line(location: str | None) -> int | None:
-    if not location or ":" not in location:
-        return None
-    try:
-        return int(location.rsplit(":", 1)[1])
-    except ValueError:
-        return None
-
-
-def _resolve_existing_path(ref: ArtifactPathConfig, base_dir: Path) -> Path:
-    path = resolve_input_path(base_dir, ref.path)
-    if not path.exists():
-        raise InputParseError(f"Input file not found: {path}")
-    return path

--- a/src/agents_shipgate/inputs/python_static.py
+++ b/src/agents_shipgate/inputs/python_static.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.models import ToolParameter
+from agents_shipgate.inputs.common import load_text_file, schema_to_parameters
+
+SKIPPED_TOOL_PARAMETERS = {
+    "self",
+    "cls",
+    "ctx",
+    "context",
+    "config",
+    "runtime",
+    "run_manager",
+    "callbacks",
+}
+
+
+def parse_python_file(path: Path, *, label: str) -> ast.Module:
+    try:
+        return ast.parse(load_text_file(path), filename=str(path))
+    except SyntaxError as exc:
+        raise InputParseError(f"Unable to parse {label} Python entrypoint {path}: {exc.msg}") from exc
+
+
+def display_path(path: Path, base_dir: Path) -> str:
+    try:
+        return path.resolve().relative_to(base_dir.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def dotted_name(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    if isinstance(node, ast.Call):
+        return dotted_name(node.func)
+    return None
+
+
+def last_name(node: ast.AST | None) -> str | None:
+    name = dotted_name(node)
+    return name.rsplit(".", 1)[-1] if name else None
+
+
+def literal_string(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def literal_bool(node: ast.AST | None) -> bool | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+        return node.value
+    return None
+
+
+def keyword(call: ast.Call, name: str) -> ast.AST | None:
+    for item in call.keywords:
+        if item.arg == name:
+            return item.value
+    return None
+
+
+def keyword_string(call: ast.Call, name: str) -> str | None:
+    return literal_string(keyword(call, name))
+
+
+def keyword_name(call: ast.Call, name: str) -> str | None:
+    value = keyword(call, name)
+    return dotted_name(value)
+
+
+def first_string_arg(call: ast.Call) -> str | None:
+    return literal_string(call.args[0]) if call.args else None
+
+
+def annotation_to_string(annotation: ast.AST | None) -> str | None:
+    if annotation is None:
+        return None
+    try:
+        return ast.unparse(annotation)
+    except Exception:  # noqa: BLE001 - best-effort annotation rendering.
+        return None
+
+
+def json_schema_type(annotation: str | None) -> str:
+    value = (annotation or "").replace("typing.", "")
+    lower = value.lower()
+    if value in {"int", "float"}:
+        return "number"
+    if value == "bool":
+        return "boolean"
+    if value in {"dict", "Dict"} or lower.startswith(("dict[", "mapping[", "typedict")):
+        return "object"
+    if value in {"list", "List", "set", "Set", "tuple", "Tuple"} or lower.startswith(
+        ("list[", "set[", "tuple[", "sequence[")
+    ):
+        return "array"
+    return "string"
+
+
+def function_parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ToolParameter]:
+    parameters: list[ToolParameter] = []
+    positional_args = [*node.args.posonlyargs, *node.args.args]
+    positional_defaults: list[ast.expr | None] = [
+        None for _ in range(len(positional_args) - len(node.args.defaults))
+    ]
+    positional_defaults.extend(node.args.defaults)
+    for arg, default in zip(positional_args, positional_defaults, strict=True):
+        if arg.arg in SKIPPED_TOOL_PARAMETERS:
+            continue
+        parameters.append(_parameter(arg, required=default is None))
+    for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults, strict=True):
+        if arg.arg in SKIPPED_TOOL_PARAMETERS:
+            continue
+        parameters.append(_parameter(arg, required=default is None))
+    return parameters
+
+
+def function_input_schema(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    *,
+    schema: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[ToolParameter]]:
+    if schema:
+        return schema, schema_to_parameters(schema)
+    parameters = function_parameters(node)
+    properties = {
+        parameter.name: {
+            "type": json_schema_type(parameter.type),
+            **({"description": parameter.description} if parameter.description else {}),
+        }
+        for parameter in parameters
+    }
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "required": [parameter.name for parameter in parameters if parameter.required],
+    }
+    return input_schema, parameters
+
+
+def function_output_schema(node: ast.FunctionDef | ast.AsyncFunctionDef) -> dict[str, Any]:
+    return_type = annotation_to_string(node.returns)
+    return {"type": json_schema_type(return_type)} if return_type else {}
+
+
+def function_signature(
+    name: str,
+    parameters: list[ToolParameter],
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> str:
+    signature = f"{name}({', '.join(parameter.name for parameter in parameters)})"
+    return_type = annotation_to_string(node.returns)
+    if return_type:
+        signature = f"{signature} -> {return_type}"
+    return signature
+
+
+def pydantic_model_schemas(tree: ast.Module) -> dict[str, dict[str, Any]]:
+    schemas: dict[str, dict[str, Any]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not any(last_name(base) == "BaseModel" for base in node.bases):
+            continue
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for statement in node.body:
+            if not isinstance(statement, ast.AnnAssign) or not isinstance(statement.target, ast.Name):
+                continue
+            field_name = statement.target.id
+            prop: dict[str, Any] = {"type": json_schema_type(annotation_to_string(statement.annotation))}
+            if description := field_description(statement.value):
+                prop["description"] = description
+            minimum, maximum = field_bounds(statement.value)
+            if minimum is not None:
+                prop["minimum"] = minimum
+            if maximum is not None:
+                prop["maximum"] = maximum
+            properties[field_name] = prop
+            if _field_required(statement.value):
+                required.append(field_name)
+        schemas[node.name] = {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        }
+    return schemas
+
+
+def field_description(node: ast.AST | None) -> str | None:
+    if not isinstance(node, ast.Call) or last_name(node.func) != "Field":
+        return None
+    return keyword_string(node, "description")
+
+
+def field_bounds(node: ast.AST | None) -> tuple[float | int | None, float | int | None]:
+    if not isinstance(node, ast.Call) or last_name(node.func) != "Field":
+        return None, None
+    minimum = _number_keyword(node, ("ge", "gt"))
+    maximum = _number_keyword(node, ("le", "lt"))
+    return minimum, maximum
+
+
+def _number_keyword(call: ast.Call, names: tuple[str, ...]) -> float | int | None:
+    for name in names:
+        value = keyword(call, name)
+        if isinstance(value, ast.Constant) and isinstance(value.value, int | float):
+            return value.value
+    return None
+
+
+def _field_required(node: ast.AST | None) -> bool:
+    if node is None:
+        return True
+    if isinstance(node, ast.Call) and last_name(node.func) == "Field":
+        if not node.args:
+            return False
+        first = node.args[0]
+        return isinstance(first, ast.Constant) and first.value is Ellipsis
+    return False
+
+
+def _parameter(arg: ast.arg, *, required: bool) -> ToolParameter:
+    return ToolParameter(
+        name=arg.arg,
+        type=annotation_to_string(arg.annotation),
+        required=required,
+    )

--- a/src/agents_shipgate/inputs/python_static.py
+++ b/src/agents_shipgate/inputs/python_static.py
@@ -203,6 +203,14 @@ def field_description(node: ast.AST | None) -> str | None:
     return keyword_string(node, "description")
 
 
+def field_default_string(node: ast.AST | None) -> str | None:
+    if not isinstance(node, ast.Call) or last_name(node.func) != "Field":
+        return None
+    if value := keyword_string(node, "default"):
+        return value
+    return literal_string(node.args[0]) if node.args else None
+
+
 def field_bounds(node: ast.AST | None) -> tuple[float | int | None, float | int | None]:
     if not isinstance(node, ast.Call) or last_name(node.func) != "Field":
         return None, None

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -198,32 +198,70 @@ def _append_api_surface(lines: list[str], report: ReadinessReport) -> None:
 
 
 def _append_frameworks(lines: list[str], report: ReadinessReport) -> None:
-    adk_surface = report.frameworks.get("google_adk") if report.frameworks else None
-    if not isinstance(adk_surface, dict):
+    if not report.frameworks:
         return
-    lines.extend(
-        [
+    specs = [
+        (
+            "google_adk",
+            "Google ADK",
             "## Google ADK Surface Summary",
-            "",
-            f"- Python entrypoints: {adk_surface.get('python_entrypoint_count', 0)}",
-            f"- Agent config files: {adk_surface.get('agent_config_count', 0)}",
-            f"- Agents: {adk_surface.get('agent_count', 0)}",
-            f"- Function tools: {adk_surface.get('function_tool_count', 0)}",
-            f"- Long-running tools: {adk_surface.get('long_running_tool_count', 0)}",
-            f"- Toolsets: {adk_surface.get('toolset_count', 0)}",
-            f"- Dynamic or unresolved toolsets: {adk_surface.get('dynamic_toolset_count', 0)}",
-            f"- Callbacks: {adk_surface.get('callback_count', 0)}",
-            f"- Plugins: {adk_surface.get('plugin_count', 0)}",
-            f"- Eval files: {adk_surface.get('eval_file_count', 0)}",
-            "",
-        ]
-    )
-    warnings = adk_surface.get("warnings")
-    if isinstance(warnings, list) and warnings:
-        lines.extend(["Google ADK warnings:", ""])
-        for warning in warnings:
-            lines.append(f"- {_safe_markdown_text(warning)}")
+            [
+                ("Python entrypoints", "python_entrypoint_count"),
+                ("Agent config files", "agent_config_count"),
+                ("Agents", "agent_count"),
+                ("Function tools", "function_tool_count"),
+                ("Long-running tools", "long_running_tool_count"),
+                ("Toolsets", "toolset_count"),
+                ("Dynamic or unresolved toolsets", "dynamic_toolset_count"),
+                ("Callbacks", "callback_count"),
+                ("Plugins", "plugin_count"),
+                ("Eval files", "eval_file_count"),
+            ],
+        ),
+        (
+            "langchain",
+            "LangChain",
+            "## LangChain Surface Summary",
+            [
+                ("Python entrypoints", "python_entrypoint_count"),
+                ("Function tools", "function_tool_count"),
+                ("Structured tools", "structured_tool_count"),
+                ("Tool nodes", "tool_node_count"),
+                ("Agent tool bindings", "agent_tool_binding_count"),
+                ("Dynamic or unresolved tool surfaces", "dynamic_tool_surface_count"),
+                ("Tool inventory files", "tool_inventory_file_count"),
+            ],
+        ),
+        (
+            "crewai",
+            "CrewAI",
+            "## CrewAI Surface Summary",
+            [
+                ("Python entrypoints", "python_entrypoint_count"),
+                ("Agents", "agent_count"),
+                ("Crews", "crew_count"),
+                ("Function tools", "function_tool_count"),
+                ("Class tools", "class_tool_count"),
+                ("Prebuilt tools", "prebuilt_tool_count"),
+                ("Dynamic or unresolved tool surfaces", "dynamic_tool_surface_count"),
+                ("Tool inventory files", "tool_inventory_file_count"),
+            ],
+        ),
+    ]
+    for framework_key, label, title, fields in specs:
+        surface = report.frameworks.get(framework_key)
+        if not isinstance(surface, dict):
+            continue
+        lines.extend([title, ""])
+        for field_label, field_name in fields:
+            lines.append(f"- {field_label}: {surface.get(field_name, 0)}")
         lines.append("")
+        warnings = surface.get("warnings")
+        if isinstance(warnings, list) and warnings:
+            lines.extend([f"{label} warnings:", ""])
+            for warning in warnings:
+                lines.append(f"- {_safe_markdown_text(warning)}")
+            lines.append("")
 
 
 def _append_findings_by_category(lines: list[str], findings: list[Finding]) -> None:

--- a/tests/test_ci_recipes.py
+++ b/tests/test_ci_recipes.py
@@ -13,6 +13,12 @@ def test_gitlab_ci_examples_are_parseable_and_store_reports():
         assert job["artifacts"]["when"] == "always"
         assert "agents-shipgate-reports/" in job["artifacts"]["paths"]
 
+    trigger = yaml.safe_load(
+        Path("examples/gitlab-ci/05-on-tool-source-changes.yml").read_text(encoding="utf-8")
+    )
+    changes = trigger["agents_shipgate"]["rules"][0]["changes"]
+    assert {"shipgate.yaml", "**/shipgate.yaml", "**/*.py"} <= set(changes)
+
 
 def test_circleci_examples_are_parseable_and_store_reports():
     for path in sorted(Path("examples/circleci").glob("*.yml")):
@@ -24,6 +30,16 @@ def test_circleci_examples_are_parseable_and_store_reports():
         assert any(_run_command(step).startswith("python -m pip install") for step in steps)
         assert any("agents-shipgate scan" in _run_command(step) for step in steps)
         assert any("store_artifacts" in step for step in steps if isinstance(step, dict))
+
+    trigger = yaml.safe_load(
+        Path("examples/circleci/05-on-tool-source-changes.yml").read_text(encoding="utf-8")
+    )
+    command = "\n".join(
+        _run_command(step) for step in trigger["jobs"]["agents-shipgate"]["steps"]
+    )
+    assert "git diff --name-only" in command
+    assert "'shipgate.yaml'" in command
+    assert "'**/*.py'" in command
 
 
 def _run_command(step: object) -> str:

--- a/tests/test_ci_recipes.py
+++ b/tests/test_ci_recipes.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_gitlab_ci_examples_are_parseable_and_store_reports():
+    for path in sorted(Path("examples/gitlab-ci").glob("*.yml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        job = data["agents_shipgate"]
+
+        assert "python -m pip install" in "\n".join(job["script"])
+        assert "agents-shipgate scan" in "\n".join(job["script"])
+        assert job["artifacts"]["when"] == "always"
+        assert "agents-shipgate-reports/" in job["artifacts"]["paths"]
+
+
+def test_circleci_examples_are_parseable_and_store_reports():
+    for path in sorted(Path("examples/circleci").glob("*.yml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        job = data["jobs"]["agents-shipgate"]
+        steps = job["steps"]
+
+        assert job["docker"][0]["image"] == "cimg/python:3.12"
+        assert any(_run_command(step).startswith("python -m pip install") for step in steps)
+        assert any("agents-shipgate scan" in _run_command(step) for step in steps)
+        assert any("store_artifacts" in step for step in steps if isinstance(step, dict))
+
+
+def _run_command(step: object) -> str:
+    if not isinstance(step, dict) or "run" not in step:
+        return ""
+    run = step["run"]
+    if isinstance(run, str):
+        return run
+    if isinstance(run, dict):
+        return str(run.get("command") or "")
+    return ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_cli_advisory_exits_zero(tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Agents Shipgate 0.4.0" in result.output
+    assert "Agents Shipgate 0.5.0" in result.output
     assert "release_blockers_detected" in result.output
 
 
@@ -99,7 +99,7 @@ def test_cli_version_outputs_version():
     result = runner.invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.output.strip() == "Agents Shipgate 0.4.0"
+    assert result.output.strip() == "Agents Shipgate 0.5.0"
 
 
 def test_cli_scan_help_hides_deferred_flags():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
+import json
 from pathlib import Path
 
 import pytest
+import yaml
+from jsonschema import validate
 
 from agents_shipgate.config.loader import KNOWN_MANIFEST_FIELDS, load_manifest
 from agents_shipgate.core.errors import ConfigError
@@ -103,6 +106,16 @@ def test_known_manifest_fields_are_derived_from_schema():
     assert "policy_rules" in KNOWN_MANIFEST_FIELDS
     assert "model_config" in KNOWN_MANIFEST_FIELDS
     assert "policy_packs" in KNOWN_MANIFEST_FIELDS
+
+
+def test_manifest_examples_validate_against_generated_schema():
+    schema = json.loads(Path("docs/manifest-v0.1.json").read_text(encoding="utf-8"))
+
+    for path in [
+        Path("docs/manifest-v0.1.example.minimal.yaml"),
+        Path("docs/manifest-v0.1.example.full.yaml"),
+    ]:
+        validate(instance=yaml.safe_load(path.read_text(encoding="utf-8")), schema=schema)
 
 
 def test_removed_top_level_severity_override_alias_has_migration_error(tmp_path):

--- a/tests/test_crewai.py
+++ b/tests/test_crewai.py
@@ -1,0 +1,235 @@
+from agents_shipgate.cli.scan import inspect_sources, run_scan
+
+
+def test_crewai_static_extraction_without_importing_user_code(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "crew.py").write_text(
+        """
+from crewai import Agent, Crew
+from crewai.tools import BaseTool, tool
+from crewai_tools import FileReadTool
+from pydantic import BaseModel, Field
+
+raise RuntimeError("this file must never be imported")
+
+class LookupInput(BaseModel):
+    case_id: str = Field(..., description="Support case identifier.")
+
+@tool("summarize_case")
+def summarize_case(case_id: str) -> dict:
+    \"\"\"Summarize read-only support case metadata.\"\"\"
+    return {"case_id": case_id}
+
+class LookupTool(BaseTool):
+    name: str = "lookup_case"
+    description: str = "Look up read-only metadata for an existing support case."
+    args_schema = LookupInput
+
+    def _run(self, case_id: str) -> dict:
+        return {"case_id": case_id}
+
+file_tool = FileReadTool()
+lookup_tool = LookupTool()
+researcher = Agent(
+    role="reader",
+    goal="read case metadata",
+    backstory="reads cases",
+    tools=[summarize_case, lookup_tool, file_tool],
+)
+crew = Crew(agents=[researcher])
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: crewai-test
+agent:
+  name: crew-agent
+environment:
+  target: local
+tool_sources:
+  - id: crewai
+    type: crewai
+    path: crew.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    assert report.frameworks["crewai"]["agent_count"] == 1
+    assert report.frameworks["crewai"]["crew_count"] == 1
+    assert report.frameworks["crewai"]["function_tool_count"] == 1
+    assert report.frameworks["crewai"]["class_tool_count"] == 1
+    assert report.frameworks["crewai"]["prebuilt_tool_count"] == 1
+    assert report.frameworks["crewai"]["dynamic_tool_surface_count"] == 0
+    inventory = {tool["name"]: tool for tool in report.tool_inventory}
+    assert {"summarize_case", "lookup_case", "FileReadTool"} <= set(inventory)
+    assert inventory["FileReadTool"]["confidence"] == "low"
+    assert "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE" not in {
+        finding.check_id for finding in report.findings
+    }
+
+
+def test_crewai_dynamic_tool_surface_fires_without_inventory(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "crew.py").write_text(
+        """
+from crewai import Agent
+
+def get_tools():
+    return []
+
+researcher = Agent(role="reader", goal="read", backstory="", tools=get_tools())
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: crewai-dynamic-test
+agent:
+  name: dynamic-crew
+environment:
+  target: local
+tool_sources:
+  - id: crewai
+    type: crewai
+    path: crew.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    dynamic = [
+        finding
+        for finding in report.findings
+        if finding.check_id == "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE"
+    ]
+    assert len(dynamic) == 1
+    assert report.frameworks["crewai"]["dynamic_tool_surface_count"] == 1
+
+
+def test_crewai_unresolved_args_schema_is_dynamic_surface(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "crew.py").write_text(
+        """
+from crewai import Agent
+from crewai.tools import BaseTool
+
+class LookupTool(BaseTool):
+    name: str = "lookup_case"
+    description: str = "Look up read-only metadata for an existing support case."
+    args_schema = ExternalLookupInput
+
+    def _run(self, case_id: str) -> dict:
+        return {"case_id": case_id}
+
+lookup_tool = LookupTool()
+researcher = Agent(role="reader", goal="read", backstory="", tools=[lookup_tool])
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: crewai-unresolved-schema-test
+agent:
+  name: dynamic-crew
+environment:
+  target: local
+tool_sources:
+  - id: crewai
+    type: crewai
+    path: crew.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    assert report.frameworks["crewai"]["dynamic_tool_surface_count"] == 1
+    assert any("ExternalLookupInput" in warning for warning in report.source_warnings)
+    assert "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE" in {
+        finding.check_id for finding in report.findings
+    }
+
+
+def test_crewai_inventory_suppresses_dynamic_surface_finding(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "crew.py").write_text(
+        'researcher = Agent(role="reader", goal="read", backstory="", tools=get_tools())\n',
+        encoding="utf-8",
+    )
+    (project / "tools.json").write_text(
+        """
+{
+  "tools": [
+    {
+      "name": "lookup_case",
+      "description": "Look up read-only metadata for an existing support case.",
+      "annotations": {"readOnlyHint": true}
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: crewai-inventory-test
+agent:
+  name: dynamic-crew
+environment:
+  target: local
+tool_sources:
+  - id: crewai
+    type: crewai
+    path: crew.py
+crewai:
+  tool_inventories:
+    - tools.json
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    doctor = inspect_sources(config_path=project / "shipgate.yaml")
+
+    assert report.frameworks["crewai"]["dynamic_tool_surface_count"] == 1
+    assert "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE" not in {
+        finding.check_id for finding in report.findings
+    }
+    assert report.tool_inventory[0]["source_type"] == "crewai_inventory"
+    assert doctor["frameworks"]["crewai"]["tool_inventory_file_count"] == 1

--- a/tests/test_crewai.py
+++ b/tests/test_crewai.py
@@ -178,6 +178,61 @@ tool_sources:
     }
 
 
+def test_crewai_basetool_field_default_description_is_extracted(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "crew.py").write_text(
+        """
+from crewai import Agent
+from crewai.tools import BaseTool
+from pydantic import Field
+
+class LookupTool(BaseTool):
+    name: str = Field(default="lookup_case", description="Tool name.")
+    description: str = Field(
+        default="Look up read-only metadata for an existing support case.",
+        description="Tool description.",
+    )
+
+    def _run(self, case_id: str) -> dict:
+        return {"case_id": case_id}
+
+lookup_tool = LookupTool()
+researcher = Agent(role="reader", goal="read", backstory="", tools=[lookup_tool])
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: crewai-field-description-test
+agent:
+  name: field-description-crew
+environment:
+  target: local
+tool_sources:
+  - id: crewai
+    type: crewai
+    path: crew.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    inventory = {tool["name"]: tool for tool in report.tool_inventory}
+    assert "lookup_case" in inventory
+    assert "SHIP-CREWAI-FUNCTION-TOOL-METADATA-MISSING" not in {
+        finding.check_id for finding in report.findings
+    }
+
+
 def test_crewai_inventory_suppresses_dynamic_surface_finding(tmp_path):
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_fixture_no_import.py
+++ b/tests/test_fixture_no_import.py
@@ -1,0 +1,62 @@
+import runpy
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def test_simple_langchain_fixture_fails_if_imported(monkeypatch):
+    _install_langchain_stubs(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="must parse this file without importing"):
+        runpy.run_path(str(Path("samples/simple_langchain_agent/agent.py")))
+
+
+def test_simple_crewai_fixture_fails_if_imported(monkeypatch):
+    _install_crewai_stubs(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="must parse this file without importing"):
+        runpy.run_path(str(Path("samples/simple_crewai_agent/crew.py")))
+
+
+def _install_langchain_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    langchain = types.ModuleType("langchain")
+    langchain.__path__ = []
+    langchain_agents = types.ModuleType("langchain.agents")
+    langchain_agents.create_agent = lambda *args, **kwargs: None
+    langchain_tools = types.ModuleType("langchain.tools")
+    langchain_tools.tool = lambda *args, **kwargs: (lambda fn: fn)
+    langchain_core = types.ModuleType("langchain_core")
+    langchain_core.__path__ = []
+    langchain_core_tools = types.ModuleType("langchain_core.tools")
+
+    class StructuredTool:
+        @classmethod
+        def from_function(cls, *args, **kwargs):
+            return cls()
+
+    langchain_core_tools.StructuredTool = StructuredTool
+    monkeypatch.setitem(sys.modules, "langchain", langchain)
+    monkeypatch.setitem(sys.modules, "langchain.agents", langchain_agents)
+    monkeypatch.setitem(sys.modules, "langchain.tools", langchain_tools)
+    monkeypatch.setitem(sys.modules, "langchain_core", langchain_core)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", langchain_core_tools)
+
+
+def _install_crewai_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    crewai = types.ModuleType("crewai")
+    crewai.Agent = lambda *args, **kwargs: None
+    crewai.Crew = lambda *args, **kwargs: None
+    crewai_tools_module = types.ModuleType("crewai.tools")
+    crewai_tools_module.tool = lambda *args, **kwargs: (lambda fn: fn)
+
+    class BaseTool:
+        pass
+
+    crewai_tools_module.BaseTool = BaseTool
+    prebuilt_tools = types.ModuleType("crewai_tools")
+    prebuilt_tools.FileReadTool = type("FileReadTool", (), {})
+    monkeypatch.setitem(sys.modules, "crewai", crewai)
+    monkeypatch.setitem(sys.modules, "crewai.tools", crewai_tools_module)
+    monkeypatch.setitem(sys.modules, "crewai_tools", prebuilt_tools)

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -164,6 +164,64 @@ tool_sources:
     }
 
 
+def test_langchain_tool_variable_shadowing_preserves_tools_and_warns(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        """
+from langchain.tools import tool
+from langchain_core.tools import StructuredTool
+
+@tool
+def summarize_case(case_id: str) -> dict:
+    \"\"\"Summarize read-only support case metadata.\"\"\"
+    return {"case_id": case_id}
+
+def summarize_case_wrapped(case_id: str) -> dict:
+    \"\"\"Summarize read-only support case metadata for reviewer handoff.\"\"\"
+    return {"case_id": case_id}
+
+summarize_case = StructuredTool.from_function(
+    func=summarize_case_wrapped,
+    name="summarize_case_wrapped",
+    description="Summarize read-only support case metadata for reviewer handoff.",
+)
+agent = create_agent(model=None, tools=[summarize_case])
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: langchain-shadow-test
+agent:
+  name: shadow-agent
+environment:
+  target: local
+tool_sources:
+  - id: langchain
+    type: langchain
+    path: agent.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    assert {tool["name"] for tool in report.tool_inventory} == {
+        "summarize_case",
+        "summarize_case_wrapped",
+    }
+    assert report.frameworks["langchain"]["dynamic_tool_surface_count"] == 1
+    assert any("tool variable 'summarize_case' is reassigned" in w for w in report.source_warnings)
+
+
 def test_langchain_inventory_suppresses_dynamic_surface_finding(tmp_path):
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -1,0 +1,218 @@
+import json
+
+from agents_shipgate.cli.scan import inspect_sources, run_scan
+
+
+def test_langchain_static_extraction_without_importing_user_code(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        """
+from langchain.tools import tool as lc_tool
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+raise RuntimeError("this file must never be imported")
+
+class LookupInput(BaseModel):
+    case_id: str = Field(..., description="Support case identifier.")
+
+@lc_tool(args_schema=LookupInput)
+def lookup_case(case_id: str) -> dict:
+    \"\"\"Look up read-only metadata for an existing support case.\"\"\"
+    return {"case_id": case_id}
+
+def summarize_case(case_id: str) -> dict:
+    \"\"\"Summarize read-only support case metadata.\"\"\"
+    return {"case_id": case_id}
+
+summary_tool = StructuredTool.from_function(
+    func=summarize_case,
+    name="summarize_case",
+    description="Summarize read-only support case metadata.",
+)
+agent = create_agent(model=None, tools=[lookup_case, summary_tool])
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: langchain-test
+agent:
+  name: support-agent
+environment:
+  target: local
+tool_sources:
+  - id: langchain
+    type: langchain
+    path: agent.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    assert report.frameworks["langchain"]["function_tool_count"] == 1
+    assert report.frameworks["langchain"]["structured_tool_count"] == 1
+    assert report.frameworks["langchain"]["agent_tool_binding_count"] == 1
+    assert report.frameworks["langchain"]["dynamic_tool_surface_count"] == 0
+    assert {tool["name"] for tool in report.tool_inventory} == {
+        "lookup_case",
+        "summarize_case",
+    }
+    assert "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE" not in {
+        finding.check_id for finding in report.findings
+    }
+
+
+def test_langchain_dynamic_tool_surface_fires_without_inventory(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        """
+def get_tools():
+    return []
+
+agent = create_react_agent(None, tools=get_tools())
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: langchain-dynamic-test
+agent:
+  name: dynamic-agent
+environment:
+  target: local
+tool_sources:
+  - id: langchain
+    type: langchain
+    path: agent.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    dynamic = [
+        finding
+        for finding in report.findings
+        if finding.check_id == "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE"
+    ]
+    assert len(dynamic) == 1
+    assert report.frameworks["langchain"]["dynamic_tool_surface_count"] == 1
+
+
+def test_langchain_unresolved_args_schema_is_dynamic_surface(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        """
+from langchain_core.tools import tool
+
+@tool(args_schema=ExternalLookupInput)
+def lookup_case(case_id: str) -> dict:
+    \"\"\"Look up read-only metadata for an existing support case.\"\"\"
+    return {"case_id": case_id}
+
+agent = create_agent(model=None, tools=[lookup_case])
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: langchain-unresolved-schema-test
+agent:
+  name: dynamic-agent
+environment:
+  target: local
+tool_sources:
+  - id: langchain
+    type: langchain
+    path: agent.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    assert report.frameworks["langchain"]["dynamic_tool_surface_count"] == 1
+    assert any("ExternalLookupInput" in warning for warning in report.source_warnings)
+    assert "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE" in {
+        finding.check_id for finding in report.findings
+    }
+
+
+def test_langchain_inventory_suppresses_dynamic_surface_finding(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text("agent = create_agent(model=None, tools=get_tools())\n", encoding="utf-8")
+    (project / "tools.json").write_text(
+        json.dumps(
+            {
+                "tools": [
+                    {
+                        "name": "lookup_case",
+                        "description": "Look up read-only metadata for an existing support case.",
+                        "annotations": {"readOnlyHint": True},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: langchain-inventory-test
+agent:
+  name: dynamic-agent
+environment:
+  target: local
+tool_sources:
+  - id: langchain
+    type: langchain
+    path: agent.py
+langchain:
+  tool_inventories:
+    - tools.json
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    doctor = inspect_sources(config_path=project / "shipgate.yaml")
+
+    assert report.frameworks["langchain"]["dynamic_tool_surface_count"] == 1
+    assert "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE" not in {
+        finding.check_id for finding in report.findings
+    }
+    assert report.tool_inventory[0]["source_type"] == "langchain_inventory"
+    assert doctor["frameworks"]["langchain"]["tool_inventory_file_count"] == 1

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -10,9 +10,14 @@ SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 EXPECTED_MARKDOWN = Path("samples/support_refund_agent/expected/report.md")
 OPENAI_API_SAMPLE = Path("samples/simple_openai_api_agent/shipgate.yaml")
 OPENAI_API_EXPECTED_MARKDOWN = Path("samples/simple_openai_api_agent/expected/report.md")
+LANGCHAIN_SAMPLE = Path("samples/simple_langchain_agent/shipgate.yaml")
+LANGCHAIN_EXPECTED_MARKDOWN = Path("samples/simple_langchain_agent/expected/report.md")
+CREWAI_SAMPLE = Path("samples/simple_crewai_agent/shipgate.yaml")
+CREWAI_EXPECTED_MARKDOWN = Path("samples/simple_crewai_agent/expected/report.md")
 REPORT_SCHEMA = Path("docs/report-schema.v0.1.json")
 REPORT_SCHEMA_V02 = Path("docs/report-schema.v0.2.json")
 REPORT_SCHEMA_V04 = Path("docs/report-schema.v0.4.json")
+REPORT_SCHEMA_V05 = Path("docs/report-schema.v0.5.json")
 
 
 def test_sample_markdown_report_matches_golden(tmp_path):
@@ -44,6 +49,34 @@ def test_openai_api_markdown_report_matches_golden(tmp_path):
     assert actual == expected
 
 
+def test_langchain_markdown_report_matches_golden(tmp_path):
+    run_scan(
+        config_path=LANGCHAIN_SAMPLE,
+        output_dir=tmp_path,
+        formats=["markdown", "json"],
+        ci_mode="advisory",
+    )
+
+    actual = (tmp_path / "report.md").read_text(encoding="utf-8")
+    expected = LANGCHAIN_EXPECTED_MARKDOWN.read_text(encoding="utf-8")
+
+    assert actual == expected
+
+
+def test_crewai_markdown_report_matches_golden(tmp_path):
+    run_scan(
+        config_path=CREWAI_SAMPLE,
+        output_dir=tmp_path,
+        formats=["markdown", "json"],
+        ci_mode="advisory",
+    )
+
+    actual = (tmp_path / "report.md").read_text(encoding="utf-8")
+    expected = CREWAI_EXPECTED_MARKDOWN.read_text(encoding="utf-8")
+
+    assert actual == expected
+
+
 def test_json_report_contains_integration_contract_keys(tmp_path):
     report, _ = run_scan(
         config_path=SAMPLE,
@@ -62,7 +95,7 @@ def test_json_report_contains_integration_contract_keys(tmp_path):
     assert "loaded_plugins" in payload
     assert payload["loaded_plugins"] == []
     assert payload["schema_version"] == "0.1"
-    assert payload["report_schema_version"] == "0.4"
+    assert payload["report_schema_version"] == "0.5"
     assert "frameworks" in payload
     assert "loaded_policy_packs" in payload
 
@@ -117,14 +150,14 @@ def test_json_schema_is_published():
     } <= set(api_surface["required"])
 
 
-def test_json_report_validates_against_v04_schema(tmp_path):
+def test_json_report_validates_against_v05_schema(tmp_path):
     report, _ = run_scan(
         config_path=SAMPLE,
         output_dir=tmp_path,
         formats=["json"],
         ci_mode="advisory",
     )
-    schema = json.loads(REPORT_SCHEMA_V04.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V05.read_text(encoding="utf-8"))
 
     validate(instance=report.model_dump(mode="json"), schema=schema)
 


### PR DESCRIPTION
## Summary

- Adds v0.5.0 static LangChain/LangGraph and CrewAI adapters, manifest fields/source types, framework report blocks, checks, fixtures, and self-check coverage.
- Promotes GitLab CI and CircleCI to first-class example suites while updating GitHub Action examples to v0.5.0.
- Adds report schema v0.5, regenerates manifest/check schemas, refreshes golden reports, and updates release docs/roadmap/version references.

## Validation

- `python scripts/generate_schemas.py`
- `python -m ruff check .`
- `python -m pytest` (`190 passed`)
- `PYTHONPATH=src python -m agents_shipgate self-check --json` (`ready: true`)
- `git grep "0.4.0\|v0.4.0\|@v0.4.0" -- . ':!docs/decks'` leaves only historical `CHANGELOG.md`
- `git diff --check`

## Notes

- Draft PR by default.
- The pre-existing untracked `docs/decks/` directory was intentionally left out of the commit.