### PR TITLE
List upgrade-shipgate-version.md in AGENTS.md reusable-prompts surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,7 @@ Prebuilt prompts for common workflows live in [`prompts/`](prompts/):
 - [`recommend-fixes.md`](prompts/recommend-fixes.md) — walk all active findings and surface targeted fix recommendations across the four autofix-policy classes
 - [`stabilize-strict-mode.md`](prompts/stabilize-strict-mode.md) — tune → baseline → promote
 - [`triage-false-positive.md`](prompts/triage-false-positive.md) — override vs suppress decision
+- [`upgrade-shipgate-version.md`](prompts/upgrade-shipgate-version.md) — bump agents-shipgate version safely (regenerate baseline if needed)
 
 Claude Code: a `/shipgate` slash command lives at [`.claude/commands/shipgate.md`](.claude/commands/shipgate.md), and an auto-discoverable skill lives at [`skills/agents-shipgate/`](skills/agents-shipgate/) (named `agents-shipgate` to avoid colliding with the slash command — Claude Code lets a same-named skill preempt a command). The skill bundles the recipes in [`skills/agents-shipgate/prompts/`](skills/agents-shipgate/prompts/) and a starter advisory CI workflow at [`skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml`](skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml); when you change anything in [`prompts/`](prompts/) or `examples/github-actions/01-advisory-pr-comment.yml`, sync the bundled copy. To install both surfaces into your own agent project, see [`docs/agents/use-with-claude-code.md`](docs/agents/use-with-claude-code.md).
 


### PR DESCRIPTION
## Summary

- AGENTS.md is the authoritative coding-agent ingest surface for non-Claude clients (Codex, Cursor, Aider). Its "Reusable prompts" list at lines 346-350 was missing [\`upgrade-shipgate-version.md\`](prompts/upgrade-shipgate-version.md), even though the file has shipped under [\`prompts/\`](prompts/) for a while.
- This adds the missing entry. Pre-existing gap noticed while landing PR #35; spinning out as its own PR to keep that change scoped.
- Six prompt files now match six entries in the list.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only

## Verification

CI is authoritative for \`python -m ruff check .\`, \`python -m compileall -q src tests\`, and \`python -m pytest\`.

Additional local checks run:

- \`ls prompts/*.md\` shows 6 prompt files; AGENTS.md now lists all 6.
- No code changes — full pytest run unaffected.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in \`docs/checks.md\` — N/A, no check changes
- [x] Report/schema changes are additive or documented in \`STABILITY.md\` — N/A, no schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)