### PR TITLE
v0.7 PR 1/6: docs surface (trigger table, agent recipes, minimal configs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,26 @@ Do NOT use it for:
 - Behavior testing (use evals)
 - Stopping a tool call in flight (use a gateway or guardrail)
 
+### Should I run Shipgate on this PR?
+
+| Trigger in this PR | Run Shipgate? |
+|---|---|
+| Adds/changes MCP exports, OpenAPI specs, or `tools/*openai*tools*.json` | Yes |
+| Adds/changes `@function_tool`/`@tool` decorators (LangChain, CrewAI, OpenAI Agents SDK) | Yes |
+| Edits `prompts/`, `policies/`, or `permissions.scopes` in `shipgate.yaml` | Yes |
+| Adds/edits `.github/workflows/agents-shipgate.yml` or related CI | Yes |
+| Pure read-only doc/test changes with no manifest impact | Skip |
+| Refactor with no behavior change to tools or policies | Skip (or dry-run only) |
+
+**Stop conditions.** Stop and do not run `init` only when **all** of these hold:
+
+- `agents-shipgate detect --json` returns `is_agent_project: false`, AND
+- `suggested_sources` is empty (no MCP/OpenAPI hits flowing in as `mcp` or `openapi`), AND
+- no `shipgate.yaml` already exists in the workspace, AND
+- the user did not explicitly request a scan.
+
+Otherwise proceed to `init`. MCP/OpenAPI tool-surface repos register as `is_agent_project: false` because they have no Python framework imports — but they are valid Shipgate targets and their hits surface as `suggested_sources`. The trigger table above is the authoritative go/no-go.
+
 ---
 
 ## Five common agent tasks

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
 is dry-run by default and refuses to mutate anything outside the
 manifest's directory.
 
+For agents driving this flow programmatically, see
+[`docs/agent-recipes.md`](docs/agent-recipes.md). For framework-by-framework
+minimal manifests, see [`docs/minimal-real-configs.md`](docs/minimal-real-configs.md).
+
 ## Use in CI
 
 ```yaml

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`checks.md`](checks.md) — full check catalog (human-readable)
 - [`checks.json`](checks.json) — machine-readable check catalog (regenerated each release)
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
-- [`report-schema.v0.5.json`](report-schema.v0.5.json) — JSON Schema for `report.json`
+- [`report-schema.v0.6.json`](report-schema.v0.6.json) — JSON Schema for `report.json` (current)
 - [`category.md`](category.md) — what an "agent release gate" is, in product terms
 
 ## Examples
@@ -41,6 +41,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 
 ## For agents
 
+- [`agent-recipes.md`](agent-recipes.md) — copy-pasteable AI-agent workflows for the canonical 4-call flow (`detect → init → scan → apply-patches`)
+- [`minimal-real-configs.md`](minimal-real-configs.md) — framework-by-framework references to the smallest working manifest
 - [`../AGENTS.md`](../AGENTS.md) — agent-facing instructions
 - [`../CLAUDE.md`](../CLAUDE.md) — Claude Code-specific notes
 - [`../STABILITY.md`](../STABILITY.md) — what won't break across `0.x`

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -1,0 +1,230 @@
+# Agent recipes
+
+Copy-pasteable workflows for AI coding agents (Claude Code, Codex, Cursor,
+Aider) that need to drive `agents-shipgate` end-to-end without prompting
+the user. Every command is read-only or schema-validated; no agent
+execution, no LLM calls, no network access.
+
+> If you are a human, [`quickstart.md`](quickstart.md) is the friendlier
+> entry point. This page is structured for agents that consume `--json`.
+
+---
+
+## Recipe 1 · Single-turn adoption (the canonical 4-call flow)
+
+Use this when a repo doesn't yet have `shipgate.yaml`. Four calls in
+one user turn take it from "looks like an agent project" to "Shipgate
+is integrated, scan green or with safe trivial findings auto-applied,
+CI workflow optionally drafted."
+
+```bash
+agents-shipgate detect --json
+agents-shipgate init --write --ci --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+agents-shipgate apply-patches \
+    --from agents-shipgate-reports/report.json \
+    --confidence high --apply
+```
+
+### Step 1 · `detect --json` (read-only)
+
+Consume the response to decide whether to proceed. Key fields:
+
+- `is_agent_project` — `true` when at least one Python framework
+  scored ≥ 2.0 with a strong signal.
+- `frameworks[]` — per-framework scores + evidence + candidate file
+  paths.
+- `agent_name_candidates[]` — ranked `{value, source}`. Source values:
+  `Agent_name_literal` (highest), `ADK_name_field`, `workspace_dir`
+  (lowest).
+- `project_name_candidates[]` — same shape; `pyproject` source seeds
+  `project.name` only.
+- `suggested_sources[]` — MCP/OpenAPI files matched by glob. These do
+  NOT bump `is_agent_project` on their own.
+
+**Stop condition.** Stop and skip `init` only when ALL of:
+
+- `is_agent_project` is `false`, AND
+- `suggested_sources` is empty, AND
+- no `shipgate.yaml` already exists, AND
+- the user did not explicitly request a scan.
+
+Otherwise proceed. MCP/OpenAPI-only tool-surface repos surface as
+`is_agent_project: false` but should still be onboarded — their
+sources will land in `tool_sources` during `init`.
+
+### Step 2 · `init --write --ci --json`
+
+Auto-detection runs again inside `init` and writes:
+
+- `shipgate.yaml` with `tool_sources` populated per detected framework
+  candidate file.
+- `.github/workflows/agents-shipgate.yml` (if `--ci` is set; refuses
+  to overwrite an existing workflow file or one that already calls
+  `ThreeMoonsLab/agents-shipgate@*` from a sibling workflow).
+
+Key response fields:
+
+- `manifest_status`: `"written"` | `"skipped_existing"` | `"not_attempted"`.
+- `workflow.status` (when `--ci`): `"written"` | `"skipped_existing_target"`
+  | `"skipped_cross_reference"`.
+- `placeholders[]` — entries the template intentionally leaves as
+  `CHANGE_ME` because no high-confidence signal was available. Each has
+  a `path` (YAML-pointer-ish location) and `current` value. Replace
+  these before scanning.
+- `auto_detected.agent_name` — the value the manifest carries
+  (`null` when the template fell back to `CHANGE_ME`; matches the YAML
+  exactly).
+
+`--ci` is orthogonal to `--write`: each gets its own overwrite-refusal.
+Exit code is the max of per-action outcomes; manifest-error and
+workflow-skip can co-occur.
+
+### Step 3 · `scan -c shipgate.yaml --suggest-patches --format json`
+
+Writes to `agents-shipgate-reports/report.json`. Read it, walk
+`findings[]` filtering on `suppressed`. Per-finding fields you can rely
+on today:
+
+- `check_id`, `title`, `severity`, `category`, `evidence`,
+  `confidence`, `recommendation`.
+- `patches[]` (only when `--suggest-patches` is set) — list of
+  patch objects with `kind` ∈ `{set_pointer, append_pointer,
+  remove_pointer, manual}`. Non-manual patches additionally carry
+  `confidence` ∈ `{low, medium, high}`, `target_file`, `pointer`,
+  `target_format`, `rationale`, `target_sha256`.
+- `manifest_dir` (top-level on the report) — absolute path to the
+  directory containing `shipgate.yaml`. `apply-patches` enforces a
+  containment check against this.
+
+When `--suggest-patches` is set, every active (unsuppressed) finding
+has at least one patch. Manual-only findings (e.g. trace approval
+flips, per-check policy decisions) carry a single `ManualPatch` with
+`instructions` instead of a machine-applicable patch.
+
+### Step 4 · `apply-patches --confidence high --apply`
+
+Default `--confidence high` only auto-applies patches whose `confidence`
+field is `"high"`. Today that's the 3 stale-manifest removals
+(`SHIP-MANIFEST-STALE-{SUPPRESSION,POLICY,RISK-OVERRIDE}`). Scope
+coverage appends ship at `medium` and require explicit
+`--confidence medium` to apply.
+
+`apply-patches` is dry-run by default — `--apply` is required to
+mutate files. Containment-checked: any `target_file` outside
+`report.manifest_dir` aborts with exit code 5 before SHA verification.
+
+### Step 5 (optional) · Summarize for the user
+
+When the flow completes, summarize `report.json`:
+
+- `summary.status` (top-level outcome string).
+- Top 3 active critical/high findings with their `check_id`,
+  `tool_name` (when present), and `recommendation`.
+- Whether any patches were applied (count from
+  `apply-patches --json` output's `files`).
+
+Link findings back to [`docs/checks.md#<id>`](checks.md) so the user
+can read full check rationale.
+
+---
+
+## Recipe 2 · Add Shipgate to a repo that already has tool surfaces
+
+Same as Recipe 1, but `detect` may report `is_agent_project: false`
+when the repo only ships MCP exports or OpenAPI specs. Per the soft
+stop rule above, proceed anyway when `suggested_sources` is non-empty.
+
+`init` will populate `tool_sources` from those globs. The rest of the
+flow (steps 2-5) is identical.
+
+---
+
+## Recipe 3 · Re-scan after editing the manifest
+
+When the user has already replaced `CHANGE_ME` placeholders or added
+policies:
+
+```bash
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+agents-shipgate apply-patches \
+    --from agents-shipgate-reports/report.json \
+    --confidence high --apply
+```
+
+`run_id` is deterministic for the same input — if the report's
+`run_id` is unchanged from the previous run, nothing semantic about
+the manifest+tool-surface changed.
+
+---
+
+## Recipe 4 · Suppress a check or finding
+
+When a finding is a known false positive, edit `shipgate.yaml`:
+
+```yaml
+checks:
+  ignore:
+    - check_id: SHIP-DOC-MISSING-DESCRIPTION
+      tool: support_lookup_v2  # optional; omit to suppress for ALL tools
+      reason: "Tool description matches the upstream OpenAPI summary."
+```
+
+`reason` is required — empty reasons fail manifest validation. Re-run
+`scan` to confirm the finding is gone (it will appear in `findings[]`
+with `suppressed: true` rather than disappearing from the report).
+
+If you suppress a check that no longer fires, the next scan emits
+`SHIP-MANIFEST-STALE-SUPPRESSION` — auto-removable via
+`apply-patches`.
+
+---
+
+## Recipe 5 · Add Shipgate to CI without changing existing workflows
+
+```bash
+agents-shipgate init --workspace . --ci  # no --write
+```
+
+Without `--write`, the manifest is printed to stdout (don't write a
+new one). With `--ci`, the workflow file is still written orthogonally
+unless an existing workflow already references the action — in which
+case `workflow.status: "skipped_cross_reference"` and the path of the
+existing workflow is reported in `cross_reference_path`.
+
+---
+
+## Output handling
+
+- Always pass `--json` (where supported) and parse the result. The
+  human-readable stdout is unstable; the JSON shape is the contract.
+- `scan` does not have `--json`; instead pass `--format json` and read
+  `agents-shipgate-reports/report.json`.
+- Errors emit a structured `next_action` JSON line on stderr when
+  `AGENTS_SHIPGATE_AGENT_MODE=1` is set. Surface that path to the user
+  rather than scraping prose.
+
+## Pre-flight reminder
+
+`agents-shipgate-reports/` is a local artifact directory. Before
+committing, ensure it's listed in `.gitignore`:
+
+```gitignore
+agents-shipgate-reports/
+```
+
+`init` does not touch `.gitignore` — leave that to the user or follow
+up with an explicit edit.
+
+---
+
+## Reference
+
+- [`docs/checks.md`](checks.md) — full check catalog with rationale
+- [`docs/autofix-policy.md`](autofix-policy.md) — which findings are
+  safe to auto-fix vs. require human review (lands with the v0.7
+  remediation metadata; not yet present)
+- [`docs/minimal-real-configs.md`](minimal-real-configs.md) —
+  framework-specific minimal manifests
+- [`AGENTS.md`](../AGENTS.md) — top-level agent instructions, install,
+  trigger table

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -221,10 +221,12 @@ up with an explicit edit.
 ## Reference
 
 - [`docs/checks.md`](checks.md) — full check catalog with rationale
-- [`docs/autofix-policy.md`](autofix-policy.md) — which findings are
-  safe to auto-fix vs. require human review (lands with the v0.7
-  remediation metadata; not yet present)
 - [`docs/minimal-real-configs.md`](minimal-real-configs.md) —
   framework-specific minimal manifests
 - [`AGENTS.md`](../AGENTS.md) — top-level agent instructions, install,
   trigger table
+
+> A dedicated `docs/autofix-policy.md` lands later in the v0.7 series
+> (with the per-finding remediation metadata) and is not present yet.
+> Until then, the per-step guidance in Recipe 1 step 4 above is the
+> authoritative answer for what `--confidence high` mutates by default.

--- a/docs/minimal-real-configs.md
+++ b/docs/minimal-real-configs.md
@@ -13,7 +13,7 @@ For the full manifest field reference, see
 | OpenAI Agents SDK (`@function_tool` Python) | [`samples/support_refund_agent`](../samples/support_refund_agent/) — `agents/refund_agent.py` is the Python entrypoint | `tool_sources[*].type: openai_agents_sdk` with `path: agents/refund_agent.py` |
 | MCP export (single agent) | [`samples/support_refund_agent`](../samples/support_refund_agent/) — `.agents-shipgate/mcp-tools.json` | `tool_sources[*].type: mcp` |
 | MCP export (multi-agent monorepo) | [`samples/multi_agent_workspace`](../samples/multi_agent_workspace/) — `support/` and `billing/` each have their own `tools.json` | one `shipgate.yaml` per agent, each with its own `tool_sources` |
-| OpenAPI tool surface | [`samples/support_refund_agent/specs/`](../samples/support_refund_agent/specs/) — `support-tools.openapi.yaml` is a real OpenAPI 3.x spec | `tool_sources[*].type: openapi` with `path: specs/support-tools.openapi.yaml` |
+| OpenAPI tool surface | [`samples/support_refund_agent`](../samples/support_refund_agent/) — `specs/support-tools.openapi.yaml` is a real OpenAPI 3.x spec referenced from the fixture's `shipgate.yaml` | `tool_sources[*].type: openapi` with `path: specs/support-tools.openapi.yaml` |
 | OpenAI API artifacts (Messages API) | [`samples/simple_openai_api_agent`](../samples/simple_openai_api_agent/) | `manifest.openai_api` block (prompts, tools, schemas, traces, policies) |
 | Anthropic Messages API | [`samples/simple_anthropic_agent`](../samples/simple_anthropic_agent/) | `manifest.anthropic` block (prompts, tools, policy_rules) |
 | Google ADK | [`samples/google_adk_agent`](../samples/google_adk_agent/) | `tool_sources[*].type: google_adk` plus `manifest.google_adk` config |

--- a/docs/minimal-real-configs.md
+++ b/docs/minimal-real-configs.md
@@ -1,0 +1,67 @@
+# Minimal real configs by framework
+
+Each row points at a runnable `samples/*` fixture rather than inlining a
+manifest snippet. The fixture is the source of truth — reading it, you
+can copy whichever sections apply to your repo. This avoids the "doc
+example fell out of sync with the schema" hazard.
+
+For the full manifest field reference, see
+[`manifest-v0.1.md`](manifest-v0.1.md).
+
+| Framework | Reference fixture | Manifest highlight |
+|---|---|---|
+| OpenAI Agents SDK (`@function_tool` Python) | [`samples/support_refund_agent`](../samples/support_refund_agent/) — `agents/refund_agent.py` is the Python entrypoint | `tool_sources[*].type: openai_agents_sdk` with `path: agents/refund_agent.py` |
+| MCP export (single agent) | [`samples/support_refund_agent`](../samples/support_refund_agent/) — `.agents-shipgate/mcp-tools.json` | `tool_sources[*].type: mcp` |
+| MCP export (multi-agent monorepo) | [`samples/multi_agent_workspace`](../samples/multi_agent_workspace/) — `support/` and `billing/` each have their own `tools.json` | one `shipgate.yaml` per agent, each with its own `tool_sources` |
+| OpenAPI tool surface | [`samples/support_refund_agent/specs/`](../samples/support_refund_agent/specs/) — `support-tools.openapi.yaml` is a real OpenAPI 3.x spec | `tool_sources[*].type: openapi` with `path: specs/support-tools.openapi.yaml` |
+| OpenAI API artifacts (Messages API) | [`samples/simple_openai_api_agent`](../samples/simple_openai_api_agent/) | `manifest.openai_api` block (prompts, tools, schemas, traces, policies) |
+| Anthropic Messages API | [`samples/simple_anthropic_agent`](../samples/simple_anthropic_agent/) | `manifest.anthropic` block (prompts, tools, policy_rules) |
+| Google ADK | [`samples/google_adk_agent`](../samples/google_adk_agent/) | `tool_sources[*].type: google_adk` plus `manifest.google_adk` config |
+| LangChain / LangGraph | [`samples/simple_langchain_agent`](../samples/simple_langchain_agent/) | `tool_sources[*].type: langchain` |
+| CrewAI | [`samples/simple_crewai_agent`](../samples/simple_crewai_agent/) | `tool_sources[*].type: crewai` |
+
+## How to use this page
+
+1. Find your framework in the table.
+2. Open the fixture's `shipgate.yaml`. That's a working manifest
+   `agents-shipgate scan` accepts as-is.
+3. Copy the `tool_sources` entry (or `manifest.<framework>` block) and
+   point its `path` at your file(s).
+4. Run [`agents-shipgate init --workspace . --write`](../AGENTS.md#install-canonical)
+   for everything else (project name, agent name, environment defaults).
+
+## What the fixtures verify
+
+Every sample is exercised by the test suite — running
+`pytest tests/` against the repo scans these fixtures end-to-end.
+That means:
+
+- Every manifest in this table is schema-valid against
+  [`manifest-v0.1.json`](manifest-v0.1.json).
+- Every tool source path exists and parses.
+- Every framework adapter loads the declared sources without error.
+
+If your manifest looks like one of these and `scan` rejects it, file
+an issue — the docs and the schema have drifted.
+
+## When to add a new minimal config
+
+If you bring up Shipgate against a framework not listed here, contribute
+a fixture. The
+[`framework-adapter-checklist.md`](framework-adapter-checklist.md) is
+the full new-framework playbook; the minimum to land in this table is:
+
+- A `samples/<framework_name>_minimal/` directory with a working
+  `shipgate.yaml`.
+- The fixture passes `agents-shipgate scan -c shipgate.yaml
+  --ci-mode advisory` in the test suite.
+- A row added to this table pointing at it.
+
+---
+
+## See also
+
+- [`agent-recipes.md`](agent-recipes.md) — what to do once your
+  manifest is in place
+- [`quickstart.md`](quickstart.md) — 60-second introduction
+- [`AGENTS.md`](../AGENTS.md) — full agent-facing instructions

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,29 +18,7 @@ python -m agents_shipgate --help           # run from a pip install without PATH
 
 The CLI binary is `agents-shipgate`; a short alias `shipgate` is also installed.
 
-## First scan
-
-In a repo containing an agent and its tools:
-
-```bash
-agents-shipgate init --workspace . --write
-agents-shipgate scan -c shipgate.yaml
-```
-
-`init --write` produces a `shipgate.yaml` with `CHANGE_ME` placeholders for
-`agent.name` and `agent.declared_purpose`. Replace the placeholders before
-running `scan`.
-
-Reports land at `agents-shipgate-reports/report.md` and `report.json`
-(the default formats). To also write SARIF for GitHub's code-scanning UI:
-
-```bash
-agents-shipgate scan -c shipgate.yaml --format markdown,json,sarif
-```
-
-The bundled GitHub Action emits all three formats by default.
-
-## Verify on a known fixture
+## First scan (60 seconds against a fixture)
 
 Without writing any YAML:
 
@@ -51,6 +29,45 @@ agents-shipgate fixture run support_refund_agent
 This runs against a bundled fixture that intentionally fails several checks,
 so you can confirm the install works and see what a real finding list looks
 like.
+
+## Second 60 seconds (your real repo)
+
+In a repo containing an agent and its tools, the canonical four-call flow
+detects, configures, scans, and auto-applies safe fixes in one turn:
+
+```bash
+agents-shipgate detect --json                                              # 1. classify
+agents-shipgate init --write --ci --json                                   # 2. manifest + workflow
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json      # 3. scan + suggest
+agents-shipgate apply-patches \
+    --from agents-shipgate-reports/report.json \
+    --confidence high --apply                                              # 4. apply safe fixes
+```
+
+`detect` reports whether the workspace looks like an agent project and which
+framework(s) are present. `init --write --ci` produces a schema-valid
+`shipgate.yaml` (with framework-specific `tool_sources` populated) and an
+optional GitHub Actions workflow. `scan --suggest-patches` attaches a Patch
+object to every active finding. `apply-patches --confidence high` mutates
+only the safe stale-manifest removals — scope-coverage appends require an
+explicit `--confidence medium`.
+
+For agent-specific guidance and decision rules, see
+[`agent-recipes.md`](agent-recipes.md). For framework-by-framework minimal
+manifests, see [`minimal-real-configs.md`](minimal-real-configs.md).
+
+When `init` produces `agent.name: CHANGE_ME` (because there was no strong
+name signal in your code), replace it with the agent's actual role before
+re-scanning.
+
+Reports land at `agents-shipgate-reports/report.md` and `report.json`
+(the default formats). To also write SARIF for GitHub's code-scanning UI:
+
+```bash
+agents-shipgate scan -c shipgate.yaml --format markdown,json,sarif
+```
+
+The bundled GitHub Action emits all three formats by default.
 
 ## GitHub Action
 
@@ -71,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+      - uses: ThreeMoonsLab/agents-shipgate@v0.6.0
         with:
           config: shipgate.yaml
           ci_mode: advisory
@@ -84,9 +101,11 @@ triaged existing findings.
 
 ## Next
 
-- [`docs/manifest-v0.1.md`](manifest-v0.1.md) — manifest schema in prose form
-- [`docs/checks.md`](checks.md) — what the scanner looks for
-- [`docs/category.md`](category.md) — what an "agent release gate" is
-- [`docs/faq.md`](faq.md) — common questions
-- [`docs/concepts.md`](concepts.md) — tool-use readiness in depth
-- [`docs/glossary.md`](glossary.md) — category vocabulary
+- [`agent-recipes.md`](agent-recipes.md) — copy-pasteable AI-agent workflows for the canonical 4-call flow
+- [`minimal-real-configs.md`](minimal-real-configs.md) — framework-by-framework minimal manifest references
+- [`manifest-v0.1.md`](manifest-v0.1.md) — manifest schema in prose form
+- [`checks.md`](checks.md) — what the scanner looks for
+- [`category.md`](category.md) — what an "agent release gate" is
+- [`faq.md`](faq.md) — common questions
+- [`concepts.md`](concepts.md) — tool-use readiness in depth
+- [`glossary.md`](glossary.md) — category vocabulary

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,6 +38,7 @@ detects, configures, scans, and auto-applies safe fixes in one turn:
 ```bash
 agents-shipgate detect --json                                              # 1. classify
 agents-shipgate init --write --ci --json                                   # 2. manifest + workflow
+# 2b. Replace any CHANGE_ME placeholders before scanning (see below)
 agents-shipgate scan -c shipgate.yaml --suggest-patches --format json      # 3. scan + suggest
 agents-shipgate apply-patches \
     --from agents-shipgate-reports/report.json \
@@ -47,18 +48,29 @@ agents-shipgate apply-patches \
 `detect` reports whether the workspace looks like an agent project and which
 framework(s) are present. `init --write --ci` produces a schema-valid
 `shipgate.yaml` (with framework-specific `tool_sources` populated) and an
-optional GitHub Actions workflow. `scan --suggest-patches` attaches a Patch
-object to every active finding. `apply-patches --confidence high` mutates
-only the safe stale-manifest removals — scope-coverage appends require an
-explicit `--confidence medium`.
+optional GitHub Actions workflow.
+
+**Replace placeholders before scanning.** `init --write --json` returns a
+`placeholders[]` array enumerating every value the template could not infer.
+On a fresh workspace the array typically contains both:
+
+- `agent.name: CHANGE_ME` — the agent's role (no strong `Agent(name="…")`
+  literal was found).
+- `agent.declared_purpose[]: CHANGE_ME` — a one-line description of what
+  the agent should do (auto-init can't infer this; the schema requires
+  a non-empty value).
+
+Walk `placeholders[]`, edit each one in `shipgate.yaml`, then re-run
+`scan`. Skipping this step leaves an invalid adoption artifact — the
+manifest validates but downstream consumers see meaningless defaults.
+
+`scan --suggest-patches` attaches a Patch object to every active finding.
+`apply-patches --confidence high` mutates only the safe stale-manifest
+removals — scope-coverage appends require an explicit `--confidence medium`.
 
 For agent-specific guidance and decision rules, see
 [`agent-recipes.md`](agent-recipes.md). For framework-by-framework minimal
 manifests, see [`minimal-real-configs.md`](minimal-real-configs.md).
-
-When `init` produces `agent.name: CHANGE_ME` (because there was no strong
-name signal in your code), replace it with the agent's actual role before
-re-scanning.
 
 Reports land at `agents-shipgate-reports/report.md` and `report.json`
 (the default formats). To also write SARIF for GitHub's code-scanning UI:


### PR DESCRIPTION
## Summary

- First of six PRs landing the v0.7 adoption activation work (per the approved plan at [`/Users/pengfeihu/.claude/plans/please-carefully-plan-for-twinkly-coral.md`](https://github.com/ThreeMoonsLab/agents-shipgate)).
- Pure docs / prose. No code changes. All references stay within v0.6-current outputs — no forward references to the remediation metadata landing in PR 3.
- Closes the "agent-facing docs are missing" gap from memo §6 ("Must do now") without depending on any of the API/schema work in subsequent PRs.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only

## What changed

| File | Change |
|---|---|
| [AGENTS.md](AGENTS.md) | New "Should I run Shipgate on this PR?" trigger table + soft stop rule |
| [docs/agent-recipes.md](docs/agent-recipes.md) | NEW. AI-agent recipes for the canonical 4-call flow |
| [docs/minimal-real-configs.md](docs/minimal-real-configs.md) | NEW. Per-framework references to runnable `samples/*` fixtures |
| [docs/INDEX.md](docs/INDEX.md) | Replace stale `report-schema.v0.5.json` link → `v0.6.json`; add new docs |
| [docs/quickstart.md](docs/quickstart.md) | Add "second 60 seconds" real-repo path; v0.5.1 → v0.6.0 action ref |
| [README.md](README.md) | One-line callouts to new agent-facing docs |

## Soft-stop rule (load-bearing)

Stop and skip `init` only when **all** of: `is_agent_project: false`, `suggested_sources` empty, no `shipgate.yaml` exists, no explicit user request. Otherwise proceed.

This is the workaround for the v0.6 detection gap: MCP/OpenAPI-only tool-surface repos register as `is_agent_project: false` (no Python framework imports) but are still valid Shipgate targets. Their hits surface as `suggested_sources`. v0.8 may classify "tool-surface project" additively in detect itself; until then, the trigger table + soft-stop rule are authoritative.

## Sample reference correction

`docs/minimal-real-configs.md` points the OpenAI Agents SDK row at [`samples/support_refund_agent`](samples/support_refund_agent/) (verified: has `agents/refund_agent.py` with `from agents` imports). [`samples/multi_agent_workspace`](samples/multi_agent_workspace/) is MCP-only (`tools.json` files), so it lives in the MCP row. Earlier review caught a wrong reference; this PR ships the corrected table.

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/` — **263 passed** (no test changes; existing suite stays green).
- `python -m ruff check .` — clean.
- All sample references verified: `support_refund_agent/agents/refund_agent.py` exists and uses `from agents import Agent, function_tool`; `support_refund_agent/specs/support-tools.openapi.yaml` exists; `support_refund_agent/.agents-shipgate/mcp-tools.json` exists.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] No new check IDs in this PR
- [x] No schema changes — `report-schema.v0.6.json` untouched
- [x] No package version bump — that lands with PR 3 (Finding fields + schema bump to v0.7)

## What's NOT in this PR (deliberate phasing)

- `docs/autofix-policy.md` — depends on the new `autofix_safe`/`requires_human_review`/`suggested_patch_kind`/`docs_url` Finding fields landing first. Ships in PR 4.
- `CheckMetadata` field additions + per-check population → PR 2.
- `Finding` field additions + derivation in `report_json_payload` + `_run_id` exclude update + `report_schema_version` bump to v0.7 → PR 3.
- Prompt updates with detect-first opening → PR 5.
- Polish + end-to-end metadata round-trip test → PR 6.

This phasing is deliberate: v1 of the plan put `autofix-policy.md` in PR 1 with references to fields that didn't land until PR 3. Reordering keeps every doc reference resolvable at the time of merge.