### PR TITLE
v0.7 PR 4/6: docs/autofix-policy.md + docs link tests

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -43,6 +43,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 ## For agents
 
 - [`agent-recipes.md`](agent-recipes.md) — copy-pasteable AI-agent workflows for the canonical 4-call flow (`detect → init → scan → apply-patches`)
+- [`autofix-policy.md`](autofix-policy.md) — which findings are safe to apply, which need review, and how `apply-patches --confidence` filters them
 - [`minimal-real-configs.md`](minimal-real-configs.md) — framework-by-framework references to the smallest working manifest
 - [`../AGENTS.md`](../AGENTS.md) — agent-facing instructions
 - [`../CLAUDE.md`](../CLAUDE.md) — Claude Code-specific notes

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -221,12 +221,10 @@ up with an explicit edit.
 ## Reference
 
 - [`docs/checks.md`](checks.md) — full check catalog with rationale
+- [`docs/autofix-policy.md`](autofix-policy.md) — which findings are
+  safe to apply, which need review, and how `apply-patches --confidence`
+  filters them
 - [`docs/minimal-real-configs.md`](minimal-real-configs.md) —
   framework-specific minimal manifests
 - [`AGENTS.md`](../AGENTS.md) — top-level agent instructions, install,
   trigger table
-
-> A dedicated `docs/autofix-policy.md` lands later in the v0.7 series
-> (with the per-finding remediation metadata) and is not present yet.
-> Until then, the per-step guidance in Recipe 1 step 4 above is the
-> authoritative answer for what `--confidence high` mutates by default.

--- a/docs/autofix-policy.md
+++ b/docs/autofix-policy.md
@@ -164,6 +164,15 @@ for finding in active_findings:
         surface_to_user(finding)
         continue
 
+    if finding.suggested_patch_kind == "none":
+        # Scan ran with --suggest-patches but the generator emitted
+        # nothing for this finding (empty patches list — see "Three
+        # patch states" above). There's nothing to apply via
+        # apply-patches at any confidence level. Surface for human
+        # triage instead.
+        surface_to_user(finding)
+        continue
+
     if finding.autofix_safe is True:
         # Safe to include in the next `apply-patches --confidence high`.
         plan_to_apply(finding)

--- a/docs/autofix-policy.md
+++ b/docs/autofix-policy.md
@@ -1,0 +1,196 @@
+# Autofix policy
+
+Which Agents Shipgate findings are safe to apply automatically, which
+need human review, and how the per-finding metadata in `report.json`
+maps to `apply-patches --confidence` flag semantics.
+
+> **Audience.** AI coding agents driving the canonical 4-call flow
+> (see [`agent-recipes.md`](agent-recipes.md)) and CI integrators
+> deciding what to gate on.
+
+---
+
+## The four classes
+
+Every active finding falls into one of four classes. The class is
+encoded by the `autofix_safe` and `requires_human_review` fields on
+each Finding, plus the `kind` and `confidence` fields on each
+attached Patch.
+
+| Class | Finding fields | Patch shape | v0.7 examples |
+|---|---|---|---|
+| **Safe auto-fix** | `autofix_safe: true`, `requires_human_review: false` | All patches non-manual AND high confidence | The 3 stale-manifest removals (`SHIP-MANIFEST-STALE-{SUPPRESSION,POLICY,RISK-OVERRIDE}`) when the match is unique |
+| **Medium-confidence config fix** | `autofix_safe: false`, `requires_human_review: true`, `suggested_patch_kind: append_pointer/set_pointer` | Non-manual patch but at `medium` confidence | `SHIP-AUTH-SCOPE-COVERAGE-MISSING` scope appends |
+| **Manual source/policy fix** | `autofix_safe: false`, `requires_human_review: true`, `suggested_patch_kind: manual` | `ManualPatch` with curated `instructions` | All other ~30 active checks (documentation, schema bounds, owner gaps, ADK/LangChain/CrewAI metadata, …) |
+| **Never auto-fix** | `autofix_safe: false`, `requires_human_review: true`, `suggested_patch_kind: manual` | `ManualPatch` with explicit anti-pattern language | `SHIP-API-TRACE-{APPROVAL,CONFIRMATION}-MISSING` (flipping the trace patches the *evidence*, not the agent's runtime gate) |
+
+Class four is a deliberate subset of class three — the distinction is
+that an agent must NEVER attempt to "auto-fix" a trace finding by
+editing the trace recording, even if the user asks. The
+`ManualPatch.instructions` for these checks spell out the
+anti-pattern in prose so even a curious operator gets the message.
+
+---
+
+## Catalog vs. Finding (the dual-source contract)
+
+Two sources describe per-check remediation policy, and they answer
+different questions:
+
+| Source | Endpoint | What it answers |
+|---|---|---|
+| **CheckMetadata** | `agents-shipgate list-checks --json`, `agents-shipgate explain <ID> --json`, `docs/checks.json` | What an agent should *assume* when it has only the catalog and no scan output. Conservative across the board. |
+| **Finding** | `agents-shipgate-reports/report.json` (per-finding) | What this *specific* instance produced. Can be more permissive than the catalog when the generator emitted clean high-confidence patches. |
+
+**Catalog `autofix_safe` and `requires_human_review` describe the
+worst-case per-check outcome.** A check whose generator USUALLY emits
+a safe non-manual patch but falls back to `ManualPatch` in edge
+cases (e.g. ambiguous duplicate matches in the stale-manifest
+generators) keeps the safe-closed defaults at the catalog level. The
+per-Finding fields tell the truth for that instance.
+
+`suggested_patch_kind` at the catalog level is **informational** —
+it documents the kind the generator *targets* when conditions are
+clean, not what the report carries. An agent that sees
+`suggested_patch_kind: "remove_pointer"` in `list-checks --json`
+should still consult `Finding.patches` (or the per-Finding
+`suggested_patch_kind`) to know whether this particular instance
+actually produced one.
+
+When in doubt, **trust the per-Finding fields over the catalog**
+for any specific finding. The catalog is for static planning
+("which check IDs *might* yield safe fixes"); the report is for
+acting on a specific scan.
+
+---
+
+## Strict derivation rule
+
+When a scan runs with `--suggest-patches`, every active finding
+gets one or more attached patches and the four per-Finding fields
+are derived from those patches with this rule:
+
+```text
+autofix_safe = True iff EVERY patch is non-manual AND has confidence == "high"
+```
+
+That is: a single `ManualPatch` mixed in, or a single `medium`/`low`
+confidence patch mixed in, drops the entire finding to safe-closed.
+The earlier "at least one safe patch wins" rule was unsafe — it
+would have marked a `[high_remove, manual]` combination
+auto-fixable while a ManualPatch still required review.
+
+`suggested_patch_kind` is the kind of the **first non-manual patch**
+even when ManualPatches are also present. (If ALL patches are
+manual: `"manual"`. If the patches list is empty: `"none"`.)
+
+`requires_human_review` is always the inverse of `autofix_safe`.
+
+`docs_url` always comes from `CheckMetadata.docs_url`. Patches
+don't carry per-instance documentation URLs.
+
+### Three patch states
+
+| `Finding.patches` | Source of derived fields |
+|---|---|
+| `None` (scan ran without `--suggest-patches`) | CheckMetadata, with safe-closed fallback for unknown check IDs |
+| `[]` (scan ran WITH `--suggest-patches` but generator emitted nothing) | Safe-closed shape, `suggested_patch_kind: "none"`. Does NOT fall back to catalog — the report carries no patches, so reporting a catalog-level kind would mislead. |
+| Non-empty | Strict derivation rule above |
+
+### Unknown check IDs (policy packs and third-party plugins)
+
+A finding whose `check_id` isn't in the loaded catalog (a policy
+pack rule, a third-party plugin emitted while plugins are disabled)
+gets the safe-closed fallback when patches are absent:
+
+```text
+autofix_safe: false
+requires_human_review: true
+suggested_patch_kind: "manual"
+docs_url: null
+```
+
+The fallback only applies when patches are absent. A high-confidence
+non-manual patch from a policy pack still derives correctly.
+
+---
+
+## How `apply-patches --confidence` filters
+
+`apply-patches` reads the report, filters patches by `--confidence`
+and `--kinds`, and applies the survivors. Default flags:
+
+```bash
+agents-shipgate apply-patches \
+    --from agents-shipgate-reports/report.json \
+    --confidence high \
+    --kinds set_pointer,append_pointer,remove_pointer \
+    --apply
+```
+
+| Flag | Default | What it accepts |
+|---|---|---|
+| `--confidence` | `high` | Minimum patch confidence. Patches below this are skipped. |
+| `--kinds` | `set_pointer,append_pointer,remove_pointer` | Patch kinds to include. ManualPatch is filtered out unconditionally — even with `--kinds manual`. |
+| `--apply` | (off) | Without this, dry-run only. Always preview before mutating. |
+
+So in v0.7 with the default flags:
+
+- The 3 stale-manifest removals (when unambiguous) auto-apply.
+- `SHIP-AUTH-SCOPE-COVERAGE-MISSING` scope appends are **skipped**
+  (medium confidence). Pass `--confidence medium` to opt in — but
+  read the appended scopes before merging, since adding scopes can
+  encode policy choices.
+- Trace approval/confirmation findings are **never** applied —
+  ManualPatch is filtered out.
+- Everything else with a ManualPatch is **never** applied.
+
+`apply-patches` enforces a **containment check**: every patch's
+`target_file` must resolve under `report.manifest_dir`. Anything
+outside aborts with exit code 5 before any SHA verification.
+
+---
+
+## Decision tree for agents
+
+When walking `findings[]` from a `--suggest-patches` report:
+
+```text
+for finding in active_findings:
+    if finding.suggested_patch_kind == "manual":
+        # Manual source/policy fix or never-auto-fix.
+        # Read finding.patches[0].instructions and surface to user.
+        # Do NOT attempt to auto-edit, especially for trace findings.
+        surface_to_user(finding)
+        continue
+
+    if finding.autofix_safe is True:
+        # Safe to include in the next `apply-patches --confidence high`.
+        plan_to_apply(finding)
+        continue
+
+    # Medium-confidence non-manual patch (e.g. scope coverage).
+    # Surface as "review and run apply-patches --confidence medium"
+    # but do not auto-apply on the high-confidence path.
+    surface_for_medium_review(finding)
+```
+
+After running `apply-patches --apply`, re-run `scan` to confirm the
+fixed findings are gone. The `run_id` will only change if the
+manifest or tool surface actually changed — patches are excluded
+from the hash so toggling `--suggest-patches` doesn't shift it.
+
+---
+
+## See also
+
+- [`agent-recipes.md`](agent-recipes.md) — copy-pasteable AI-agent
+  workflows, including the soft-stop rule for `detect`.
+- [`checks.md`](checks.md) — full check catalog with rationale.
+- [`minimal-real-configs.md`](minimal-real-configs.md) — per-framework
+  minimal manifests to build from.
+- [`report-schema.v0.7.json`](report-schema.v0.7.json) — JSON Schema
+  for `report.json` (current).
+- [`AGENTS.md`](../AGENTS.md) — top-level agent instructions, install,
+  trigger table.
+- [`STABILITY.md`](../STABILITY.md) — what won't break across `0.x`.

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -1,0 +1,120 @@
+"""Docs link integrity tests for the v0.7 agent-facing docs surface.
+
+Per the v0.7 plan §3 verification:
+- The three agent-facing docs exist on disk.
+- Each is linked from `docs/INDEX.md` so agents walking the index can
+  find them.
+- Internal links inside the agent-facing docs resolve to files that
+  actually exist (catches the "future-doc link" hazard from PR 1
+  review).
+- The stale `report-schema.v0.5.json` reference no longer appears in
+  `docs/INDEX.md` (cleanup landed in PR 1).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+INDEX_MD = DOCS_DIR / "INDEX.md"
+
+AGENT_FACING_DOCS = (
+    "agent-recipes.md",
+    "autofix-policy.md",
+    "minimal-real-configs.md",
+)
+
+
+def test_agent_facing_docs_exist():
+    for name in AGENT_FACING_DOCS:
+        path = DOCS_DIR / name
+        assert path.is_file(), f"Expected {path} to exist (v0.7 docs surface)"
+
+
+def test_agent_facing_docs_linked_from_index():
+    index_text = INDEX_MD.read_text(encoding="utf-8")
+    for name in AGENT_FACING_DOCS:
+        # Match the markdown link form `[label](agent-recipes.md)` or
+        # `[label](agent-recipes.md "...")`. Index links use bare
+        # filenames since the index lives in the same dir.
+        link_pattern = re.compile(rf"\]\({re.escape(name)}(?:\s|\))")
+        assert link_pattern.search(index_text), (
+            f"docs/INDEX.md must link to docs/{name}; agents walking "
+            "the index would otherwise miss this v0.7 surface."
+        )
+
+
+def test_index_no_longer_references_v05_schema():
+    """v0.5 schema cleanup landed in PR 1; this test pins it so a
+    future doc edit doesn't accidentally re-introduce the stale link."""
+    index_text = INDEX_MD.read_text(encoding="utf-8")
+    assert "report-schema.v0.5.json" not in index_text, (
+        "docs/INDEX.md should no longer reference the v0.5 report schema; "
+        "v0.6 is the frozen reference, v0.7 is current."
+    )
+
+
+def test_index_lists_current_v07_schema():
+    """The current schema version moved to v0.7 in PR 3; the index
+    must point agents at v0.7 for fresh report.json validation."""
+    index_text = INDEX_MD.read_text(encoding="utf-8")
+    assert "report-schema.v0.7.json" in index_text, (
+        "docs/INDEX.md must list report-schema.v0.7.json as the current schema "
+        "since emitted reports carry report_schema_version: \"0.7\"."
+    )
+
+
+def test_agent_recipes_internal_links_resolve():
+    """Internal markdown links in `agent-recipes.md` (the doc most
+    likely to grow forward references) must point at files that
+    actually exist. Regression for the v0.7 PR 1 review where
+    `autofix-policy.md` was linked before it shipped."""
+    text = (DOCS_DIR / "agent-recipes.md").read_text(encoding="utf-8")
+    # Match markdown links of the form [label](relative-path) where
+    # the path is local (no scheme, no anchor-only).
+    link_re = re.compile(r"\[[^\]]+\]\(([^)#:][^)#]*)(?:#[^)]*)?\)")
+    for href in link_re.findall(text):
+        href = href.strip()
+        if not href or href.startswith(("http://", "https://", "mailto:")):
+            continue
+        target = (DOCS_DIR / "agent-recipes.md").parent / href
+        target = target.resolve()
+        assert target.exists(), (
+            f"docs/agent-recipes.md links to non-existent {href} "
+            f"(resolved to {target}). Update the link or land the "
+            "missing file in the same PR."
+        )
+
+
+def test_autofix_policy_internal_links_resolve():
+    """Same hazard — autofix-policy.md will accumulate references over
+    time. Pin them now."""
+    text = (DOCS_DIR / "autofix-policy.md").read_text(encoding="utf-8")
+    link_re = re.compile(r"\[[^\]]+\]\(([^)#:][^)#]*)(?:#[^)]*)?\)")
+    for href in link_re.findall(text):
+        href = href.strip()
+        if not href or href.startswith(("http://", "https://", "mailto:")):
+            continue
+        target = (DOCS_DIR / "autofix-policy.md").parent / href
+        target = target.resolve()
+        assert target.exists(), (
+            f"docs/autofix-policy.md links to non-existent {href} "
+            f"(resolved to {target})."
+        )
+
+
+def test_minimal_real_configs_internal_links_resolve():
+    text = (DOCS_DIR / "minimal-real-configs.md").read_text(encoding="utf-8")
+    link_re = re.compile(r"\[[^\]]+\]\(([^)#:][^)#]*)(?:#[^)]*)?\)")
+    for href in link_re.findall(text):
+        href = href.strip()
+        if not href or href.startswith(("http://", "https://", "mailto:")):
+            continue
+        target = (DOCS_DIR / "minimal-real-configs.md").parent / href
+        target = target.resolve()
+        assert target.exists(), (
+            f"docs/minimal-real-configs.md links to non-existent {href} "
+            f"(resolved to {target})."
+        )


### PR DESCRIPTION
## Summary

- Lands the dedicated remediation policy doc that was deferred from PR 1 (it depended on the PR 3 Finding fields landing first).
- Documents the four classes (Safe auto-fix, Medium-confidence config fix, Manual source/policy fix, Never auto-fix), the catalog-vs-Finding contract, the strict derivation rule, the three patch states (None / [] / non-empty), the unknown-check-id fallback, and the `apply-patches --confidence` flag table.
- Adds a decision tree agents can lift directly into their workflow.
- Removes the placeholder note from `agent-recipes.md` (PR 1 review fix that called out the broken forward reference) — now linking the real doc.
- Adds `tests/test_docs_links.py` (7 tests) — pins doc existence, INDEX linkage, and **internal-link resolution** for the three agent-facing v0.7 docs. Future forward references to missing files will fail the test in the same PR rather than slipping into review.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only (plus a link-integrity test that catches future regressions)

## What changed

| File | Change |
|---|---|
| [docs/autofix-policy.md](docs/autofix-policy.md) | NEW. Four classes table, catalog-vs-Finding contract, strict derivation rule, three patch states, unknown-check-id fallback, `apply-patches --confidence` table, agent decision tree. |
| [docs/agent-recipes.md](docs/agent-recipes.md) | Replaces the PR 1 placeholder note with a real link to `docs/autofix-policy.md`. |
| [docs/INDEX.md](docs/INDEX.md) | Adds `autofix-policy.md` to the "For agents" section. |
| [tests/test_docs_links.py](tests/test_docs_links.py) | NEW (7 tests). Doc existence, INDEX linkage, v0.5/v0.7 schema link assertions, and internal-link resolution for all three agent-facing docs. |

## Why this surface matters

Per the adoption memo §6 ("Must do now"), this doc gives agents a single page to consult before acting on a finding. The decision tree at the bottom is the load-bearing artifact:

```text
for finding in active_findings:
    if finding.suggested_patch_kind == "manual":
        surface_to_user(finding)
        continue
    if finding.autofix_safe is True:
        plan_to_apply(finding)
        continue
    surface_for_medium_review(finding)
```

That keeps trace-flip findings (and other never-auto-fix categories) from being mishandled by a curious agent — the doc explicitly documents the anti-pattern.

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/` — **298 passed** (was 291; +7 new tests in `tests/test_docs_links.py`).
- `python -m ruff check .` — clean.
- `python scripts/generate_schemas.py` — leaves a clean tree.

Specific link-integrity tests:
- `test_agent_facing_docs_exist` — the three docs are on disk.
- `test_agent_facing_docs_linked_from_index` — INDEX.md links to all three.
- `test_index_no_longer_references_v05_schema` — pins the PR 1 cleanup.
- `test_index_lists_current_v07_schema` — pins the PR 3 schema bump.
- `test_{agent_recipes,autofix_policy,minimal_real_configs}_internal_links_resolve` — every relative link in each doc resolves to a real file.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] No new check IDs in this PR
- [x] **No schema changes** — `docs/report-schema.v0.7.json` byte-identical post-PR.

## What's NOT in this PR (deliberate phasing)

- Prompt updates with detect-first opening + parity test → PR 5.
- Package version bump (`pyproject.toml` + `__init__.py` from `0.6.0` → `0.7.0`) + version-string sweeps + end-to-end metadata round-trip test → PR 6 (final polish).