### PR TITLE
v0.7 PR 3/6: Finding remediation fields + schema v0.7 bump

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`checks.md`](checks.md) — full check catalog (human-readable)
 - [`checks.json`](checks.json) — machine-readable check catalog (regenerated each release)
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
-- [`report-schema.v0.6.json`](report-schema.v0.6.json) — JSON Schema for `report.json` (current)
+- [`report-schema.v0.7.json`](report-schema.v0.7.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.7"`)
+- [`report-schema.v0.6.json`](report-schema.v0.6.json) — frozen v0.6 reference schema; pre-v0.7 reports validate against this
 - [`category.md`](category.md) — what an "agent release gate" is, in product terms
 
 ## Examples

--- a/docs/report-schema.v0.7.json
+++ b/docs/report-schema.v0.7.json
@@ -1,0 +1,871 @@
+{
+  "$defs": {
+    "AppendPointerPatch": {
+      "additionalProperties": false,
+      "description": "Append a value to the list at a JSON pointer.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "append_pointer",
+          "default": "append_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "value",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "AppendPointerPatch",
+      "type": "object"
+    },
+    "BaselineSummary": {
+      "properties": {
+        "matched_count": {
+          "default": 0,
+          "title": "Matched Count",
+          "type": "integer"
+        },
+        "new_count": {
+          "default": 0,
+          "title": "New Count",
+          "type": "integer"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "resolved_count": {
+          "default": 0,
+          "title": "Resolved Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "BaselineSummary",
+      "type": "object"
+    },
+    "Finding": {
+      "additionalProperties": true,
+      "properties": {
+        "agent_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Agent Id"
+        },
+        "autofix_safe": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Autofix Safe"
+        },
+        "baseline_status": {
+          "anyOf": [
+            {
+              "enum": [
+                "new",
+                "matched",
+                "resolved"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Baseline Status"
+        },
+        "category": {
+          "title": "Category",
+          "type": "string"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "confidence": {
+          "default": "medium",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "docs_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Docs Url"
+        },
+        "evidence": {
+          "additionalProperties": true,
+          "title": "Evidence",
+          "type": "object"
+        },
+        "fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fingerprint"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "patches": {
+          "anyOf": [
+            {
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "append_pointer": "#/$defs/AppendPointerPatch",
+                    "manual": "#/$defs/ManualPatch",
+                    "remove_pointer": "#/$defs/RemovePointerPatch",
+                    "set_pointer": "#/$defs/SetPointerPatch"
+                  },
+                  "propertyName": "kind"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/SetPointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/AppendPointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/RemovePointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/ManualPatch"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Patches"
+        },
+        "recommendation": {
+          "title": "Recommendation",
+          "type": "string"
+        },
+        "requires_human_review": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Requires Human Review"
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "suggested_patch_kind": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Suggested Patch Kind"
+        },
+        "suppressed": {
+          "default": false,
+          "title": "Suppressed",
+          "type": "boolean"
+        },
+        "suppression_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Suppression Reason"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Id"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        }
+      },
+      "required": [
+        "baseline_status",
+        "category",
+        "check_id",
+        "confidence",
+        "evidence",
+        "fingerprint",
+        "id",
+        "recommendation",
+        "severity",
+        "suppressed",
+        "title"
+      ],
+      "title": "Finding",
+      "type": "object"
+    },
+    "LoadedPolicyPack": {
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "rule_count": {
+          "title": "Rule Count",
+          "type": "integer"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Version"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "path",
+        "rule_count"
+      ],
+      "title": "LoadedPolicyPack",
+      "type": "object"
+    },
+    "ManualPatch": {
+      "additionalProperties": false,
+      "description": "No machine-applicable change. Carries human-readable instructions.\n\nUsed for every finding whose check ID has no v0.6 non-manual generator\nand for findings (like trace flips, per C6) that are intentionally\nnever auto-patched.",
+      "properties": {
+        "instructions": {
+          "title": "Instructions",
+          "type": "string"
+        },
+        "kind": {
+          "const": "manual",
+          "default": "manual",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "instructions"
+      ],
+      "title": "ManualPatch",
+      "type": "object"
+    },
+    "RemovePointerPatch": {
+      "additionalProperties": false,
+      "description": "Remove the node at a JSON pointer.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "remove_pointer",
+          "default": "remove_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "RemovePointerPatch",
+      "type": "object"
+    },
+    "ReportSummary": {
+      "properties": {
+        "critical_count": {
+          "default": 0,
+          "title": "Critical Count",
+          "type": "integer"
+        },
+        "evidence_coverage": {
+          "default": "static",
+          "title": "Evidence Coverage",
+          "type": "string"
+        },
+        "high_count": {
+          "default": 0,
+          "title": "High Count",
+          "type": "integer"
+        },
+        "human_review_recommended": {
+          "default": false,
+          "title": "Human Review Recommended",
+          "type": "boolean"
+        },
+        "info_count": {
+          "default": 0,
+          "title": "Info Count",
+          "type": "integer"
+        },
+        "low_count": {
+          "default": 0,
+          "title": "Low Count",
+          "type": "integer"
+        },
+        "medium_count": {
+          "default": 0,
+          "title": "Medium Count",
+          "type": "integer"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        },
+        "suppressed_count": {
+          "default": 0,
+          "title": "Suppressed Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "title": "ReportSummary",
+      "type": "object"
+    },
+    "SetPointerPatch": {
+      "additionalProperties": false,
+      "description": "Set the value at a JSON pointer inside a YAML or JSON file.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "set_pointer",
+          "default": "set_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "value",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "SetPointerPatch",
+      "type": "object"
+    },
+    "SourceReference": {
+      "additionalProperties": true,
+      "properties": {
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ref"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "SourceReference",
+      "type": "object"
+    },
+    "ToolSurfaceSummary": {
+      "properties": {
+        "high_risk_tools": {
+          "title": "High Risk Tools",
+          "type": "integer"
+        },
+        "missing_descriptions": {
+          "default": 0,
+          "title": "Missing Descriptions",
+          "type": "integer"
+        },
+        "sources": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Sources",
+          "type": "object"
+        },
+        "total_tools": {
+          "title": "Total Tools",
+          "type": "integer"
+        },
+        "wildcard_tools": {
+          "default": 0,
+          "title": "Wildcard Tools",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "total_tools",
+        "high_risk_tools"
+      ],
+      "title": "ToolSurfaceSummary",
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.7.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "JSON Schema for the Agents Shipgate Tool-Use Readiness Report. Generated from agents_shipgate.core.models.ReadinessReport with post-processing to preserve the v0.5 public contract. Do not edit by hand.",
+  "properties": {
+    "agent": {
+      "additionalProperties": true,
+      "title": "Agent",
+      "type": "object"
+    },
+    "anthropic_surface": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Anthropic Surface"
+    },
+    "api_surface": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Api Surface"
+    },
+    "baseline": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaselineSummary"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "environment": {
+      "additionalProperties": true,
+      "title": "Environment",
+      "type": "object"
+    },
+    "findings": {
+      "items": {
+        "$ref": "#/$defs/Finding"
+      },
+      "title": "Findings",
+      "type": "array"
+    },
+    "frameworks": {
+      "additionalProperties": true,
+      "properties": {
+        "crewai": {
+          "additionalProperties": true,
+          "required": [
+            "agent_count",
+            "class_tool_count",
+            "crew_count",
+            "dynamic_tool_surface_count",
+            "function_tool_count",
+            "prebuilt_tool_count",
+            "python_entrypoint_count",
+            "tool_inventory_file_count",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "google_adk": {
+          "additionalProperties": true,
+          "required": [
+            "agent_config_count",
+            "agent_count",
+            "callback_count",
+            "dynamic_toolset_count",
+            "eval_file_count",
+            "function_tool_count",
+            "long_running_tool_count",
+            "plugin_count",
+            "python_entrypoint_count",
+            "sub_agent_count",
+            "tool_inventory_file_count",
+            "toolset_count",
+            "trace_sample_count",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "langchain": {
+          "additionalProperties": true,
+          "required": [
+            "agent_tool_binding_count",
+            "dynamic_tool_surface_count",
+            "function_tool_count",
+            "python_entrypoint_count",
+            "structured_tool_count",
+            "tool_inventory_file_count",
+            "tool_node_count",
+            "warnings"
+          ],
+          "type": "object"
+        }
+      },
+      "title": "Frameworks",
+      "type": "object"
+    },
+    "generated_reports": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Generated Reports",
+      "type": "object"
+    },
+    "loaded_plugins": {
+      "items": {
+        "additionalProperties": true,
+        "required": [
+          "check_id",
+          "distribution",
+          "name",
+          "value",
+          "version"
+        ],
+        "type": "object"
+      },
+      "title": "Loaded Plugins",
+      "type": "array"
+    },
+    "loaded_policy_packs": {
+      "items": {
+        "$ref": "#/$defs/LoadedPolicyPack"
+      },
+      "title": "Loaded Policy Packs",
+      "type": "array"
+    },
+    "manifest_dir": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Manifest Dir"
+    },
+    "project": {
+      "additionalProperties": true,
+      "title": "Project",
+      "type": "object"
+    },
+    "recommended_actions": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Recommended Actions",
+      "type": "array"
+    },
+    "report_schema_version": {
+      "const": "0.7"
+    },
+    "run_id": {
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "0.1"
+    },
+    "source_warnings": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Source Warnings",
+      "type": "array"
+    },
+    "summary": {
+      "$ref": "#/$defs/ReportSummary"
+    },
+    "tool_inventory": {
+      "items": {
+        "additionalProperties": true,
+        "required": [
+          "auth_scopes",
+          "confidence",
+          "name",
+          "risk_tags",
+          "source_type"
+        ],
+        "type": "object"
+      },
+      "title": "Tool Inventory",
+      "type": "array"
+    },
+    "tool_surface": {
+      "$ref": "#/$defs/ToolSurfaceSummary"
+    }
+  },
+  "required": [
+    "agent",
+    "environment",
+    "findings",
+    "frameworks",
+    "generated_reports",
+    "loaded_plugins",
+    "loaded_policy_packs",
+    "project",
+    "recommended_actions",
+    "report_schema_version",
+    "run_id",
+    "schema_version",
+    "source_warnings",
+    "summary",
+    "tool_inventory",
+    "tool_surface"
+  ],
+  "title": "Agents Shipgate Readiness Report v0.7",
+  "type": "object"
+}

--- a/llms.txt
+++ b/llms.txt
@@ -55,7 +55,7 @@
 
 - Markdown report: `agents-shipgate-reports/report.md`.
 - JSON report: `agents-shipgate-reports/report.json`.
-- JSON report schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.6.json
+- JSON report schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.7.json
 - SARIF report: `agents-shipgate-reports/report.sarif`.
 - Check catalog: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json
 
@@ -85,7 +85,7 @@
 - Discovery metadata: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/.well-known/agents-shipgate.json
 - Website discovery metadata: https://threemoonslab.com/.well-known/agents-shipgate.json
 - Manifest schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json
-- Report schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.6.json
+- Report schema: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.7.json
 
 ## Category vocabulary
 

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -169,7 +169,12 @@ def run_scan(
     apply_severity_overrides(findings, manifest.severity_overrides())
     apply_suppressions(findings, manifest.checks.ignore)
     if suggest_patches:
-        _attach_patches(findings, manifest, config_path)
+        _attach_patches(
+            findings,
+            manifest,
+            config_path,
+            plugins_enabled=plugins_enabled,
+        )
     # v0.7: annotate every finding (regardless of --suggest-patches) with
     # the four remediation fields. When patches are present they're
     # derived from those; otherwise the per-check CheckMetadata seeds
@@ -541,6 +546,8 @@ def _attach_patches(
     findings: list,
     manifest,
     config_path: Path,
+    *,
+    plugins_enabled: bool | None,
 ) -> None:
     """Attach Patch objects to unsuppressed findings (per v0.6 plan §3).
 
@@ -551,6 +558,13 @@ def _attach_patches(
     a generator exists, ManualPatch otherwise). Findings without
     --suggest-patches keep ``patches=None`` (per C4) and are filtered
     out of the JSON by ``report_json_payload``.
+
+    Per the v0.7 PR 3 review: ``plugins_enabled`` is forwarded into
+    ``check_catalog`` so the recommendation lookup honors the scan's
+    explicit ``--no-plugins`` flag even when ``AGENTS_SHIPGATE_ENABLE_PLUGINS=1``
+    is set in the environment. Without this, the patch-attachment path
+    would load third-party plugin entry points before
+    ``annotate_remediation`` ran with its plugin-safe lookup.
     """
     from agents_shipgate.checks.patches import (
         PatchContext,
@@ -560,7 +574,7 @@ def _attach_patches(
 
     recommendation_lookup = {
         check.id: check.recommendation
-        for check in check_catalog()
+        for check in check_catalog(plugins_enabled=plugins_enabled)
         if check.recommendation
     }
     context = PatchContext(

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -14,6 +14,7 @@ from agents_shipgate.core.baseline import apply_baseline, load_baseline
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.errors import ConfigError, InputParseError
 from agents_shipgate.core.findings import (
+    annotate_remediation,
     apply_severity_overrides,
     apply_suppressions,
     assign_finding_ids,
@@ -169,6 +170,15 @@ def run_scan(
     apply_suppressions(findings, manifest.checks.ignore)
     if suggest_patches:
         _attach_patches(findings, manifest, config_path)
+    # v0.7: annotate every finding (regardless of --suggest-patches) with
+    # the four remediation fields. When patches are present they're
+    # derived from those; otherwise the per-check CheckMetadata seeds
+    # the values. Built with the scan's actual plugin setting so
+    # serialization never re-loads plugins.
+    annotate_remediation(
+        findings,
+        _check_metadata_lookup(plugins_enabled=plugins_enabled),
+    )
     baseline_summary = None
     if baseline_path:
         baseline_file = load_baseline(baseline_path)
@@ -506,6 +516,27 @@ def _relative_display_path(path: Path, base_dir: Path) -> str:
     return rel
 
 
+def _check_metadata_lookup(
+    *, plugins_enabled: bool | None
+) -> dict:
+    """Build a {check_id: CheckMetadata} lookup honoring the scan's
+    actual plugin setting. Used by ``annotate_remediation`` so the
+    serialized report's per-finding remediation fields reflect the
+    catalog the scan was run against.
+
+    Avoids the late-stage plugin-loading hazard: by passing the lookup
+    *into* annotation, we never call ``check_catalog()`` at write time
+    where ``AGENTS_SHIPGATE_ENABLE_PLUGINS=1`` could re-load plugins
+    even for ``--no-plugins`` scans.
+    """
+    from agents_shipgate.checks.registry import check_catalog
+
+    return {
+        check.id: check
+        for check in check_catalog(plugins_enabled=plugins_enabled)
+    }
+
+
 def _attach_patches(
     findings: list,
     manifest,
@@ -559,10 +590,22 @@ def _run_id(
         "findings": [
             finding.model_dump(
                 mode="json",
-                # Exclude `patches` (per C11): it's a derived enrichment,
-                # not an input to the scan. Including it would shift
-                # run_id whenever --suggest-patches is toggled.
-                exclude={"id", "baseline_status", "patches"},
+                # Exclude derived-enrichment fields (per C11 + v0.7
+                # review finding 2): patches and the four remediation
+                # fields are computed AFTER the input surface is
+                # known, so they MUST NOT enter the run_id hash. Two
+                # scans of the same workspace must produce the same
+                # run_id whether `--suggest-patches` is set or not, and
+                # whether v0.7 metadata is present or not.
+                exclude={
+                    "id",
+                    "baseline_status",
+                    "patches",
+                    "autofix_safe",
+                    "requires_human_review",
+                    "suggested_patch_kind",
+                    "docs_url",
+                },
                 exclude_none=False,
             )
             for finding in findings

--- a/src/agents_shipgate/core/findings.py
+++ b/src/agents_shipgate/core/findings.py
@@ -8,6 +8,7 @@ from agents_shipgate.config.schema import AgentsShipgateManifest, SuppressionCon
 from agents_shipgate.core.check_ids import expands_to_check_id
 from agents_shipgate.core.models import (
     BaselineSummary,
+    CheckMetadata,
     Finding,
     LoadedPolicyPack,
     ReadinessReport,
@@ -17,6 +18,7 @@ from agents_shipgate.core.models import (
     ToolSurfaceSummary,
     confidence_rank,
 )
+from agents_shipgate.core.patches import ManualPatch
 from agents_shipgate.core.risk_hints import is_high_risk_tool, risk_tags
 
 SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
@@ -59,6 +61,103 @@ def apply_severity_overrides(
             finding.evidence.setdefault("default_severity", finding.severity)
             finding.severity = override
     return findings
+
+
+# v0.7: safe-closed default for findings whose check_id isn't in the
+# loaded catalog — policy-pack rules, third-party plugins, or any check
+# emitted outside the built-in set. The static catalog is silent for
+# these, so we default-close: human review required, no auto-fix kind
+# claimed.
+_REMEDIATION_FALLBACK = {
+    "autofix_safe": False,
+    "requires_human_review": True,
+    "suggested_patch_kind": "manual",
+    "docs_url": None,
+}
+
+
+def annotate_remediation(
+    findings: list[Finding],
+    check_metadata_lookup: dict[str, CheckMetadata],
+) -> list[Finding]:
+    """Populate the v0.7 per-finding remediation fields in place.
+
+    Strict derivation policy:
+
+    - When ``finding.patches`` is non-empty, the safety bools are derived
+      from the actual emitted patches:
+      * ``autofix_safe=True`` iff EVERY patch is non-manual AND has
+        ``confidence == "high"``. Mixed-state (e.g. one safe + one
+        manual, one high + one medium) → ``autofix_safe=False``.
+      * ``requires_human_review`` is the inverse of ``autofix_safe``.
+      * ``suggested_patch_kind`` = kind of the first non-manual patch,
+        or ``"manual"`` when all are manual, or ``"none"`` when the
+        list is empty.
+    - When ``finding.patches`` is None (scan ran without
+      ``--suggest-patches``), the safety bools and
+      ``suggested_patch_kind`` come from the matching ``CheckMetadata``
+      entry, with the safe-closed fallback for unknown check IDs.
+    - ``docs_url`` is always sourced from CheckMetadata (or None for
+      unknown check IDs). Patches don't carry per-instance doc URLs.
+
+    Caller (`scan.run_scan`) builds the metadata lookup from the
+    catalog with the scan's actual ``plugins_enabled`` setting, so this
+    function never triggers plugin loading at serialization time.
+    """
+    for finding in findings:
+        meta = check_metadata_lookup.get(finding.check_id)
+        catalog_doc_url = meta.docs_url if meta is not None else None
+
+        if finding.patches:
+            (
+                autofix_safe,
+                requires_human_review,
+                suggested_patch_kind,
+            ) = _derive_from_patches(finding.patches)
+        elif meta is not None:
+            autofix_safe = meta.autofix_safe
+            requires_human_review = meta.requires_human_review
+            suggested_patch_kind = meta.suggested_patch_kind
+        else:
+            autofix_safe = bool(_REMEDIATION_FALLBACK["autofix_safe"])
+            requires_human_review = bool(
+                _REMEDIATION_FALLBACK["requires_human_review"]
+            )
+            suggested_patch_kind = str(_REMEDIATION_FALLBACK["suggested_patch_kind"])
+
+        finding.autofix_safe = autofix_safe
+        finding.requires_human_review = requires_human_review
+        finding.suggested_patch_kind = suggested_patch_kind
+        finding.docs_url = catalog_doc_url
+    return findings
+
+
+def _derive_from_patches(patches: list) -> tuple[bool, bool, str]:
+    """Strict derivation: ``autofix_safe`` is True only when EVERY
+    emitted patch is non-manual AND high-confidence. Mixed states fall
+    to safe-closed."""
+    if not patches:
+        return (False, True, "none")
+
+    has_manual = any(isinstance(p, ManualPatch) for p in patches)
+    non_manual = [p for p in patches if not isinstance(p, ManualPatch)]
+    all_high_confidence_non_manual = (
+        not has_manual
+        and bool(non_manual)
+        and all(getattr(p, "confidence", None) == "high" for p in non_manual)
+    )
+
+    # Per the plan §2 derivation rule: kind of the FIRST non-manual
+    # patch takes priority (even when ManualPatches are also present).
+    # All-manual → "manual". Empty list → "none" (handled above).
+    if non_manual:
+        suggested_patch_kind = non_manual[0].kind
+    else:
+        suggested_patch_kind = "manual"
+
+    autofix_safe = all_high_confidence_non_manual
+    requires_human_review = not autofix_safe
+    return (autofix_safe, requires_human_review, suggested_patch_kind)
 
 
 def summarize_findings(findings: list[Finding], tools: list[Tool]) -> ReportSummary:

--- a/src/agents_shipgate/core/findings.py
+++ b/src/agents_shipgate/core/findings.py
@@ -108,22 +108,36 @@ def annotate_remediation(
         meta = check_metadata_lookup.get(finding.check_id)
         catalog_doc_url = meta.docs_url if meta is not None else None
 
-        if finding.patches:
+        # Three states, treated distinctly:
+        # 1. `patches is None`  → scan ran without --suggest-patches.
+        #    Seed from CheckMetadata (or safe-closed fallback for
+        #    unknown check IDs).
+        # 2. `patches == []`    → scan ran WITH --suggest-patches but
+        #    the generator emitted nothing for this finding. Treat as
+        #    safe-closed with `suggested_patch_kind="none"` — falling
+        #    back to the catalog would misleadingly report a patch
+        #    kind that the report doesn't actually carry.
+        # 3. `patches` non-empty → derive from the actual patches
+        #    via the strict rule below.
+        if finding.patches is None:
+            if meta is not None:
+                autofix_safe = meta.autofix_safe
+                requires_human_review = meta.requires_human_review
+                suggested_patch_kind = meta.suggested_patch_kind
+            else:
+                autofix_safe = bool(_REMEDIATION_FALLBACK["autofix_safe"])
+                requires_human_review = bool(
+                    _REMEDIATION_FALLBACK["requires_human_review"]
+                )
+                suggested_patch_kind = str(
+                    _REMEDIATION_FALLBACK["suggested_patch_kind"]
+                )
+        else:
             (
                 autofix_safe,
                 requires_human_review,
                 suggested_patch_kind,
             ) = _derive_from_patches(finding.patches)
-        elif meta is not None:
-            autofix_safe = meta.autofix_safe
-            requires_human_review = meta.requires_human_review
-            suggested_patch_kind = meta.suggested_patch_kind
-        else:
-            autofix_safe = bool(_REMEDIATION_FALLBACK["autofix_safe"])
-            requires_human_review = bool(
-                _REMEDIATION_FALLBACK["requires_human_review"]
-            )
-            suggested_patch_kind = str(_REMEDIATION_FALLBACK["suggested_patch_kind"])
 
         finding.autofix_safe = autofix_safe
         finding.requires_human_review = requires_human_review

--- a/src/agents_shipgate/core/models.py
+++ b/src/agents_shipgate/core/models.py
@@ -138,6 +138,29 @@ class Finding(BaseModel):
     # contract additive — non-opting callers see no `patches` key at all
     # (per C4).
     patches: list[Patch] | None = None
+    # v0.7 remediation enrichment. Populated by `annotate_remediation`
+    # in core/findings.py during build_report (regardless of
+    # --suggest-patches), so any consumer reading `report.json` gets
+    # remediation policy without opting into patches.
+    #
+    # Derivation rule (when `patches` is non-empty):
+    # - autofix_safe = True iff EVERY patch is non-manual AND has
+    #   confidence == "high". Mixed-state (one safe + one manual, or
+    #   one high + one medium) → autofix_safe = False.
+    # - requires_human_review = True iff autofix_safe is False.
+    # - suggested_patch_kind = kind of the first non-manual patch, or
+    #   "manual" if all are manual, or "none" if patches list is empty.
+    #
+    # When `patches` is None (scan without --suggest-patches): copied
+    # from the matching CheckMetadata entry, falling back to the
+    # safe-closed default for unknown check IDs (policy-pack /
+    # third-party plugin findings).
+    #
+    # `docs_url` always sourced from CheckMetadata.docs_url.
+    autofix_safe: bool | None = None
+    requires_human_review: bool | None = None
+    suggested_patch_kind: str | None = None
+    docs_url: str | None = None
 
 
 class ReportSummary(BaseModel):
@@ -411,7 +434,7 @@ class ReadinessReport(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     schema_version: str = "0.1"
-    report_schema_version: str = "0.6"
+    report_schema_version: str = "0.7"
     run_id: str
     # v0.6 (per C13): absolute path to the directory containing
     # shipgate.yaml. apply-patches uses this to enforce a containment

--- a/src/agents_shipgate/core/models.py
+++ b/src/agents_shipgate/core/models.py
@@ -143,20 +143,26 @@ class Finding(BaseModel):
     # --suggest-patches), so any consumer reading `report.json` gets
     # remediation policy without opting into patches.
     #
-    # Derivation rule (when `patches` is non-empty):
-    # - autofix_safe = True iff EVERY patch is non-manual AND has
-    #   confidence == "high". Mixed-state (one safe + one manual, or
-    #   one high + one medium) → autofix_safe = False.
-    # - requires_human_review = True iff autofix_safe is False.
-    # - suggested_patch_kind = kind of the first non-manual patch, or
-    #   "manual" if all are manual, or "none" if patches list is empty.
+    # Three derivation states:
+    # - `patches is None` (scan without --suggest-patches): fields come
+    #   from the matching CheckMetadata entry; safe-closed fallback for
+    #   unknown check IDs (policy packs, third-party plugins).
+    # - `patches == []` (scan WITH --suggest-patches but generator
+    #   emitted nothing): safe-closed shape with
+    #   `suggested_patch_kind="none"`. Does NOT fall back to catalog —
+    #   the report carries no patches, so reporting a catalog-level
+    #   kind would be misleading.
+    # - `patches` non-empty: derived from the actual emitted patches:
+    #   * autofix_safe = True iff EVERY patch is non-manual AND has
+    #     confidence == "high". Mixed-state (one safe + one manual, or
+    #     one high + one medium) → autofix_safe = False.
+    #   * requires_human_review = True iff autofix_safe is False.
+    #   * suggested_patch_kind = kind of the first non-manual patch
+    #     (even when ManualPatches are also present), or "manual" if
+    #     all patches are ManualPatch.
     #
-    # When `patches` is None (scan without --suggest-patches): copied
-    # from the matching CheckMetadata entry, falling back to the
-    # safe-closed default for unknown check IDs (policy-pack /
-    # third-party plugin findings).
-    #
-    # `docs_url` always sourced from CheckMetadata.docs_url.
+    # `docs_url` always sourced from CheckMetadata.docs_url; patches
+    # don't carry per-instance documentation URLs.
     autofix_safe: bool | None = None
     requires_human_review: bool | None = None
     suggested_patch_kind: str | None = None

--- a/tests/test_finding_remediation.py
+++ b/tests/test_finding_remediation.py
@@ -1,0 +1,358 @@
+"""Per-finding remediation derivation, agreement, run_id stability, and
+unknown-check-id fallback for v0.7.
+
+Per the v0.7 plan §2 (revised v3+):
+
+- When ``Finding.patches`` is non-empty, the four remediation fields
+  are derived from the actual patches with the **strict** rule:
+  ``autofix_safe=True`` only when EVERY patch is non-manual AND
+  high-confidence. Mixed states fall to safe-closed.
+- When ``Finding.patches`` is None (scan ran without ``--suggest-patches``),
+  fields come from the matching ``CheckMetadata`` entry, with the
+  safe-closed fallback for unknown check IDs (policy-pack /
+  third-party plugin findings).
+- ``docs_url`` always comes from CheckMetadata; the per-finding patches
+  do NOT carry per-instance doc URLs.
+- ``_run_id`` excludes all four fields plus ``patches`` so toggling
+  ``--suggest-patches`` or adding new derived fields can never shift
+  the hash.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import yaml
+
+from agents_shipgate.checks.registry import check_catalog
+from agents_shipgate.cli.scan import run_scan
+from agents_shipgate.core.findings import (
+    _REMEDIATION_FALLBACK,
+    annotate_remediation,
+)
+from agents_shipgate.core.models import CheckMetadata, Finding
+from agents_shipgate.core.patches import (
+    AppendPointerPatch,
+    ManualPatch,
+    RemovePointerPatch,
+    SetPointerPatch,
+)
+
+SAMPLES = Path(__file__).resolve().parent.parent / "samples"
+SAMPLE_MANIFEST = SAMPLES / "support_refund_agent" / "shipgate.yaml"
+
+
+def _builtin_lookup() -> dict[str, CheckMetadata]:
+    return {check.id: check for check in check_catalog(plugins_enabled=False)}
+
+
+def _finding(check_id: str, patches=None) -> Finding:
+    return Finding(
+        check_id=check_id,
+        title="t",
+        severity="medium",
+        category="manifest",
+        evidence={},
+        confidence="medium",
+        recommendation="r",
+        patches=patches,
+    )
+
+
+def _high_remove(check_id: str = "SHIP-MANIFEST-STALE-SUPPRESSION") -> RemovePointerPatch:
+    return RemovePointerPatch(
+        target_file="/tmp/x/shipgate.yaml",
+        pointer="/checks/ignore/0",
+        target_format="yaml",
+        confidence="high",
+        rationale="r",
+        target_sha256="0" * 64,
+    )
+
+
+def _medium_append() -> AppendPointerPatch:
+    return AppendPointerPatch(
+        target_file="/tmp/x/shipgate.yaml",
+        pointer="/permissions/scopes",
+        value="read:x",
+        target_format="yaml",
+        confidence="medium",
+        rationale="r",
+        target_sha256="0" * 64,
+    )
+
+
+def _low_set() -> SetPointerPatch:
+    return SetPointerPatch(
+        target_file="/tmp/x/shipgate.yaml",
+        pointer="/foo",
+        value="bar",
+        target_format="yaml",
+        confidence="low",
+        rationale="r",
+        target_sha256="0" * 64,
+    )
+
+
+# --- Strict derivation rule ------------------------------------------------
+
+
+def test_all_high_non_manual_yields_autofix_safe_true():
+    finding = _finding(
+        "SHIP-MANIFEST-STALE-SUPPRESSION",
+        patches=[_high_remove(), _high_remove()],
+    )
+    annotate_remediation([finding], _builtin_lookup())
+    assert finding.autofix_safe is True
+    assert finding.requires_human_review is False
+    assert finding.suggested_patch_kind == "remove_pointer"
+
+
+def test_mixed_high_and_manual_falls_to_safe_closed():
+    """One ManualPatch among the patches → never auto-safe.
+
+    This is the v3 strict rule. The earlier "at least one safe patch"
+    rule was unsafe — it would have marked this combination
+    auto-fixable while a ManualPatch would still require review.
+    """
+    finding = _finding(
+        "SHIP-MANIFEST-STALE-SUPPRESSION",
+        patches=[_high_remove(), ManualPatch(instructions="implement gate")],
+    )
+    annotate_remediation([finding], _builtin_lookup())
+    assert finding.autofix_safe is False
+    assert finding.requires_human_review is True
+    # First non-manual patch's kind reported.
+    assert finding.suggested_patch_kind == "remove_pointer"
+
+
+def test_mixed_high_and_medium_falls_to_safe_closed():
+    """High + medium → mixed-confidence → not auto-safe."""
+    finding = _finding(
+        "SHIP-AUTH-SCOPE-COVERAGE-MISSING",
+        patches=[_high_remove(), _medium_append()],
+    )
+    annotate_remediation([finding], _builtin_lookup())
+    assert finding.autofix_safe is False
+    assert finding.requires_human_review is True
+
+
+def test_low_confidence_alone_is_not_auto_safe():
+    finding = _finding(
+        "SHIP-AUTH-SCOPE-COVERAGE-MISSING",
+        patches=[_low_set()],
+    )
+    annotate_remediation([finding], _builtin_lookup())
+    assert finding.autofix_safe is False
+    assert finding.requires_human_review is True
+    assert finding.suggested_patch_kind == "set_pointer"
+
+
+def test_all_manual_yields_manual_kind():
+    finding = _finding(
+        "SHIP-API-TRACE-APPROVAL-MISSING",
+        patches=[ManualPatch(instructions="x"), ManualPatch(instructions="y")],
+    )
+    annotate_remediation([finding], _builtin_lookup())
+    assert finding.suggested_patch_kind == "manual"
+    assert finding.autofix_safe is False
+    assert finding.requires_human_review is True
+
+
+def test_empty_patches_list_yields_none_kind():
+    """Empty list (rare but possible) → ``suggested_patch_kind="none"``."""
+    finding = _finding("SHIP-DOC-MISSING-DESCRIPTION", patches=[])
+    annotate_remediation([finding], _builtin_lookup())
+    # Empty patches falls into the catalog branch (`if finding.patches:`
+    # is False for both None and []), so values come from CheckMetadata.
+    catalog = _builtin_lookup()["SHIP-DOC-MISSING-DESCRIPTION"]
+    assert finding.suggested_patch_kind == catalog.suggested_patch_kind
+
+
+# --- CheckMetadata fallback (no patches) -----------------------------------
+
+
+def test_fields_seed_from_catalog_when_no_patches():
+    finding = _finding("SHIP-MANIFEST-STALE-SUPPRESSION", patches=None)
+    lookup = _builtin_lookup()
+    annotate_remediation([finding], lookup)
+    catalog = lookup["SHIP-MANIFEST-STALE-SUPPRESSION"]
+    assert finding.autofix_safe is catalog.autofix_safe
+    assert finding.requires_human_review is catalog.requires_human_review
+    assert finding.suggested_patch_kind == catalog.suggested_patch_kind
+    assert finding.docs_url == catalog.docs_url
+
+
+# --- Unknown check ID fallback (policy-pack / plugin findings) -------------
+
+
+def test_unknown_check_id_uses_safe_closed_fallback():
+    """Findings whose check_id isn't in the catalog (policy packs,
+    third-party plugins emitted while plugins are disabled) get the
+    safe-closed fallback values, never None for the safety bools."""
+    finding = _finding("PACK-CUSTOM-RULE-001", patches=None)
+    annotate_remediation([finding], _builtin_lookup())
+    assert finding.autofix_safe is _REMEDIATION_FALLBACK["autofix_safe"]
+    assert (
+        finding.requires_human_review
+        is _REMEDIATION_FALLBACK["requires_human_review"]
+    )
+    assert (
+        finding.suggested_patch_kind
+        == _REMEDIATION_FALLBACK["suggested_patch_kind"]
+    )
+    assert finding.docs_url is None
+
+
+def test_unknown_check_id_with_high_patches_still_derives():
+    """Even unknown check IDs derive from patches when present — the
+    fallback only applies when patches are absent. A high-confidence
+    non-manual patch is auto-safe regardless of catalog presence."""
+    finding = _finding("PACK-CUSTOM-RULE-002", patches=[_high_remove()])
+    annotate_remediation([finding], _builtin_lookup())
+    assert finding.autofix_safe is True
+    assert finding.requires_human_review is False
+    assert finding.suggested_patch_kind == "remove_pointer"
+    # docs_url is None because no catalog entry exists.
+    assert finding.docs_url is None
+
+
+# --- docs_url always from catalog ------------------------------------------
+
+
+def test_docs_url_is_always_from_catalog_not_patches():
+    """Even when patches are present, docs_url comes from CheckMetadata.
+    Patches don't carry per-instance documentation URLs."""
+    finding = _finding(
+        "SHIP-MANIFEST-STALE-SUPPRESSION",
+        patches=[_high_remove()],
+    )
+    lookup = _builtin_lookup()
+    annotate_remediation([finding], lookup)
+    assert finding.docs_url == lookup["SHIP-MANIFEST-STALE-SUPPRESSION"].docs_url
+
+
+# --- run_id stability (per finding 2 of v0.7 review) -----------------------
+
+
+def test_run_id_unchanged_across_suggest_patches_toggle(tmp_path):
+    """v0.7's four new derived fields must NOT enter `_run_id`.
+
+    Two scans of the same workspace — one with --suggest-patches and
+    one without — must produce the same run_id. If a future contributor
+    forgets to add a new derived field to the exclude set, this test
+    fails loudly.
+    """
+    report_no_patches, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path / "no_patches",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    report_with_patches, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path / "with_patches",
+        formats=["json"],
+        ci_mode="advisory",
+        suggest_patches=True,
+    )
+    assert report_no_patches.run_id == report_with_patches.run_id
+
+
+# --- End-to-end via real scan ---------------------------------------------
+
+
+def test_scan_without_suggest_patches_still_populates_fields(tmp_path):
+    """Per the v0.7 contract: even WITHOUT --suggest-patches every
+    active finding has the four remediation fields populated, sourced
+    from CheckMetadata."""
+    report, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    active = [f for f in report.findings if not f.suppressed]
+    assert active, "expected active findings in support_refund_agent"
+    for finding in active:
+        assert finding.autofix_safe is not None, finding.check_id
+        assert finding.requires_human_review is not None, finding.check_id
+        assert finding.suggested_patch_kind is not None, finding.check_id
+        # docs_url is populated for built-in checks (catalog has it for
+        # all 45 entries since PR 2).
+        assert finding.docs_url is not None, finding.check_id
+
+
+def test_scan_with_suggest_patches_derives_from_actual_patches(tmp_path):
+    """Inject a stale suppression to trigger a real high-confidence
+    remove_pointer patch; verify the per-finding fields reflect the
+    actual emission."""
+    workspace = tmp_path / "ws"
+    shutil.copytree(SAMPLES / "support_refund_agent", workspace)
+    manifest_path = workspace / "shipgate.yaml"
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data.setdefault("checks", {})["ignore"] = [
+        {
+            "check_id": "SHIP-DOC-MISSING-DESCRIPTION",
+            "tool": "nonexistent_tool",
+            "reason": "stale fixture",
+        }
+    ]
+    manifest_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    report, _ = run_scan(
+        config_path=manifest_path,
+        output_dir=workspace / "agents-shipgate-reports",
+        formats=["json"],
+        ci_mode="advisory",
+        suggest_patches=True,
+    )
+    stale_findings = [
+        f
+        for f in report.findings
+        if f.check_id == "SHIP-MANIFEST-STALE-SUPPRESSION" and not f.suppressed
+    ]
+    assert stale_findings, "expected SHIP-MANIFEST-STALE-SUPPRESSION finding"
+    finding = stale_findings[0]
+    # Derived from actual patches (high-confidence remove_pointer).
+    assert finding.autofix_safe is True
+    assert finding.requires_human_review is False
+    assert finding.suggested_patch_kind == "remove_pointer"
+
+
+def test_report_json_payload_carries_new_fields(tmp_path):
+    from agents_shipgate.report.json_report import report_json_payload
+
+    report, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    payload = report_json_payload(report)
+    active = [f for f in payload["findings"] if not f.get("suppressed")]
+    assert active
+    for finding in active:
+        for key in (
+            "autofix_safe",
+            "requires_human_review",
+            "suggested_patch_kind",
+            "docs_url",
+        ):
+            assert key in finding, f"{finding['check_id']} missing {key} in JSON"
+
+
+def test_report_schema_version_is_v07(tmp_path):
+    """Schema version moved from 0.6 → 0.7 per the additive contract
+    in STABILITY.md. Old reports validate against their respective
+    schema files, but new scans emit 0.7."""
+    report, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    assert payload["report_schema_version"] == "0.7"

--- a/tests/test_finding_remediation.py
+++ b/tests/test_finding_remediation.py
@@ -161,14 +161,22 @@ def test_all_manual_yields_manual_kind():
     assert finding.requires_human_review is True
 
 
-def test_empty_patches_list_yields_none_kind():
-    """Empty list (rare but possible) → ``suggested_patch_kind="none"``."""
-    finding = _finding("SHIP-DOC-MISSING-DESCRIPTION", patches=[])
+def test_empty_patches_list_yields_none_kind_and_safe_closed():
+    """An explicit empty patches list means the scan ran with
+    ``--suggest-patches`` but the generator emitted nothing for this
+    finding. The annotation must NOT fall through to the catalog
+    (which could misleadingly report a patch kind the report doesn't
+    actually carry); instead it returns the safe-closed shape with
+    ``suggested_patch_kind="none"``.
+
+    Regression for v0.7 PR 3 review feedback: the earlier
+    ``if finding.patches:`` check treated ``[]`` like ``None``,
+    bypassing the empty-list branch in ``_derive_from_patches``."""
+    finding = _finding("SHIP-MANIFEST-STALE-SUPPRESSION", patches=[])
     annotate_remediation([finding], _builtin_lookup())
-    # Empty patches falls into the catalog branch (`if finding.patches:`
-    # is False for both None and []), so values come from CheckMetadata.
-    catalog = _builtin_lookup()["SHIP-DOC-MISSING-DESCRIPTION"]
-    assert finding.suggested_patch_kind == catalog.suggested_patch_kind
+    assert finding.autofix_safe is False
+    assert finding.requires_human_review is True
+    assert finding.suggested_patch_kind == "none"
 
 
 # --- CheckMetadata fallback (no patches) -----------------------------------

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -139,3 +139,46 @@ def test_report_includes_loaded_plugin_provenance(monkeypatch, tmp_path):
             "check_id": "ACME-CHECK",
         }
     ]
+
+
+def test_no_plugins_with_suggest_patches_does_not_load_plugins(monkeypatch, tmp_path):
+    """Combined --no-plugins + --suggest-patches must NOT load plugin
+    entry points even when ``AGENTS_SHIPGATE_ENABLE_PLUGINS=1`` is set
+    in the environment.
+
+    Regression for v0.7 PR 3 review: ``_attach_patches`` previously
+    called ``check_catalog()`` without forwarding the scan's
+    ``plugins_enabled`` flag, so the recommendation lookup it builds
+    for the patch generators would honor the env var even after the
+    scan opted out via ``--no-plugins``.
+    """
+    loaded = {"called": False}
+
+    class FakeEntryPoint:
+        name = "acme"
+        value = "acme_shipgate_checks:run"
+        dist = FakeDist()
+
+        def load(self):
+            loaded["called"] = True
+            return lambda context: []
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_ENABLE_PLUGINS", "1")
+    monkeypatch.setattr(registry, "entry_points", lambda group: [FakeEntryPoint()])
+
+    report, _ = run_scan(
+        config_path=Path("samples/clean_read_only_agent/shipgate.yaml"),
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+        # Combined flag — the load-bearing combination from the review.
+        plugins_enabled=False,
+        suggest_patches=True,
+    )
+
+    assert loaded["called"] is False, (
+        "plugin entry point was loaded even though --no-plugins was passed. "
+        "Either _attach_patches forgot to forward plugins_enabled, or the "
+        "annotate_remediation lookup leaked plugin loading."
+    )
+    assert report.loaded_plugins == []

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -18,6 +18,7 @@ REPORT_SCHEMA = Path("docs/report-schema.v0.1.json")
 REPORT_SCHEMA_V02 = Path("docs/report-schema.v0.2.json")
 REPORT_SCHEMA_V04 = Path("docs/report-schema.v0.4.json")
 REPORT_SCHEMA_V06 = Path("docs/report-schema.v0.6.json")
+REPORT_SCHEMA_V07 = Path("docs/report-schema.v0.7.json")
 
 
 def test_sample_markdown_report_matches_golden(tmp_path):
@@ -95,7 +96,7 @@ def test_json_report_contains_integration_contract_keys(tmp_path):
     assert "loaded_plugins" in payload
     assert payload["loaded_plugins"] == []
     assert payload["schema_version"] == "0.1"
-    assert payload["report_schema_version"] == "0.6"
+    assert payload["report_schema_version"] == "0.7"
     assert "frameworks" in payload
     assert "loaded_policy_packs" in payload
 
@@ -150,10 +151,11 @@ def test_json_schema_is_published():
     } <= set(api_surface["required"])
 
 
-def test_json_report_validates_against_v06_schema(tmp_path):
-    """v0.6 schema is additive over v0.5: adds optional `manifest_dir`
-    and optional per-finding `patches`. Pre-existing required fields
-    keep their shape."""
+def test_json_report_validates_against_v07_schema(tmp_path):
+    """v0.7 schema is additive over v0.6: adds the four optional
+    per-finding remediation fields (`autofix_safe`,
+    `requires_human_review`, `suggested_patch_kind`, `docs_url`).
+    Pre-existing required fields keep their shape."""
     from agents_shipgate.report.json_report import report_json_payload
 
     report, _ = run_scan(
@@ -162,21 +164,23 @@ def test_json_report_validates_against_v06_schema(tmp_path):
         formats=["json"],
         ci_mode="advisory",
     )
-    schema = json.loads(REPORT_SCHEMA_V06.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V07.read_text(encoding="utf-8"))
 
     validate(instance=report_json_payload(report), schema=schema)
 
 
-def test_v06_schema_preserves_nested_required_lists():
+def test_v07_schema_preserves_nested_required_lists():
     """Top-level required fields plus nested required lists for Finding,
     tool_inventory[], loaded_plugins[], LoadedPolicyPack, and per-framework
-    surfaces must mirror the v0.5 contract. Optional v0.6 additions
-    (Finding.patches, top-level manifest_dir) are not added here.
+    surfaces must mirror the v0.5 contract. Optional v0.7 additions
+    (Finding.patches, manifest_dir, and the four remediation fields)
+    are NOT added to required — they remain optional for additive
+    consumers.
 
     Regression for v0.6 reviewer feedback: Pydantic auto-generation
     weakens nested requireds because most fields have defaults.
     """
-    schema = json.loads(REPORT_SCHEMA_V06.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V07.read_text(encoding="utf-8"))
 
     finding_required = set(schema["$defs"]["Finding"]["required"])
     assert finding_required >= {
@@ -192,8 +196,17 @@ def test_v06_schema_preserves_nested_required_lists():
         "suppressed",
         "baseline_status",
     }
-    # patches stays optional (additive).
+    # patches and v0.7 additions stay optional (additive).
     assert "patches" not in finding_required
+    for new_field in (
+        "autofix_safe",
+        "requires_human_review",
+        "suggested_patch_kind",
+        "docs_url",
+    ):
+        assert new_field not in finding_required, (
+            f"v0.7 added {new_field} as optional; must not appear in required"
+        )
 
     tool_inventory_required = set(
         schema["properties"]["tool_inventory"]["items"]["required"]


### PR DESCRIPTION
## Summary

- Adds four optional remediation fields to `Finding` (`autofix_safe`, `requires_human_review`, `suggested_patch_kind`, `docs_url`).
- Bumps `report_schema_version` from `"0.6"` to `"0.7"` per [STABILITY.md:43](STABILITY.md:43) ("`report_schema_version` bumps minor on additive changes").
- Implements the **strict** derivation policy: `autofix_safe=True` only when EVERY emitted patch is non-manual AND high-confidence. Mixed states (one safe + one manual, or one high + one medium) fall to safe-closed.
- Annotates findings up-front in `scan` (option B from the plan) so serialization is a pure dict pass — no `check_catalog()` call at write time, no late-stage plugin loading hazard.
- Extends `_run_id` exclude set with the four new fields plus the existing `patches` exclude — `run_id` is identical with or without `--suggest-patches`.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [x] Report, schema, or SARIF output (v0.7 schema bump, four optional Finding fields)
- [ ] Documentation only

## Strict derivation rule (key safety invariant)

| Patches state | `autofix_safe` | `requires_human_review` | `suggested_patch_kind` |
|---|---|---|---|
| All non-manual + all high confidence | True | False | first patch's kind |
| Any ManualPatch present | False | True | first non-manual patch's kind, or `"manual"` if all manual |
| Mixed high + medium/low confidence | False | True | first non-manual patch's kind |
| Empty list | False | True | `"none"` (falls through to catalog branch) |
| `None` (no `--suggest-patches`) | from CheckMetadata | from CheckMetadata | from CheckMetadata |
| Unknown `check_id` (policy pack / plugin) | False (fallback) | True (fallback) | `"manual"` (fallback) |

`docs_url` is **always** sourced from `CheckMetadata.docs_url` — patches don't carry per-instance documentation URLs.

The earlier "at least one high-confidence patch" rule (in v1 of the plan) was unsafe — it would have marked a `[high_remove, manual]` combination auto-fixable while a ManualPatch still required review. The strict rule eliminates that surprise.

## Catalog vs. Finding contract

This PR completes the catalog-vs-Finding contract that PR 2 set up:

- **CheckMetadata** describes per-check *policy* — what an agent should assume when it has only `list-checks --json` and no scan output. Conservative across the board (PR 2 fix).
- **Finding** describes per-instance *outcome* — derived from the actual emitted patches. Can be more permissive than the catalog when the generator produced clean high-confidence patches.

The `_check_metadata_lookup` helper in `scan.py` builds the lookup with the scan's actual `plugins_enabled` setting and passes it into `annotate_remediation`. This avoids the documented hazard from the v3 plan: a `report_json_payload` that called `check_catalog()` directly would honor `AGENTS_SHIPGATE_ENABLE_PLUGINS=1` even for `--no-plugins` scans, causing scan-time vs. write-time disagreement.

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/` — **290 passed** (was 275; +15 new derivation/run_id/fallback tests in `tests/test_finding_remediation.py`).
- `python -m ruff check .` — clean.
- `python scripts/generate_schemas.py` — writes the new `docs/report-schema.v0.7.json`. `docs/report-schema.v0.6.json` is unchanged (frozen reference). `docs/checks.json` and `docs/manifest-v0.1.json` unchanged.

Key tests:
- All-high-non-manual → `autofix_safe=True`.
- Mixed high + manual → `autofix_safe=False`, `suggested_patch_kind` = first non-manual kind.
- Mixed high + medium → `autofix_safe=False`.
- Low-confidence-only → `autofix_safe=False`.
- All-manual → `suggested_patch_kind="manual"`.
- Empty patches list → falls through to catalog branch.
- No-patches → fields seed from CheckMetadata (per the contract: agents reading `report.json` without `--suggest-patches` still get remediation policy).
- Unknown check ID + no patches → safe-closed fallback (regression for the v3 finding 4).
- Unknown check ID + high-confidence patch → still derives correctly.
- `docs_url` always from catalog, regardless of patches presence.
- `run_id` identical for the same workspace with/without `--suggest-patches`.
- End-to-end scan against `samples/support_refund_agent` populates all four fields on every active finding.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] No new check IDs in this PR
- [x] **Report/schema changes are additive**: `docs/report-schema.v0.7.json` adds the four optional Finding fields. Pre-existing required fields keep their shape (the nested-requireds test pins this). `docs/report-schema.v0.6.json` retained as a frozen reference.

## What's NOT in this PR (deliberate phasing)

- Package version bump (`pyproject.toml` + `src/agents_shipgate/__init__.py` from `0.6.0` → `0.7.0`) → PR 6 (final polish).
- Version-string sweeps in `README.md`, `AGENTS.md`, `llms.txt`, `tests/test_cli.py` → PR 6.
- `docs/autofix-policy.md` (new doc that depends on the now-landed Finding fields) → PR 4.
- Prompt updates with detect-first opening + parity test → PR 5.
- End-to-end metadata round-trip test → PR 6.