### PR TITLE
v0.7 PR 5/6: detect-first prompt + dual-copy parity test

### DIFF
--- a/prompts/add-shipgate-to-repo.md
+++ b/prompts/add-shipgate-to-repo.md
@@ -57,7 +57,7 @@ Your job is to drive the canonical 4-call flow end-to-end in one tool-using turn
 
 7. **Apply the safe patches:**
    ```bash
-   agents-shipgate apply-patches --from agents-shipgate-reports/report.json --confidence high --apply
+   agents-shipgate apply-patches --from agents-shipgate-reports/report.json --confidence high --apply --json
    ```
    Default `--confidence high` only mutates patches whose `confidence` field is `"high"`. Today that's the 3 stale-manifest removals. Scope-coverage appends ship at `medium` and require explicit `--confidence medium` to apply. ManualPatches are never auto-applied.
 

--- a/prompts/add-shipgate-to-repo.md
+++ b/prompts/add-shipgate-to-repo.md
@@ -1,6 +1,8 @@
 # Prompt · Add Agents Shipgate to a repo
 
-You are working in a repo that contains an AI agent — likely one of: an MCP server tool list, a Python file with `@function_tool` decorators (OpenAI Agents SDK), a Google ADK agent in `agent.py`, or an OpenAPI spec the agent calls.
+You are working in a repo that may contain an AI agent — likely one of: an MCP server tool list (`*mcp*.json` or `.agents-shipgate/*.json`), an OpenAPI spec the agent calls, a Python file with `@function_tool` / `@tool` decorators (OpenAI Agents SDK, LangChain, CrewAI), a Google ADK agent in `agent.py`, an Anthropic Messages API artifact set under `prompts/`/`tools/anthropic-tools.json`/`policies/anthropic-policy.yaml`, or an OpenAI API artifact set under `prompts/`/`tools/openai-tools.json`/`openai-config.json`.
+
+Your job is to drive the canonical 4-call flow end-to-end in one tool-using turn.
 
 ## Your task
 
@@ -16,31 +18,70 @@ You are working in a repo that contains an AI agent — likely one of: an MCP se
    ```
    Confirm `"ready": true`. If not, surface the failure to the user.
 
-3. **Generate a starter manifest:**
+3. **Detect:**
    ```bash
-   agents-shipgate init --workspace . --write --json
+   agents-shipgate detect --workspace . --json
    ```
-   The `--json` form returns a structured response including a `placeholders` array. Each placeholder has a `path` (a YAML pointer-ish location) and `current` (the literal value, typically `CHANGE_ME`).
+   Read the response: `is_agent_project`, `frameworks[]` (per-framework score + evidence + candidate files), `agent_name_candidates[]`, `suggested_sources[]` (MCP/OpenAPI files matched by glob).
 
-4. **Replace placeholders.** Read the agent's prompt or main file, then edit `shipgate.yaml`:
-   - `agent.name`: the actual agent name from the codebase
-   - `agent.declared_purpose`: 1-2 short bullet points describing what the agent is allowed to do (read the system prompt or main agent definition for this)
+   **Stop only when ALL of these hold:** `is_agent_project: false`, `suggested_sources` is empty, no `shipgate.yaml` already exists in the workspace, AND the user did not explicitly request a scan. Otherwise proceed — MCP/OpenAPI tool-surface repos register as `is_agent_project: false` because they have no Python framework imports, but they are valid Shipgate targets and their hits surface as `suggested_sources`.
 
-5. **Run the scan:**
+4. **Generate a starter manifest + GitHub Actions workflow:**
    ```bash
-   agents-shipgate scan -c shipgate.yaml --ci-mode advisory
+   agents-shipgate init --workspace . --write --ci --json
+   ```
+   The `--json` form returns:
+   - `manifest_status`: `"written"` | `"skipped_existing"` | `"not_attempted"`
+   - `workflow.status` (with `--ci`): `"written"` | `"skipped_existing_target"` | `"skipped_cross_reference"`
+   - `placeholders[]` — entries the template intentionally left as `CHANGE_ME` because no high-confidence signal was available
+   - `auto_detected.agent_name` — the value the manifest carries (`null` when the template fell back to `CHANGE_ME`)
+
+   `--ci` writes `.github/workflows/agents-shipgate.yml` orthogonally to `--write`. Each gets its own overwrite-refusal check; existing workflows that already call `ThreeMoonsLab/agents-shipgate` skip with a distinct `cross_reference_path`.
+
+5. **Replace placeholders.** Walk `placeholders[]` from the JSON output. On a fresh workspace the template typically leaves two:
+   - `agent.name: CHANGE_ME` — replace with the agent's actual role (no strong `Agent(name="…")` literal was found in the source).
+   - `agent.declared_purpose[]: CHANGE_ME` — replace with a one-line description of what the agent should do (auto-init can't infer this; the schema requires a non-empty value).
+
+   Read the agent's prompt or main file to derive both. Skipping this leaves an invalid adoption artifact — the manifest validates but downstream consumers see meaningless defaults.
+
+6. **Run the scan with patch suggestions:**
+   ```bash
+   agents-shipgate scan -c shipgate.yaml --suggest-patches --format json --ci-mode advisory
+   ```
+   The report lands at `agents-shipgate-reports/report.json`. Parse it. Per-finding fields you can rely on (v0.7+):
+   - `check_id`, `severity`, `category`, `tool_name`, `recommendation`, `suppressed`
+   - `autofix_safe`, `requires_human_review`, `suggested_patch_kind`, `docs_url`
+   - `patches[]` (only with `--suggest-patches`) — each has `kind` ∈ `{set_pointer, append_pointer, remove_pointer, manual}` plus `confidence` + `target_file` + etc. for non-manual kinds.
+
+   Top-level: `summary.{status, critical_count, high_count, medium_count}`, `manifest_dir` (absolute path of the manifest's directory — used by `apply-patches` for the containment check).
+
+7. **Apply the safe patches:**
+   ```bash
+   agents-shipgate apply-patches --from agents-shipgate-reports/report.json --confidence high --apply
+   ```
+   Default `--confidence high` only mutates patches whose `confidence` field is `"high"`. Today that's the 3 stale-manifest removals. Scope-coverage appends ship at `medium` and require explicit `--confidence medium` to apply. ManualPatches are never auto-applied.
+
+   **Decision tree** for walking the report:
+   ```
+   for finding in active_findings:
+       if finding.suggested_patch_kind in ("manual", "none"):
+           surface_to_user(finding)              # Surface; do NOT auto-apply.
+           continue
+       if finding.autofix_safe is True:
+           plan_to_apply(finding)                # Will be applied at --confidence high.
+           continue
+       surface_for_medium_review(finding)        # Medium-confidence — opt-in only.
    ```
 
-6. **Read the JSON report** at `agents-shipgate-reports/report.json` (not the markdown — the JSON is the stable contract). Stable fields:
-   - `summary.{critical_count, high_count, medium_count, status}`
-   - `findings[].{check_id, severity, tool_name, recommendation}`
+   Trace findings (`SHIP-API-TRACE-{APPROVAL,CONFIRMATION}-MISSING`) are permanent ManualPatch by policy. Implement the runtime gate; never edit the trace recording — that patches the evidence, not the agent. See [`docs/autofix-policy.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/autofix-policy.md) for the full classification.
 
-7. **Add `agents-shipgate-reports/` to `.gitignore`** if it isn't already. The reports are scan artifacts, not source.
+8. **Add `agents-shipgate-reports/` to `.gitignore`** if it isn't already. The reports are scan artifacts, not source.
 
-8. **Report back to the user**:
-   - The status (`release_blockers_detected`, `warnings_detected`, etc.)
-   - The top 3 findings by severity (use the JSON, not stdout)
-   - Any check IDs the user should investigate first (use `agents-shipgate explain <CHECK_ID> --json` for details)
+9. **Report back to the user**:
+   - The `summary.status` (`release_blockers_detected`, `warnings_detected`, etc.)
+   - The top 3 active critical/high findings (use `report.json`, not stdout)
+   - Which patches were applied (count from `apply-patches --json` output's `files`)
+   - Any check IDs the user should investigate first — link to `docs_url` from the finding for full rationale, or use `agents-shipgate explain <CHECK_ID> --json` for the same content via CLI
 
 ## What to do if the scan errors out
 
@@ -53,6 +94,7 @@ Common errors and fixes:
 | `Config file not found: shipgate.yaml` | Run `agents-shipgate init --workspace . --write` first |
 | `Input path '...' resolves outside manifest directory` | The declared `tool_sources[].path` is outside the manifest dir. Move the spec inside the tree, symlink it, or copy it |
 | `Invalid shipgate.yaml: ... Did you mean X?` | A field is at the wrong nesting level; move it as suggested |
+| `Containment violation` (apply-patches exit 5) | A patch's `target_file` resolved outside `report.manifest_dir`. Re-run scan to refresh; never patch arbitrary system files |
 
 ## What NOT to do
 
@@ -60,11 +102,13 @@ Common errors and fixes:
 - Do **not** run `agents-shipgate baseline save` until the user has reviewed the initial findings. Baselining ratchets in noise that strict CI will silently ignore. The right time to baseline is **after** the user has decided which findings they accept.
 - Do **not** suppress findings without a real `reason` — the manifest validator rejects empty reasons, and the `reason` field is the audit trail when someone asks "why is this OK?"
 - Do **not** use `risk_overrides.tools.{tool}.remove_tags` to silence a finding without checking whether the heuristic is actually wrong. Prefer `checks.ignore` with a reason.
+- Do **not** edit a trace recording to flip `approved` or `confirmed` — implement the runtime gate instead.
 
 ## Verification before reporting success
 
-- `agents-shipgate-reports/report.json` exists
-- `agents-shipgate-reports/report.json` parses as JSON
-- `shipgate.yaml` has no `CHANGE_ME` strings
+- `agents-shipgate-reports/report.json` exists and parses as JSON
+- `report.json` carries `report_schema_version: "0.7"` (or higher) and a non-empty `manifest_dir`
+- `shipgate.yaml` has no `CHANGE_ME` values (comments containing the literal `CHANGE_ME` are informational and OK)
 - `.gitignore` contains `agents-shipgate-reports/` (or equivalent)
+- If `--ci` ran with `workflow.status: "written"`: `.github/workflows/agents-shipgate.yml` exists and references `ThreeMoonsLab/agents-shipgate@v…`
 - The user knows the top 3 findings and at least one suggested next step

--- a/skills/agents-shipgate/prompts/add-shipgate-to-repo.md
+++ b/skills/agents-shipgate/prompts/add-shipgate-to-repo.md
@@ -57,7 +57,7 @@ Your job is to drive the canonical 4-call flow end-to-end in one tool-using turn
 
 7. **Apply the safe patches:**
    ```bash
-   agents-shipgate apply-patches --from agents-shipgate-reports/report.json --confidence high --apply
+   agents-shipgate apply-patches --from agents-shipgate-reports/report.json --confidence high --apply --json
    ```
    Default `--confidence high` only mutates patches whose `confidence` field is `"high"`. Today that's the 3 stale-manifest removals. Scope-coverage appends ship at `medium` and require explicit `--confidence medium` to apply. ManualPatches are never auto-applied.
 

--- a/skills/agents-shipgate/prompts/add-shipgate-to-repo.md
+++ b/skills/agents-shipgate/prompts/add-shipgate-to-repo.md
@@ -1,6 +1,8 @@
 # Prompt · Add Agents Shipgate to a repo
 
-You are working in a repo that contains an AI agent — likely one of: an MCP server tool list, a Python file with `@function_tool` decorators (OpenAI Agents SDK), a Google ADK agent in `agent.py`, or an OpenAPI spec the agent calls.
+You are working in a repo that may contain an AI agent — likely one of: an MCP server tool list (`*mcp*.json` or `.agents-shipgate/*.json`), an OpenAPI spec the agent calls, a Python file with `@function_tool` / `@tool` decorators (OpenAI Agents SDK, LangChain, CrewAI), a Google ADK agent in `agent.py`, an Anthropic Messages API artifact set under `prompts/`/`tools/anthropic-tools.json`/`policies/anthropic-policy.yaml`, or an OpenAI API artifact set under `prompts/`/`tools/openai-tools.json`/`openai-config.json`.
+
+Your job is to drive the canonical 4-call flow end-to-end in one tool-using turn.
 
 ## Your task
 
@@ -16,31 +18,70 @@ You are working in a repo that contains an AI agent — likely one of: an MCP se
    ```
    Confirm `"ready": true`. If not, surface the failure to the user.
 
-3. **Generate a starter manifest:**
+3. **Detect:**
    ```bash
-   agents-shipgate init --workspace . --write --json
+   agents-shipgate detect --workspace . --json
    ```
-   The `--json` form returns a structured response including a `placeholders` array. Each placeholder has a `path` (a YAML pointer-ish location) and `current` (the literal value, typically `CHANGE_ME`).
+   Read the response: `is_agent_project`, `frameworks[]` (per-framework score + evidence + candidate files), `agent_name_candidates[]`, `suggested_sources[]` (MCP/OpenAPI files matched by glob).
 
-4. **Replace placeholders.** Read the agent's prompt or main file, then edit `shipgate.yaml`:
-   - `agent.name`: the actual agent name from the codebase
-   - `agent.declared_purpose`: 1-2 short bullet points describing what the agent is allowed to do (read the system prompt or main agent definition for this)
+   **Stop only when ALL of these hold:** `is_agent_project: false`, `suggested_sources` is empty, no `shipgate.yaml` already exists in the workspace, AND the user did not explicitly request a scan. Otherwise proceed — MCP/OpenAPI tool-surface repos register as `is_agent_project: false` because they have no Python framework imports, but they are valid Shipgate targets and their hits surface as `suggested_sources`.
 
-5. **Run the scan:**
+4. **Generate a starter manifest + GitHub Actions workflow:**
    ```bash
-   agents-shipgate scan -c shipgate.yaml --ci-mode advisory
+   agents-shipgate init --workspace . --write --ci --json
+   ```
+   The `--json` form returns:
+   - `manifest_status`: `"written"` | `"skipped_existing"` | `"not_attempted"`
+   - `workflow.status` (with `--ci`): `"written"` | `"skipped_existing_target"` | `"skipped_cross_reference"`
+   - `placeholders[]` — entries the template intentionally left as `CHANGE_ME` because no high-confidence signal was available
+   - `auto_detected.agent_name` — the value the manifest carries (`null` when the template fell back to `CHANGE_ME`)
+
+   `--ci` writes `.github/workflows/agents-shipgate.yml` orthogonally to `--write`. Each gets its own overwrite-refusal check; existing workflows that already call `ThreeMoonsLab/agents-shipgate` skip with a distinct `cross_reference_path`.
+
+5. **Replace placeholders.** Walk `placeholders[]` from the JSON output. On a fresh workspace the template typically leaves two:
+   - `agent.name: CHANGE_ME` — replace with the agent's actual role (no strong `Agent(name="…")` literal was found in the source).
+   - `agent.declared_purpose[]: CHANGE_ME` — replace with a one-line description of what the agent should do (auto-init can't infer this; the schema requires a non-empty value).
+
+   Read the agent's prompt or main file to derive both. Skipping this leaves an invalid adoption artifact — the manifest validates but downstream consumers see meaningless defaults.
+
+6. **Run the scan with patch suggestions:**
+   ```bash
+   agents-shipgate scan -c shipgate.yaml --suggest-patches --format json --ci-mode advisory
+   ```
+   The report lands at `agents-shipgate-reports/report.json`. Parse it. Per-finding fields you can rely on (v0.7+):
+   - `check_id`, `severity`, `category`, `tool_name`, `recommendation`, `suppressed`
+   - `autofix_safe`, `requires_human_review`, `suggested_patch_kind`, `docs_url`
+   - `patches[]` (only with `--suggest-patches`) — each has `kind` ∈ `{set_pointer, append_pointer, remove_pointer, manual}` plus `confidence` + `target_file` + etc. for non-manual kinds.
+
+   Top-level: `summary.{status, critical_count, high_count, medium_count}`, `manifest_dir` (absolute path of the manifest's directory — used by `apply-patches` for the containment check).
+
+7. **Apply the safe patches:**
+   ```bash
+   agents-shipgate apply-patches --from agents-shipgate-reports/report.json --confidence high --apply
+   ```
+   Default `--confidence high` only mutates patches whose `confidence` field is `"high"`. Today that's the 3 stale-manifest removals. Scope-coverage appends ship at `medium` and require explicit `--confidence medium` to apply. ManualPatches are never auto-applied.
+
+   **Decision tree** for walking the report:
+   ```
+   for finding in active_findings:
+       if finding.suggested_patch_kind in ("manual", "none"):
+           surface_to_user(finding)              # Surface; do NOT auto-apply.
+           continue
+       if finding.autofix_safe is True:
+           plan_to_apply(finding)                # Will be applied at --confidence high.
+           continue
+       surface_for_medium_review(finding)        # Medium-confidence — opt-in only.
    ```
 
-6. **Read the JSON report** at `agents-shipgate-reports/report.json` (not the markdown — the JSON is the stable contract). Stable fields:
-   - `summary.{critical_count, high_count, medium_count, status}`
-   - `findings[].{check_id, severity, tool_name, recommendation}`
+   Trace findings (`SHIP-API-TRACE-{APPROVAL,CONFIRMATION}-MISSING`) are permanent ManualPatch by policy. Implement the runtime gate; never edit the trace recording — that patches the evidence, not the agent. See [`docs/autofix-policy.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/autofix-policy.md) for the full classification.
 
-7. **Add `agents-shipgate-reports/` to `.gitignore`** if it isn't already. The reports are scan artifacts, not source.
+8. **Add `agents-shipgate-reports/` to `.gitignore`** if it isn't already. The reports are scan artifacts, not source.
 
-8. **Report back to the user**:
-   - The status (`release_blockers_detected`, `warnings_detected`, etc.)
-   - The top 3 findings by severity (use the JSON, not stdout)
-   - Any check IDs the user should investigate first (use `agents-shipgate explain <CHECK_ID> --json` for details)
+9. **Report back to the user**:
+   - The `summary.status` (`release_blockers_detected`, `warnings_detected`, etc.)
+   - The top 3 active critical/high findings (use `report.json`, not stdout)
+   - Which patches were applied (count from `apply-patches --json` output's `files`)
+   - Any check IDs the user should investigate first — link to `docs_url` from the finding for full rationale, or use `agents-shipgate explain <CHECK_ID> --json` for the same content via CLI
 
 ## What to do if the scan errors out
 
@@ -53,6 +94,7 @@ Common errors and fixes:
 | `Config file not found: shipgate.yaml` | Run `agents-shipgate init --workspace . --write` first |
 | `Input path '...' resolves outside manifest directory` | The declared `tool_sources[].path` is outside the manifest dir. Move the spec inside the tree, symlink it, or copy it |
 | `Invalid shipgate.yaml: ... Did you mean X?` | A field is at the wrong nesting level; move it as suggested |
+| `Containment violation` (apply-patches exit 5) | A patch's `target_file` resolved outside `report.manifest_dir`. Re-run scan to refresh; never patch arbitrary system files |
 
 ## What NOT to do
 
@@ -60,11 +102,13 @@ Common errors and fixes:
 - Do **not** run `agents-shipgate baseline save` until the user has reviewed the initial findings. Baselining ratchets in noise that strict CI will silently ignore. The right time to baseline is **after** the user has decided which findings they accept.
 - Do **not** suppress findings without a real `reason` — the manifest validator rejects empty reasons, and the `reason` field is the audit trail when someone asks "why is this OK?"
 - Do **not** use `risk_overrides.tools.{tool}.remove_tags` to silence a finding without checking whether the heuristic is actually wrong. Prefer `checks.ignore` with a reason.
+- Do **not** edit a trace recording to flip `approved` or `confirmed` — implement the runtime gate instead.
 
 ## Verification before reporting success
 
-- `agents-shipgate-reports/report.json` exists
-- `agents-shipgate-reports/report.json` parses as JSON
-- `shipgate.yaml` has no `CHANGE_ME` strings
+- `agents-shipgate-reports/report.json` exists and parses as JSON
+- `report.json` carries `report_schema_version: "0.7"` (or higher) and a non-empty `manifest_dir`
+- `shipgate.yaml` has no `CHANGE_ME` values (comments containing the literal `CHANGE_ME` are informational and OK)
 - `.gitignore` contains `agents-shipgate-reports/` (or equivalent)
+- If `--ci` ran with `workflow.status: "written"`: `.github/workflows/agents-shipgate.yml` exists and references `ThreeMoonsLab/agents-shipgate@v…`
 - The user knows the top 3 findings and at least one suggested next step

--- a/tests/test_prompt_parity.py
+++ b/tests/test_prompt_parity.py
@@ -1,0 +1,128 @@
+"""Byte-parity test for the dual-copy agent prompts.
+
+Each prompt under ``prompts/`` is also bundled inside
+``skills/agents-shipgate/prompts/`` so the Claude Code skill ships
+self-contained. The two copies must stay byte-identical — they
+describe the same workflow and any drift between them creates
+silent inconsistency for users who follow one or the other.
+
+Per the v0.7 PR 5 plan: this test fails the moment a future PR
+edits one copy without the other. The longer-term fix (per the v3
+plan risk list) is to convert one copy into a generated artifact
+of the other; until then, byte parity is the contract.
+
+Why both copies exist:
+- ``prompts/`` is the canonical surface, exposed in the repo's
+  top-level structure for humans/agents discovering the project on
+  GitHub.
+- ``skills/agents-shipgate/prompts/`` ships inside the Claude Code
+  skill so behavior is pinned to the installed version and works
+  offline; the skill cannot reach back into the canonical surface
+  at runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOP_LEVEL_PROMPTS = REPO_ROOT / "prompts"
+SKILL_PROMPTS = REPO_ROOT / "skills" / "agents-shipgate" / "prompts"
+
+# README is intentionally top-level only — describes the directory
+# itself, not a workflow to bundle with the skill.
+PARITY_EXEMPT = {"README.md"}
+
+
+def _expected_prompt_names() -> list[str]:
+    return sorted(
+        path.name
+        for path in TOP_LEVEL_PROMPTS.iterdir()
+        if path.is_file()
+        and path.suffix == ".md"
+        and path.name not in PARITY_EXEMPT
+    )
+
+
+def test_skill_bundles_every_top_level_prompt():
+    """Every prompt under ``prompts/`` (except README) must also exist
+    under the skill bundle. Catches the case where a new prompt is
+    added top-level but not mirrored to the skill."""
+    expected = set(_expected_prompt_names())
+    bundled = {
+        path.name
+        for path in SKILL_PROMPTS.iterdir()
+        if path.is_file() and path.suffix == ".md"
+    }
+    missing = expected - bundled
+    assert not missing, (
+        f"Skill bundle is missing prompts that exist in prompts/: "
+        f"{sorted(missing)}. Copy them to skills/agents-shipgate/prompts/."
+    )
+
+
+def test_skill_bundle_has_no_extra_prompts():
+    """The skill bundle should not contain prompts that don't exist
+    top-level. Catches drift in the other direction (prompt added to
+    the skill without a top-level canonical copy)."""
+    expected = set(_expected_prompt_names())
+    bundled = {
+        path.name
+        for path in SKILL_PROMPTS.iterdir()
+        if path.is_file() and path.suffix == ".md"
+    }
+    extra = bundled - expected
+    assert not extra, (
+        f"Skill bundle has prompts not present in prompts/: "
+        f"{sorted(extra)}. Add the canonical top-level copy or "
+        f"remove the bundled file."
+    )
+
+
+@pytest.mark.parametrize("name", _expected_prompt_names())
+def test_prompt_byte_identical_across_locations(name: str):
+    """Each prompt must be byte-identical between the top-level
+    canonical location and the skill bundle copy. Future contributors
+    editing only one copy will fail this test in the same PR."""
+    top = TOP_LEVEL_PROMPTS / name
+    bundled = SKILL_PROMPTS / name
+    assert top.is_file(), f"Top-level prompt {top} missing"
+    assert bundled.is_file(), f"Bundled prompt {bundled} missing"
+    top_bytes = top.read_bytes()
+    bundled_bytes = bundled.read_bytes()
+    assert top_bytes == bundled_bytes, (
+        f"{name} differs between prompts/ and skills/agents-shipgate/prompts/. "
+        "These two copies must stay byte-identical (they describe the same "
+        "workflow). Update the canonical copy under prompts/ and run "
+        "`cp prompts/{name} skills/agents-shipgate/prompts/{name}` to mirror."
+    )
+
+
+def test_add_shipgate_prompt_starts_with_detect_first_flow():
+    """The canonical onboarding prompt must lead with the v0.7
+    `detect → init --write --ci → scan --suggest-patches → apply-patches`
+    flow, not the pre-v0.6 install→init→scan path. Pin this so a
+    future edit doesn't accidentally regress to the older flow.
+    """
+    text = (TOP_LEVEL_PROMPTS / "add-shipgate-to-repo.md").read_text(encoding="utf-8")
+    assert "agents-shipgate detect" in text, (
+        "add-shipgate-to-repo.md must reference `agents-shipgate detect` "
+        "(canonical 4-call flow leads with detection)."
+    )
+    assert "--suggest-patches" in text, (
+        "add-shipgate-to-repo.md must reference `--suggest-patches` "
+        "(scan step in the canonical flow)."
+    )
+    assert "apply-patches" in text, (
+        "add-shipgate-to-repo.md must reference `apply-patches` "
+        "(safe-fix step in the canonical flow)."
+    )
+    # Soft-stop rule from the trigger table: do not stop just because
+    # is_agent_project is false.
+    assert "suggested_sources" in text, (
+        "add-shipgate-to-repo.md must mention `suggested_sources` so "
+        "agents apply the soft-stop rule (don't skip MCP/OpenAPI-only "
+        "repos that surface as is_agent_project: false)."
+    )


### PR DESCRIPTION
## Summary

- Rewrites the canonical onboarding prompt (`prompts/add-shipgate-to-repo.md`) to lead with the v0.7 4-call flow (`detect → init --write --ci → scan --suggest-patches → apply-patches`) instead of the pre-v0.6 install→init→scan path.
- Mirrors byte-identically into the skill bundle copy at `skills/agents-shipgate/prompts/add-shipgate-to-repo.md`.
- Adds `tests/test_prompt_parity.py` (8 tests) so the two copies can't drift silently — future edits to one copy fail in the same PR if the other isn't updated.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only (plus a parity test that catches future drift)

## Why this matters

The pre-v0.6 prompt drove agents through `pipx install → self-check → init → CHANGE_ME edit → scan`. The v0.6 release added `detect` (so agents can decide whether to onboard a repo at all) and `--suggest-patches` + `apply-patches` (so agents can mechanically fix the safe subset). The v0.7 release added per-finding remediation metadata (so agents can route patch-by-patch without re-walking the catalog). None of that was reflected in the canonical onboarding prompt — the most-followed surface for AI coding agents.

This PR closes the gap.

## Soft-stop rule (from PR 1's AGENTS.md trigger table)

The new step 3 documents the load-bearing decision rule:

> **Stop only when ALL of these hold:** `is_agent_project: false`, `suggested_sources` is empty, no `shipgate.yaml` already exists in the workspace, AND the user did not explicitly request a scan. Otherwise proceed — MCP/OpenAPI tool-surface repos register as `is_agent_project: false` because they have no Python framework imports, but they are valid Shipgate targets and their hits surface as `suggested_sources`.

## Decision tree (from PR 4's autofix-policy.md)

The new step 7 includes the inline decision tree:

```
for finding in active_findings:
    if finding.suggested_patch_kind in ("manual", "none"):
        surface_to_user(finding)
        continue
    if finding.autofix_safe is True:
        plan_to_apply(finding)
        continue
    surface_for_medium_review(finding)
```

This includes the PR 4 review fix (branch on `"none"` so empty-patches findings don't get misrouted to medium-confidence apply).

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/` — **306 passed** (was 298; +8 new tests in `tests/test_prompt_parity.py`).
- `python -m ruff check .` — clean.
- `diff -q prompts/add-shipgate-to-repo.md skills/agents-shipgate/prompts/add-shipgate-to-repo.md` — byte-identical.

Tests:
- `test_skill_bundles_every_top_level_prompt` — every prompt under `prompts/` (except README) is mirrored.
- `test_skill_bundle_has_no_extra_prompts` — no orphaned bundled-only prompts.
- `test_prompt_byte_identical_across_locations` — parametrized over the 5 dual-copy prompts; each pair must be byte-identical.
- `test_add_shipgate_prompt_starts_with_detect_first_flow` — pins the canonical prompt's content (must reference `agents-shipgate detect`, `--suggest-patches`, `apply-patches`, `suggested_sources`) so a future edit can't regress to the older flow or drop the soft-stop rule.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] No new check IDs in this PR
- [x] No schema changes — `report-schema.v0.7.json` byte-identical post-PR.

## What's NOT in this PR (final phasing)

PR 6 (final polish) lands:
- Package version bump (`pyproject.toml` + `src/agents_shipgate/__init__.py` from `0.6.0` → `0.7.0`)
- Version-string sweeps in `README.md`, `AGENTS.md`, `llms.txt`, `tests/test_cli.py`
- End-to-end metadata round-trip test (asserts the four new Finding fields appear in `list-checks --json`, in `report.json` with and without `--suggest-patches`, and that an agent following the canonical 4-call flow against `samples/support_refund_agent` gets the populated metadata throughout)
- CHANGELOG.md v0.7.0 entry