### PR TITLE
Add release_decision block to report schema (v0.8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,14 +184,18 @@ agents-shipgate scan -c shipgate.yaml
 
 Always parse `agents-shipgate-reports/report.json`, not the markdown. Stable fields:
 
-- `summary.{critical_count, high_count, medium_count, status}`
+- `release_decision.{decision, reason, blockers, review_items, evidence_coverage, baseline_delta, fail_policy}` (v0.8+) — **read this first for release gating**
+- `release_decision.fail_policy.{would_fail_ci, exit_code}` matches the process exit code
+- `summary.{critical_count, high_count, medium_count, status}` (status preserved for v0.7 compat — see note below)
 - `findings[].{id, fingerprint, check_id, severity, tool_name, evidence, recommendation, suppressed}`
 - `findings[].{autofix_safe, requires_human_review, suggested_patch_kind, docs_url}` (v0.7+)
 - `findings[].patches[]` (v0.6+, only when scan ran with `--suggest-patches`)
 - `baseline.{matched_count, new_count, resolved_count}`
 - `tool_inventory[]`
 
-The full schema is at [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) (current; emitted reports carry `report_schema_version: "0.7"`). Older reports validate against [`docs/report-schema.v0.6.json`](docs/report-schema.v0.6.json) (frozen reference). What's-stable is documented in [STABILITY.md](STABILITY.md).
+The full schema is at [`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) (current; emitted reports carry `report_schema_version: "0.8"`). Older reports validate against [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) (frozen reference). What's-stable is documented in [STABILITY.md](STABILITY.md).
+
+**Release gating signal**: prefer `release_decision.decision` (`"blocked" | "review_required" | "passed"`) over `summary.status`. The new field is **baseline-aware** — a baseline-matched critical surfaces in `release_decision.review_items` (accepted debt), not `release_decision.blockers`. `summary.status` stays baseline-blind for v0.7 compatibility, so a baseline-matched-only critical produces both `summary.status = "release_blockers_detected"` AND `release_decision.decision = "review_required"` (intentional divergence — see [STABILITY.md](STABILITY.md#release_decisiondecision-vs-summarystatus)).
 
 ### Task 3 · Suppress a finding with a reason
 
@@ -242,9 +246,9 @@ validation and [`docs/manifest-v0.1.md`](docs/manifest-v0.1.md) for prose.
 ### Where is the report schema?
 
 Parse `agents-shipgate-reports/report.json` and validate against
-[`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) (current).
-Older reports (`report_schema_version: "0.6"`) validate against the
-frozen [`docs/report-schema.v0.6.json`](docs/report-schema.v0.6.json).
+[`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) (current).
+Older reports (`report_schema_version: "0.7"`) validate against the
+frozen [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json).
 Do not scrape Markdown when JSON is available.
 
 ### How do I add a new check?
@@ -278,7 +282,8 @@ glossary: https://threemoonslab.com/glossary/.
 | What | Path | Stable |
 |---|---|---|
 | Manifest schema | [`docs/manifest-v0.1.json`](docs/manifest-v0.1.json) | `0.1` |
-| Report schema (current) | [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) | `0.7` |
+| Report schema (current) | [`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) | `0.8` |
+| Report schema (v0.7 frozen reference) | [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) | `0.7` |
 | Report schema (v0.6 frozen reference) | [`docs/report-schema.v0.6.json`](docs/report-schema.v0.6.json) | `0.6` |
 | Check catalog | [`docs/checks.json`](docs/checks.json) | regenerated each release |
 | Anti-patterns (what NOT to write) | [`samples/_anti_patterns/`](samples/_anti_patterns/) | reference |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+- Report schema bumped to `v0.8`. New top-level required `release_decision` block:
+  `{decision, reason, blockers, review_items, evidence_coverage, baseline_delta, fail_policy}`.
+  - `decision` is one of `"blocked" | "review_required" | "passed"` and is the
+    recommended release-gate signal for v0.8+ consumers.
+  - `blockers` and `review_items` are reference-only entries
+    (`id, fingerprint, check_id, severity, title, baseline_status`) — full
+    Finding payloads stay in `findings[]`.
+  - `release_decision` is **baseline-aware**: matched criticals appear in
+    `review_items` (accepted debt), not `blockers`. Critical severity is
+    **policy-independent** — even advisory CI surfaces a new critical as a
+    blocker (with `would_fail_ci=false`).
+  - `release_decision.fail_policy.exit_code` matches the process exit code
+    one-for-one across all `ci_mode` × `fail_on` × `--baseline` combinations.
+- `summary.status` is preserved byte-for-byte for backwards compatibility
+  with v0.7 consumers. It stays baseline-blind (a baseline-matched critical
+  still flips status to `release_blockers_detected`). The intentional
+  divergence from `release_decision.decision` is documented in
+  [STABILITY.md](STABILITY.md#release_decisiondecision-vs-summarystatus).
+- `docs/report-schema.v0.8.json` added; `v0.7.json` retained as a frozen
+  reference. JSON-schema validation catches missing `release_decision` on
+  any emitted report.
+- Markdown / GitHub Action / CLI summaries now lead with the Release
+  Decision block (Decision → Reason → Blockers → Review items → Evidence
+  coverage → Baseline delta → Fail policy). SARIF output is unchanged.
+- GitHub Action exposes four new outputs: `decision`, `blocker_count`,
+  `review_item_count`, `ci_would_fail`. Existing outputs (`status`,
+  `critical_count`, `baseline_*`, `adk_*`, `report_*`, `exit_code`)
+  unchanged.
+- `exit_code_for_report()` refactored to share `effective_fail_on()` and
+  `baseline_filtered_active()` helpers with `build_release_decision()`,
+  so the standalone exit code and `release_decision.fail_policy.exit_code`
+  cannot drift. New regression test pins this across the matrix.
+
 ## 0.7.0 - 2026-05-01
 
 Adoption activation: makes the v0.6 features visible to humans and AI

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Agents Shipgate is designed to be agent-friendly. If you're a coding agent (Clau
 - **[`prompts/`](prompts/)** — reusable prompts for common workflows
 - **[`skills/agents-shipgate/`](skills/agents-shipgate/)** + **[`.claude/commands/shipgate.md`](.claude/commands/shipgate.md)** — self-contained Claude Code skill (bundled prompts and CI recipe) and `/shipgate` slash command. See [`docs/agents/use-with-claude-code.md`](docs/agents/use-with-claude-code.md) to install in your own project.
 - **[`docs/ai-search-summary.md`](docs/ai-search-summary.md)** — human-readable summary for AI search, answer engines, and coding agents
-- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json)** — JSON Schemas for live editor validation (current; emitted reports carry `report_schema_version: "0.7"`)
+- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json)** — JSON Schemas for live editor validation (current; emitted reports carry `report_schema_version: "0.8"`). v0.8 adds the required `release_decision` block — read `release_decision.decision` for release gating in new consumers.
 - **[`docs/checks.json`](docs/checks.json)** — machine-readable check catalog
 
 Every command has a `--json` form. Errors emit a structured `next_action` line on stderr when `AGENTS_SHIPGATE_AGENT_MODE=1`.
@@ -337,7 +337,7 @@ Agents Shipgate is a static, manifest-first scanner. It is intentionally narrow:
 - It does not verify runtime behavior, latency, prompt quality, or routing decisions.
 - It does not replace dynamic security testing or human security review of the underlying systems.
 - It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, simple OpenAI API artifacts, optional SDK AST metadata, and static Google ADK/LangChain/CrewAI inputs; tools that are not declared or statically discoverable are not scanned.
-- The manifest remains `version: "0.1"` so existing configs keep working. Current reports carry `report_schema_version: "0.7"` while preserving the stable payload contract documented in the report schema.
+- The manifest remains `version: "0.1"` so existing configs keep working. Current reports carry `report_schema_version: "0.8"` and add the `release_decision` block while preserving the stable payload contract documented in the report schema.
 
 See [ROADMAP.md](ROADMAP.md) for what is planned next.
 
@@ -398,7 +398,7 @@ contact details.
 - [Check catalog](docs/checks.md)
 - [Policy packs](docs/policy-packs.md)
 - [Baseline workflow](docs/baseline.md)
-- [JSON report schema v0.7](docs/report-schema.v0.7.json)
+- [JSON report schema v0.8](docs/report-schema.v0.8.json)
 - [Trust model](docs/trust-model.md)
 - [AI search summary](docs/ai-search-summary.md)
 - [Design partners](docs/design-partners.md)

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -41,6 +41,9 @@ These commands and flags are stable across all `0.x.y` releases. They will only 
 In `agents-shipgate-reports/report.json`, the following are guaranteed:
 
 - `report_schema_version` — bumps minor on additive changes, major on breaking
+- `release_decision.{decision, reason, blockers, review_items, evidence_coverage, baseline_delta, fail_policy}` (v0.8+)
+- `release_decision.fail_policy.{ci_mode, fail_on, new_findings_only, would_fail_ci, exit_code}`
+- `release_decision.blockers[].{id, fingerprint, check_id, severity, title, baseline_status}` (reference-only — full Finding payload is in `findings[]`)
 - `summary.{critical_count, high_count, medium_count, low_count, info_count, suppressed_count, status, human_review_recommended}`
 - `findings[].{id, fingerprint, check_id, severity, category, title, recommendation, suppressed}`
 - `findings[].tool_name` (string or null)
@@ -48,6 +51,17 @@ In `agents-shipgate-reports/report.json`, the following are guaranteed:
 - `baseline.{matched_count, new_count, resolved_count, path}` (when `--baseline` is used)
 - `tool_inventory[].{name, source_type, source_ref, risk_tags, auth_scopes, owner, confidence}`
 - `loaded_plugins[].{name, value, distribution, version, check_id}`
+
+#### `release_decision.decision` vs `summary.status`
+
+These are **intentionally different signals**, kept apart for backwards compatibility:
+
+| Field | Baseline-aware? | Recommended for release gating? |
+|---|---|---|
+| `release_decision.decision` | yes — baseline-matched criticals appear in `review_items`, not `blockers` | **yes (v0.8+)** |
+| `summary.status` | no — any unsuppressed critical flips status to `release_blockers_detected` | preserved for v0.7 callers |
+
+Concretely: a scan with one baseline-matched critical and zero new findings produces `summary.status = "release_blockers_detected"` AND `release_decision.decision = "review_required"`. Both are correct under their respective contracts. New consumers should read `release_decision.decision`.
 
 ### Check IDs
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -43,7 +43,7 @@ In `agents-shipgate-reports/report.json`, the following are guaranteed:
 - `report_schema_version` — bumps minor on additive changes, major on breaking
 - `release_decision.{decision, reason, blockers, review_items, evidence_coverage, baseline_delta, fail_policy}` (v0.8+)
 - `release_decision.fail_policy.{ci_mode, fail_on, new_findings_only, would_fail_ci, exit_code}`
-- `release_decision.blockers[].{id, fingerprint, check_id, severity, title, baseline_status}` (reference-only — full Finding payload is in `findings[]`)
+- `release_decision.blockers[].{id, fingerprint, check_id, severity, title, baseline_status}` and `release_decision.review_items[].{id, fingerprint, check_id, severity, title, baseline_status}` (reference-only — both arrays share the same item shape; full Finding payload is in `findings[]`)
 - `summary.{critical_count, high_count, medium_count, low_count, info_count, suppressed_count, status, human_review_recommended}`
 - `findings[].{id, fingerprint, check_id, severity, category, title, recommendation, suppressed}`
 - `findings[].tool_name` (string or null)

--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,18 @@ outputs:
   exit_code:
     description: Agents Shipgate CLI exit code.
     value: ${{ steps.scan.outputs.exit_code }}
+  decision:
+    description: Release decision (`blocked`, `review_required`, or `passed`). v0.8+.
+    value: ${{ steps.report_outputs.outputs.decision }}
+  blocker_count:
+    description: Number of blockers in release_decision (v0.8+).
+    value: ${{ steps.report_outputs.outputs.blocker_count }}
+  review_item_count:
+    description: Number of review items in release_decision (v0.8+).
+    value: ${{ steps.report_outputs.outputs.review_item_count }}
+  ci_would_fail:
+    description: Whether the active fail policy would fail CI (`true`/`false`). v0.8+.
+    value: ${{ steps.report_outputs.outputs.ci_would_fail }}
 
 runs:
   using: composite
@@ -181,12 +193,16 @@ runs:
         summary = {}
         baseline = {}
         adk_surface = {}
+        release_decision = {}
+        fail_policy = {}
         if report_json.exists():
             with report_json.open(encoding="utf-8") as handle:
                 payload = json.load(handle)
                 summary = payload.get("summary") or {}
                 baseline = payload.get("baseline") or {}
                 adk_surface = (payload.get("frameworks") or {}).get("google_adk") or {}
+                release_decision = payload.get("release_decision") or {}
+                fail_policy = release_decision.get("fail_policy") or {}
 
         def clean(value: object) -> str:
             return str(value or "").replace("\r", "").replace("\n", "")
@@ -204,6 +220,10 @@ runs:
             "report_json": report_json,
             "report_markdown": report_markdown,
             "report_sarif": report_sarif,
+            "decision": release_decision.get("decision", ""),
+            "blocker_count": len(release_decision.get("blockers") or []),
+            "review_item_count": len(release_decision.get("review_items") or []),
+            "ci_would_fail": str(bool(fail_policy.get("would_fail_ci"))).lower(),
         }
         with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
             for key, value in values.items():
@@ -235,6 +255,7 @@ runs:
           }
           const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
           const summary = report.summary || {};
+          const decision = report.release_decision || null;
           const adk = ((report.frameworks || {}).google_adk) || null;
           const escapeMarkdown = (value) =>
             String(value || "")
@@ -249,12 +270,22 @@ runs:
             .slice(0, 3)
             .map((finding, index) => `${index + 1}. ${escapeMarkdown(truncate(finding.title || finding.check_id, 240))}`)
             .join("\n");
+          const decisionLines = decision
+            ? [
+                `Decision: \`${decision.decision}\``,
+                `Reason: ${escapeMarkdown(decision.reason || "")}`,
+                `Blockers: ${(decision.blockers || []).length} · Review items: ${(decision.review_items || []).length}`,
+                `Fail policy: would_fail_ci=\`${(decision.fail_policy || {}).would_fail_ci ? "true" : "false"}\` (exit ${(decision.fail_policy || {}).exit_code ?? "?"})`,
+              ]
+            : [
+                `Status: ${summary.status || "unknown"}`,
+                `Critical: ${summary.critical_count || 0} · High: ${summary.high_count || 0} · Medium: ${summary.medium_count || 0}`,
+                `Human review: ${summary.human_review_recommended ? "recommended" : "not required"}`,
+              ];
           const body = truncate([
             "## Agents Shipgate",
             "",
-            `Status: ${summary.status || "unknown"}`,
-            `Critical: ${summary.critical_count || 0} · High: ${summary.high_count || 0} · Medium: ${summary.medium_count || 0}`,
-            `Human review: ${summary.human_review_recommended ? "recommended" : "not required"}`,
+            ...decisionLines,
             adk ? `Google ADK: ${adk.agent_count || 0} agents · ${adk.dynamic_toolset_count || 0} dynamic toolsets` : "",
             "",
             top ? `Top findings:\n${top}` : "No critical or high findings.",

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,11 @@ runs:
                 fail_policy = release_decision.get("fail_policy") or {}
 
         def clean(value: object) -> str:
-            return str(value or "").replace("\r", "").replace("\n", "")
+            # `value or ""` would emit 0 as "", which breaks workflow
+            # checks like `if: outputs.blocker_count == '0'`. Treat None
+            # as empty; stringify everything else (including 0 and False).
+            text = "" if value is None else str(value)
+            return text.replace("\r", "").replace("\n", "")
 
         values = {
             "status": summary.get("status", ""),

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,7 +21,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`checks.md`](checks.md) — full check catalog (human-readable)
 - [`checks.json`](checks.json) — machine-readable check catalog (regenerated each release)
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
-- [`report-schema.v0.7.json`](report-schema.v0.7.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.7"`)
+- [`report-schema.v0.8.json`](report-schema.v0.8.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.8"` with the required `release_decision` block)
+- [`report-schema.v0.7.json`](report-schema.v0.7.json) — frozen v0.7 reference schema; pre-v0.8 reports validate against this
 - [`report-schema.v0.6.json`](report-schema.v0.6.json) — frozen v0.6 reference schema; pre-v0.7 reports validate against this
 - [`category.md`](category.md) — what an "agent release gate" is, in product terms
 

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -118,7 +118,10 @@ mutate files. Containment-checked: any `target_file` outside
 
 When the flow completes, summarize `report.json`:
 
-- `summary.status` (top-level outcome string).
+- `release_decision.decision` (`"blocked" | "review_required" | "passed"`)
+  — the v0.8+ release-gate signal. Prefer this over `summary.status`,
+  which stays baseline-blind for backwards compat.
+- `release_decision.reason` (one-sentence explanation).
 - Top 3 active critical/high findings with their `check_id`,
   `tool_name` (when present), and `recommendation`.
 - Whether any patches were applied (count from

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -50,7 +50,11 @@ Action outputs:
 
 | Output | Meaning |
 | --- | --- |
-| `status` | Report summary status, such as `release_blockers_detected`. |
+| `decision` | Release decision (`blocked`, `review_required`, or `passed`). v0.8+. **Prefer this over `status` for gating.** |
+| `blocker_count` | Number of blockers in `release_decision.blockers`. v0.8+. |
+| `review_item_count` | Number of review items in `release_decision.review_items`. v0.8+. |
+| `ci_would_fail` | `true`/`false` — whether the active fail policy would fail CI. v0.8+. |
+| `status` | Legacy report summary status, such as `release_blockers_detected`. Baseline-blind; preserved for v0.7 compat. |
 | `critical_count` | Unsuppressed critical finding count. |
 | `high_count` | Unsuppressed high finding count. |
 | `medium_count` | Unsuppressed medium finding count. |
@@ -62,7 +66,7 @@ Action outputs:
 | `report_json` | Path to `report.json`. |
 | `report_markdown` | Path to `report.md`. |
 | `report_sarif` | Path to `report.sarif`. |
-| `exit_code` | Agents Shipgate CLI exit code. |
+| `exit_code` | Agents Shipgate CLI exit code. Matches `release_decision.fail_policy.exit_code`. |
 
 The action writes Markdown, JSON, and SARIF reports. Upload `report.sarif` to
 GitHub code scanning from your workflow if you want SARIF annotations.

--- a/docs/report-schema.v0.8.json
+++ b/docs/report-schema.v0.8.json
@@ -1047,15 +1047,7 @@
       "type": "array"
     },
     "release_decision": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ReleaseDecision"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null
+      "$ref": "#/$defs/ReleaseDecision"
     },
     "report_schema_version": {
       "const": "0.8"

--- a/docs/report-schema.v0.8.json
+++ b/docs/report-schema.v0.8.json
@@ -630,7 +630,10 @@
         }
       },
       "required": [
+        "baseline_status",
         "check_id",
+        "fingerprint",
+        "id",
         "severity",
         "title"
       ],

--- a/docs/report-schema.v0.8.json
+++ b/docs/report-schema.v0.8.json
@@ -1,0 +1,1120 @@
+{
+  "$defs": {
+    "AppendPointerPatch": {
+      "additionalProperties": false,
+      "description": "Append a value to the list at a JSON pointer.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "append_pointer",
+          "default": "append_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "value",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "AppendPointerPatch",
+      "type": "object"
+    },
+    "BaselineDelta": {
+      "properties": {
+        "enabled": {
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "matched_count": {
+          "default": 0,
+          "title": "Matched Count",
+          "type": "integer"
+        },
+        "new_count": {
+          "default": 0,
+          "title": "New Count",
+          "type": "integer"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "resolved_count": {
+          "default": 0,
+          "title": "Resolved Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "matched_count",
+        "new_count",
+        "resolved_count"
+      ],
+      "title": "BaselineDelta",
+      "type": "object"
+    },
+    "BaselineSummary": {
+      "properties": {
+        "matched_count": {
+          "default": 0,
+          "title": "Matched Count",
+          "type": "integer"
+        },
+        "new_count": {
+          "default": 0,
+          "title": "New Count",
+          "type": "integer"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "resolved_count": {
+          "default": 0,
+          "title": "Resolved Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "BaselineSummary",
+      "type": "object"
+    },
+    "EvidenceCoverageDecision": {
+      "properties": {
+        "human_review_recommended": {
+          "title": "Human Review Recommended",
+          "type": "boolean"
+        },
+        "level": {
+          "title": "Level",
+          "type": "string"
+        },
+        "low_confidence_tool_count": {
+          "title": "Low Confidence Tool Count",
+          "type": "integer"
+        },
+        "source_warning_count": {
+          "title": "Source Warning Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "human_review_recommended",
+        "level",
+        "low_confidence_tool_count",
+        "source_warning_count"
+      ],
+      "title": "EvidenceCoverageDecision",
+      "type": "object"
+    },
+    "FailPolicy": {
+      "properties": {
+        "ci_mode": {
+          "title": "Ci Mode",
+          "type": "string"
+        },
+        "exit_code": {
+          "title": "Exit Code",
+          "type": "integer"
+        },
+        "fail_on": {
+          "items": {
+            "enum": [
+              "info",
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "type": "string"
+          },
+          "title": "Fail On",
+          "type": "array"
+        },
+        "new_findings_only": {
+          "default": false,
+          "title": "New Findings Only",
+          "type": "boolean"
+        },
+        "would_fail_ci": {
+          "title": "Would Fail Ci",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ci_mode",
+        "exit_code",
+        "fail_on",
+        "new_findings_only",
+        "would_fail_ci"
+      ],
+      "title": "FailPolicy",
+      "type": "object"
+    },
+    "Finding": {
+      "additionalProperties": true,
+      "properties": {
+        "agent_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Agent Id"
+        },
+        "autofix_safe": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Autofix Safe"
+        },
+        "baseline_status": {
+          "anyOf": [
+            {
+              "enum": [
+                "new",
+                "matched",
+                "resolved"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Baseline Status"
+        },
+        "category": {
+          "title": "Category",
+          "type": "string"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "confidence": {
+          "default": "medium",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "docs_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Docs Url"
+        },
+        "evidence": {
+          "additionalProperties": true,
+          "title": "Evidence",
+          "type": "object"
+        },
+        "fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fingerprint"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "patches": {
+          "anyOf": [
+            {
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "append_pointer": "#/$defs/AppendPointerPatch",
+                    "manual": "#/$defs/ManualPatch",
+                    "remove_pointer": "#/$defs/RemovePointerPatch",
+                    "set_pointer": "#/$defs/SetPointerPatch"
+                  },
+                  "propertyName": "kind"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/SetPointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/AppendPointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/RemovePointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/ManualPatch"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Patches"
+        },
+        "recommendation": {
+          "title": "Recommendation",
+          "type": "string"
+        },
+        "requires_human_review": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Requires Human Review"
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "suggested_patch_kind": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Suggested Patch Kind"
+        },
+        "suppressed": {
+          "default": false,
+          "title": "Suppressed",
+          "type": "boolean"
+        },
+        "suppression_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Suppression Reason"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Id"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        }
+      },
+      "required": [
+        "baseline_status",
+        "category",
+        "check_id",
+        "confidence",
+        "evidence",
+        "fingerprint",
+        "id",
+        "recommendation",
+        "severity",
+        "suppressed",
+        "title"
+      ],
+      "title": "Finding",
+      "type": "object"
+    },
+    "LoadedPolicyPack": {
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "rule_count": {
+          "title": "Rule Count",
+          "type": "integer"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Version"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "path",
+        "rule_count"
+      ],
+      "title": "LoadedPolicyPack",
+      "type": "object"
+    },
+    "ManualPatch": {
+      "additionalProperties": false,
+      "description": "No machine-applicable change. Carries human-readable instructions.\n\nUsed for every finding whose check ID has no v0.6 non-manual generator\nand for findings (like trace flips, per C6) that are intentionally\nnever auto-patched.",
+      "properties": {
+        "instructions": {
+          "title": "Instructions",
+          "type": "string"
+        },
+        "kind": {
+          "const": "manual",
+          "default": "manual",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "instructions"
+      ],
+      "title": "ManualPatch",
+      "type": "object"
+    },
+    "ReleaseDecision": {
+      "properties": {
+        "baseline_delta": {
+          "$ref": "#/$defs/BaselineDelta"
+        },
+        "blockers": {
+          "items": {
+            "$ref": "#/$defs/ReleaseDecisionItem"
+          },
+          "title": "Blockers",
+          "type": "array"
+        },
+        "decision": {
+          "enum": [
+            "blocked",
+            "review_required",
+            "passed"
+          ],
+          "title": "Decision",
+          "type": "string"
+        },
+        "evidence_coverage": {
+          "$ref": "#/$defs/EvidenceCoverageDecision"
+        },
+        "fail_policy": {
+          "$ref": "#/$defs/FailPolicy"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "review_items": {
+          "items": {
+            "$ref": "#/$defs/ReleaseDecisionItem"
+          },
+          "title": "Review Items",
+          "type": "array"
+        }
+      },
+      "required": [
+        "baseline_delta",
+        "blockers",
+        "decision",
+        "evidence_coverage",
+        "fail_policy",
+        "reason",
+        "review_items"
+      ],
+      "title": "ReleaseDecision",
+      "type": "object"
+    },
+    "ReleaseDecisionItem": {
+      "properties": {
+        "baseline_status": {
+          "anyOf": [
+            {
+              "enum": [
+                "new",
+                "matched",
+                "resolved"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Baseline Status"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fingerprint"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "check_id",
+        "severity",
+        "title"
+      ],
+      "title": "ReleaseDecisionItem",
+      "type": "object"
+    },
+    "RemovePointerPatch": {
+      "additionalProperties": false,
+      "description": "Remove the node at a JSON pointer.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "remove_pointer",
+          "default": "remove_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "RemovePointerPatch",
+      "type": "object"
+    },
+    "ReportSummary": {
+      "properties": {
+        "critical_count": {
+          "default": 0,
+          "title": "Critical Count",
+          "type": "integer"
+        },
+        "evidence_coverage": {
+          "default": "static",
+          "title": "Evidence Coverage",
+          "type": "string"
+        },
+        "high_count": {
+          "default": 0,
+          "title": "High Count",
+          "type": "integer"
+        },
+        "human_review_recommended": {
+          "default": false,
+          "title": "Human Review Recommended",
+          "type": "boolean"
+        },
+        "info_count": {
+          "default": 0,
+          "title": "Info Count",
+          "type": "integer"
+        },
+        "low_count": {
+          "default": 0,
+          "title": "Low Count",
+          "type": "integer"
+        },
+        "medium_count": {
+          "default": 0,
+          "title": "Medium Count",
+          "type": "integer"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        },
+        "suppressed_count": {
+          "default": 0,
+          "title": "Suppressed Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "title": "ReportSummary",
+      "type": "object"
+    },
+    "SetPointerPatch": {
+      "additionalProperties": false,
+      "description": "Set the value at a JSON pointer inside a YAML or JSON file.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "set_pointer",
+          "default": "set_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "value",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "SetPointerPatch",
+      "type": "object"
+    },
+    "SourceReference": {
+      "additionalProperties": true,
+      "properties": {
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ref"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "SourceReference",
+      "type": "object"
+    },
+    "ToolSurfaceSummary": {
+      "properties": {
+        "high_risk_tools": {
+          "title": "High Risk Tools",
+          "type": "integer"
+        },
+        "missing_descriptions": {
+          "default": 0,
+          "title": "Missing Descriptions",
+          "type": "integer"
+        },
+        "sources": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Sources",
+          "type": "object"
+        },
+        "total_tools": {
+          "title": "Total Tools",
+          "type": "integer"
+        },
+        "wildcard_tools": {
+          "default": 0,
+          "title": "Wildcard Tools",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "total_tools",
+        "high_risk_tools"
+      ],
+      "title": "ToolSurfaceSummary",
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.8.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "JSON Schema for the Agents Shipgate Tool-Use Readiness Report. Generated from agents_shipgate.core.models.ReadinessReport with post-processing to preserve the v0.5 public contract. Do not edit by hand.",
+  "properties": {
+    "agent": {
+      "additionalProperties": true,
+      "title": "Agent",
+      "type": "object"
+    },
+    "anthropic_surface": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Anthropic Surface"
+    },
+    "api_surface": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Api Surface"
+    },
+    "baseline": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaselineSummary"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "environment": {
+      "additionalProperties": true,
+      "title": "Environment",
+      "type": "object"
+    },
+    "findings": {
+      "items": {
+        "$ref": "#/$defs/Finding"
+      },
+      "title": "Findings",
+      "type": "array"
+    },
+    "frameworks": {
+      "additionalProperties": true,
+      "properties": {
+        "crewai": {
+          "additionalProperties": true,
+          "required": [
+            "agent_count",
+            "class_tool_count",
+            "crew_count",
+            "dynamic_tool_surface_count",
+            "function_tool_count",
+            "prebuilt_tool_count",
+            "python_entrypoint_count",
+            "tool_inventory_file_count",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "google_adk": {
+          "additionalProperties": true,
+          "required": [
+            "agent_config_count",
+            "agent_count",
+            "callback_count",
+            "dynamic_toolset_count",
+            "eval_file_count",
+            "function_tool_count",
+            "long_running_tool_count",
+            "plugin_count",
+            "python_entrypoint_count",
+            "sub_agent_count",
+            "tool_inventory_file_count",
+            "toolset_count",
+            "trace_sample_count",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "langchain": {
+          "additionalProperties": true,
+          "required": [
+            "agent_tool_binding_count",
+            "dynamic_tool_surface_count",
+            "function_tool_count",
+            "python_entrypoint_count",
+            "structured_tool_count",
+            "tool_inventory_file_count",
+            "tool_node_count",
+            "warnings"
+          ],
+          "type": "object"
+        }
+      },
+      "title": "Frameworks",
+      "type": "object"
+    },
+    "generated_reports": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Generated Reports",
+      "type": "object"
+    },
+    "loaded_plugins": {
+      "items": {
+        "additionalProperties": true,
+        "required": [
+          "check_id",
+          "distribution",
+          "name",
+          "value",
+          "version"
+        ],
+        "type": "object"
+      },
+      "title": "Loaded Plugins",
+      "type": "array"
+    },
+    "loaded_policy_packs": {
+      "items": {
+        "$ref": "#/$defs/LoadedPolicyPack"
+      },
+      "title": "Loaded Policy Packs",
+      "type": "array"
+    },
+    "manifest_dir": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Manifest Dir"
+    },
+    "project": {
+      "additionalProperties": true,
+      "title": "Project",
+      "type": "object"
+    },
+    "recommended_actions": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Recommended Actions",
+      "type": "array"
+    },
+    "release_decision": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ReleaseDecision"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "report_schema_version": {
+      "const": "0.8"
+    },
+    "run_id": {
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "0.1"
+    },
+    "source_warnings": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Source Warnings",
+      "type": "array"
+    },
+    "summary": {
+      "$ref": "#/$defs/ReportSummary"
+    },
+    "tool_inventory": {
+      "items": {
+        "additionalProperties": true,
+        "required": [
+          "auth_scopes",
+          "confidence",
+          "name",
+          "risk_tags",
+          "source_type"
+        ],
+        "type": "object"
+      },
+      "title": "Tool Inventory",
+      "type": "array"
+    },
+    "tool_surface": {
+      "$ref": "#/$defs/ToolSurfaceSummary"
+    }
+  },
+  "required": [
+    "agent",
+    "environment",
+    "findings",
+    "frameworks",
+    "generated_reports",
+    "loaded_plugins",
+    "loaded_policy_packs",
+    "project",
+    "recommended_actions",
+    "release_decision",
+    "report_schema_version",
+    "run_id",
+    "schema_version",
+    "source_warnings",
+    "summary",
+    "tool_inventory",
+    "tool_surface"
+  ],
+  "title": "Agents Shipgate Readiness Report v0.8",
+  "type": "object"
+}

--- a/samples/simple_crewai_agent/expected/report.json
+++ b/samples/simple_crewai_agent/expected/report.json
@@ -114,7 +114,7 @@
   "findings": [],
   "recommended_actions": [],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpuph5wcaa/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpca_apmad/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_crewai_agent/expected/report.json
+++ b/samples/simple_crewai_agent/expected/report.json
@@ -1,7 +1,8 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.5",
+  "report_schema_version": "0.8",
   "run_id": "agents_shipgate_1c4577c21998a147",
+  "manifest_dir": "<REPO>/samples/simple_crewai_agent",
   "project": {
     "name": "simple-crewai-agent"
   },
@@ -55,6 +56,32 @@
     "human_review_recommended": true,
     "evidence_coverage": "mixed"
   },
+  "release_decision": {
+    "decision": "review_required",
+    "reason": "Static-only scan with low-confidence evidence; human review recommended.",
+    "blockers": [],
+    "review_items": [],
+    "evidence_coverage": {
+      "level": "mixed",
+      "human_review_recommended": true,
+      "source_warning_count": 1,
+      "low_confidence_tool_count": 3
+    },
+    "baseline_delta": {
+      "enabled": false,
+      "path": null,
+      "matched_count": 0,
+      "new_count": 0,
+      "resolved_count": 0
+    },
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
   "tool_surface": {
     "total_tools": 3,
     "high_risk_tools": 0,
@@ -87,8 +114,7 @@
   "findings": [],
   "recommended_actions": [],
   "generated_reports": {
-    "markdown": "expected/report.md",
-    "json": "expected/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpuph5wcaa/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_crewai_agent/expected/report.md
+++ b/samples/simple_crewai_agent/expected/report.md
@@ -4,15 +4,29 @@ Project: simple-crewai-agent
 Agent: support-case-crew
 Target: local
 
-Result: PASS - no static findings across 3 tools.
-Status: Human review recommended
-Critical: 0
-High: 0
-Medium: 0
-Low: 0
-Suppressed: 0
-Evidence coverage: mixed
-Human review: recommended
+## Release Decision
+
+Decision: review_required
+Reason: Static-only scan with low-confidence evidence; human review recommended.
+
+Blockers (0): none
+
+Review items (0): none
+
+Evidence coverage: mixed (3 low-confidence tool(s); 1 source warning(s); human review recommended)
+
+Baseline delta: not enabled
+
+Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fail_ci=false (exit 0)
+
+## Summary
+
+- Critical: 0
+- High: 0
+- Medium: 0
+- Low: 0
+- Suppressed: 0
+- Status: Human review recommended (legacy; see Release Decision above)
 
 ## Top Findings
 

--- a/samples/simple_langchain_agent/expected/report.json
+++ b/samples/simple_langchain_agent/expected/report.json
@@ -1,7 +1,8 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.5",
+  "report_schema_version": "0.8",
   "run_id": "agents_shipgate_09ab0114a3ecb63a",
+  "manifest_dir": "<REPO>/samples/simple_langchain_agent",
   "project": {
     "name": "simple-langchain-agent"
   },
@@ -54,6 +55,32 @@
     "human_review_recommended": true,
     "evidence_coverage": "mixed"
   },
+  "release_decision": {
+    "decision": "review_required",
+    "reason": "Static-only scan with low-confidence evidence; human review recommended.",
+    "blockers": [],
+    "review_items": [],
+    "evidence_coverage": {
+      "level": "mixed",
+      "human_review_recommended": true,
+      "source_warning_count": 0,
+      "low_confidence_tool_count": 2
+    },
+    "baseline_delta": {
+      "enabled": false,
+      "path": null,
+      "matched_count": 0,
+      "new_count": 0,
+      "resolved_count": 0
+    },
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
   "tool_surface": {
     "total_tools": 2,
     "high_risk_tools": 0,
@@ -82,8 +109,7 @@
   "findings": [],
   "recommended_actions": [],
   "generated_reports": {
-    "markdown": "expected/report.md",
-    "json": "expected/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpfw8b29qd/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_langchain_agent/expected/report.json
+++ b/samples/simple_langchain_agent/expected/report.json
@@ -109,7 +109,7 @@
   "findings": [],
   "recommended_actions": [],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpfw8b29qd/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpzx40if7x/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_langchain_agent/expected/report.md
+++ b/samples/simple_langchain_agent/expected/report.md
@@ -4,15 +4,29 @@ Project: simple-langchain-agent
 Agent: support-case-reader
 Target: local
 
-Result: PASS - no static findings across 2 tools.
-Status: Human review recommended
-Critical: 0
-High: 0
-Medium: 0
-Low: 0
-Suppressed: 0
-Evidence coverage: mixed
-Human review: recommended
+## Release Decision
+
+Decision: review_required
+Reason: Static-only scan with low-confidence evidence; human review recommended.
+
+Blockers (0): none
+
+Review items (0): none
+
+Evidence coverage: mixed (2 low-confidence tool(s); human review recommended)
+
+Baseline delta: not enabled
+
+Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fail_ci=false (exit 0)
+
+## Summary
+
+- Critical: 0
+- High: 0
+- Medium: 0
+- Low: 0
+- Suppressed: 0
+- Status: Human review recommended (legacy; see Release Decision above)
 
 ## Top Findings
 

--- a/samples/simple_openai_api_agent/expected/report.json
+++ b/samples/simple_openai_api_agent/expected/report.json
@@ -1,7 +1,8 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.5",
+  "report_schema_version": "0.8",
   "run_id": "agents_shipgate_d07e1421099084ae",
+  "manifest_dir": "<REPO>/samples/simple_openai_api_agent",
   "project": {
     "name": "simple-openai-api-agent",
     "owner": "support-platform"
@@ -56,6 +57,193 @@
     "human_review_recommended": true,
     "evidence_coverage": "static"
   },
+  "release_decision": {
+    "decision": "review_required",
+    "reason": "20 findings need review and evidence coverage is incomplete.",
+    "blockers": [],
+    "review_items": [
+      {
+        "id": "fp_c2d773062468ceac",
+        "fingerprint": "fp_c2d773062468ceac",
+        "check_id": "SHIP-SCHEMA-MISSING-BOUNDS",
+        "severity": "high",
+        "title": "create_refund.amount has no maximum bound",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_07538ba8f9532359",
+        "fingerprint": "fp_07538ba8f9532359",
+        "check_id": "SHIP-SCHEMA-BROAD-FREE-TEXT",
+        "severity": "high",
+        "title": "send_customer_email accepts broad free-form action input",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_58b3202c0a4d9793",
+        "fingerprint": "fp_58b3202c0a4d9793",
+        "check_id": "SHIP-AUTH-MISSING-SCOPE",
+        "severity": "high",
+        "title": "create_refund lacks declared auth scopes",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_45ef3ff3ce2cf187",
+        "fingerprint": "fp_45ef3ff3ce2cf187",
+        "check_id": "SHIP-AUTH-MISSING-SCOPE",
+        "severity": "high",
+        "title": "send_customer_email lacks declared auth scopes",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_a8a615b5a4f2597b",
+        "fingerprint": "fp_a8a615b5a4f2597b",
+        "check_id": "SHIP-SCOPE-PROHIBITED-TOOL-PRESENT",
+        "severity": "high",
+        "title": "create_refund appears to overlap with a prohibited action",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_cf260ff7c72d64b7",
+        "fingerprint": "fp_cf260ff7c72d64b7",
+        "check_id": "SHIP-SCOPE-PROHIBITED-TOOL-PRESENT",
+        "severity": "high",
+        "title": "send_customer_email appears to overlap with a prohibited action",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_e9d63903757dfe07",
+        "fingerprint": "fp_e9d63903757dfe07",
+        "check_id": "SHIP-SIDEFX-IDEMPOTENCY-MISSING",
+        "severity": "high",
+        "title": "create_refund lacks idempotency evidence",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_4466eb2871434dc5",
+        "fingerprint": "fp_4466eb2871434dc5",
+        "check_id": "SHIP-SIDEFX-IDEMPOTENCY-MISSING",
+        "severity": "high",
+        "title": "send_customer_email lacks idempotency evidence",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_9675d1799680d81d",
+        "fingerprint": "fp_9675d1799680d81d",
+        "check_id": "SHIP-API-FUNCTION-SCHEMA-STRICTNESS",
+        "severity": "high",
+        "title": "create_refund function schema is not strict enough",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_29e718b3bbde0e7d",
+        "fingerprint": "fp_29e718b3bbde0e7d",
+        "check_id": "SHIP-API-FUNCTION-SCHEMA-STRICTNESS",
+        "severity": "high",
+        "title": "send_customer_email function schema is not strict enough",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_64f825faa751b7f8",
+        "fingerprint": "fp_64f825faa751b7f8",
+        "check_id": "SHIP-API-STRUCTURED-OUTPUT-READINESS",
+        "severity": "medium",
+        "title": "Response format schemas/refund_decision.schema.json is under-specified",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_1b64e136ace3472a_dacf6678",
+        "fingerprint": "fp_1b64e136ace3472a",
+        "check_id": "SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH",
+        "severity": "high",
+        "title": "Prompt says read-only or advise-only while write/high-risk tools are enabled",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_1b64e136ace3472a_fe9f9e46",
+        "fingerprint": "fp_1b64e136ace3472a",
+        "check_id": "SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH",
+        "severity": "medium",
+        "title": "Prompt lacks approval/confirmation language for high-risk tools",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_28483a22a9ed40cb",
+        "fingerprint": "fp_28483a22a9ed40cb",
+        "check_id": "SHIP-API-TIMEOUT-MISSING",
+        "severity": "medium",
+        "title": "OpenAI API flow lacks timeout metadata",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_b8df99c94ef3aa60",
+        "fingerprint": "fp_b8df99c94ef3aa60",
+        "check_id": "SHIP-API-TOOL-OUTPUT-SCHEMA-MISSING",
+        "severity": "medium",
+        "title": "create_refund lacks success/failure output modeling",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_2bf957380e89863f",
+        "fingerprint": "fp_2bf957380e89863f",
+        "check_id": "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY",
+        "severity": "high",
+        "title": "create_refund may be retried without idempotency evidence",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_efb42c5b5aea7be6",
+        "fingerprint": "fp_efb42c5b5aea7be6",
+        "check_id": "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY",
+        "severity": "high",
+        "title": "send_customer_email may be retried without idempotency evidence",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_245bcdb96d8220e2",
+        "fingerprint": "fp_245bcdb96d8220e2",
+        "check_id": "SHIP-API-TRACE-APPROVAL-MISSING",
+        "severity": "medium",
+        "title": "Trace sample shows create_refund without approval",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_d9059d0c1f3540af",
+        "fingerprint": "fp_d9059d0c1f3540af",
+        "check_id": "SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING",
+        "severity": "high",
+        "title": "create_refund is high-risk but has no owner",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_a95adeb6338f8b3e",
+        "fingerprint": "fp_a95adeb6338f8b3e",
+        "check_id": "SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING",
+        "severity": "high",
+        "title": "send_customer_email is high-risk but has no owner",
+        "baseline_status": null
+      }
+    ],
+    "evidence_coverage": {
+      "level": "static",
+      "human_review_recommended": true,
+      "source_warning_count": 0,
+      "low_confidence_tool_count": 0
+    },
+    "baseline_delta": {
+      "enabled": false,
+      "path": null,
+      "matched_count": 0,
+      "new_count": 0,
+      "resolved_count": 0
+    },
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
   "tool_surface": {
     "total_tools": 2,
     "high_risk_tools": 2,
@@ -101,7 +289,11 @@
       "recommendation": "Add a maximum bound to create_refund.amount or document an equivalent limit in the tool policy.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-schema-missing-bounds"
     },
     {
       "id": "fp_07538ba8f9532359",
@@ -126,7 +318,11 @@
       "recommendation": "Constrain send_customer_email.message with an enum, structured schema, or narrower field-specific parameters.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-schema-broad-free-text"
     },
     {
       "id": "fp_58b3202c0a4d9793",
@@ -153,7 +349,11 @@
       "recommendation": "Declare auth scopes for create_refund in OpenAPI, MCP metadata, or the manifest before release review.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-auth-missing-scope"
     },
     {
       "id": "fp_45ef3ff3ce2cf187",
@@ -181,7 +381,11 @@
       "recommendation": "Declare auth scopes for send_customer_email in OpenAPI, MCP metadata, or the manifest before release review.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-auth-missing-scope"
     },
     {
       "id": "fp_a8a615b5a4f2597b",
@@ -209,7 +413,11 @@
       "recommendation": "Remove create_refund, narrow its policy, or revise prohibited_actions so the manifest and tool surface do not contradict each other.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-scope-prohibited-tool-present"
     },
     {
       "id": "fp_cf260ff7c72d64b7",
@@ -238,7 +446,11 @@
       "recommendation": "Remove send_customer_email, narrow its policy, or revise prohibited_actions so the manifest and tool surface do not contradict each other.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-scope-prohibited-tool-present"
     },
     {
       "id": "fp_e9d63903757dfe07",
@@ -266,7 +478,11 @@
       "recommendation": "Add an idempotency key, idempotent annotation, or declared idempotency policy for create_refund.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-sidefx-idempotency-missing"
     },
     {
       "id": "fp_4466eb2871434dc5",
@@ -295,7 +511,11 @@
       "recommendation": "Add an idempotency key, idempotent annotation, or declared idempotency policy for send_customer_email.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-sidefx-idempotency-missing"
     },
     {
       "id": "fp_9675d1799680d81d",
@@ -328,7 +548,11 @@
       "recommendation": "Make create_refund a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-function-schema-strictness"
     },
     {
       "id": "fp_29e718b3bbde0e7d",
@@ -359,7 +583,11 @@
       "recommendation": "Make send_customer_email a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-function-schema-strictness"
     },
     {
       "id": "fp_64f825faa751b7f8",
@@ -392,7 +620,11 @@
       "recommendation": "Tighten the structured output schema with enums, needs_review/refusal/error modeling, and declared critical fields.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-structured-output-readiness"
     },
     {
       "id": "fp_1b64e136ace3472a_dacf6678",
@@ -419,7 +651,11 @@
       "recommendation": "Align prompt scope with enabled tools or remove write/high-risk tools.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-prompt-tool-scope-mismatch"
     },
     {
       "id": "fp_1b64e136ace3472a_fe9f9e46",
@@ -446,7 +682,11 @@
       "recommendation": "Add prompt instructions requiring human approval and explicit confirmation before financial, destructive, or external customer actions.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-prompt-tool-scope-mismatch"
     },
     {
       "id": "fp_28483a22a9ed40cb",
@@ -473,7 +713,11 @@
       "recommendation": "Declare tool-call timeout metadata for high-risk OpenAI API flows.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-timeout-missing"
     },
     {
       "id": "fp_b8df99c94ef3aa60",
@@ -499,7 +743,11 @@
       "recommendation": "Declare success_fields and failure_fields for create_refund in openai_api policy rules.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-tool-output-schema-missing"
     },
     {
       "id": "fp_2bf957380e89863f",
@@ -529,7 +777,11 @@
       "recommendation": "Add idempotency evidence for create_refund or avoid retrying this side effect.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-retry-without-idempotency"
     },
     {
       "id": "fp_efb42c5b5aea7be6",
@@ -560,7 +812,11 @@
       "recommendation": "Add idempotency evidence for send_customer_email or avoid retrying this side effect.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-retry-without-idempotency"
     },
     {
       "id": "fp_245bcdb96d8220e2",
@@ -585,7 +841,11 @@
       "recommendation": "Require approval before calling create_refund.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-api-trace-approval-missing"
     },
     {
       "id": "fp_d9059d0c1f3540af",
@@ -613,7 +873,11 @@
       "recommendation": "Declare an owner for each high-risk production tool in risk_overrides.tools.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-manifest-high-risk-owner-missing"
     },
     {
       "id": "fp_a95adeb6338f8b3e",
@@ -642,7 +906,11 @@
       "recommendation": "Declare an owner for each high-risk production tool in risk_overrides.tools.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-manifest-high-risk-owner-missing"
     }
   ],
   "recommended_actions": [
@@ -656,8 +924,7 @@
     "Declare an owner for each high-risk production tool in risk_overrides.tools."
   ],
   "generated_reports": {
-    "markdown": "expected/report.md",
-    "json": "expected/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpz7lss8bm/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_openai_api_agent/expected/report.json
+++ b/samples/simple_openai_api_agent/expected/report.json
@@ -59,7 +59,7 @@
   },
   "release_decision": {
     "decision": "review_required",
-    "reason": "20 findings need review and evidence coverage is incomplete.",
+    "reason": "20 findings require human review before shipping.",
     "blockers": [],
     "review_items": [
       {
@@ -924,7 +924,7 @@
     "Declare an owner for each high-risk production tool in risk_overrides.tools."
   ],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpz7lss8bm/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpdb6iza32/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_openai_api_agent/expected/report.md
+++ b/samples/simple_openai_api_agent/expected/report.md
@@ -7,7 +7,7 @@ Target: production\_like
 ## Release Decision
 
 Decision: review_required
-Reason: 20 findings need review and evidence coverage is incomplete.
+Reason: 20 findings require human review before shipping.
 
 Blockers (0): none
 

--- a/samples/simple_openai_api_agent/expected/report.md
+++ b/samples/simple_openai_api_agent/expected/report.md
@@ -4,15 +4,49 @@ Project: simple-openai-api-agent
 Agent: api-refund-assistant
 Target: production\_like
 
-Result: REVIEW - static findings require human review.
-Status: Warnings detected
-Critical: 0
-High: 15
-Medium: 5
-Low: 0
-Suppressed: 0
-Evidence coverage: static
-Human review: recommended
+## Release Decision
+
+Decision: review_required
+Reason: 20 findings need review and evidence coverage is incomplete.
+
+Blockers (0): none
+
+Review items (20):
+- HIGH SHIP-SCHEMA-MISSING-BOUNDS — create\_refund.amount has no maximum bound
+- HIGH SHIP-SCHEMA-BROAD-FREE-TEXT — send\_customer\_email accepts broad free-form action input
+- HIGH SHIP-AUTH-MISSING-SCOPE — create\_refund lacks declared auth scopes
+- HIGH SHIP-AUTH-MISSING-SCOPE — send\_customer\_email lacks declared auth scopes
+- HIGH SHIP-SCOPE-PROHIBITED-TOOL-PRESENT — create\_refund appears to overlap with a prohibited action
+- HIGH SHIP-SCOPE-PROHIBITED-TOOL-PRESENT — send\_customer\_email appears to overlap with a prohibited action
+- HIGH SHIP-SIDEFX-IDEMPOTENCY-MISSING — create\_refund lacks idempotency evidence
+- HIGH SHIP-SIDEFX-IDEMPOTENCY-MISSING — send\_customer\_email lacks idempotency evidence
+- HIGH SHIP-API-FUNCTION-SCHEMA-STRICTNESS — create\_refund function schema is not strict enough
+- HIGH SHIP-API-FUNCTION-SCHEMA-STRICTNESS — send\_customer\_email function schema is not strict enough
+- MEDIUM SHIP-API-STRUCTURED-OUTPUT-READINESS — Response format schemas/refund\_decision.schema.json is under-specified
+- HIGH SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH — Prompt says read-only or advise-only while write/high-risk tools are enabled
+- MEDIUM SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH — Prompt lacks approval/confirmation language for high-risk tools
+- MEDIUM SHIP-API-TIMEOUT-MISSING — OpenAI API flow lacks timeout metadata
+- MEDIUM SHIP-API-TOOL-OUTPUT-SCHEMA-MISSING — create\_refund lacks success/failure output modeling
+- HIGH SHIP-API-RETRY-WITHOUT-IDEMPOTENCY — create\_refund may be retried without idempotency evidence
+- HIGH SHIP-API-RETRY-WITHOUT-IDEMPOTENCY — send\_customer\_email may be retried without idempotency evidence
+- MEDIUM SHIP-API-TRACE-APPROVAL-MISSING — Trace sample shows create\_refund without approval
+- HIGH SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING — create\_refund is high-risk but has no owner
+- HIGH SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING — send\_customer\_email is high-risk but has no owner
+
+Evidence coverage: static (human review recommended)
+
+Baseline delta: not enabled
+
+Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fail_ci=false (exit 0)
+
+## Summary
+
+- Critical: 0
+- High: 15
+- Medium: 5
+- Low: 0
+- Suppressed: 0
+- Status: Warnings detected (legacy; see Release Decision above)
 
 ## Top Findings
 

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -1,7 +1,8 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.5",
+  "report_schema_version": "0.8",
   "run_id": "agents_shipgate_3716da0eb0ec2fad",
+  "manifest_dir": "<REPO>/samples/support_refund_agent",
   "project": {
     "name": "support-refund-agent",
     "owner": "support-platform",
@@ -75,6 +76,178 @@
     "human_review_recommended": true,
     "evidence_coverage": "mixed"
   },
+  "release_decision": {
+    "decision": "blocked",
+    "reason": "2 active findings block release.",
+    "blockers": [
+      {
+        "id": "fp_f092940f62fbb012",
+        "fingerprint": "fp_f092940f62fbb012",
+        "check_id": "SHIP-POLICY-APPROVAL-MISSING",
+        "severity": "critical",
+        "title": "stripe.create_refund lacks a declared approval policy",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_dac8011e14c53777",
+        "fingerprint": "fp_dac8011e14c53777",
+        "check_id": "SHIP-SIDEFX-IDEMPOTENCY-MISSING",
+        "severity": "critical",
+        "title": "stripe.create_refund lacks idempotency evidence",
+        "baseline_status": null
+      }
+    ],
+    "review_items": [
+      {
+        "id": "fp_fc02d8ecd30f2578",
+        "fingerprint": "fp_fc02d8ecd30f2578",
+        "check_id": "SHIP-INVENTORY-WILDCARD-TOOLS",
+        "severity": "high",
+        "title": "Wildcard tool exposure declared",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_ab60b01cb53cfcbe",
+        "fingerprint": "fp_ab60b01cb53cfcbe",
+        "check_id": "SHIP-SCHEMA-MISSING-BOUNDS",
+        "severity": "high",
+        "title": "stripe.create_refund.amount has no maximum bound",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_ff2f028953d1c220",
+        "fingerprint": "fp_ff2f028953d1c220",
+        "check_id": "SHIP-SCHEMA-BROAD-FREE-TEXT",
+        "severity": "high",
+        "title": "zendesk.update_ticket accepts broad free-form action input",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_acd63b899d49aa1c",
+        "fingerprint": "fp_acd63b899d49aa1c",
+        "check_id": "SHIP-SCHEMA-BROAD-FREE-TEXT",
+        "severity": "high",
+        "title": "gmail.send_customer_email accepts broad free-form action input",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_85f8513ad72cd9ea",
+        "fingerprint": "fp_85f8513ad72cd9ea",
+        "check_id": "SHIP-SCHEMA-FREEFORM-OUTPUT",
+        "severity": "medium",
+        "title": "send_email_preview returns free-form text output",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_d27325cbdbbf5483",
+        "fingerprint": "fp_d27325cbdbbf5483",
+        "check_id": "SHIP-AUTH-MANIFEST-BROAD-SCOPE",
+        "severity": "high",
+        "title": "Manifest declares broad permission scopes",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_83852fbd6b440524",
+        "fingerprint": "fp_83852fbd6b440524",
+        "check_id": "SHIP-AUTH-SCOPE-COVERAGE-MISSING",
+        "severity": "high",
+        "title": "shopify.cancel_order requires scopes not declared in the manifest",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_d8e6d1865dae97cc",
+        "fingerprint": "fp_d8e6d1865dae97cc",
+        "check_id": "SHIP-AUTH-SCOPE-COVERAGE-MISSING",
+        "severity": "high",
+        "title": "support.search_kb requires scopes not declared in the manifest",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_1f6cfd6b7daa9b7c",
+        "fingerprint": "fp_1f6cfd6b7daa9b7c",
+        "check_id": "SHIP-AUTH-SCOPE-COVERAGE-MISSING",
+        "severity": "high",
+        "title": "gmail.send_customer_email requires scopes not declared in the manifest",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_12985c36a06026de",
+        "fingerprint": "fp_12985c36a06026de",
+        "check_id": "SHIP-SCOPE-PROHIBITED-TOOL-PRESENT",
+        "severity": "high",
+        "title": "stripe.create_refund appears to overlap with a prohibited action",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_e090c62e390e70ab",
+        "fingerprint": "fp_e090c62e390e70ab",
+        "check_id": "SHIP-SCOPE-PROHIBITED-TOOL-PRESENT",
+        "severity": "high",
+        "title": "gmail.send_customer_email appears to overlap with a prohibited action",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_a62ca2fd9a68a1d1",
+        "fingerprint": "fp_a62ca2fd9a68a1d1",
+        "check_id": "SHIP-POLICY-CONFIRMATION-MISSING",
+        "severity": "high",
+        "title": "stripe.create_refund lacks a declared confirmation policy",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_8e08a4fe6b0917f6",
+        "fingerprint": "fp_8e08a4fe6b0917f6",
+        "check_id": "SHIP-POLICY-CONFIRMATION-MISSING",
+        "severity": "high",
+        "title": "gmail.send_customer_email lacks a declared confirmation policy",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_0f8aaa912d589cf0",
+        "fingerprint": "fp_0f8aaa912d589cf0",
+        "check_id": "SHIP-SIDEFX-IDEMPOTENCY-MISSING",
+        "severity": "high",
+        "title": "gmail.send_customer_email lacks idempotency evidence",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_fd2577850cef1f87",
+        "fingerprint": "fp_fd2577850cef1f87",
+        "check_id": "SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING",
+        "severity": "high",
+        "title": "shopify.cancel_order is high-risk but has no owner",
+        "baseline_status": null
+      },
+      {
+        "id": "fp_39b9ae878f343d1b",
+        "fingerprint": "fp_39b9ae878f343d1b",
+        "check_id": "SHIP-MANIFEST-UNUSED-SCOPE",
+        "severity": "medium",
+        "title": "Manifest declares unused permission scope zendesk:tickets:read",
+        "baseline_status": null
+      }
+    ],
+    "evidence_coverage": {
+      "level": "mixed",
+      "human_review_recommended": true,
+      "source_warning_count": 1,
+      "low_confidence_tool_count": 1
+    },
+    "baseline_delta": {
+      "enabled": false,
+      "path": null,
+      "matched_count": 0,
+      "new_count": 0,
+      "resolved_count": 0
+    },
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
   "tool_surface": {
     "total_tools": 8,
     "high_risk_tools": 3,
@@ -114,7 +287,11 @@
       "recommendation": "Replace wildcard tool exposure with an explicit tool allowlist before release review.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-inventory-wildcard-tools"
     },
     {
       "id": "fp_ab60b01cb53cfcbe",
@@ -139,7 +316,11 @@
       "recommendation": "Add a maximum bound to stripe.create_refund.amount or document an equivalent limit in the tool policy.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-schema-missing-bounds"
     },
     {
       "id": "fp_ff2f028953d1c220",
@@ -164,7 +345,11 @@
       "recommendation": "Constrain zendesk.update_ticket.updates with an enum, structured schema, or narrower field-specific parameters.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-schema-broad-free-text"
     },
     {
       "id": "fp_acd63b899d49aa1c",
@@ -189,7 +374,11 @@
       "recommendation": "Constrain gmail.send_customer_email.body with an enum, structured schema, or narrower field-specific parameters.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-schema-broad-free-text"
     },
     {
       "id": "fp_85f8513ad72cd9ea",
@@ -215,7 +404,11 @@
       "recommendation": "Prefer a structured output schema for send_email_preview, especially when output is later passed back into model context.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-schema-freeform-output"
     },
     {
       "id": "fp_d27325cbdbbf5483",
@@ -241,7 +434,11 @@
       "recommendation": "Replace broad manifest permission scopes with the narrowest scopes needed for this release.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-auth-manifest-broad-scope"
     },
     {
       "id": "fp_83852fbd6b440524",
@@ -275,7 +472,11 @@
       "recommendation": "Add the required scopes for shopify.cancel_order to permissions.scopes or narrow the tool's declared auth requirements.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "append_pointer",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-auth-scope-coverage-missing"
     },
     {
       "id": "fp_d8e6d1865dae97cc",
@@ -309,7 +510,11 @@
       "recommendation": "Add the required scopes for support.search_kb to permissions.scopes or narrow the tool's declared auth requirements.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "append_pointer",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-auth-scope-coverage-missing"
     },
     {
       "id": "fp_1f6cfd6b7daa9b7c",
@@ -343,7 +548,11 @@
       "recommendation": "Add the required scopes for gmail.send_customer_email to permissions.scopes or narrow the tool's declared auth requirements.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "append_pointer",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-auth-scope-coverage-missing"
     },
     {
       "id": "fp_12985c36a06026de",
@@ -372,7 +581,11 @@
       "recommendation": "Remove stripe.create_refund, narrow its policy, or revise prohibited_actions so the manifest and tool surface do not contradict each other.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-scope-prohibited-tool-present"
     },
     {
       "id": "fp_e090c62e390e70ab",
@@ -400,7 +613,11 @@
       "recommendation": "Remove gmail.send_customer_email, narrow its policy, or revise prohibited_actions so the manifest and tool surface do not contradict each other.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-scope-prohibited-tool-present"
     },
     {
       "id": "fp_f092940f62fbb012",
@@ -429,7 +646,11 @@
       "recommendation": "Declare an approval policy for stripe.create_refund or remove this tool from the release.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-policy-approval-missing"
     },
     {
       "id": "fp_a62ca2fd9a68a1d1",
@@ -458,7 +679,11 @@
       "recommendation": "Declare a user confirmation policy for stripe.create_refund or remove this action from the release.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-policy-confirmation-missing"
     },
     {
       "id": "fp_8e08a4fe6b0917f6",
@@ -486,7 +711,11 @@
       "recommendation": "Declare a user confirmation policy for gmail.send_customer_email or remove this action from the release.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-policy-confirmation-missing"
     },
     {
       "id": "fp_dac8011e14c53777",
@@ -515,7 +744,11 @@
       "recommendation": "Add an idempotency key, idempotent annotation, or declared idempotency policy for stripe.create_refund.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-sidefx-idempotency-missing"
     },
     {
       "id": "fp_0f8aaa912d589cf0",
@@ -543,7 +776,11 @@
       "recommendation": "Add an idempotency key, idempotent annotation, or declared idempotency policy for gmail.send_customer_email.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-sidefx-idempotency-missing"
     },
     {
       "id": "fp_fd2577850cef1f87",
@@ -571,7 +808,11 @@
       "recommendation": "Declare an owner for each high-risk production tool in risk_overrides.tools.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-manifest-high-risk-owner-missing"
     },
     {
       "id": "fp_39b9ae878f343d1b",
@@ -602,7 +843,11 @@
       "recommendation": "Remove unused manifest scopes or add tool metadata showing why they are required.",
       "suppressed": false,
       "suppression_reason": null,
-      "baseline_status": null
+      "baseline_status": null,
+      "autofix_safe": false,
+      "requires_human_review": true,
+      "suggested_patch_kind": "manual",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-manifest-unused-scope"
     }
   ],
   "recommended_actions": [
@@ -616,8 +861,7 @@
     "Declare an owner for each high-risk production tool in risk_overrides.tools."
   ],
   "generated_reports": {
-    "markdown": "expected/report.md",
-    "json": "expected/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpwmgzxru8/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -861,7 +861,7 @@
     "Declare an owner for each high-risk production tool in risk_overrides.tools."
   ],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpwmgzxru8/report.json"
+    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmp94ljt4m7/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/support_refund_agent/expected/report.md
+++ b/samples/support_refund_agent/expected/report.md
@@ -4,15 +4,47 @@ Project: support-refund-agent
 Agent: refund-assistant
 Target: production\_like
 
-Result: BLOCKED - release blockers detected.
-Status: Release blockers detected
-Critical: 2
-High: 14
-Medium: 2
-Low: 0
-Suppressed: 0
-Evidence coverage: mixed
-Human review: recommended
+## Release Decision
+
+Decision: blocked
+Reason: 2 active findings block release.
+
+Blockers (2):
+- CRITICAL SHIP-POLICY-APPROVAL-MISSING — stripe.create\_refund lacks a declared approval policy
+- CRITICAL SHIP-SIDEFX-IDEMPOTENCY-MISSING — stripe.create\_refund lacks idempotency evidence
+
+Review items (16):
+- HIGH SHIP-INVENTORY-WILDCARD-TOOLS — Wildcard tool exposure declared
+- HIGH SHIP-SCHEMA-MISSING-BOUNDS — stripe.create\_refund.amount has no maximum bound
+- HIGH SHIP-SCHEMA-BROAD-FREE-TEXT — zendesk.update\_ticket accepts broad free-form action input
+- HIGH SHIP-SCHEMA-BROAD-FREE-TEXT — gmail.send\_customer\_email accepts broad free-form action input
+- MEDIUM SHIP-SCHEMA-FREEFORM-OUTPUT — send\_email\_preview returns free-form text output
+- HIGH SHIP-AUTH-MANIFEST-BROAD-SCOPE — Manifest declares broad permission scopes
+- HIGH SHIP-AUTH-SCOPE-COVERAGE-MISSING — shopify.cancel\_order requires scopes not declared in the manifest
+- HIGH SHIP-AUTH-SCOPE-COVERAGE-MISSING — support.search\_kb requires scopes not declared in the manifest
+- HIGH SHIP-AUTH-SCOPE-COVERAGE-MISSING — gmail.send\_customer\_email requires scopes not declared in the manifest
+- HIGH SHIP-SCOPE-PROHIBITED-TOOL-PRESENT — stripe.create\_refund appears to overlap with a prohibited action
+- HIGH SHIP-SCOPE-PROHIBITED-TOOL-PRESENT — gmail.send\_customer\_email appears to overlap with a prohibited action
+- HIGH SHIP-POLICY-CONFIRMATION-MISSING — stripe.create\_refund lacks a declared confirmation policy
+- HIGH SHIP-POLICY-CONFIRMATION-MISSING — gmail.send\_customer\_email lacks a declared confirmation policy
+- HIGH SHIP-SIDEFX-IDEMPOTENCY-MISSING — gmail.send\_customer\_email lacks idempotency evidence
+- HIGH SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING — shopify.cancel\_order is high-risk but has no owner
+- MEDIUM SHIP-MANIFEST-UNUSED-SCOPE — Manifest declares unused permission scope zendesk:tickets:read
+
+Evidence coverage: mixed (1 low-confidence tool(s); 1 source warning(s); human review recommended)
+
+Baseline delta: not enabled
+
+Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fail_ci=false (exit 0)
+
+## Summary
+
+- Critical: 2
+- High: 14
+- Medium: 2
+- Low: 0
+- Suppressed: 0
+- Status: Release blockers detected (legacy; see Release Decision above)
 
 ## Top Findings
 

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -7,7 +7,9 @@ Run from the repo root:
 Writes:
 - docs/manifest-v0.1.json       (from agents_shipgate.config.schema)
 - docs/checks.json              (from agents-shipgate list-checks --json)
-- docs/report-schema.v0.6.json  (from agents_shipgate.core.models.ReadinessReport)
+- docs/report-schema.v0.<minor>.json
+                                (from agents_shipgate.core.models.ReadinessReport;
+                                 minor derived from report_schema_version default)
 
 CI calls this script and asserts the working tree is clean afterward, so
 out-of-date generated files fail the build — drift protection for any
@@ -82,9 +84,12 @@ def write_report_schema() -> None:
         "post-processing to preserve the v0.5 public contract. "
         "Do not edit by hand."
     )
-    # Preserve v0.5's stable required list. Optional v0.6 additions
-    # (manifest_dir, per-finding patches) are not added here, so they stay
-    # optional for additive consumers.
+    # Preserve v0.5's stable required list, plus v0.8 additions.
+    # Optional intermediate additions (manifest_dir, per-finding patches)
+    # are not added here, so they stay optional for additive consumers.
+    # `release_decision` is required at v0.8: every emitted report has it
+    # (build_report always populates it). Marking it required at the
+    # schema level catches drift early.
     schema["required"] = sorted(
         [
             "schema_version",
@@ -94,6 +99,7 @@ def write_report_schema() -> None:
             "agent",
             "environment",
             "summary",
+            "release_decision",
             "tool_surface",
             "frameworks",
             "findings",
@@ -137,6 +143,49 @@ def write_report_schema() -> None:
     if "LoadedPolicyPack" in defs:
         defs["LoadedPolicyPack"]["required"] = sorted(
             ["id", "name", "path", "rule_count"]
+        )
+
+    # v0.8 release_decision: pin required keys so consumers can rely on
+    # the full block being present (Pydantic only marks fields without
+    # defaults as required, but our consumers depend on the whole shape).
+    if "ReleaseDecision" in defs:
+        defs["ReleaseDecision"]["required"] = sorted(
+            [
+                "decision",
+                "reason",
+                "blockers",
+                "review_items",
+                "evidence_coverage",
+                "baseline_delta",
+                "fail_policy",
+            ]
+        )
+    if "ReleaseDecisionItem" in defs:
+        defs["ReleaseDecisionItem"]["required"] = sorted(
+            ["check_id", "severity", "title"]
+        )
+    if "EvidenceCoverageDecision" in defs:
+        defs["EvidenceCoverageDecision"]["required"] = sorted(
+            [
+                "level",
+                "human_review_recommended",
+                "source_warning_count",
+                "low_confidence_tool_count",
+            ]
+        )
+    if "BaselineDelta" in defs:
+        defs["BaselineDelta"]["required"] = sorted(
+            ["enabled", "matched_count", "new_count", "resolved_count"]
+        )
+    if "FailPolicy" in defs:
+        defs["FailPolicy"]["required"] = sorted(
+            [
+                "ci_mode",
+                "fail_on",
+                "new_findings_only",
+                "would_fail_ci",
+                "exit_code",
+            ]
         )
 
     # tool_inventory[] and loaded_plugins[] are typed as

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -169,8 +169,13 @@ def write_report_schema() -> None:
             ]
         )
     if "ReleaseDecisionItem" in defs:
+        # Pin the full v0.8 contract documented in STABILITY.md. `id`,
+        # `fingerprint`, and `baseline_status` are nullable in the model
+        # but every emitted item carries them — requiring the key to be
+        # present (value may be null) lets agent/CI consumers rely on
+        # the documented shape without conditional key checks.
         defs["ReleaseDecisionItem"]["required"] = sorted(
-            ["check_id", "severity", "title"]
+            ["id", "fingerprint", "check_id", "severity", "title", "baseline_status"]
         )
     if "EvidenceCoverageDecision" in defs:
         defs["EvidenceCoverageDecision"]["required"] = sorted(

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -117,6 +117,14 @@ def write_report_schema() -> None:
     properties = schema.setdefault("properties", {})
     properties["schema_version"] = {"const": "0.1"}
     properties["report_schema_version"] = {"const": minor}
+    # v0.8: tighten release_decision to a direct $ref. The Pydantic
+    # model declares `release_decision: ReleaseDecision | None = None`
+    # so older test fixtures and SARIF-only callers can construct
+    # minimal reports — but every emitted report has it populated.
+    # Without this override the schema would emit
+    # `anyOf: [ReleaseDecision, null]`, which would let `null` pass
+    # validation and silently violate the v0.8 contract.
+    properties["release_decision"] = {"$ref": "#/$defs/ReleaseDecision"}
 
     # Preserve nested v0.5 required lists. Pydantic auto-generation marks
     # only fields without defaults as required, but consumers depend on

--- a/src/agents_shipgate/ci/exit_policy.py
+++ b/src/agents_shipgate/ci/exit_policy.py
@@ -1,8 +1,33 @@
 from __future__ import annotations
 
-from agents_shipgate.core.models import ReadinessReport, Severity
+from agents_shipgate.core.models import Finding, ReadinessReport, Severity
 
 GATE_FAILURE_EXIT_CODE = 20
+
+
+def effective_fail_on(
+    ci_mode: str, fail_on: list[Severity] | None
+) -> list[Severity]:
+    """Resolve the active fail-on severity list for a given CI mode.
+
+    Shared with build_release_decision so the FailPolicy block in
+    release_decision and the process exit code can never disagree.
+    """
+    return fail_on if fail_on is not None else _default_fail_on(ci_mode)
+
+
+def baseline_filtered_active(
+    report: ReadinessReport, *, new_findings_only: bool
+) -> list[Finding]:
+    """Active (non-suppressed) findings, filtered by baseline new-only."""
+    active = [finding for finding in report.findings if not finding.suppressed]
+    if new_findings_only:
+        active = [
+            finding
+            for finding in active
+            if finding.baseline_status in {None, "new"}
+        ]
+    return active
 
 
 def exit_code_for_report(
@@ -14,17 +39,11 @@ def exit_code_for_report(
 ) -> int:
     # Summary counts exclude suppressed findings, so strict mode intentionally
     # passes when every critical finding has an explicit suppression reason.
-    effective_fail_on = fail_on if fail_on is not None else _default_fail_on(ci_mode)
-    if not effective_fail_on:
+    fail_on_resolved = effective_fail_on(ci_mode, fail_on)
+    if not fail_on_resolved:
         return 0
-    active = [finding for finding in report.findings if not finding.suppressed]
-    if new_findings_only:
-        active = [
-            finding
-            for finding in active
-            if finding.baseline_status in {None, "new"}
-        ]
-    if any(finding.severity in effective_fail_on for finding in active):
+    active = baseline_filtered_active(report, new_findings_only=new_findings_only)
+    if any(finding.severity in fail_on_resolved for finding in active):
         return GATE_FAILURE_EXIT_CODE
     return 0
 

--- a/src/agents_shipgate/ci/github_summary.py
+++ b/src/agents_shipgate/ci/github_summary.py
@@ -12,16 +12,53 @@ def write_github_step_summary(report: ReadinessReport) -> None:
         return
     path = Path(summary_path)
     summary = report.summary
+    decision = report.release_decision
     formats = ", ".join(sorted(report.generated_reports)) or "configured"
-    lines = [
-        "## Agents Shipgate",
-        "",
-        f"Status: `{summary.status}`",
-        f"Critical: {summary.critical_count} · High: {summary.high_count} · Medium: {summary.medium_count}",
-        f"Human review: {'recommended' if summary.human_review_recommended else 'not required'}",
-        "",
-        f"Generated reports: {formats}.",
-        "",
-    ]
+    lines = ["## Agents Shipgate", ""]
+    if decision is not None:
+        lines.extend(
+            [
+                f"Decision: `{decision.decision}`",
+                f"Reason: {decision.reason}",
+                (
+                    f"Blockers: {len(decision.blockers)} · "
+                    f"Review items: {len(decision.review_items)}"
+                ),
+            ]
+        )
+        fp = decision.fail_policy
+        lines.append(
+            f"Fail policy: ci_mode=`{fp.ci_mode}`, "
+            f"would_fail_ci=`{str(fp.would_fail_ci).lower()}` "
+            f"(exit `{fp.exit_code}`)"
+        )
+    else:
+        # Defensive fallback for older reports loaded without
+        # release_decision (e.g., baselines from <v0.8).
+        lines.extend(
+            [
+                f"Status: `{summary.status}`",
+                (
+                    f"Critical: {summary.critical_count} · "
+                    f"High: {summary.high_count} · "
+                    f"Medium: {summary.medium_count}"
+                ),
+                (
+                    "Human review: "
+                    f"{'recommended' if summary.human_review_recommended else 'not required'}"
+                ),
+            ]
+        )
+    lines.extend(
+        [
+            (
+                f"Counts: critical={summary.critical_count}, "
+                f"high={summary.high_count}, medium={summary.medium_count}"
+            ),
+            "",
+            f"Generated reports: {formats}.",
+            "",
+        ]
+    )
     with path.open("a", encoding="utf-8") as handle:
         handle.write("\n".join(lines))

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -137,6 +137,15 @@ def _decision_reason(
             if item.severity == "critical" and item.baseline_status == "matched"
         )
         n_reviews = len(review_items)
+        # Gate "evidence coverage is incomplete" wording on actual
+        # measurable gaps. summary.human_review_recommended is also True
+        # for any critical/high finding (see findings.summarize_findings),
+        # so using it here would falsely claim evidence gaps for clean
+        # static scans that simply have high-severity findings.
+        has_evidence_gaps = (
+            evidence.low_confidence_tool_count > 0
+            or evidence.source_warning_count > 0
+        )
         if (
             review_items
             and matched_criticals == n_reviews
@@ -146,18 +155,23 @@ def _decision_reason(
                 "All critical findings are baseline-matched; review "
                 "accepted debt before shipping."
             )
-        if not review_items and evidence.human_review_recommended:
-            return (
-                "Static-only scan with low-confidence evidence; human "
-                "review recommended."
-            )
-        if review_items and evidence.human_review_recommended:
+        if review_items and has_evidence_gaps:
             noun = "finding" if n_reviews == 1 else "findings"
             return (
                 f"{n_reviews} {noun} need review and evidence coverage "
                 "is incomplete."
             )
-        noun = "finding" if n_reviews == 1 else "findings"
-        verb = "requires" if n_reviews == 1 else "require"
-        return f"{n_reviews} {noun} {verb} human review before shipping."
+        if review_items:
+            noun = "finding" if n_reviews == 1 else "findings"
+            verb = "requires" if n_reviews == 1 else "require"
+            return f"{n_reviews} {noun} {verb} human review before shipping."
+        if has_evidence_gaps:
+            return (
+                "Static-only scan with low-confidence evidence; human "
+                "review recommended."
+            )
+        # Defensive: review_required with no review_items and no
+        # measurable evidence gaps. summarize_findings doesn't produce
+        # this combination today, but cover the case explicitly.
+        return "Human review recommended."
     return "No active blockers and evidence coverage is full."

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from agents_shipgate.ci.exit_policy import (
+    baseline_filtered_active,
+    effective_fail_on,
+    exit_code_for_report,
+)
+from agents_shipgate.core.models import (
+    BaselineDelta,
+    EvidenceCoverageDecision,
+    FailPolicy,
+    Finding,
+    ReadinessReport,
+    ReleaseDecision,
+    ReleaseDecisionItem,
+    ReleaseDecisionStatus,
+    Severity,
+    Tool,
+)
+
+
+def build_release_decision(
+    *,
+    report: ReadinessReport,
+    tools: list[Tool],
+    ci_mode: str,
+    fail_on: list[Severity] | None,
+    new_findings_only: bool,
+) -> ReleaseDecision:
+    fail_on_resolved = effective_fail_on(ci_mode, fail_on)
+
+    # blockers/review_items consider the full active set, NOT
+    # new_findings_only: baseline-matched criticals must remain visible
+    # as accepted debt in review_items. The new_findings_only filter
+    # only affects fail_policy.exit_code (via exit_code_for_report).
+    active = baseline_filtered_active(report, new_findings_only=False)
+
+    blockers: list[ReleaseDecisionItem] = []
+    review_items: list[ReleaseDecisionItem] = []
+    blocker_severities: set[Severity] = {"critical", *fail_on_resolved}
+
+    for finding in active:
+        if (
+            finding.baseline_status != "matched"
+            and finding.severity in blocker_severities
+        ):
+            blockers.append(_to_item(finding))
+            continue
+        if (
+            finding.severity in {"critical", "high", "medium"}
+            or finding.requires_human_review is True
+        ):
+            review_items.append(_to_item(finding))
+
+    low_confidence_tool_count = sum(
+        1 for tool in tools if tool.extraction_confidence != "high"
+    )
+    evidence = EvidenceCoverageDecision(
+        level=report.summary.evidence_coverage,
+        human_review_recommended=report.summary.human_review_recommended,
+        source_warning_count=len(report.source_warnings),
+        low_confidence_tool_count=low_confidence_tool_count,
+    )
+
+    if report.baseline is None:
+        baseline_delta = BaselineDelta(enabled=False)
+    else:
+        baseline_delta = BaselineDelta(
+            enabled=True,
+            path=report.baseline.path,
+            matched_count=report.baseline.matched_count,
+            new_count=report.baseline.new_count,
+            resolved_count=report.baseline.resolved_count,
+        )
+
+    exit_code = exit_code_for_report(
+        report,
+        ci_mode,
+        fail_on=fail_on,
+        new_findings_only=new_findings_only,
+    )
+    fail_policy = FailPolicy(
+        ci_mode=ci_mode,
+        fail_on=fail_on_resolved,
+        new_findings_only=new_findings_only,
+        would_fail_ci=(exit_code != 0),
+        exit_code=exit_code,
+    )
+
+    decision: ReleaseDecisionStatus
+    if blockers:
+        decision = "blocked"
+    elif review_items or evidence.human_review_recommended:
+        decision = "review_required"
+    else:
+        decision = "passed"
+
+    reason = _decision_reason(decision, blockers, review_items, evidence)
+
+    return ReleaseDecision(
+        decision=decision,
+        reason=reason,
+        blockers=blockers,
+        review_items=review_items,
+        evidence_coverage=evidence,
+        baseline_delta=baseline_delta,
+        fail_policy=fail_policy,
+    )
+
+
+def _to_item(finding: Finding) -> ReleaseDecisionItem:
+    return ReleaseDecisionItem(
+        id=finding.id,
+        fingerprint=finding.fingerprint,
+        check_id=finding.check_id,
+        severity=finding.severity,
+        title=finding.title,
+        baseline_status=finding.baseline_status,
+    )
+
+
+def _decision_reason(
+    decision: ReleaseDecisionStatus,
+    blockers: list[ReleaseDecisionItem],
+    review_items: list[ReleaseDecisionItem],
+    evidence: EvidenceCoverageDecision,
+) -> str:
+    if decision == "blocked":
+        n = len(blockers)
+        noun = "finding" if n == 1 else "findings"
+        verb = "blocks" if n == 1 else "block"
+        return f"{n} active {noun} {verb} release."
+    if decision == "review_required":
+        matched_criticals = sum(
+            1
+            for item in review_items
+            if item.severity == "critical" and item.baseline_status == "matched"
+        )
+        n_reviews = len(review_items)
+        if (
+            review_items
+            and matched_criticals == n_reviews
+            and matched_criticals > 0
+        ):
+            return (
+                "All critical findings are baseline-matched; review "
+                "accepted debt before shipping."
+            )
+        if not review_items and evidence.human_review_recommended:
+            return (
+                "Static-only scan with low-confidence evidence; human "
+                "review recommended."
+            )
+        if review_items and evidence.human_review_recommended:
+            noun = "finding" if n_reviews == 1 else "findings"
+            return (
+                f"{n_reviews} {noun} need review and evidence coverage "
+                "is incomplete."
+            )
+        noun = "finding" if n_reviews == 1 else "findings"
+        verb = "requires" if n_reviews == 1 else "require"
+        return f"{n_reviews} {noun} {verb} human review before shipping."
+    return "No active blockers and evidence coverage is full."

--- a/src/agents_shipgate/cli/fixture.py
+++ b/src/agents_shipgate/cli/fixture.py
@@ -93,7 +93,13 @@ def fixture_run(
         raise typer.Exit(4) from exc
 
     typer.echo(f"Fixture: {name}")
-    typer.echo(f"Status:  {report.summary.status}")
+    decision = report.release_decision
+    if decision is not None:
+        typer.echo(f"Decision: {decision.decision}")
+        typer.echo(
+            f"Blockers: {len(decision.blockers)}  "
+            f"Review items: {len(decision.review_items)}"
+        )
     typer.echo(
         f"Counts:  critical={report.summary.critical_count} "
         f"high={report.summary.high_count} medium={report.summary.medium_count}"

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -743,25 +743,52 @@ def _safe_output_name(config_path: Path) -> str:
 
 def _print_cli_summary(report, ci_mode: str, exit_code: int, *, verbose: bool = False) -> None:
     summary = report.summary
+    decision = report.release_decision
     typer.echo(f"Agents Shipgate {__version__}")
     typer.echo("")
     typer.echo(f"Project: {report.project.get('name')}")
     typer.echo(f"Agent: {report.agent.get('name')}")
     typer.echo(f"Target: {report.environment.get('target')}")
     typer.echo("")
-    typer.echo(f"Status: {summary.status}")
-    typer.echo(f"Critical: {summary.critical_count}")
-    typer.echo(f"High: {summary.high_count}")
-    typer.echo(f"Medium: {summary.medium_count}")
-    typer.echo(f"Human review: {'recommended' if summary.human_review_recommended else 'not required'}")
-    typer.echo(f"Evidence coverage: {summary.evidence_coverage}")
-    if report.baseline:
+    if decision is not None:
+        typer.echo(f"Decision: {decision.decision}")
+        typer.echo(f"Reason: {decision.reason}")
+        typer.echo(f"Blockers: {len(decision.blockers)}")
+        typer.echo(f"Review items: {len(decision.review_items)}")
+        ev = decision.evidence_coverage
+        ev_extras: list[str] = []
+        if ev.low_confidence_tool_count:
+            ev_extras.append(f"{ev.low_confidence_tool_count} low-confidence tool(s)")
+        if ev.source_warning_count:
+            ev_extras.append(f"{ev.source_warning_count} source warning(s)")
+        if ev.human_review_recommended:
+            ev_extras.append("human review recommended")
+        suffix = f" ({'; '.join(ev_extras)})" if ev_extras else ""
+        typer.echo(f"Evidence coverage: {ev.level}{suffix}")
+        bd = decision.baseline_delta
+        if bd.enabled:
+            typer.echo(
+                "Baseline delta: "
+                f"matched={bd.matched_count}, new={bd.new_count}, "
+                f"resolved={bd.resolved_count}"
+            )
+        else:
+            typer.echo("Baseline delta: not enabled")
+        fp = decision.fail_policy
+        fail_on_text = ", ".join(fp.fail_on) if fp.fail_on else "none"
         typer.echo(
-            "Baseline: "
-            f"matched={report.baseline.matched_count}, "
-            f"new={report.baseline.new_count}, "
-            f"resolved={report.baseline.resolved_count}"
+            f"Fail policy: ci_mode={fp.ci_mode}, fail_on=[{fail_on_text}], "
+            f"new_findings_only={str(fp.new_findings_only).lower()}, "
+            f"would_fail_ci={str(fp.would_fail_ci).lower()}"
         )
+    else:
+        typer.echo("Decision: (not recorded)")
+    typer.echo("")
+    typer.echo(
+        f"Counts: critical={summary.critical_count}, high={summary.high_count}, "
+        f"medium={summary.medium_count}, low={summary.low_count}, "
+        f"suppressed={summary.suppressed_count}"
+    )
     if verbose:
         typer.echo(f"Tool count: {report.tool_surface.total_tools}")
         typer.echo(f"Source warnings: {len(report.source_warnings)}")

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -718,10 +718,25 @@ def _run_multi_scan(
                 logger.exception("unhandled exception while scanning %s", config_path)
             typer.echo(f"{config_path}: internal_error - {exc}", err=True)
         else:
-            typer.echo(
-                f"{config_path}: {report.summary.status} "
-                f"(critical={report.summary.critical_count}, high={report.summary.high_count})"
-            )
+            # v0.8: lead with release_decision.decision (baseline-aware,
+            # the recommended release-gate signal). Fall back to the
+            # legacy summary.status only if the report somehow lacks
+            # release_decision (older baselines loaded for diff, etc.).
+            decision = report.release_decision
+            if decision is not None:
+                typer.echo(
+                    f"{config_path}: {decision.decision} "
+                    f"(blockers={len(decision.blockers)}, "
+                    f"review_items={len(decision.review_items)}, "
+                    f"critical={report.summary.critical_count}, "
+                    f"high={report.summary.high_count})"
+                )
+            else:
+                typer.echo(
+                    f"{config_path}: {report.summary.status} "
+                    f"(critical={report.summary.critical_count}, "
+                    f"high={report.summary.high_count})"
+                )
         exit_code = max(exit_code, scan_exit_code)
     typer.echo("")
     typer.echo(f"Exit code: {exit_code}")

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 
 from agents_shipgate.checks.registry import run_checks
-from agents_shipgate.ci.exit_policy import exit_code_for_report
 from agents_shipgate.ci.github_summary import write_github_step_summary
 from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.baseline import apply_baseline, load_baseline
@@ -231,6 +230,9 @@ def run_scan(
             key: _relative_display_path(path, base_dir)
             for key, path in generated_paths.items()
         },
+        ci_mode=manifest.ci.mode,
+        fail_on=manifest.ci.fail_on,
+        new_findings_only=baseline_summary is not None,
         loaded_policy_packs=policy_packs.loaded,
         loaded_plugins=loaded_plugins,
         source_warnings=warnings,
@@ -241,12 +243,8 @@ def run_scan(
     )
     _write_reports(report, generated_paths, manifest.output.formats)
     write_github_step_summary(report)
-    return report, exit_code_for_report(
-        report,
-        manifest.ci.mode,
-        fail_on=manifest.ci.fail_on,
-        new_findings_only=baseline_summary is not None,
-    )
+    assert report.release_decision is not None  # build_report always populates it
+    return report, report.release_decision.fail_policy.exit_code
 
 
 def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, object]:

--- a/src/agents_shipgate/core/findings.py
+++ b/src/agents_shipgate/core/findings.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from collections import Counter, defaultdict
 
+from agents_shipgate.ci.release_decision import build_release_decision
 from agents_shipgate.config.schema import AgentsShipgateManifest, SuppressionConfig
 from agents_shipgate.core.check_ids import expands_to_check_id
 from agents_shipgate.core.models import (
@@ -252,6 +253,9 @@ def build_report(
     tools: list[Tool],
     findings: list[Finding],
     generated_reports: dict[str, str],
+    ci_mode: str,
+    fail_on: list[Severity] | None = None,
+    new_findings_only: bool = False,
     loaded_policy_packs: list[LoadedPolicyPack] | None = None,
     loaded_plugins: list[dict[str, object]] | None = None,
     source_warnings: list[str] | None = None,
@@ -261,7 +265,7 @@ def build_report(
     baseline: BaselineSummary | None = None,
     manifest_dir: str | None = None,
 ) -> ReadinessReport:
-    return ReadinessReport(
+    report = ReadinessReport(
         run_id=run_id,
         manifest_dir=manifest_dir,
         project=manifest.project.model_dump(exclude_none=True),
@@ -281,6 +285,14 @@ def build_report(
         tool_inventory=tool_inventory(tools),
         source_warnings=source_warnings or [],
     )
+    report.release_decision = build_release_decision(
+        report=report,
+        tools=tools,
+        ci_mode=ci_mode,
+        fail_on=fail_on,
+        new_findings_only=new_findings_only,
+    )
+    return report
 
 
 def _matching_suppression(

--- a/src/agents_shipgate/core/models.py
+++ b/src/agents_shipgate/core/models.py
@@ -196,6 +196,54 @@ class BaselineSummary(BaseModel):
     resolved_count: int = 0
 
 
+# v0.8: release_decision block — see docs/STABILITY.md for the
+# divergence contract with summary.status (which stays baseline-blind
+# for backwards compatibility).
+ReleaseDecisionStatus = Literal["blocked", "review_required", "passed"]
+
+
+class ReleaseDecisionItem(BaseModel):
+    id: str | None = None
+    fingerprint: str | None = None
+    check_id: str
+    severity: Severity
+    title: str
+    baseline_status: BaselineStatus | None = None
+
+
+class EvidenceCoverageDecision(BaseModel):
+    level: str
+    human_review_recommended: bool
+    source_warning_count: int
+    low_confidence_tool_count: int
+
+
+class BaselineDelta(BaseModel):
+    enabled: bool
+    path: str | None = None
+    matched_count: int = 0
+    new_count: int = 0
+    resolved_count: int = 0
+
+
+class FailPolicy(BaseModel):
+    ci_mode: str
+    fail_on: list[Severity] = Field(default_factory=list)
+    new_findings_only: bool = False
+    would_fail_ci: bool
+    exit_code: int
+
+
+class ReleaseDecision(BaseModel):
+    decision: ReleaseDecisionStatus
+    reason: str
+    blockers: list[ReleaseDecisionItem] = Field(default_factory=list)
+    review_items: list[ReleaseDecisionItem] = Field(default_factory=list)
+    evidence_coverage: EvidenceCoverageDecision
+    baseline_delta: BaselineDelta
+    fail_policy: FailPolicy
+
+
 class ApiResponseFormat(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
@@ -440,7 +488,7 @@ class ReadinessReport(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     schema_version: str = "0.1"
-    report_schema_version: str = "0.7"
+    report_schema_version: str = "0.8"
     run_id: str
     # v0.6 (per C13): absolute path to the directory containing
     # shipgate.yaml. apply-patches uses this to enforce a containment
@@ -451,6 +499,10 @@ class ReadinessReport(BaseModel):
     agent: dict[str, Any]
     environment: dict[str, Any]
     summary: ReportSummary
+    # v0.8: required at JSON-schema level (see scripts/generate_schemas.py),
+    # but Python-optional so older test fixtures and SARIF-only callers
+    # can construct minimal reports. build_report() always populates it.
+    release_decision: ReleaseDecision | None = None
     tool_surface: ToolSurfaceSummary
     api_surface: dict[str, Any] | None = None
     anthropic_surface: dict[str, Any] | None = None

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -49,15 +49,22 @@ def render_markdown_report(report: ReadinessReport) -> str:
             f"Agent: {_safe_markdown_text(report.agent.get('name'))}",
             f"Target: {_safe_markdown_text(report.environment.get('target'))}",
             "",
-            _result_line(report),
-            f"Status: {_human_status(summary.status)}",
-            f"Critical: {summary.critical_count}",
-            f"High: {summary.high_count}",
-            f"Medium: {summary.medium_count}",
-            f"Low: {summary.low_count}",
-            f"Suppressed: {summary.suppressed_count}",
-            f"Evidence coverage: {summary.evidence_coverage}",
-            f"Human review: {'recommended' if summary.human_review_recommended else 'not required'}",
+        ]
+    )
+    _append_release_decision(lines, report)
+    lines.extend(
+        [
+            "## Summary",
+            "",
+            f"- Critical: {summary.critical_count}",
+            f"- High: {summary.high_count}",
+            f"- Medium: {summary.medium_count}",
+            f"- Low: {summary.low_count}",
+            f"- Suppressed: {summary.suppressed_count}",
+            (
+                f"- Status: {_human_status(summary.status)} "
+                "(legacy; see Release Decision above)"
+            ),
             "",
         ]
     )
@@ -74,6 +81,70 @@ def render_markdown_report(report: ReadinessReport) -> str:
     _append_inventory(lines, report)
     lines.extend(["", "## Disclaimer", "", DISCLAIMER, ""])
     return "\n".join(lines)
+
+
+def _append_release_decision(lines: list[str], report: ReadinessReport) -> None:
+    decision = report.release_decision
+    lines.extend(["## Release Decision", ""])
+    if decision is None:
+        lines.extend(["No release decision recorded.", ""])
+        return
+    lines.append(f"Decision: {decision.decision}")
+    lines.append(f"Reason: {_safe_markdown_text(decision.reason)}")
+    lines.append("")
+    _append_decision_items(lines, "Blockers", decision.blockers)
+    _append_decision_items(lines, "Review items", decision.review_items)
+    ev = decision.evidence_coverage
+    ev_extras: list[str] = []
+    if ev.low_confidence_tool_count:
+        ev_extras.append(f"{ev.low_confidence_tool_count} low-confidence tool(s)")
+    if ev.source_warning_count:
+        ev_extras.append(f"{ev.source_warning_count} source warning(s)")
+    if ev.human_review_recommended:
+        ev_extras.append("human review recommended")
+    suffix = f" ({'; '.join(ev_extras)})" if ev_extras else ""
+    lines.append(f"Evidence coverage: {ev.level}{suffix}")
+    lines.append("")
+    bd = decision.baseline_delta
+    if bd.enabled:
+        path = _safe_markdown_text(bd.path) if bd.path else "(unknown path)"
+        lines.append(
+            f"Baseline delta: enabled ({path}) — "
+            f"{bd.matched_count} matched, {bd.new_count} new, "
+            f"{bd.resolved_count} resolved"
+        )
+    else:
+        lines.append("Baseline delta: not enabled")
+    lines.append("")
+    fp = decision.fail_policy
+    fail_on_text = ", ".join(fp.fail_on) if fp.fail_on else "none"
+    lines.append(
+        f"Fail policy: ci_mode={fp.ci_mode}, fail_on=[{fail_on_text}], "
+        f"new_findings_only={str(fp.new_findings_only).lower()}, "
+        f"would_fail_ci={str(fp.would_fail_ci).lower()} "
+        f"(exit {fp.exit_code})"
+    )
+    lines.append("")
+
+
+def _append_decision_items(
+    lines: list[str], label: str, items: list[object]
+) -> None:
+    if not items:
+        lines.append(f"{label} (0): none")
+        lines.append("")
+        return
+    lines.append(f"{label} ({len(items)}):")
+    for item in items:
+        # Items are ReleaseDecisionItem; reference attrs directly.
+        baseline_suffix = (
+            f" [{item.baseline_status}]" if item.baseline_status else ""
+        )
+        lines.append(
+            f"- {item.severity.upper()} {_safe_markdown_text(item.check_id)}"
+            f"{baseline_suffix} — {_safe_markdown_text(item.title)}"
+        )
+    lines.append("")
 
 
 def _append_top_findings(lines: list[str], findings: list[Finding]) -> None:
@@ -330,16 +401,6 @@ def _risk_confidence_summary(value: object) -> str:
     if not isinstance(value, dict):
         return ""
     return ", ".join(f"{tag}={confidence}" for tag, confidence in value.items())
-
-
-def _result_line(report: ReadinessReport) -> str:
-    active = [finding for finding in report.findings if not finding.suppressed]
-    total_tools = report.tool_surface.total_tools
-    if not active:
-        return f"Result: PASS - no static findings across {total_tools} tools."
-    if report.summary.critical_count:
-        return "Result: BLOCKED - release blockers detected."
-    return "Result: REVIEW - static findings require human review."
 
 
 def _safe_markdown_text(value: object) -> str:

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -16,4 +16,9 @@ def test_github_step_summary_is_written(monkeypatch, tmp_path):
 
     summary = summary_path.read_text(encoding="utf-8")
     assert "## Agents Shipgate" in summary
-    assert "Status: `release_blockers_detected`" in summary
+    # v0.8: lead with release_decision instead of summary.status. The
+    # support_refund_agent sample has new criticals → decision=blocked.
+    assert "Decision: `blocked`" in summary
+    assert "Reason:" in summary
+    assert "Blockers:" in summary
+    assert "Fail policy:" in summary

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,6 +301,19 @@ def test_cli_scan_workspace_writes_separate_report_dirs(tmp_path):
     assert result.exit_code == 0
     assert "Scanning 2 manifests" in result.output
     assert len(list(tmp_path.glob("*/report.json"))) == 2
+    # v0.8: per-manifest workspace summary leads with the baseline-aware
+    # release_decision.decision, NOT the legacy baseline-blind summary.status.
+    # Regression for PR #38 reviewer feedback.
+    decision_lines = [
+        line for line in result.output.splitlines() if "shipgate.yaml:" in line
+    ]
+    assert decision_lines, "expected per-manifest summary lines in workspace output"
+    for line in decision_lines:
+        assert any(
+            f": {decision} " in line
+            for decision in ("blocked", "review_required", "passed")
+        ), f"workspace summary line should lead with decision: {line!r}"
+        assert "blockers=" in line
 
 
 def test_cli_scan_workspace_continues_after_config_error(tmp_path):
@@ -359,7 +372,9 @@ tool_sources:
     )
 
     assert result.exit_code == 2
-    assert "valid/shipgate.yaml: no_release_blockers_detected" in result.output
+    # v0.8: workspace per-manifest summaries lead with release_decision.
+    # The clean valid manifest produces decision=passed.
+    assert "valid/shipgate.yaml: passed" in result.output
     assert "invalid/shipgate.yaml: config_error" in result.output
     assert len(list((tmp_path / "reports").glob("*/report.json"))) == 1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,11 @@ def test_cli_advisory_exits_zero(tmp_path):
 
     assert result.exit_code == 0
     assert "Agents Shipgate 0.7.0" in result.output
-    assert "release_blockers_detected" in result.output
+    # v0.8: CLI summary leads with the release decision; the support_refund
+    # sample has new criticals → decision=blocked. (Advisory exit is still 0.)
+    assert "Decision: blocked" in result.output
+    assert "Reason:" in result.output
+    assert "Fail policy:" in result.output
 
 
 def test_cli_strict_exits_gate_failure_code(tmp_path):
@@ -444,7 +448,7 @@ def test_cli_baseline_save_and_scan(tmp_path):
     )
 
     assert scan.exit_code == 0
-    assert "Baseline: matched=" in scan.output
+    assert "Baseline delta: matched=" in scan.output
 
 
 def test_cli_scan_missing_baseline_exits_three(tmp_path):

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -56,13 +56,18 @@ def test_index_no_longer_references_v05_schema():
     )
 
 
-def test_index_lists_current_v07_schema():
-    """The current schema version moved to v0.7 in PR 3; the index
-    must point agents at v0.7 for fresh report.json validation."""
+def test_index_lists_current_v08_schema():
+    """The current schema version moved to v0.8; the index must point
+    agents at v0.8 for fresh report.json validation. v0.7 stays linked
+    as the frozen reference for older reports."""
     index_text = INDEX_MD.read_text(encoding="utf-8")
+    assert "report-schema.v0.8.json" in index_text, (
+        "docs/INDEX.md must list report-schema.v0.8.json as the current schema "
+        "since emitted reports carry report_schema_version: \"0.8\"."
+    )
     assert "report-schema.v0.7.json" in index_text, (
-        "docs/INDEX.md must list report-schema.v0.7.json as the current schema "
-        "since emitted reports carry report_schema_version: \"0.7\"."
+        "docs/INDEX.md must keep report-schema.v0.7.json linked as the "
+        "frozen reference for pre-v0.8 reports."
     )
 
 

--- a/tests/test_finding_remediation.py
+++ b/tests/test_finding_remediation.py
@@ -352,10 +352,11 @@ def test_report_json_payload_carries_new_fields(tmp_path):
             assert key in finding, f"{finding['check_id']} missing {key} in JSON"
 
 
-def test_report_schema_version_is_v07(tmp_path):
-    """Schema version moved from 0.6 → 0.7 per the additive contract
+def test_report_schema_version_is_v08(tmp_path):
+    """Schema version moved from 0.7 → 0.8 per the additive contract
     in STABILITY.md. Old reports validate against their respective
-    schema files, but new scans emit 0.7."""
+    schema files, but new scans emit 0.8 with the required
+    `release_decision` block."""
     report, _ = run_scan(
         config_path=SAMPLE_MANIFEST,
         output_dir=tmp_path,
@@ -363,4 +364,5 @@ def test_report_schema_version_is_v07(tmp_path):
         ci_mode="advisory",
     )
     payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
-    assert payload["report_schema_version"] == "0.7"
+    assert payload["report_schema_version"] == "0.8"
+    assert "release_decision" in payload

--- a/tests/test_release_decision.py
+++ b/tests/test_release_decision.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import pytest
+
+from agents_shipgate.ci.exit_policy import (
+    GATE_FAILURE_EXIT_CODE,
+    exit_code_for_report,
+)
+from agents_shipgate.ci.release_decision import build_release_decision
+from agents_shipgate.core.models import (
+    AuthInfo,
+    BaselineSummary,
+    Finding,
+    ReadinessReport,
+    ReportSummary,
+    Tool,
+    ToolSurfaceSummary,
+)
+
+
+def _finding(
+    *,
+    check_id: str = "check.x",
+    severity: str = "critical",
+    baseline_status: str | None = None,
+    requires_human_review: bool | None = None,
+    suppressed: bool = False,
+) -> Finding:
+    return Finding(
+        id=f"id-{check_id}-{severity}-{baseline_status or 'new'}",
+        fingerprint=f"fp-{check_id}",
+        check_id=check_id,
+        title=f"{check_id} title",
+        severity=severity,
+        category="test",
+        recommendation="do the thing",
+        suppressed=suppressed,
+        baseline_status=baseline_status,
+        requires_human_review=requires_human_review,
+    )
+
+
+def _tool(*, name: str = "t1", confidence: str = "high") -> Tool:
+    return Tool(
+        id=f"tool-{name}",
+        name=name,
+        source_type="manual",
+        auth=AuthInfo(),
+        extraction_confidence=confidence,
+    )
+
+
+def _report(
+    *,
+    findings: list[Finding] | None = None,
+    tools: list[Tool] | None = None,
+    summary_status: str = "warnings_detected",
+    human_review_recommended: bool = False,
+    evidence_coverage: str = "static",
+    baseline: BaselineSummary | None = None,
+    source_warnings: list[str] | None = None,
+) -> ReadinessReport:
+    findings = findings or []
+    tools = tools or []
+    return ReadinessReport(
+        run_id="r",
+        project={"name": "p"},
+        agent={"name": "a"},
+        environment={"target": "local"},
+        summary=ReportSummary(
+            status=summary_status,
+            critical_count=sum(1 for f in findings if f.severity == "critical"),
+            high_count=sum(1 for f in findings if f.severity == "high"),
+            medium_count=sum(1 for f in findings if f.severity == "medium"),
+            human_review_recommended=human_review_recommended,
+            evidence_coverage=evidence_coverage,
+        ),
+        tool_surface=ToolSurfaceSummary(
+            total_tools=len(tools), high_risk_tools=0
+        ),
+        baseline=baseline,
+        findings=findings,
+        source_warnings=source_warnings or [],
+    )
+
+
+def _build(
+    report: ReadinessReport,
+    *,
+    tools: list[Tool] | None = None,
+    ci_mode: str = "advisory",
+    fail_on: list[str] | None = None,
+    new_findings_only: bool = False,
+):
+    return build_release_decision(
+        report=report,
+        tools=tools or [],
+        ci_mode=ci_mode,
+        fail_on=fail_on,
+        new_findings_only=new_findings_only,
+    )
+
+
+def test_advisory_with_new_critical_blocks_but_does_not_fail_ci():
+    report = _report(findings=[_finding(severity="critical", baseline_status="new")])
+    decision = _build(report, ci_mode="advisory")
+    assert decision.decision == "blocked"
+    assert len(decision.blockers) == 1
+    assert decision.fail_policy.would_fail_ci is False
+    assert decision.fail_policy.exit_code == 0
+
+
+def test_strict_with_new_critical_blocks_and_fails_ci():
+    report = _report(findings=[_finding(severity="critical", baseline_status="new")])
+    decision = _build(report, ci_mode="strict")
+    assert decision.decision == "blocked"
+    assert decision.fail_policy.would_fail_ci is True
+    assert decision.fail_policy.exit_code == GATE_FAILURE_EXIT_CODE
+    assert decision.fail_policy.fail_on == ["critical"]
+
+
+def test_baseline_matched_critical_only_is_review_required():
+    report = _report(
+        findings=[_finding(severity="critical", baseline_status="matched")],
+        baseline=BaselineSummary(path=".agents-shipgate/baseline.json", matched_count=1),
+    )
+    decision = _build(report, ci_mode="strict", new_findings_only=True)
+    assert decision.decision == "review_required"
+    assert decision.blockers == []
+    assert len(decision.review_items) == 1
+    assert decision.review_items[0].baseline_status == "matched"
+    assert "baseline-matched" in decision.reason
+
+
+def test_explicit_fail_on_high_with_high_finding_blocks():
+    report = _report(findings=[_finding(severity="high", baseline_status="new")])
+    decision = _build(report, ci_mode="strict", fail_on=["high"])
+    assert decision.decision == "blocked"
+    assert len(decision.blockers) == 1
+    assert decision.blockers[0].severity == "high"
+    assert decision.fail_policy.fail_on == ["high"]
+    assert decision.fail_policy.would_fail_ci is True
+
+
+def test_clean_scan_with_high_confidence_tools_passes():
+    report = _report(
+        tools=[_tool(confidence="high")],
+        summary_status="no_release_blockers_detected",
+        human_review_recommended=False,
+    )
+    decision = _build(report, ci_mode="strict", tools=[_tool(confidence="high")])
+    assert decision.decision == "passed"
+    assert decision.blockers == []
+    assert decision.review_items == []
+    assert decision.fail_policy.would_fail_ci is False
+
+
+def test_clean_scan_with_low_confidence_tool_is_review_required():
+    report = _report(
+        tools=[_tool(confidence="low")],
+        summary_status="human_review_recommended",
+        human_review_recommended=True,
+    )
+    decision = _build(
+        report, ci_mode="strict", tools=[_tool(confidence="low")]
+    )
+    assert decision.decision == "review_required"
+    assert decision.review_items == []  # no findings, just evidence gate
+    assert decision.evidence_coverage.human_review_recommended is True
+    assert decision.evidence_coverage.low_confidence_tool_count == 1
+    assert "low-confidence" in decision.reason
+
+
+def test_fail_policy_exit_code_matches_exit_code_for_report():
+    """The shared-helper refactor must keep release_decision.fail_policy.exit_code
+    in lockstep with the standalone exit_code_for_report() across the matrix."""
+    matrix = [
+        ("advisory", None, False, [_finding(severity="critical")]),
+        ("strict", None, False, [_finding(severity="critical")]),
+        ("strict", ["high"], False, [_finding(severity="high")]),
+        ("strict", ["critical"], True, [_finding(severity="critical", baseline_status="matched")]),
+        ("advisory", None, False, []),
+    ]
+    for ci_mode, fail_on, new_only, findings in matrix:
+        report = _report(findings=findings)
+        decision = _build(
+            report, ci_mode=ci_mode, fail_on=fail_on, new_findings_only=new_only
+        )
+        expected = exit_code_for_report(
+            report, ci_mode, fail_on=fail_on, new_findings_only=new_only
+        )
+        assert decision.fail_policy.exit_code == expected, (
+            f"mismatch for ci_mode={ci_mode}, fail_on={fail_on}, "
+            f"new_findings_only={new_only}"
+        )
+        assert decision.fail_policy.would_fail_ci == (expected != 0)
+
+
+def test_summary_status_remains_baseline_blind():
+    """Regression: summary.status MUST stay baseline-blind for v0.7 compat
+    even though release_decision.decision is baseline-aware. A baseline-matched
+    critical produces summary.status='release_blockers_detected' AND
+    release_decision.decision='review_required' — that intentional divergence
+    is documented in STABILITY.md."""
+    from agents_shipgate.core.findings import summarize_findings
+
+    findings = [_finding(severity="critical", baseline_status="matched")]
+    summary = summarize_findings(findings, [])
+    assert summary.status == "release_blockers_detected"
+
+    report = _report(
+        findings=findings,
+        summary_status=summary.status,
+        baseline=BaselineSummary(path=".agents-shipgate/baseline.json", matched_count=1),
+    )
+    decision = _build(report, ci_mode="strict", new_findings_only=True)
+    assert decision.decision == "review_required"
+
+
+def test_blockers_and_review_items_use_reference_only_shape():
+    finding = _finding(severity="critical", baseline_status="new")
+    report = _report(findings=[finding])
+    decision = _build(report, ci_mode="strict")
+    assert len(decision.blockers) == 1
+    item = decision.blockers[0]
+    # Reference-only shape: id/fingerprint/check_id/severity/title/baseline_status only.
+    assert item.id == finding.id
+    assert item.fingerprint == finding.fingerprint
+    assert item.check_id == finding.check_id
+    assert item.severity == finding.severity
+    assert item.title == finding.title
+    assert item.baseline_status == finding.baseline_status
+    # Must NOT carry full Finding fields like recommendation or evidence.
+    assert not hasattr(item, "recommendation")
+    assert not hasattr(item, "evidence")
+
+
+@pytest.mark.parametrize(
+    "decision_branch,findings_kwargs,build_kwargs,expected_keyword",
+    [
+        ("blocked", {"severity": "critical", "baseline_status": "new"}, {"ci_mode": "strict"}, "block"),
+        (
+            "review_required_matched",
+            {"severity": "critical", "baseline_status": "matched"},
+            {"ci_mode": "strict", "new_findings_only": True},
+            "baseline-matched",
+        ),
+    ],
+)
+def test_decision_reason_strings_are_deterministic(
+    decision_branch, findings_kwargs, build_kwargs, expected_keyword
+):
+    report = _report(findings=[_finding(**findings_kwargs)])
+    decision = _build(report, **build_kwargs)
+    assert expected_keyword in decision.reason

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -294,6 +294,19 @@ def test_v08_schema_requires_release_decision():
         "source_warning_count",
         "low_confidence_tool_count",
     }
+    # STABILITY.md guarantees the full v0.8 contract on each item: id,
+    # fingerprint, check_id, severity, title, baseline_status. The
+    # nullable ones (id/fingerprint/baseline_status) must still appear
+    # as keys so consumers can read them without conditional checks.
+    item_required = set(schema["$defs"]["ReleaseDecisionItem"]["required"])
+    assert item_required == {
+        "id",
+        "fingerprint",
+        "check_id",
+        "severity",
+        "title",
+        "baseline_status",
+    }
 
 
 def test_v08_schema_rejects_null_release_decision(tmp_path):

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from jsonschema import validate
 
 from agents_shipgate.cli.scan import run_scan
@@ -259,6 +260,12 @@ def test_v08_schema_requires_release_decision():
     schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
     assert "release_decision" in schema["required"]
     assert schema["properties"]["report_schema_version"] == {"const": "0.8"}
+    # The Pydantic model declares `release_decision: ReleaseDecision | None`
+    # for test-helper convenience, but the published schema must NOT allow
+    # null — every emitted v0.8 report has a populated release_decision.
+    assert schema["properties"]["release_decision"] == {
+        "$ref": "#/$defs/ReleaseDecision"
+    }
 
     decision_required = set(schema["$defs"]["ReleaseDecision"]["required"])
     assert decision_required == {
@@ -287,6 +294,32 @@ def test_v08_schema_requires_release_decision():
         "source_warning_count",
         "low_confidence_tool_count",
     }
+
+
+def test_v08_schema_rejects_null_release_decision(tmp_path):
+    """A v0.8 payload with `release_decision: null` MUST fail validation.
+    Regression for the original schema which emitted
+    `anyOf: [ReleaseDecision, null]` and silently accepted null."""
+    import jsonschema
+
+    from agents_shipgate.report.json_report import report_json_payload
+
+    report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
+    payload = report_json_payload(report)
+
+    # Sanity: real payload validates.
+    validate(instance=payload, schema=schema)
+
+    # Tamper: setting release_decision to null must be rejected.
+    payload["release_decision"] = None
+    with pytest.raises(jsonschema.ValidationError):
+        validate(instance=payload, schema=schema)
 
 
 def test_json_report_omits_patches_key_when_not_suggested(tmp_path):

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -19,6 +19,7 @@ REPORT_SCHEMA_V02 = Path("docs/report-schema.v0.2.json")
 REPORT_SCHEMA_V04 = Path("docs/report-schema.v0.4.json")
 REPORT_SCHEMA_V06 = Path("docs/report-schema.v0.6.json")
 REPORT_SCHEMA_V07 = Path("docs/report-schema.v0.7.json")
+REPORT_SCHEMA_V08 = Path("docs/report-schema.v0.8.json")
 
 
 def test_sample_markdown_report_matches_golden(tmp_path):
@@ -96,7 +97,13 @@ def test_json_report_contains_integration_contract_keys(tmp_path):
     assert "loaded_plugins" in payload
     assert payload["loaded_plugins"] == []
     assert payload["schema_version"] == "0.1"
-    assert payload["report_schema_version"] == "0.7"
+    assert payload["report_schema_version"] == "0.8"
+    assert "release_decision" in payload
+    assert payload["release_decision"]["decision"] in {
+        "blocked",
+        "review_required",
+        "passed",
+    }
     assert "frameworks" in payload
     assert "loaded_policy_packs" in payload
 
@@ -151,11 +158,9 @@ def test_json_schema_is_published():
     } <= set(api_surface["required"])
 
 
-def test_json_report_validates_against_v07_schema(tmp_path):
-    """v0.7 schema is additive over v0.6: adds the four optional
-    per-finding remediation fields (`autofix_safe`,
-    `requires_human_review`, `suggested_patch_kind`, `docs_url`).
-    Pre-existing required fields keep their shape."""
+def test_json_report_validates_against_v08_schema(tmp_path):
+    """v0.8 schema adds top-level required `release_decision`. Emitted
+    reports must validate against the v0.8 schema."""
     from agents_shipgate.report.json_report import report_json_payload
 
     report, _ = run_scan(
@@ -164,9 +169,18 @@ def test_json_report_validates_against_v07_schema(tmp_path):
         formats=["json"],
         ci_mode="advisory",
     )
-    schema = json.loads(REPORT_SCHEMA_V07.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
 
     validate(instance=report_json_payload(report), schema=schema)
+
+
+def test_v07_schema_file_is_frozen():
+    """v0.7 schema file stays parseable and pinned to const "0.7".
+    Catches accidental edits or regeneration overwrites of frozen
+    schemas."""
+    schema = json.loads(REPORT_SCHEMA_V07.read_text(encoding="utf-8"))
+    assert schema["properties"]["report_schema_version"] == {"const": "0.7"}
+    assert "release_decision" not in schema.get("required", [])
 
 
 def test_v07_schema_preserves_nested_required_lists():
@@ -236,6 +250,43 @@ def test_v07_schema_preserves_nested_required_lists():
     )
     assert "agent_count" in google_adk_required
     assert "dynamic_toolset_count" in google_adk_required
+
+
+def test_v08_schema_requires_release_decision():
+    """Top-level required must include `release_decision` and the
+    ReleaseDecision $def must require all leaf blocks. Catches drift
+    between the model and the published v0.8 contract."""
+    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
+    assert "release_decision" in schema["required"]
+    assert schema["properties"]["report_schema_version"] == {"const": "0.8"}
+
+    decision_required = set(schema["$defs"]["ReleaseDecision"]["required"])
+    assert decision_required == {
+        "decision",
+        "reason",
+        "blockers",
+        "review_items",
+        "evidence_coverage",
+        "baseline_delta",
+        "fail_policy",
+    }
+    fail_policy_required = set(schema["$defs"]["FailPolicy"]["required"])
+    assert fail_policy_required == {
+        "ci_mode",
+        "fail_on",
+        "new_findings_only",
+        "would_fail_ci",
+        "exit_code",
+    }
+    evidence_required = set(
+        schema["$defs"]["EvidenceCoverageDecision"]["required"]
+    )
+    assert evidence_required == {
+        "level",
+        "human_review_recommended",
+        "source_warning_count",
+        "low_confidence_tool_count",
+    }
 
 
 def test_json_report_omits_patches_key_when_not_suggested(tmp_path):
@@ -365,4 +416,9 @@ tool_sources:
         ci_mode="advisory",
     )
 
-    assert "Result: PASS - no static findings across 1 tools." in render_markdown_report(report)
+    # v0.8: the legacy "Result: PASS ..." line was removed in favor of
+    # the leading Release Decision block. A clean scan with high-confidence
+    # tools yields decision=passed.
+    markdown = render_markdown_report(report)
+    assert "## Release Decision" in markdown
+    assert "Decision: passed" in markdown

--- a/tests/test_v07_metadata_roundtrip.py
+++ b/tests/test_v07_metadata_roundtrip.py
@@ -39,6 +39,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SAMPLES = REPO_ROOT / "samples"
 SAMPLE_MANIFEST = SAMPLES / "support_refund_agent" / "shipgate.yaml"
 REPORT_SCHEMA_V07 = REPO_ROOT / "docs" / "report-schema.v0.7.json"
+REPORT_SCHEMA_V08 = REPO_ROOT / "docs" / "report-schema.v0.8.json"
 
 REQUIRED_REMEDIATION_KEYS = (
     "autofix_safe",
@@ -137,7 +138,11 @@ def test_report_json_populates_metadata_with_suggest_patches(tmp_path):
 # --- v0.7 schema validation ------------------------------------------------
 
 
-def test_report_json_validates_against_v07_schema_with_patches(tmp_path):
+def test_report_json_validates_against_v08_schema_with_patches(tmp_path):
+    """v0.7 contract: every active finding has the four remediation
+    fields populated. v0.8 added required `release_decision` on top.
+    Validate against the current v0.8 schema (the v0.7 file stays
+    frozen — see test_reports.py::test_v07_schema_file_is_frozen)."""
     report, _ = run_scan(
         config_path=SAMPLE_MANIFEST,
         output_dir=tmp_path,
@@ -146,11 +151,11 @@ def test_report_json_validates_against_v07_schema_with_patches(tmp_path):
         suggest_patches=True,
     )
     payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
-    schema = json.loads(REPORT_SCHEMA_V07.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
     validate(instance=payload, schema=schema)
 
 
-def test_report_schema_version_is_v07_in_emitted_report(tmp_path):
+def test_report_schema_version_is_v08_in_emitted_report(tmp_path):
     report, _ = run_scan(
         config_path=SAMPLE_MANIFEST,
         output_dir=tmp_path,
@@ -158,7 +163,7 @@ def test_report_schema_version_is_v07_in_emitted_report(tmp_path):
         ci_mode="advisory",
     )
     payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
-    assert payload["report_schema_version"] == "0.7"
+    assert payload["report_schema_version"] == "0.8"
 
 
 # --- Catalog-vs-Finding contract holds in practice -------------------------


### PR DESCRIPTION
## Summary

- Adds a top-level `release_decision` block to `report.json` so consumers (CI, agents, humans) get a single first-class signal — `\"blocked\" | \"review_required\" | \"passed\"` — instead of stitching together `summary.status`, severity counts, baseline delta, and exit-code config.
- **Baseline-aware**: matched criticals appear in `review_items` (accepted debt), not `blockers`. **Policy-independent for criticals**: even advisory CI surfaces a new critical as a blocker (with `would_fail_ci=false`).
- **Compatibility**: `summary.status` preserved byte-for-byte for v0.7 callers. The intentional divergence with `release_decision.decision` is documented in [STABILITY.md](STABILITY.md).
- Schema bumped to v0.8; v0.7.json stays frozen. SARIF unchanged.

## Type

- [x] Report, schema, or SARIF output
- [x] CLI or GitHub Action behavior
- [x] Documentation only

## What changed

**New**
- `src/agents_shipgate/ci/release_decision.py` — `build_release_decision()` + deterministic reason strings
- `docs/report-schema.v0.8.json` — required \`release_decision\` at the top level
- `tests/test_release_decision.py` — 11 tests covering the decision matrix + regression for the divergence

**Models / wiring**
- `core/models.py` — 5 new models (`ReleaseDecision`, `ReleaseDecisionItem`, `EvidenceCoverageDecision`, `BaselineDelta`, `FailPolicy`); `report_schema_version` default → \"0.8\"
- `ci/exit_policy.py` — extracted `effective_fail_on()` and `baseline_filtered_active()` helpers shared with `build_release_decision()`. `exit_code_for_report()` behavior unchanged
- `core/findings.py::build_report` — accepts `ci_mode/fail_on/new_findings_only` and populates `release_decision`
- `cli/scan.py` — reads exit code from `report.release_decision.fail_policy.exit_code`

**Rendering**
- Markdown report leads with `## Release Decision` (Decision → Reason → Blockers → Review items → Evidence coverage → Baseline delta → Fail policy). Detailed sections unchanged.
- CLI scan + fixture summaries lead with the decision block.
- GitHub Action step summary + PR comment lead with the decision; falls back to `summary.*` for older reports.
- 4 new GitHub Action outputs: `decision`, `blocker_count`, `review_item_count`, `ci_would_fail`.

**Docs** — STABILITY.md, README.md, AGENTS.md, docs/INDEX.md, docs/integrations.md, docs/agent-recipes.md, CHANGELOG.md updated. STABILITY.md gains a \"Status divergence\" section.

## Reviewer notes

- The divergence is the load-bearing design call. A scan with one baseline-matched critical and zero new findings now produces **both** \`summary.status = \"release_blockers_detected\"\` (legacy, baseline-blind) AND \`release_decision.decision = \"review_required\"\` (new, baseline-aware). Both are correct under their respective contracts. The new \`tests/test_release_decision.py::test_summary_status_remains_baseline_blind\` regression pins this.
- \`release_decision.fail_policy.exit_code\` MUST equal \`exit_code_for_report(...)\` for the same args. Pinned by \`test_release_decision.py::test_fail_policy_exit_code_matches_exit_code_for_report\` across the matrix.
- Block items in \`blockers\` / \`review_items\` are **reference-only** (id, fingerprint, check_id, severity, title, baseline_status) — full Finding payload stays in \`findings[]\`. Avoids ballooning report size and double-source-of-truth.
- Evidence-only \`human_review_recommended\` (e.g., low-confidence tool extraction with zero findings) forces \`decision=review_required\`, not \`passed\`. Matches the existing \`summary.status = \"human_review_recommended\"\` semantics.

## Verification

CI is authoritative for \`python -m ruff check .\`, \`python -m compileall -q src tests\`, and \`python -m pytest\`.

Local checks run:

- \`python -m pytest tests/\` — **328 passed** (was 314)
- \`python -m ruff check .\` — clean
- \`python scripts/generate_schemas.py\` — idempotent (no drift in manifest/checks; v0.7.json frozen; v0.8.json regenerates byte-identically)
- \`agents-shipgate scan --ci-mode advisory samples/support_refund_agent/\` → decision=blocked, exit=0
- \`agents-shipgate scan --ci-mode strict samples/support_refund_agent/\` → decision=blocked, exit=20
- \`agents-shipgate scan --ci-mode strict --baseline=...\` against a re-saved baseline → decision=review_required, blockers=0, 2 baseline-matched criticals in review_items, exit=0; \`summary.status\` correctly stays \`release_blockers_detected\` (divergence verified end-to-end)

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in \`docs/checks.md\` *(no new checks)*
- [x] Report/schema changes are additive or documented in \`STABILITY.md\` (new required \`release_decision\` documented; \`summary.status\` divergence documented; v0.7.json kept frozen as the reference for older reports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)