### PR TITLE
Add recommend-fixes recipe to agents-shipgate skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,7 @@ Prebuilt prompts for common workflows live in [`prompts/`](prompts/):
 
 - [`add-shipgate-to-repo.md`](prompts/add-shipgate-to-repo.md) — bootstrap a repo
 - [`fix-top-finding.md`](prompts/fix-top-finding.md) — iterate on a single finding
+- [`recommend-fixes.md`](prompts/recommend-fixes.md) — walk all active findings and surface targeted fix recommendations across the four autofix-policy classes
 - [`stabilize-strict-mode.md`](prompts/stabilize-strict-mode.md) — tune → baseline → promote
 - [`triage-false-positive.md`](prompts/triage-false-positive.md) — override vs suppress decision
 

--- a/docs/agents/use-with-claude-code.md
+++ b/docs/agents/use-with-claude-code.md
@@ -9,7 +9,7 @@ Two pieces of agent-facing surface ship with this repo. Drop them into your own 
 
 The skill is named `agents-shipgate`, not `shipgate`, on purpose: Claude Code lets a skill with the same name as a command preempt it, which would silently bypass the `/shipgate` slash command. Keeping the names distinct lets users invoke the slash command explicitly **and** lets the skill auto-trigger on relevant phrases.
 
-The skill bundles all five [`prompts/`](../../prompts/) recipes plus the advisory CI YAML in its own directory, so a user project does not depend on the upstream `main` branch at runtime. When you change anything in [`prompts/`](../../prompts/) or [`examples/github-actions/01-advisory-pr-comment.yml`](../../examples/github-actions/01-advisory-pr-comment.yml), sync the bundled copy under `skills/agents-shipgate/`.
+The skill bundles all six [`prompts/`](../../prompts/) recipes plus the advisory CI YAML in its own directory, so a user project does not depend on the upstream `main` branch at runtime. When you change anything in [`prompts/`](../../prompts/) or [`examples/github-actions/01-advisory-pr-comment.yml`](../../examples/github-actions/01-advisory-pr-comment.yml), sync the bundled copy under `skills/agents-shipgate/`.
 
 ## Install in your agent project
 
@@ -26,6 +26,7 @@ mkdir -p .claude/skills/agents-shipgate
 for f in SKILL.md \
          prompts/add-shipgate-to-repo.md \
          prompts/fix-top-finding.md \
+         prompts/recommend-fixes.md \
          prompts/triage-false-positive.md \
          prompts/stabilize-strict-mode.md \
          prompts/upgrade-shipgate-version.md \
@@ -59,6 +60,7 @@ The `agents-shipgate` skill routes to bundled recipes (relative paths inside the
 - Bootstrap a repo → `prompts/add-shipgate-to-repo.md`
 - First-time CI (advisory PR comment) → `ci-recipes/advisory-pr-comment.yml`
 - Fix the top finding → `prompts/fix-top-finding.md`
+- Recommend fixes across all findings → `prompts/recommend-fixes.md`
 - Triage a false positive → `prompts/triage-false-positive.md`
 - Promote advisory CI to strict → `prompts/stabilize-strict-mode.md`
 - Upgrade the version → `prompts/upgrade-shipgate-version.md`

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -6,6 +6,7 @@ Prebuilt prompts for AI coding agents (Claude Code, Codex, Cursor, Aider) workin
 |---|---|
 | [`add-shipgate-to-repo.md`](add-shipgate-to-repo.md) | Bootstrap Agents Shipgate in a repo that doesn't have it yet |
 | [`fix-top-finding.md`](fix-top-finding.md) | Iterate on a single highest-severity finding |
+| [`recommend-fixes.md`](recommend-fixes.md) | Walk all active findings and surface targeted fix recommendations across the four autofix-policy classes (with optional dry-run + apply for safe patches) |
 | [`stabilize-strict-mode.md`](stabilize-strict-mode.md) | Tune → baseline → promote workflow for going from advisory to strict CI |
 | [`triage-false-positive.md`](triage-false-positive.md) | Decide whether to override the heuristic, suppress the finding, or fix the underlying issue |
 | [`upgrade-shipgate-version.md`](upgrade-shipgate-version.md) | Bump agents-shipgate version safely (regenerate baseline if needed) |

--- a/prompts/recommend-fixes.md
+++ b/prompts/recommend-fixes.md
@@ -1,0 +1,69 @@
+# Prompt · Recommend fixes for active Agents Shipgate findings
+
+You are working in a repo with `shipgate.yaml` already in place and want a coordinated remediation pass across **all** active findings — not just the top one. Walk every finding, classify it against the v0.7 autofix policy, and surface targeted fix recommendations. Apply only the safe, high-confidence patches (after preview + explicit confirmation); leave the rest for human review with concrete advice.
+
+## Your task
+
+1. **Always run a fresh v0.7 scan with patches.** Do not reuse a stale report — earlier scans may be pre-v0.7 (no remediation fields) or may lack `patches[]` (no `--suggest-patches`). Set `AGENTS_SHIPGATE_AGENT_MODE=1` so errors emit a `next_action` JSON line on stderr.
+   ```bash
+   AGENTS_SHIPGATE_AGENT_MODE=1 agents-shipgate scan -c shipgate.yaml \
+       --suggest-patches --format json --ci-mode advisory
+   ```
+   Read `agents-shipgate-reports/report.json`. Verify `report_schema_version` is `"0.7"` or higher. Filter `findings[]` to entries with `"suppressed": false`.
+
+2. **Bucket each active finding into one of four classes.** Use the per-Finding fields (the catalog values are worst-case; per-Finding fields tell the truth for this scan). The buckets come from [`docs/autofix-policy.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/autofix-policy.md):
+
+   | Bucket | Detect by | Example check IDs |
+   |---|---|---|
+   | **A. Safe auto-fix** | `autofix_safe == true` | `SHIP-MANIFEST-STALE-{SUPPRESSION,POLICY,RISK-OVERRIDE}` when the match is unique |
+   | **B. Medium-confidence config fix** | `autofix_safe == false` AND `suggested_patch_kind` ∈ `{set_pointer, append_pointer, remove_pointer}` | `SHIP-AUTH-SCOPE-COVERAGE-MISSING` |
+   | **C. Manual** | `suggested_patch_kind == "manual"` | Documentation, schema bounds, owner gaps, ADK/LangChain/CrewAI metadata, and the never-auto-fix trace findings |
+   | **D. No patch emitted** | `suggested_patch_kind == "none"` | The generator emitted nothing — but the finding can still be high/critical (e.g. low-confidence inventory). Treat as **human triage**, not informational. |
+
+3. **Build a recommendation card per finding.** For each, present:
+   - `check_id`, `title`, `severity`, `tool_name`, `confidence`
+   - The verbatim `recommendation` string (per-finding fix text from the check author)
+   - `docs_url` as a markdown link (when non-null)
+   - **Concrete fix step** — branch on patch kind, since the patch shapes differ:
+     - `set_pointer` / `append_pointer`: show `target_file`, `pointer`, `value`, `confidence`, `rationale`
+     - `remove_pointer`: show `target_file`, `pointer`, `confidence`, `rationale`
+     - `manual`: show `instructions` verbatim. `ManualPatch` has only `kind` and `instructions` — do NOT try to read `target_file`/`pointer`/`value`; they don't exist.
+     - No patches (bucket D): use `evidence` and `source` to make `recommendation` concrete — quote the offending parameter name, the file path from `source.ref`, the manifest key. Generic advice is not acceptable here.
+
+4. **Present the prioritised plan.** Severity-ordered (critical → high → medium → low → info), grouped by bucket within each severity tier. Show counts per bucket up front. For low/info findings in bucket D, summary-link via `docs_url` rather than full cards — avoid wall-of-text.
+
+5. **Decision points — ask the user explicitly. Always preview before mutating.**
+   - **Bucket A (safe auto-fix).** First run a **dry-run** (omit `--apply`):
+     ```bash
+     agents-shipgate apply-patches \
+         --from agents-shipgate-reports/report.json \
+         --confidence high
+     ```
+     Show the user the planned file diffs. Only after explicit confirmation, re-run with `--apply --json`. Never silently apply.
+   - **Bucket B (medium-confidence config).** Surface the patches with their `pointer` and `value`. Tell the user the opt-in command (`apply-patches --confidence medium`) and that they must read the appended values first — scope strings can encode policy choices. Do not apply on the user's behalf in this recipe.
+   - **Bucket C (manual).** Ask whether to walk through them now or defer. For deep dive on a single finding, cross-link to [`fix-top-finding.md`](fix-top-finding.md). Never edit a trace recording to silence `SHIP-API-TRACE-{APPROVAL,CONFIRMATION}-MISSING` — that patches the evidence, not the agent. Implement the runtime gate instead.
+   - **Bucket D (no patch).** Ask whether to walk through them — these need diagnosis, not patch application. Cross-link to [`fix-top-finding.md`](fix-top-finding.md); the four-response decision tree (add policy / override / suppress / fix tool spec) applies.
+
+6. **Re-scan after applying any Bucket A patches.** Show the diff in `summary.{critical_count, high_count, medium_count}`. Confirm the previously-fixed fingerprints are gone from `report.json`.
+
+7. **Report back**:
+   - Counts per bucket (A/B/C/D) and per severity
+   - What was applied (from `apply-patches --apply --json` output's `files`)
+   - What remains, with one clear next action per remaining bucket
+   - Any cross-links the user should follow ([`fix-top-finding.md`](fix-top-finding.md), [`triage-false-positive.md`](triage-false-positive.md))
+
+## What NOT to do
+
+- Do **not** run `apply-patches --apply` without showing the dry-run preview first AND getting explicit user confirmation, even when `autofix_safe == true`.
+- Do **not** apply `--confidence medium` patches in this recipe. They are opt-in only and require the user to read the appended values.
+- Do **not** edit a trace recording to silence `SHIP-API-TRACE-{APPROVAL,CONFIRMATION}-MISSING`. Trace findings are class-four "never auto-fix" per the autofix policy. Implement the runtime approval/confirmation gate.
+- Do **not** recommend `checks.ignore` as a fix here. That's the [`triage-false-positive.md`](triage-false-positive.md) workflow's job — cross-link to it.
+- Do **not** claim a finding is fixed without re-running `agents-shipgate scan` and showing the diff in counts.
+- Do **not** invent recommendations not grounded in `recommendation`, `evidence`, `patches[].instructions`, or `docs_url`. Use evidence to make advice concrete; do not replace check-author guidance with a guess.
+
+## Verification
+
+- A fresh `report.json` exists, validates as `report_schema_version: "0.7"` (or higher), and was generated with `--suggest-patches`.
+- Each presented card cites a concrete location: `target_file` + `pointer` for non-manual patches, `instructions` verbatim for manual patches, file path + parameter name from `evidence`/`source` for bucket D.
+- If Bucket A patches were applied: re-scan shows lower active counts AND the previously-failing fingerprints are absent from the new `report.json`.
+- If only B/C/D were surfaced: counts are unchanged (expected); the user has a clear list of next actions.

--- a/skills/agents-shipgate/SKILL.md
+++ b/skills/agents-shipgate/SKILL.md
@@ -34,6 +34,7 @@ Pick the matching task and follow the linked recipe verbatim. Recipes are bundle
 | Bootstrap a repo (install, init, scan, report) | [`prompts/add-shipgate-to-repo.md`](prompts/add-shipgate-to-repo.md) |
 | Add Shipgate to CI for the first time (advisory, PR comment) | See "First-time CI setup" below; copy [`ci-recipes/advisory-pr-comment.yml`](ci-recipes/advisory-pr-comment.yml) |
 | Fix the highest-severity finding | [`prompts/fix-top-finding.md`](prompts/fix-top-finding.md) |
+| Recommend fixes across all active findings | [`prompts/recommend-fixes.md`](prompts/recommend-fixes.md) |
 | Triage a suspected false positive | [`prompts/triage-false-positive.md`](prompts/triage-false-positive.md) |
 | Promote advisory CI to strict CI (assumes advisory is already running) | [`prompts/stabilize-strict-mode.md`](prompts/stabilize-strict-mode.md) |
 | Upgrade agents-shipgate version | [`prompts/upgrade-shipgate-version.md`](prompts/upgrade-shipgate-version.md) |

--- a/skills/agents-shipgate/prompts/recommend-fixes.md
+++ b/skills/agents-shipgate/prompts/recommend-fixes.md
@@ -1,0 +1,69 @@
+# Prompt · Recommend fixes for active Agents Shipgate findings
+
+You are working in a repo with `shipgate.yaml` already in place and want a coordinated remediation pass across **all** active findings — not just the top one. Walk every finding, classify it against the v0.7 autofix policy, and surface targeted fix recommendations. Apply only the safe, high-confidence patches (after preview + explicit confirmation); leave the rest for human review with concrete advice.
+
+## Your task
+
+1. **Always run a fresh v0.7 scan with patches.** Do not reuse a stale report — earlier scans may be pre-v0.7 (no remediation fields) or may lack `patches[]` (no `--suggest-patches`). Set `AGENTS_SHIPGATE_AGENT_MODE=1` so errors emit a `next_action` JSON line on stderr.
+   ```bash
+   AGENTS_SHIPGATE_AGENT_MODE=1 agents-shipgate scan -c shipgate.yaml \
+       --suggest-patches --format json --ci-mode advisory
+   ```
+   Read `agents-shipgate-reports/report.json`. Verify `report_schema_version` is `"0.7"` or higher. Filter `findings[]` to entries with `"suppressed": false`.
+
+2. **Bucket each active finding into one of four classes.** Use the per-Finding fields (the catalog values are worst-case; per-Finding fields tell the truth for this scan). The buckets come from [`docs/autofix-policy.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/autofix-policy.md):
+
+   | Bucket | Detect by | Example check IDs |
+   |---|---|---|
+   | **A. Safe auto-fix** | `autofix_safe == true` | `SHIP-MANIFEST-STALE-{SUPPRESSION,POLICY,RISK-OVERRIDE}` when the match is unique |
+   | **B. Medium-confidence config fix** | `autofix_safe == false` AND `suggested_patch_kind` ∈ `{set_pointer, append_pointer, remove_pointer}` | `SHIP-AUTH-SCOPE-COVERAGE-MISSING` |
+   | **C. Manual** | `suggested_patch_kind == "manual"` | Documentation, schema bounds, owner gaps, ADK/LangChain/CrewAI metadata, and the never-auto-fix trace findings |
+   | **D. No patch emitted** | `suggested_patch_kind == "none"` | The generator emitted nothing — but the finding can still be high/critical (e.g. low-confidence inventory). Treat as **human triage**, not informational. |
+
+3. **Build a recommendation card per finding.** For each, present:
+   - `check_id`, `title`, `severity`, `tool_name`, `confidence`
+   - The verbatim `recommendation` string (per-finding fix text from the check author)
+   - `docs_url` as a markdown link (when non-null)
+   - **Concrete fix step** — branch on patch kind, since the patch shapes differ:
+     - `set_pointer` / `append_pointer`: show `target_file`, `pointer`, `value`, `confidence`, `rationale`
+     - `remove_pointer`: show `target_file`, `pointer`, `confidence`, `rationale`
+     - `manual`: show `instructions` verbatim. `ManualPatch` has only `kind` and `instructions` — do NOT try to read `target_file`/`pointer`/`value`; they don't exist.
+     - No patches (bucket D): use `evidence` and `source` to make `recommendation` concrete — quote the offending parameter name, the file path from `source.ref`, the manifest key. Generic advice is not acceptable here.
+
+4. **Present the prioritised plan.** Severity-ordered (critical → high → medium → low → info), grouped by bucket within each severity tier. Show counts per bucket up front. For low/info findings in bucket D, summary-link via `docs_url` rather than full cards — avoid wall-of-text.
+
+5. **Decision points — ask the user explicitly. Always preview before mutating.**
+   - **Bucket A (safe auto-fix).** First run a **dry-run** (omit `--apply`):
+     ```bash
+     agents-shipgate apply-patches \
+         --from agents-shipgate-reports/report.json \
+         --confidence high
+     ```
+     Show the user the planned file diffs. Only after explicit confirmation, re-run with `--apply --json`. Never silently apply.
+   - **Bucket B (medium-confidence config).** Surface the patches with their `pointer` and `value`. Tell the user the opt-in command (`apply-patches --confidence medium`) and that they must read the appended values first — scope strings can encode policy choices. Do not apply on the user's behalf in this recipe.
+   - **Bucket C (manual).** Ask whether to walk through them now or defer. For deep dive on a single finding, cross-link to [`fix-top-finding.md`](fix-top-finding.md). Never edit a trace recording to silence `SHIP-API-TRACE-{APPROVAL,CONFIRMATION}-MISSING` — that patches the evidence, not the agent. Implement the runtime gate instead.
+   - **Bucket D (no patch).** Ask whether to walk through them — these need diagnosis, not patch application. Cross-link to [`fix-top-finding.md`](fix-top-finding.md); the four-response decision tree (add policy / override / suppress / fix tool spec) applies.
+
+6. **Re-scan after applying any Bucket A patches.** Show the diff in `summary.{critical_count, high_count, medium_count}`. Confirm the previously-fixed fingerprints are gone from `report.json`.
+
+7. **Report back**:
+   - Counts per bucket (A/B/C/D) and per severity
+   - What was applied (from `apply-patches --apply --json` output's `files`)
+   - What remains, with one clear next action per remaining bucket
+   - Any cross-links the user should follow ([`fix-top-finding.md`](fix-top-finding.md), [`triage-false-positive.md`](triage-false-positive.md))
+
+## What NOT to do
+
+- Do **not** run `apply-patches --apply` without showing the dry-run preview first AND getting explicit user confirmation, even when `autofix_safe == true`.
+- Do **not** apply `--confidence medium` patches in this recipe. They are opt-in only and require the user to read the appended values.
+- Do **not** edit a trace recording to silence `SHIP-API-TRACE-{APPROVAL,CONFIRMATION}-MISSING`. Trace findings are class-four "never auto-fix" per the autofix policy. Implement the runtime approval/confirmation gate.
+- Do **not** recommend `checks.ignore` as a fix here. That's the [`triage-false-positive.md`](triage-false-positive.md) workflow's job — cross-link to it.
+- Do **not** claim a finding is fixed without re-running `agents-shipgate scan` and showing the diff in counts.
+- Do **not** invent recommendations not grounded in `recommendation`, `evidence`, `patches[].instructions`, or `docs_url`. Use evidence to make advice concrete; do not replace check-author guidance with a guess.
+
+## Verification
+
+- A fresh `report.json` exists, validates as `report_schema_version: "0.7"` (or higher), and was generated with `--suggest-patches`.
+- Each presented card cites a concrete location: `target_file` + `pointer` for non-manual patches, `instructions` verbatim for manual patches, file path + parameter name from `evidence`/`source` for bucket D.
+- If Bucket A patches were applied: re-scan shows lower active counts AND the previously-failing fingerprints are absent from the new `report.json`.
+- If only B/C/D were surfaced: counts are unchanged (expected); the user has a clear list of next actions.


### PR DESCRIPTION
## Summary

- Adds a sixth prompt `recommend-fixes.md` that walks **all** active findings (not just the top one) and surfaces targeted fix recommendations grouped by the four autofix-policy classes from `docs/autofix-policy.md`: safe auto-fix, medium-confidence config, manual, and no-patch.
- For Bucket A (safe auto-fix) the recipe runs `apply-patches --confidence high` as a dry-run first, shows the diff, asks for explicit confirmation, then re-runs with `--apply`. Other buckets surface evidence-grounded advice and cross-link to `fix-top-finding.md` / `triage-false-positive.md` rather than reimplementing those flows.
- Pure prompt/skill change — no CLI, schema, or check changes. Mirrors the dual-copy convention enforced by `tests/test_prompt_parity.py` (byte-identical copy under `skills/agents-shipgate/prompts/`) and updates `docs/agents/use-with-claude-code.md` so the install loop fetches all six recipes.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only (skill prompt + skill manifest + install docs)

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `pytest tests/test_prompt_parity.py` → 9/9 pass (proves byte-parity of the dual-copy prompt and that the skill bundle inventory matches `prompts/`).
- `pytest` (full suite) → 315/315 pass; no regressions (expected, since no Python source changed).
- Manual exercise against a freshly generated v0.7 report from `samples/simple_openai_api_agent` (with a stale `checks.ignore` entry injected to force a Bucket A finding):
  - Bucket A correctly classified `SHIP-MANIFEST-STALE-SUPPRESSION` (`autofix_safe=true`, `suggested_patch_kind=remove_pointer`); patch carried `target_file`, `pointer`, `confidence` — exactly the fields the recipe surfaces.
  - Bucket C `ManualPatch` shape confirmed to be `{kind, instructions}` only — validates the recipe's explicit "do NOT read `target_file`/`pointer` for manual patches" instruction.
  - `agents-shipgate apply-patches --confidence high` (no `--apply`) prints the diff and "Dry-run only. Pass --apply to mutate files." — matches the recipe's step-5 dry-run-then-apply sequence.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in \`docs/checks.md\` — N/A, no check changes
- [x] Report/schema changes are additive or documented in \`STABILITY.md\` — N/A, no schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)