### PR TITLE
[codex] Prepare v0.8.0 release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ evidence around them:
 
 - MCP exports, OpenAPI specs, or local tool inventories.
 - OpenAI Agents SDK, Google ADK, LangChain/LangGraph, CrewAI, Anthropic
-  Messages API, or OpenAI Agents API tool definitions.
+  Messages API, or OpenAI API artifact tool definitions.
 - Prompts, permission scopes, approval policies, confirmation policies,
   prohibited actions, or `shipgate.yaml`.
 - GitHub Actions or CI release gates for a tool-using AI agent.
@@ -151,11 +151,13 @@ Agents Shipgate produces a deterministic answer to that question, before promoti
 The bundled support-refund fixture demonstrates the kind of release risks Agents Shipgate is designed to surface:
 
 ```text
-## Agents Shipgate
+## Release Decision
 
-Status: Release blockers detected
-Critical: 2 - High: 14 - Medium: 2
-Human review: recommended
+Decision: blocked
+Reason: 2 active findings block release.
+Blockers: 2
+Review items: 16
+Fail policy: would_fail_ci=false (exit 0)
 
 Top findings:
 1. stripe.create_refund lacks a declared approval policy

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ reviewable before production-like permissions are granted.
 An AI agent tool surface is the set of named, schemaed actions an agent can
 invoke at runtime. agents-shipgate reads tool surfaces from MCP exports,
 OpenAPI specs, OpenAI Agents SDK Python entrypoints, Anthropic Messages API
-artifacts, Google ADK, LangChain/LangGraph, CrewAI, and OpenAI Agents API
+artifacts, Google ADK, LangChain/LangGraph, CrewAI, and OpenAI API
 artifacts.
 
 ## How does agents-shipgate work?

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -285,7 +285,7 @@ Tool names are validated against Anthropic's documented regex `^[a-zA-Z0-9_-]{1,
 
 `cache_control` values are captured verbatim into `tool.annotations.anthropicCacheControl`. They have no influence on risk classification in v0.4.
 
-`policy_rules` files share the same shape as the OpenAI Agents API policy file (`approval_required`, `confirmation_required`, `idempotency_required`). They feed `SHIP-POLICY-APPROVAL-MISSING`, `SHIP-POLICY-CONFIRMATION-MISSING`, and `SHIP-SIDEFX-IDEMPOTENCY-MISSING` checks alongside the manifest's top-level `policies` block.
+`policy_rules` files share the same shape as the OpenAI API policy file (`approval_required`, `confirmation_required`, `idempotency_required`). They feed `SHIP-POLICY-APPROVAL-MISSING`, `SHIP-POLICY-CONFIRMATION-MISSING`, and `SHIP-SIDEFX-IDEMPOTENCY-MISSING` checks alongside the manifest's top-level `policies` block.
 
 The framework-agnostic checks (`SHIP-INVENTORY-*`, `SHIP-DOC-*`, `SHIP-SCHEMA-*`, `SHIP-AUTH-*`, `SHIP-SCOPE-*`, `SHIP-POLICY-*`, `SHIP-SIDEFX-*`, `SHIP-MANIFEST-*`) all fire on Anthropic tools without any extra configuration. From the `SHIP-API-*` family, `SHIP-API-FUNCTION-SCHEMA-STRICTNESS` and `SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH` apply; the others key on OpenAI-specific data (response formats, retry policy, trace samples) and intentionally do not fire on Anthropic-only manifests. No new `SHIP-ANTHROPIC-*` check IDs are introduced.
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -13,7 +13,8 @@ By default Agents Shipgate does not:
 - connect to MCP servers;
 - resolve remote or local filesystem OpenAPI `$ref` values;
 - make network calls;
-- shell out to subprocesses;
+- shell out to subprocesses, except for bounded local `git` discovery in
+  `detect` and auto-init;
 - import third-party check plugins;
 - collect telemetry.
 
@@ -23,6 +24,12 @@ By default Agents Shipgate does not:
 - Declared local input paths are resolved relative to the manifest directory and rejected if they escape that base directory. This prevents a manifest from reading sibling repositories or absolute host files unless the source is first copied or symlinked into the reviewed workspace.
 - OpenAPI `$ref` resolution only follows internal JSON pointers beginning with `#/`.
 - `file://`, `http://`, and other external `$ref` values are left as inert schema values.
+- Workspace discovery for `detect` and auto-init may invoke the local `git`
+  binary (`rev-parse` and `ls-files`) with short timeouts to enumerate
+  tracked/unignored files. This does not contact remotes, execute user code,
+  run framework CLIs, connect to MCP servers, call tools, call models, or
+  affect scan verdict semantics. If `git` is unavailable or fails, Agents
+  Shipgate falls back to local filesystem walking with skip rules.
 - OpenAI Agents SDK enrichment uses `ast.parse` only. It does not import or execute Python modules.
 - `openai_api` artifacts are local prompt, JSON, YAML, or JSONL files. Agents Shipgate parses them locally and does not call OpenAI APIs, validate model availability, estimate pricing, or execute traces.
 - Google ADK support is static-only. Agents Shipgate parses Python AST and Agent Config YAML, but does not import ADK code, run `adk run`, run `adk web`, run `adk eval`, connect to MCP servers, call tools, call models, or fetch remote specs by default.

--- a/src/agents_shipgate/checks/api.py
+++ b/src/agents_shipgate/checks/api.py
@@ -67,7 +67,7 @@ def _function_schema_strictness(context: ScanContext):
 
 def _structured_output_readiness(context: ScanContext):
     # Anthropic config has no first-class response-format artifact in MVP,
-    # so this check stays scoped to the OpenAI Agents API surface. Use the
+    # so this check stays scoped to the OpenAI API artifact surface. Use the
     # OpenAI-only tool filter so a mixed manifest (anthropic + openai_api)
     # doesn't list Anthropic tools as high-risk under an OpenAI-shaped
     # finding.
@@ -192,7 +192,7 @@ def _prompt_tool_scope_mismatch(context: ScanContext):
 
 def _operational_readiness(context: ScanContext):
     # The retry / timeout / test-case / output-schema readiness checks key on
-    # OpenAI Agents API artifacts. Anthropic MVP doesn't carry equivalent data,
+    # OpenAI API artifacts. Anthropic MVP doesn't carry equivalent data,
     # so we filter to OpenAI tools only — otherwise a mixed manifest would
     # fire OpenAI-shaped findings against Anthropic tools that have no
     # response_formats / retry_policy / test_cases / tool_output_schemas
@@ -412,7 +412,7 @@ def _broad_free_text(parameter: ToolParameter) -> bool:
 
 
 def _api_tools(context: ScanContext) -> list[Tool]:
-    """Tools backed by an artifact-style adapter (OpenAI Agents API or
+    """Tools backed by an artifact-style adapter (OpenAI API artifacts or
     Anthropic Messages API). Used by checks that apply to both surfaces:
     function-schema strictness and prompt/tool scope mismatch.
     """
@@ -424,7 +424,7 @@ def _api_tools(context: ScanContext) -> list[Tool]:
 
 
 def _openai_api_tools(context: ScanContext) -> list[Tool]:
-    """Tools backed only by the OpenAI Agents API adapter. Used by checks
+    """Tools backed only by the OpenAI API artifact adapter. Used by checks
     that key on OpenAI-specific artifacts (response_formats, retry_policy,
     test_cases, tool_output_schemas) — these have no Anthropic equivalent
     in the v0.4 MVP and would produce false positives on Anthropic tools.

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -71,6 +71,20 @@ def test_index_lists_current_v08_schema():
     )
 
 
+def test_trust_model_documents_bounded_git_discovery_exception():
+    """The trust model must keep the local git subprocess exception explicit.
+
+    Discovery can use git to avoid private/cache/generated workspace noise, but
+    the no-user-code/no-network boundary still holds.
+    """
+    text = (DOCS_DIR / "trust-model.md").read_text(encoding="utf-8")
+    assert "- shell out to subprocesses;" not in text
+    assert "bounded local `git` discovery" in text
+    assert "`rev-parse` and `ls-files`" in text
+    assert "does not contact remotes" in text
+    assert "run framework CLIs" in text
+
+
 def test_agent_recipes_internal_links_resolve():
     """Internal markdown links in `agent-recipes.md` (the doc most
     likely to grow forward references) must point at files that


### PR DESCRIPTION
## Summary

Prepare the v0.8.0 release candidate after PR #39 landed by tightening the last tag-blocking public docs and trust-model surfaces.

Changes:
- Document the bounded local `git rev-parse` / `git ls-files` discovery exception in the trust model.
- Add a docs regression test so the trust model does not drift back to an unqualified “no subprocesses” claim.
- Clean remaining user-facing “OpenAI Agents API” wording where the intended surface is OpenAI API artifacts.
- Update the README Findings Gallery to lead with the v0.8 `Release Decision` shape.

## Why

Merged v0.8 discovery intentionally uses local git enumeration to avoid private/cache/generated workspace noise. The public trust model needed to say that precisely before tagging v0.8.0.

## Validation

- `python -m pytest tests/test_docs_links.py tests/test_action_metadata.py tests/test_reports.py tests/test_release_decision.py tests/test_detect.py tests/test_prompt_parity.py -q`
- `python -m agents_shipgate self-check --json`
- `python -m ruff check .`
- `python -m pytest` (`337 passed`)
- `python -m build`
- `python -m twine check dist/*`

Manual QA:
- Fresh support-refund advisory report: `decision=blocked`, `blockers=2`, `review_items=16`, `would_fail_ci=false`, `exit_code=0`.
- Strict support-refund scan: process exit code and `release_decision.fail_policy.exit_code` both `20`.
- Bundled critical/high sweep found no obvious P0 false positives.
