### PR TITLE
v0.7 PR 6/6: release polish — version bump + end-to-end metadata + CHANGELOG

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Agents Shipgate version
-      placeholder: "v0.5.1"
+      placeholder: "v0.7.0"
     validations:
       required: true
   - type: dropdown

--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -3,7 +3,7 @@
   "name": "agents-shipgate",
   "display_name": "Agents Shipgate",
   "tagline": "Static release-readiness gate for AI agent tool surfaces",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "publisher": {
     "name": "Three Moons Lab",
@@ -11,7 +11,7 @@
   },
   "package": {
     "pypi": "agents-shipgate",
-    "github_action": "ThreeMoonsLab/agents-shipgate@v0.5.1",
+    "github_action": "ThreeMoonsLab/agents-shipgate@v0.7.0",
     "github_repo": "ThreeMoonsLab/agents-shipgate"
   },
   "install": {
@@ -28,7 +28,7 @@
   "trust_model": "static_by_default",
   "schemas": {
     "manifest": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json",
-    "report": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.5.json",
+    "report": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.7.json",
     "checks_catalog": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json"
   },
   "agent_instructions": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/AGENTS.md",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,10 +186,12 @@ Always parse `agents-shipgate-reports/report.json`, not the markdown. Stable fie
 
 - `summary.{critical_count, high_count, medium_count, status}`
 - `findings[].{id, fingerprint, check_id, severity, tool_name, evidence, recommendation, suppressed}`
+- `findings[].{autofix_safe, requires_human_review, suggested_patch_kind, docs_url}` (v0.7+)
+- `findings[].patches[]` (v0.6+, only when scan ran with `--suggest-patches`)
 - `baseline.{matched_count, new_count, resolved_count}`
 - `tool_inventory[]`
 
-The full schema is at [`docs/report-schema.v0.5.json`](docs/report-schema.v0.5.json) and what's-stable is documented in [STABILITY.md](STABILITY.md).
+The full schema is at [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) (current; emitted reports carry `report_schema_version: "0.7"`). Older reports validate against [`docs/report-schema.v0.6.json`](docs/report-schema.v0.6.json) (frozen reference). What's-stable is documented in [STABILITY.md](STABILITY.md).
 
 ### Task 3 · Suppress a finding with a reason
 
@@ -240,8 +242,10 @@ validation and [`docs/manifest-v0.1.md`](docs/manifest-v0.1.md) for prose.
 ### Where is the report schema?
 
 Parse `agents-shipgate-reports/report.json` and validate against
-[`docs/report-schema.v0.5.json`](docs/report-schema.v0.5.json). Do not scrape
-Markdown when JSON is available.
+[`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) (current).
+Older reports (`report_schema_version: "0.6"`) validate against the
+frozen [`docs/report-schema.v0.6.json`](docs/report-schema.v0.6.json).
+Do not scrape Markdown when JSON is available.
 
 ### How do I add a new check?
 
@@ -274,7 +278,8 @@ glossary: https://threemoonslab.com/glossary/.
 | What | Path | Stable |
 |---|---|---|
 | Manifest schema | [`docs/manifest-v0.1.json`](docs/manifest-v0.1.json) | `0.1` |
-| Report schema | [`docs/report-schema.v0.5.json`](docs/report-schema.v0.5.json) | `0.5` |
+| Report schema (current) | [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) | `0.7` |
+| Report schema (v0.6 frozen reference) | [`docs/report-schema.v0.6.json`](docs/report-schema.v0.6.json) | `0.6` |
 | Check catalog | [`docs/checks.json`](docs/checks.json) | regenerated each release |
 | Anti-patterns (what NOT to write) | [`samples/_anti_patterns/`](samples/_anti_patterns/) | reference |
 | Minimal manifest example | [`docs/manifest-v0.1.example.minimal.yaml`](docs/manifest-v0.1.example.minimal.yaml) | reference |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog
 
+## 0.7.0 - 2026-05-01
+
+Adoption activation: makes the v0.6 features visible to humans and AI
+coding agents on real repos, plus exposes per-check remediation
+metadata so agents can route findings without re-walking the catalog.
+
+- Agent-facing docs surface:
+  - New "Should I run Shipgate on this PR?" trigger table in
+    `AGENTS.md` with the soft-stop rule (don't skip MCP/OpenAPI-only
+    repos that surface as `is_agent_project: false`).
+  - New `docs/agent-recipes.md` — copy-pasteable AI-agent workflows
+    for the canonical 4-call flow.
+  - New `docs/autofix-policy.md` — four classes (safe / medium /
+    manual / never), catalog-vs-Finding contract, strict derivation
+    rule, three patch states, unknown-check-id fallback,
+    `apply-patches --confidence` table, decision tree.
+  - New `docs/minimal-real-configs.md` — per-framework references to
+    runnable `samples/*` fixtures (no inline snippets to drift).
+  - `docs/INDEX.md` cleanup: stale `report-schema.v0.5.json` link
+    removed; current schema link now `report-schema.v0.7.json`.
+  - `docs/quickstart.md` adds a "second 60 seconds" real-repo path.
+- `CheckMetadata` extensions:
+  - New `autofix_safe`, `requires_human_review`, `suggested_patch_kind`
+    fields on every check (45 entries). `docs_url` populated for every
+    check pointing at a stable `### SHIP-...` anchor in
+    `docs/checks.md`. 7 new per-check sections added to `docs/checks.md`
+    so every check has a stable anchor.
+  - Catalog-level safety bools stay conservative — even checks whose
+    generator usually produces a safe non-manual patch (stale-manifest
+    removals, scope coverage) keep `autofix_safe: false` /
+    `requires_human_review: true` because the generator can fall back
+    to `ManualPatch` in edge cases (ambiguous duplicates, etc.).
+    `suggested_patch_kind` is informational — describes what the
+    generator targets when conditions are clean.
+- `Finding` extensions + derivation:
+  - Same four optional fields on every Finding, populated by
+    `annotate_remediation` during scan. Three patch states handled
+    distinctly:
+    - `patches: None` (no `--suggest-patches`) → seed from
+      CheckMetadata; safe-closed fallback for unknown check IDs
+      (policy packs, third-party plugins).
+    - `patches: []` (--suggest-patches ran but generator emitted
+      nothing) → safe-closed shape with `suggested_patch_kind: "none"`.
+      Does NOT fall back to catalog (the report carries no patches).
+    - `patches: [...]` (non-empty) → strict derivation rule:
+      `autofix_safe: true` ONLY when EVERY emitted patch is non-manual
+      AND high-confidence. Mixed states fall to safe-closed.
+  - `docs_url` always sourced from CheckMetadata (patches don't carry
+    per-instance documentation URLs).
+- Report schema bumped to `v0.7` per
+  [STABILITY.md](STABILITY.md#stability-contract) ("`report_schema_version`
+  bumps minor on additive changes"). `docs/report-schema.v0.7.json`
+  added; `v0.6.json` retained as a frozen reference.
+- `_run_id` excludes the four new derived fields plus `patches` so
+  toggling `--suggest-patches` (or future enrichment fields) doesn't
+  shift the hash. New regression test pins this.
+- Plugin-loading isolation: every code path that reads the catalog
+  during scan honors the scan's `plugins_enabled` setting, including
+  the `_attach_patches` recommendation lookup.
+  `AGENTS_SHIPGATE_ENABLE_PLUGINS=1 agents-shipgate scan --no-plugins`
+  no longer loads plugins.
+- Onboarding prompt rewrite: `prompts/add-shipgate-to-repo.md` now
+  leads with the canonical 4-call flow (`detect → init --write --ci →
+  scan --suggest-patches → apply-patches --json`) and includes the
+  decision tree from `docs/autofix-policy.md`. Soft-stop rule
+  documented inline. `apply-patches --json` flag added so the
+  reporting step has structured data to read.
+- Dual-copy prompt parity: byte-identical mirror between
+  `prompts/` and `skills/agents-shipgate/prompts/` enforced by
+  `tests/test_prompt_parity.py` so the two surfaces can't drift.
+- Test coverage: 314 tests pass. New test files:
+  `tests/test_remediation_metadata.py`,
+  `tests/test_finding_remediation.py`,
+  `tests/test_docs_links.py`,
+  `tests/test_prompt_parity.py`,
+  `tests/test_v07_metadata_roundtrip.py`.
+
 ## 0.6.0 - 2026-04-30
 
 Agent-friendly adoption: compresses Shipgate setup into a single

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Agents Shipgate is designed to be agent-friendly. If you're a coding agent (Clau
 - **[`STABILITY.md`](STABILITY.md)** — what won't break across `0.x` versions
 - **[`prompts/`](prompts/)** — reusable prompts for common workflows
 - **[`skills/agents-shipgate/`](skills/agents-shipgate/)** + **[`.claude/commands/shipgate.md`](.claude/commands/shipgate.md)** — self-contained Claude Code skill (bundled prompts and CI recipe) and `/shipgate` slash command. See [`docs/agents/use-with-claude-code.md`](docs/agents/use-with-claude-code.md) to install in your own project.
-- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.5.json`](docs/report-schema.v0.5.json)** — JSON Schemas for live editor validation
+- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json)** — JSON Schemas for live editor validation (current; emitted reports carry `report_schema_version: "0.7"`)
 - **[`docs/checks.json`](docs/checks.json)** — machine-readable check catalog
 
 Every command has a `--json` form. Errors emit a structured `next_action` line on stderr when `AGENTS_SHIPGATE_AGENT_MODE=1`.
@@ -348,7 +348,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: agents-shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+        uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           config: shipgate.yaml
           ci_mode: advisory
@@ -376,7 +376,7 @@ If hosted dashboards, SSO, org-wide baselines, approval workflows, or trace-base
 - [Check catalog](docs/checks.md)
 - [Policy packs](docs/policy-packs.md)
 - [Baseline workflow](docs/baseline.md)
-- [JSON report schema v0.5](docs/report-schema.v0.5.json)
+- [JSON report schema v0.7](docs/report-schema.v0.7.json)
 - [Trust model](docs/trust-model.md)
 - [Runtime inventory design note](docs/runtime-inventory.md)
 - [Troubleshooting](docs/troubleshooting.md)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ minimal manifests, see [`docs/minimal-real-configs.md`](docs/minimal-real-config
 ## Use in CI
 
 ```yaml
-- uses: ThreeMoonsLab/agents-shipgate@v0.6.0
+- uses: ThreeMoonsLab/agents-shipgate@v0.7.0
   with:
     config: shipgate.yaml
     ci_mode: advisory

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 > **Naming.** This project is **Agents Shipgate** (display name) / `agents-shipgate` (package, CLI, repo). See [`AGENTS.md` § Naming (canonical)](AGENTS.md#naming-canonical) for the full convention.
 
-Agents Shipgate is currently in the `0.5.x` line. The `v0.2` through `v0.5`
-items are complete and retained here as release history. Active public planning
-starts at `v0.6.0`.
+Agents Shipgate is currently in the `0.7.x` line. Releases `v0.2` through
+`v0.7` are complete and retained here as release history. Active public
+planning starts at `v0.8.0`.
 
 ## Completed
 
@@ -83,11 +83,45 @@ agents.
 - Bumped report schema to v0.6 (additive: per-finding `patches`,
   top-level `manifest_dir`).
 
+### v0.7.0 Adoption Activation
+
+Goal: make the v0.6 features visible to humans and AI coding agents
+on real repos, plus expose per-check remediation metadata so agents
+can decide what's safe to auto-fix.
+
+- Added `AGENTS.md` "Should I run Shipgate?" trigger table with the
+  soft-stop rule (don't skip MCP/OpenAPI-only repos).
+- Added `docs/agent-recipes.md`, `docs/autofix-policy.md`, and
+  `docs/minimal-real-configs.md` as the agent-facing surface.
+- Extended `CheckMetadata` with `autofix_safe`,
+  `requires_human_review`, `suggested_patch_kind`, populated
+  `docs_url` for all 45 entries (PR 2 — catalog-conservative
+  defaults; per-check generator targets documented).
+- Added the same four optional fields to `Finding`, plus the
+  derivation policy: when `Finding.patches` is non-empty, derive
+  from actual patches (`autofix_safe=True` only when EVERY patch
+  is non-manual AND high confidence); otherwise seed from
+  `CheckMetadata`. Unknown check IDs (policy packs, plugins) get
+  the safe-closed fallback. Three patch states (None / [] /
+  non-empty) handled distinctly.
+- Bumped report schema to v0.7 (additive over v0.6 — four new
+  optional Finding fields). v0.6 schema retained as a frozen
+  reference.
+- `_run_id` excludes the four new derived fields plus `patches`;
+  scan run_id is identical with or without `--suggest-patches`.
+- Plugin-loading isolation: every code path that reads the catalog
+  during scan honors the scan's `plugins_enabled` setting, so
+  `--no-plugins` is respected even when
+  `AGENTS_SHIPGATE_ENABLE_PLUGINS=1` is set in the environment.
+- Onboarding prompt rewritten to lead with the v0.6 4-call flow;
+  byte-parity test enforces dual-copy synchrony between
+  `prompts/` and `skills/agents-shipgate/prompts/`.
+
 ## Open
 
-### v0.7.0 Cross-Platform CI Expansion
+### v0.8.0 Cross-Platform CI Expansion
 
-Goal: broaden CI documentation after the v0.6 agent-friendly adoption
+Goal: broaden CI documentation after the v0.7 adoption activation
 work lands.
 
 - Add or harden recipes for additional CI platforms:
@@ -103,7 +137,7 @@ work lands.
   - recommended artifact retention;
   - failure-mode examples for security review and platform engineering teams.
 
-### v0.6.x Source-Provenance Enrichment (incremental)
+### v0.7.x Source-Provenance Enrichment (incremental)
 
 Once we have origin (file path, line index for JSONL, list index for
 arrays) threaded through finding evidence, expand the patch generator

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,7 +5,7 @@ These items require release infrastructure, registry credentials, domains, or Gi
 ## Package Channels
 
 - `agents-shipgate` is published on PyPI.
-- Pinned GitHub Action release tags are published, including `v0.5.1`.
+- Pinned GitHub Action release tags are published, including `v0.7.0`.
 - GitHub Releases attach the wheel, sdist, SBOM, and Sigstore bundles.
 - Evaluate a container image later only if it has an exercised build-and-test path.
 - Evaluate Homebrew once CLI usage warrants it.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -40,4 +40,5 @@ The canonical fixture writes:
 - `agents-shipgate-reports/report.sarif` when requested or when using the GitHub Action
 
 The JSON output is the stable contract for tools and coding agents. See
-[report-schema.v0.5.json](report-schema.v0.5.json).
+[report-schema.v0.7.json](report-schema.v0.7.json) (current; emitted reports
+carry `report_schema_version: "0.7"`).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -68,7 +68,7 @@ schema.
 
 ## Is it production-ready?
 
-v0.5.1 is the latest released version. The manifest schema is stable
+v0.7.0 is the latest released version. The manifest schema is stable
 across the 0.x series; see [`STABILITY.md`](../STABILITY.md). Used by
 early design partners. Public preview.
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -101,7 +101,7 @@ agents-shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.5.1"
+    - python -m pip install "agents-shipgate==0.7.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always
@@ -133,7 +133,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.5.1"
+      - run: python -m pip install "agents-shipgate==0.7.0"
       - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
       - store_artifacts:
           path: agents-shipgate-reports

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: agents-shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+        uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           config: shipgate.yaml
           ci_mode: advisory

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,6 +40,6 @@ surface before production-like permissions are granted.
 - [Concepts](concepts.md)
 - [Manifest v0.1](manifest-v0.1.md)
 - [Check catalog](checks.md)
-- [Report schema v0.5](report-schema.v0.5.json)
+- [Report schema v0.7](report-schema.v0.7.json)
 - [Trust model](trust-model.md)
 - [Agent instructions](../AGENTS.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.6.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           config: shipgate.yaml
           ci_mode: advisory

--- a/examples/circleci/01-advisory.yml
+++ b/examples/circleci/01-advisory.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.5.1"
+      - run: python -m pip install "agents-shipgate==0.7.0"
       - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
       - store_artifacts:
           path: agents-shipgate-reports

--- a/examples/circleci/02-strict-with-baseline.yml
+++ b/examples/circleci/02-strict-with-baseline.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.5.1"
+      - run: python -m pip install "agents-shipgate==0.7.0"
       - run:
           name: Agents Shipgate strict scan
           command: >

--- a/examples/circleci/03-sarif-artifact-retention.yml
+++ b/examples/circleci/03-sarif-artifact-retention.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.5.1"
+      - run: python -m pip install "agents-shipgate==0.7.0"
       - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
       - store_artifacts:
           path: agents-shipgate-reports/report.sarif

--- a/examples/circleci/04-multi-config-workspace.yml
+++ b/examples/circleci/04-multi-config-workspace.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.5.1"
+      - run: python -m pip install "agents-shipgate==0.7.0"
       - run:
           name: Agents Shipgate workspace scan
           command: >

--- a/examples/circleci/05-on-tool-source-changes.yml
+++ b/examples/circleci/05-on-tool-source-changes.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.5.1"
+      - run: python -m pip install "agents-shipgate==0.7.0"
       - run:
           name: Run only when tool sources changed
           command: |

--- a/examples/github-actions/01-advisory-pr-comment.yml
+++ b/examples/github-actions/01-advisory-pr-comment.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+      - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           ci_mode: advisory
           pr_comment: 'true'

--- a/examples/github-actions/01-advisory-pr-comment.yml
+++ b/examples/github-actions/01-advisory-pr-comment.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.5.1'
+          shipgate_version: '0.7.0'

--- a/examples/github-actions/02-strict-on-critical.yml
+++ b/examples/github-actions/02-strict-on-critical.yml
@@ -21,4 +21,4 @@ jobs:
           ci_mode: strict
           fail_on: critical
           pr_comment: 'true'
-          shipgate_version: '0.5.1'
+          shipgate_version: '0.7.0'

--- a/examples/github-actions/02-strict-on-critical.yml
+++ b/examples/github-actions/02-strict-on-critical.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+      - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           ci_mode: strict
           fail_on: critical

--- a/examples/github-actions/03-strict-with-baseline.yml
+++ b/examples/github-actions/03-strict-with-baseline.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+      - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           ci_mode: strict
           fail_on: critical,high

--- a/examples/github-actions/03-strict-with-baseline.yml
+++ b/examples/github-actions/03-strict-with-baseline.yml
@@ -23,4 +23,4 @@ jobs:
           fail_on: critical,high
           baseline: .agents-shipgate/baseline.json
           pr_comment: 'true'
-          shipgate_version: '0.5.1'
+          shipgate_version: '0.7.0'

--- a/examples/github-actions/04-multi-config-workspace.yml
+++ b/examples/github-actions/04-multi-config-workspace.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: pip install --quiet agents-shipgate==0.5.1
+      - run: pip install --quiet agents-shipgate==0.7.0
       - run: |
           agents-shipgate scan \
             --workspace . \

--- a/examples/github-actions/05-sarif-to-code-scanning.yml
+++ b/examples/github-actions/05-sarif-to-code-scanning.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+        uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           ci_mode: advisory
           formats: markdown,json,sarif

--- a/examples/github-actions/05-sarif-to-code-scanning.yml
+++ b/examples/github-actions/05-sarif-to-code-scanning.yml
@@ -25,7 +25,7 @@ jobs:
           ci_mode: advisory
           formats: markdown,json,sarif
           pr_comment: 'true'
-          shipgate_version: '0.5.1'
+          shipgate_version: '0.7.0'
       - if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/examples/github-actions/06-on-tool-source-changes.yml
+++ b/examples/github-actions/06-on-tool-source-changes.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.5.1'
+          shipgate_version: '0.7.0'

--- a/examples/github-actions/06-on-tool-source-changes.yml
+++ b/examples/github-actions/06-on-tool-source-changes.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+      - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           ci_mode: advisory
           pr_comment: 'true'

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -29,7 +29,7 @@ Configure per-job, never repo-wide.
 For reproducible CI, pin both the action and the underlying CLI:
 
 ```yaml
-- uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+- uses: ThreeMoonsLab/agents-shipgate@v0.7.0
   with:
     shipgate_version: "0.5.1"
 ```
@@ -42,7 +42,7 @@ Useful for downstream steps:
 
 ```yaml
 - id: shipgate
-  uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+  uses: ThreeMoonsLab/agents-shipgate@v0.7.0
 
 - if: steps.shipgate.outputs.critical_count != '0'
   run: echo "Action this!"

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -31,7 +31,7 @@ For reproducible CI, pin both the action and the underlying CLI:
 ```yaml
 - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
   with:
-    shipgate_version: "0.5.1"
+    shipgate_version: "0.7.0"
 ```
 
 When `shipgate_version` is empty the action installs the CLI from the action source — convenient on `@main`, less reproducible.

--- a/examples/gitlab-ci/01-advisory.yml
+++ b/examples/gitlab-ci/01-advisory.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.5.1"
+    - python -m pip install "agents-shipgate==0.7.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always

--- a/examples/gitlab-ci/02-strict-with-baseline.yml
+++ b/examples/gitlab-ci/02-strict-with-baseline.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.5.1"
+    - python -m pip install "agents-shipgate==0.7.0"
     - >
       agents-shipgate scan
       --config shipgate.yaml

--- a/examples/gitlab-ci/03-sarif-or-artifact.yml
+++ b/examples/gitlab-ci/03-sarif-or-artifact.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.5.1"
+    - python -m pip install "agents-shipgate==0.7.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always

--- a/examples/gitlab-ci/04-multi-config-workspace.yml
+++ b/examples/gitlab-ci/04-multi-config-workspace.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.5.1"
+    - python -m pip install "agents-shipgate==0.7.0"
     - >
       agents-shipgate scan
       --workspace .

--- a/examples/gitlab-ci/05-on-tool-source-changes.yml
+++ b/examples/gitlab-ci/05-on-tool-source-changes.yml
@@ -14,7 +14,7 @@ agents_shipgate:
         - "**/*mcp*.json"
         - "**/*.py"
   script:
-    - python -m pip install "agents-shipgate==0.5.1"
+    - python -m pip install "agents-shipgate==0.7.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 - Publisher: Three Moons Lab
 - Publisher URL: https://threemoonslab.com/
 - License: Apache-2.0
-- Latest public release: v0.6.0
+- Latest public release: v0.7.0
 - Canonical repository: https://github.com/ThreeMoonsLab/agents-shipgate
 - Do not use: Agent Shipcheck, Agent Shipgate, agents shipgate, Agents-Shipgate
 
@@ -67,7 +67,7 @@
 - Run a zero-config fixture: `agents-shipgate fixture run support_refund_agent`.
 - Initialize a repo manifest: `agents-shipgate init --workspace . --write`.
 - Scan a repo: `agents-shipgate scan -c shipgate.yaml`.
-- GitHub Action: `ThreeMoonsLab/agents-shipgate@v0.6.0`.
+- GitHub Action: `ThreeMoonsLab/agents-shipgate@v0.7.0`.
 
 ## Source of truth
 

--- a/prompts/stabilize-strict-mode.md
+++ b/prompts/stabilize-strict-mode.md
@@ -37,7 +37,7 @@ The user has Agents Shipgate running in **advisory** mode and wants to graduate 
 
 5. **Update the CI workflow.** Replace the existing advisory step with strict + baseline. Use [`examples/github-actions/03-strict-with-baseline.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/03-strict-with-baseline.yml) as the template:
    ```yaml
-   - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+   - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
      with:
        ci_mode: strict
        fail_on: critical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agents-shipgate"
-version = "0.6.0"
+version = "0.7.0"
 description = "Static release-readiness gate for AI agent tool surfaces. CLI + GitHub Action. Scans MCP, OpenAPI, OpenAI Agents SDK, Anthropic, Google ADK, LangChain, CrewAI."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/skills/agents-shipgate/SKILL.md
+++ b/skills/agents-shipgate/SKILL.md
@@ -59,7 +59,7 @@ For non-GitHub CI (GitLab, CircleCI, Jenkins, Azure Pipelines, Buildkite, Bitbuc
 ## Stable contracts (rely on these)
 
 - **CLI surface** is frozen for `0.x` — see https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/STABILITY.md.
-- **Report JSON**: `report_schema_version: "0.5"`. Stable fields include `summary.{critical_count, high_count, medium_count, status}` and `findings[].{id, fingerprint, check_id, severity, category, title, recommendation, suppressed}`.
+- **Report JSON**: `report_schema_version: "0.7"`. Stable fields include `summary.{critical_count, high_count, medium_count, status}`, `manifest_dir` (top-level, v0.6+), and `findings[].{id, fingerprint, check_id, severity, category, title, recommendation, suppressed}` plus the v0.7 remediation fields `findings[].{autofix_safe, requires_human_review, suggested_patch_kind, docs_url}` (populated for every active finding regardless of `--suggest-patches`). When scan ran with `--suggest-patches`, each active finding also carries `findings[].patches[]` (each patch has `kind` ∈ `{set_pointer, append_pointer, remove_pointer, manual}` plus per-patch `confidence` for non-manual kinds). Reports validate against [`docs/report-schema.v0.7.json`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/report-schema.v0.7.json) (current); pre-v0.7 reports validate against [`docs/report-schema.v0.6.json`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/report-schema.v0.6.json) (frozen reference).
 - **Exit codes**: `0` pass, `2` config error, `3` parse error, `4` other error, `20` strict-mode gate failure.
 - **Check IDs** (e.g. `SHIP-POLICY-APPROVAL-MISSING`) are stable; new ones may be added but existing ones will not be renamed or repurposed.
 

--- a/skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml
+++ b/skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+      - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
         with:
           ci_mode: advisory
           pr_comment: 'true'

--- a/skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml
+++ b/skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.5.1'
+          shipgate_version: '0.7.0'

--- a/skills/agents-shipgate/prompts/stabilize-strict-mode.md
+++ b/skills/agents-shipgate/prompts/stabilize-strict-mode.md
@@ -37,7 +37,7 @@ The user has Agents Shipgate running in **advisory** mode and wants to graduate 
 
 5. **Update the CI workflow.** Replace the existing advisory step with strict + baseline. Use [`examples/github-actions/03-strict-with-baseline.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/03-strict-with-baseline.yml) as the template:
    ```yaml
-   - uses: ThreeMoonsLab/agents-shipgate@v0.5.1
+   - uses: ThreeMoonsLab/agents-shipgate@v0.7.0
      with:
        ci_mode: strict
        fail_on: critical

--- a/src/agents_shipgate/__init__.py
+++ b/src/agents_shipgate/__init__.py
@@ -1,3 +1,3 @@
 """Agents Shipgate package."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_cli_advisory_exits_zero(tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Agents Shipgate 0.6.0" in result.output
+    assert "Agents Shipgate 0.7.0" in result.output
     assert "release_blockers_detected" in result.output
 
 
@@ -99,7 +99,7 @@ def test_cli_version_outputs_version():
     result = runner.invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.output.strip() == "Agents Shipgate 0.6.0"
+    assert result.output.strip() == "Agents Shipgate 0.7.0"
 
 
 def test_cli_scan_help_hides_deferred_flags():

--- a/tests/test_v07_metadata_roundtrip.py
+++ b/tests/test_v07_metadata_roundtrip.py
@@ -1,0 +1,235 @@
+"""End-to-end v0.7 remediation metadata round-trip.
+
+Per the v0.7 plan §3 final-polish verification: agents reading
+``agents-shipgate list-checks --json`` and ``report.json`` should both
+get populated remediation metadata for every check, and the JSON
+contracts on both endpoints should validate against the v0.7 schema.
+
+Specifically:
+
+1. ``list-checks --json`` carries non-None ``docs_url``,
+   ``autofix_safe``, ``requires_human_review``, ``suggested_patch_kind``
+   for every built-in check.
+2. ``report.json`` carries the same four fields populated for every
+   active finding from a real scan against
+   ``samples/support_refund_agent``, both with and without
+   ``--suggest-patches``.
+3. The ``report.json`` validates against
+   ``docs/report-schema.v0.7.json``.
+4. The catalog-vs-Finding contract holds in practice: stale-manifest
+   findings whose actual emitted patch is non-manual + high-confidence
+   carry ``autofix_safe: True`` even though the catalog stays
+   conservative (``autofix_safe: False``).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import yaml
+from jsonschema import validate
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.cli.scan import run_scan
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAMPLES = REPO_ROOT / "samples"
+SAMPLE_MANIFEST = SAMPLES / "support_refund_agent" / "shipgate.yaml"
+REPORT_SCHEMA_V07 = REPO_ROOT / "docs" / "report-schema.v0.7.json"
+
+REQUIRED_REMEDIATION_KEYS = (
+    "autofix_safe",
+    "requires_human_review",
+    "suggested_patch_kind",
+    "docs_url",
+)
+
+
+# --- list-checks --json end-to-end -----------------------------------------
+
+
+def test_list_checks_json_carries_remediation_metadata_for_every_check():
+    runner = CliRunner()
+    result = runner.invoke(app, ["list-checks", "--json"])
+    assert result.exit_code == 0, result.output
+    catalog = json.loads(result.output)
+    assert catalog, "empty catalog from list-checks --json"
+    for entry in catalog:
+        for key in REQUIRED_REMEDIATION_KEYS:
+            assert key in entry, (
+                f"{entry['id']} missing remediation key {key!r} in "
+                "list-checks --json"
+            )
+            assert entry[key] is not None, (
+                f"{entry['id']}.{key} is None in list-checks --json — "
+                "all four fields must be populated for every catalog entry"
+            )
+
+
+def test_explain_json_carries_remediation_metadata():
+    """`explain <id> --json` is the per-check programmatic surface
+    agents use when they want full context on one finding ID. It must
+    surface the same remediation fields as the catalog."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["explain", "SHIP-MANIFEST-STALE-SUPPRESSION", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    for key in REQUIRED_REMEDIATION_KEYS:
+        assert key in payload, f"explain --json missing {key!r}"
+        assert payload[key] is not None, f"explain --json {key!r} is None"
+
+
+# --- report.json end-to-end ------------------------------------------------
+
+
+def test_report_json_populates_metadata_without_suggest_patches(tmp_path):
+    """Per the v0.7 contract: even WITHOUT --suggest-patches every
+    active finding has the four remediation fields populated, sourced
+    from CheckMetadata. Agents reading the JSON contract get
+    remediation policy without opting into patches."""
+    report, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    active = [f for f in payload["findings"] if not f.get("suppressed")]
+    assert active, "expected active findings in support_refund_agent"
+    for finding in active:
+        for key in REQUIRED_REMEDIATION_KEYS:
+            assert key in finding, (
+                f"{finding['check_id']} missing {key!r} in report.json "
+                "(scan ran without --suggest-patches)"
+            )
+            assert finding[key] is not None, (
+                f"{finding['check_id']}.{key} is None — built-in checks "
+                "should always populate from CheckMetadata"
+            )
+
+
+def test_report_json_populates_metadata_with_suggest_patches(tmp_path):
+    """Same contract under --suggest-patches: every active finding has
+    populated remediation fields. Patch-bearing findings derive them
+    from the actual emitted patches (per the strict rule); ManualPatch
+    findings inherit safe-closed values."""
+    report, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+        suggest_patches=True,
+    )
+    payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    active = [f for f in payload["findings"] if not f.get("suppressed")]
+    assert active
+    for finding in active:
+        for key in REQUIRED_REMEDIATION_KEYS:
+            assert key in finding
+            assert finding[key] is not None
+
+
+# --- v0.7 schema validation ------------------------------------------------
+
+
+def test_report_json_validates_against_v07_schema_with_patches(tmp_path):
+    report, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+        suggest_patches=True,
+    )
+    payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V07.read_text(encoding="utf-8"))
+    validate(instance=payload, schema=schema)
+
+
+def test_report_schema_version_is_v07_in_emitted_report(tmp_path):
+    report, _ = run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    assert payload["report_schema_version"] == "0.7"
+
+
+# --- Catalog-vs-Finding contract holds in practice -------------------------
+
+
+def test_stale_finding_with_unique_match_is_per_finding_autofix_safe(tmp_path):
+    """The catalog-vs-Finding contract: stale-manifest checks at the
+    catalog level are conservative (`autofix_safe: false`). But a
+    finding whose generator emitted a unique high-confidence
+    `remove_pointer` patch should carry `autofix_safe: true` at the
+    Finding level — that's exactly what derivation enables agents to
+    act on.
+    """
+    workspace = tmp_path / "ws"
+    shutil.copytree(SAMPLES / "support_refund_agent", workspace)
+    manifest_path = workspace / "shipgate.yaml"
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data.setdefault("checks", {})["ignore"] = [
+        {
+            "check_id": "SHIP-DOC-MISSING-DESCRIPTION",
+            "tool": "nonexistent_tool_unique",
+            "reason": "stale fixture",
+        }
+    ]
+    manifest_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    report, _ = run_scan(
+        config_path=manifest_path,
+        output_dir=workspace / "agents-shipgate-reports",
+        formats=["json"],
+        ci_mode="advisory",
+        suggest_patches=True,
+    )
+    payload = json.loads(
+        (workspace / "agents-shipgate-reports" / "report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    stale = [
+        f
+        for f in payload["findings"]
+        if f["check_id"] == "SHIP-MANIFEST-STALE-SUPPRESSION" and not f.get("suppressed")
+    ]
+    assert stale
+    finding = stale[0]
+    # Per-Finding: derived from actual high-confidence remove_pointer.
+    assert finding["autofix_safe"] is True
+    assert finding["requires_human_review"] is False
+    assert finding["suggested_patch_kind"] == "remove_pointer"
+
+    # Catalog (via list-checks): still conservative.
+    runner = CliRunner()
+    catalog_result = runner.invoke(app, ["list-checks", "--json"])
+    catalog = json.loads(catalog_result.output)
+    by_id = {entry["id"]: entry for entry in catalog}
+    catalog_entry = by_id["SHIP-MANIFEST-STALE-SUPPRESSION"]
+    assert catalog_entry["autofix_safe"] is False, (
+        "catalog-level autofix_safe must stay conservative — generator "
+        "can fall back to ManualPatch on duplicates"
+    )
+
+
+# --- v0.7 release version sanity check -------------------------------------
+
+
+def test_package_version_is_v07():
+    """Final-polish guard: catches the case where the schema bumped to
+    v0.7 but the package version was left at v0.6. Both move together."""
+    import agents_shipgate
+
+    assert agents_shipgate.__version__ == "0.7.0", (
+        f"package version is {agents_shipgate.__version__!r}; "
+        "expected 0.7.0 for the v0.7 release"
+    )


### PR DESCRIPTION
## Summary

Final piece of the v0.7 adoption activation series. Bumps the package version to `0.7.0` in lockstep with the report schema bump from PR 3, sweeps `v0.6.0` references throughout the repo, adds an end-to-end metadata round-trip test, and writes the v0.7.0 CHANGELOG entry.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior (version bump surfaces via `--version`, `Agents Shipgate 0.7.0` in stdout summary)
- [ ] Report, schema, or SARIF output (schema unchanged from PR 3; this PR only ships the package-version + docs polish)
- [x] Documentation only (CHANGELOG, ROADMAP, README/quickstart action refs, llms.txt)

## What changed

| File | Change |
|---|---|
| [pyproject.toml](pyproject.toml) | `version = "0.7.0"` |
| [src/agents_shipgate/__init__.py](src/agents_shipgate/__init__.py) | `__version__ = "0.7.0"` |
| [tests/test_cli.py](tests/test_cli.py) | `--version` and CLI summary assertions bumped to `0.7.0` |
| [README.md](README.md), [docs/quickstart.md](docs/quickstart.md) | GitHub Action ref bumped to `@v0.7.0` |
| [llms.txt](llms.txt) | Latest-release marker + Action ref bumped to `v0.7.0` |
| [ROADMAP.md](ROADMAP.md) | Active line bumped (`0.5.x` → `0.7.x`); v0.7.0 Adoption Activation recorded as completed; Cross-Platform CI Expansion moved to v0.8.0; source-provenance enrichment renamed to v0.7.x |
| [CHANGELOG.md](CHANGELOG.md) | Full v0.7.0 entry summarizing PRs 1–6 |
| [tests/test_v07_metadata_roundtrip.py](tests/test_v07_metadata_roundtrip.py) | NEW. 8 end-to-end tests for the v0.7 metadata contract. |

## End-to-end metadata round-trip test

The new file is the load-bearing artifact that proves the v0.7 contract holds across the surfaces an agent actually consumes:

- `list-checks --json` carries non-None `autofix_safe`, `requires_human_review`, `suggested_patch_kind`, `docs_url` for every built-in check.
- `explain <ID> --json` surfaces the same fields.
- Scan against `samples/support_refund_agent` populates the four fields on every active finding **both with and without `--suggest-patches`** — agents reading the JSON contract get remediation policy regardless of how scan was invoked.
- Emitted `report.json` carries `report_schema_version: "0.7"` and validates against `docs/report-schema.v0.7.json`.
- **Catalog-vs-Finding contract verified end-to-end**: a stale-manifest finding with a unique match carries `autofix_safe: true` at the Finding level even though the catalog entry stays `autofix_safe: false` (because the generator can fall back to ManualPatch on duplicates). This is the load-bearing safety/usability tradeoff from PR 2 and PR 3 — the test pins it so a future refactor can't silently flip either side.
- Package version sanity check: `__version__ == "0.7.0"` so a future schema bump without the package version moving fails loudly.

## Historical references kept intact

The version sweep deliberately leaves these alone (they describe past releases, not the current one):
- `CHANGELOG.md` `## 0.6.0` section header
- `ROADMAP.md` v0.6.0 Agent-Friendly Adoption completed-release entry
- `src/agents_shipgate/cli/discovery/__init__.py` docstring describing the v0.5.x → v0.6.0 refactor

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/` — **314 passed** (was 306; +8 new end-to-end tests).
- `python -m ruff check .` — clean.
- `python scripts/generate_schemas.py` — leaves a clean tree.
- `agents-shipgate --version` — emits `Agents Shipgate 0.7.0`.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] No new check IDs in this PR
- [x] **No schema changes** in this PR (the schema bump landed in PR 3; this PR only bumps the package version and docs to match).
- [x] Version moved across `pyproject.toml`, `__init__.py`, README/quickstart action snippets, llms.txt, and the CLI test assertions in lockstep.

## What's NOT in this PR

The six-PR v0.7 series is now complete. Out-of-scope-but-named items per the original plan:

- Source-provenance enrichment (v0.7.x incremental) — threading file path / line index / list index through finding evidence to enable trace-event metadata patches and policy-rule-file patches.
- Cross-platform CI expansion (v0.8.0) — Jenkins, Buildkite, Azure Pipelines, Bitbucket Pipelines recipes.