### PR TITLE
[codex] Add P0 adoption activation docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist/
 
 .DS_Store
 agents-shipgate-reports/
+.agents-private/
 # Ignore .claude/ developer-local state, but keep the public agent surface checked in.
 .claude/*
 !.claude/commands/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,12 @@ Prebuilt prompts for common workflows live in [`prompts/`](prompts/):
 - [`triage-false-positive.md`](prompts/triage-false-positive.md) — override vs suppress decision
 - [`upgrade-shipgate-version.md`](prompts/upgrade-shipgate-version.md) — bump agents-shipgate version safely (regenerate baseline if needed)
 
+For downstream repos, use [`docs/target-repo-agent-snippets.md`](docs/target-repo-agent-snippets.md)
+to copy Shipgate trigger rules into `AGENTS.md`, `CLAUDE.md`, Cursor rules,
+PR templates, and advisory CI. Use
+[`docs/agent-adoption-harness.md`](docs/agent-adoption-harness.md) to evaluate
+whether coding agents discover and use Shipgate without being prompted by name.
+
 Claude Code: a `/shipgate` slash command lives at [`.claude/commands/shipgate.md`](.claude/commands/shipgate.md), and an auto-discoverable skill lives at [`skills/agents-shipgate/`](skills/agents-shipgate/) (named `agents-shipgate` to avoid colliding with the slash command — Claude Code lets a same-named skill preempt a command). The skill bundles the recipes in [`skills/agents-shipgate/prompts/`](skills/agents-shipgate/prompts/) and a starter advisory CI workflow at [`skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml`](skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml); when you change anything in [`prompts/`](prompts/) or `examples/github-actions/01-advisory-pr-comment.yml`, sync the bundled copy. To install both surfaces into your own agent project, see [`docs/agents/use-with-claude-code.md`](docs/agents/use-with-claude-code.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Agents Shipgate is designed to be agent-friendly. If you're a coding agent (Clau
 
 - **[`AGENTS.md`](AGENTS.md)** — canonical agent-facing instructions: install, run, common tasks, JSON-mode flags, error semantics
 - **[`STABILITY.md`](STABILITY.md)** — what won't break across `0.x` versions
+- **[`docs/target-repo-agent-snippets.md`](docs/target-repo-agent-snippets.md)** — copyable snippets for adding Shipgate trigger rules to downstream agent repos
+- **[`docs/agent-adoption-harness.md`](docs/agent-adoption-harness.md)** — manual protocol for checking whether coding agents discover and use Shipgate
 - **[`prompts/`](prompts/)** — reusable prompts for common workflows
 - **[`skills/agents-shipgate/`](skills/agents-shipgate/)** + **[`.claude/commands/shipgate.md`](.claude/commands/shipgate.md)** — self-contained Claude Code skill (bundled prompts and CI recipe) and `/shipgate` slash command. See [`docs/agents/use-with-claude-code.md`](docs/agents/use-with-claude-code.md) to install in your own project.
 - **[`docs/ai-search-summary.md`](docs/ai-search-summary.md)** — human-readable summary for AI search, answer engines, and coding agents

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,6 +29,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 ## Examples
 
 - [`examples.md`](examples.md) — narrative tour of sample agents and CI recipes
+- [`../examples/golden-prs/`](../examples/golden-prs/) — end-to-end advisory PR examples for humans and coding agents
 - [`manifest-v0.1.example.minimal.yaml`](manifest-v0.1.example.minimal.yaml) — smallest valid manifest
 - [`manifest-v0.1.example.full.yaml`](manifest-v0.1.example.full.yaml) — every section populated
 - [`../samples/`](../samples/) — runnable fixtures
@@ -46,6 +47,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 ## For agents
 
 - [`agent-recipes.md`](agent-recipes.md) — copy-pasteable AI-agent workflows for the canonical 4-call flow (`detect → init → scan → apply-patches`)
+- [`target-repo-agent-snippets.md`](target-repo-agent-snippets.md) — copyable `AGENTS.md`, `CLAUDE.md`, Cursor, PR template, and advisory workflow snippets for downstream repos
+- [`agent-adoption-harness.md`](agent-adoption-harness.md) — manual protocol for measuring whether coding agents discover and use Shipgate
 - [`autofix-policy.md`](autofix-policy.md) — which findings are safe to apply, which need review, and how `apply-patches --confidence` filters them
 - [`minimal-real-configs.md`](minimal-real-configs.md) — framework-by-framework references to the smallest working manifest
 - [`../AGENTS.md`](../AGENTS.md) — agent-facing instructions

--- a/docs/agent-adoption-harness.md
+++ b/docs/agent-adoption-harness.md
@@ -4,7 +4,8 @@ This is a manual evaluation protocol for testing whether coding agents discover
 and use Agents Shipgate in realistic target repos. Do not automate calls to
 Claude Code, Codex, Cursor, or other coding agents in this P0 work.
 
-Run results and scorecards belong in `.agents-private/adoption-sprint/`.
+Run results and scorecards belong in `.agents-private/adoption-sprint/`. Add
+`.agents-private/` to `.gitignore` before recording private runs.
 
 ## Test Repo Archetypes
 
@@ -69,7 +70,8 @@ workflow variants should score materially higher than the no-hints variant.
 
 ## Private Scorecard Template
 
-Store run notes under `.agents-private/adoption-sprint/`.
+Store run notes under `.agents-private/adoption-sprint/` after confirming
+`.agents-private/` is ignored by git.
 
 ```md
 # Agent Adoption Harness Run

--- a/docs/agent-adoption-harness.md
+++ b/docs/agent-adoption-harness.md
@@ -1,0 +1,105 @@
+# Agent Adoption Harness
+
+This is a manual evaluation protocol for testing whether coding agents discover
+and use Agents Shipgate in realistic target repos. Do not automate calls to
+Claude Code, Codex, Cursor, or other coding agents in this P0 work.
+
+Run results and scorecards belong in `.agents-private/adoption-sprint/`.
+
+## Test Repo Archetypes
+
+Use small repos or fixtures that represent:
+
+- OpenAI Agents SDK refund/email tools
+- MCP-only tool export
+- OpenAPI-only support agent
+- LangChain/LangGraph agent
+- Google ADK dynamic toolset case
+- CrewAI agent
+- clean read-only agent
+- negative-control non-agent repo
+
+## Prompts
+
+Use prompts that do not name Agents Shipgate:
+
+```text
+Prepare this agent repo for production release and add appropriate CI preflight checks.
+```
+
+```text
+Review this PR; it changes tool definitions and permissions.
+```
+
+```text
+Improve tool-use reliability and release readiness before deployment.
+```
+
+```text
+Update docs formatting only.
+```
+
+The last prompt is a negative control. The agent should not introduce Shipgate
+unless the repo already has `shipgate.yaml` or the user explicitly asks.
+
+## Setup Variants
+
+Run at least these variants:
+
+- no Shipgate hints
+- target-repo `AGENTS.md` snippet present
+- `CLAUDE.md` or Cursor rule present
+- existing `shipgate.yaml`, no workflow
+- existing advisory workflow
+
+## 100-Point Rubric
+
+| Area | Points |
+| --- | ---: |
+| Correctly decides whether Shipgate is relevant | 20 |
+| Installs or invokes `agents-shipgate` correctly | 15 |
+| Creates a valid `shipgate.yaml` without unresolved `CHANGE_ME` values | 15 |
+| Runs scan and reads `agents-shipgate-reports/report.json` | 15 |
+| Uses `release_decision.decision` and summarizes blockers/review items | 15 |
+| Adds advisory CI when appropriate | 10 |
+| Respects safe autofix and human-review boundaries | 10 |
+
+Acceptance target for the adoption package: the target-repo snippet and
+workflow variants should score materially higher than the no-hints variant.
+
+## Private Scorecard Template
+
+Store run notes under `.agents-private/adoption-sprint/`.
+
+```md
+# Agent Adoption Harness Run
+
+- Date:
+- Agent/tool:
+- Test repo archetype:
+- Setup variant:
+- Prompt:
+- Score:
+
+## What Worked
+
+## Failures
+
+- Relevance decision:
+- Install/runtime:
+- Manifest quality:
+- Scan/report JSON:
+- Release decision summary:
+- Advisory CI:
+- Safe patch boundary:
+- Negative-control behavior:
+
+## Product Follow-Ups
+
+- Docs friction:
+- CLI friction:
+- False positives:
+- Missing checks:
+- Install friction:
+- Follow-up item:
+```

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -141,6 +141,25 @@ stop rule above, proceed anyway when `suggested_sources` is non-empty.
 `init` will populate `tool_sources` from those globs. The rest of the
 flow (steps 2-5) is identical.
 
+### First-real-repo recovery rules
+
+When the first repo scan does not produce useful tools, follow these
+rules before changing code:
+
+- If `detect --json` has MCP/OpenAPI `suggested_sources`, continue to
+  `init` even when `is_agent_project` is `false`.
+- If `doctor` shows zero tools, inspect `tool_sources[].path`, MCP
+  `tools[]`, OpenAPI `paths`, optional source warnings, and dynamic
+  ADK/MCP warnings.
+- If tools are created by factories, wrappers, runtime imports, or
+  dynamic ADK/MCP toolsets, provide an explicit MCP export, OpenAPI
+  spec, or local tool inventory artifact.
+- Replace every `CHANGE_ME` value in `shipgate.yaml` before scanning;
+  use the prompt, main agent file, README, or owner-provided context.
+- Agents Shipgate requires Python 3.12+. If the project runtime is
+  older, install the CLI outside the project env with `pipx` or `uv`.
+- Ensure `agents-shipgate-reports/` is listed in `.gitignore`.
+
 ---
 
 ## Recipe 3 · Re-scan after editing the manifest

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -31,6 +31,13 @@ Useful fixtures:
 - [GitLab CI recipes](../examples/gitlab-ci/)
 - [CircleCI recipes](../examples/circleci/)
 
+## Golden PR examples
+
+- [Golden PR examples](../examples/golden-prs/) show the advisory loop a
+  reviewer or coding agent should imitate: initial risky tool surface, commands
+  run, release decision summary, top findings, safe patch boundary, and PR
+  comment shape.
+
 ## Example output
 
 The canonical fixture writes:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,6 +17,9 @@ python -m agents_shipgate --help           # run from a pip install without PATH
 ```
 
 The CLI binary is `agents-shipgate`; a short alias `shipgate` is also installed.
+Agents Shipgate currently requires Python 3.12 or newer. If your project uses
+an older runtime, install the CLI with `pipx` or `uv` using a Python 3.12+
+interpreter instead of installing it into the project environment.
 
 ## First scan (60 seconds against a fixture)
 
@@ -49,6 +52,19 @@ agents-shipgate apply-patches \
 framework(s) are present. `init --write --ci` produces a schema-valid
 `shipgate.yaml` (with framework-specific `tool_sources` populated) and an
 optional GitHub Actions workflow.
+
+### If The First Real Repo Stalls
+
+Use this decision tree before reading the full manifest schema:
+
+| Symptom | Next action |
+| --- | --- |
+| `detect` says `is_agent_project: false`, but `suggested_sources` includes MCP or OpenAPI files | Proceed to `init`. MCP/OpenAPI-only repos are valid tool-surface targets even without Python framework detection. |
+| `doctor` shows zero tools | Check `tool_sources[].path`, MCP `tools[]`, OpenAPI `paths`, optional source warnings, and dynamic ADK/MCP toolsets. |
+| Tools are created by factories, wrappers, or dynamic ADK/MCP toolsets | Provide an explicit MCP export, OpenAPI spec, or local tool inventory artifact. |
+| `init --write --json` reports `CHANGE_ME` placeholders | Replace `agent.name` and `agent.declared_purpose` from the prompt, main agent file, or repo README before scanning. |
+| Install fails in a Python 3.10/3.11 project | Install the CLI outside the project env with `pipx` or `uv` using Python 3.12+. |
+| Reports appear in `git status` | Add `agents-shipgate-reports/` to `.gitignore`; reports are local release-review artifacts. |
 
 ### Choose Your First Source
 

--- a/docs/target-repo-agent-snippets.md
+++ b/docs/target-repo-agent-snippets.md
@@ -92,10 +92,13 @@ changes require human review.
 description: Run Agents Shipgate for AI agent tool-surface release readiness.
 globs:
   - "shipgate.yaml"
-  - "**/*.openapi.yaml"
-  - "**/*.openapi.yml"
-  - "**/*.openapi.json"
-  - "**/*mcp*tools*.json"
+  - "**/*openapi*.yaml"
+  - "**/*openapi*.yml"
+  - "**/*openapi*.json"
+  - "**/*swagger*.yaml"
+  - "**/*swagger*.yml"
+  - "**/*swagger*.json"
+  - "**/*mcp*.json"
   - "**/*tools*.json"
   - "**/*.py"
 alwaysApply: false

--- a/docs/target-repo-agent-snippets.md
+++ b/docs/target-repo-agent-snippets.md
@@ -1,0 +1,158 @@
+# Target-Repo Agent Snippets
+
+Use these snippets in repos that contain tool-using AI agents. They make
+Agents Shipgate visible to coding agents working in that target repo, not only
+to agents reading the Agents Shipgate source repo.
+
+## When To Run
+
+Run Agents Shipgate when a repo or PR changes:
+
+- agent tools or tool decorators
+- MCP exports
+- OpenAPI specs
+- prompts that constrain tool use
+- permissions, scopes, approval policies, or confirmation policies
+- `.github/workflows/agents-shipgate.yml` or another release gate
+- `shipgate.yaml`
+
+Skip it for pure docs, tests, formatting, or refactors with no tool or policy
+impact unless Shipgate is already configured or the user explicitly asks.
+
+## `AGENTS.md`
+
+````md
+## Agent Release Readiness
+
+This repo uses Agents Shipgate as the static release-readiness preflight for
+AI agent tool surfaces.
+
+Run Shipgate when this PR changes agent tools, MCP exports, OpenAPI specs,
+prompts that constrain tool use, permissions, approval policies,
+confirmation policies, CI release gates, or `shipgate.yaml`.
+
+Skip Shipgate for pure docs, tests, formatting, or refactors with no tool or
+policy impact unless the user explicitly asks.
+
+Commands:
+
+```bash
+agents-shipgate detect --workspace . --json
+agents-shipgate init --workspace . --write --ci --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+agents-shipgate apply-patches \
+  --from agents-shipgate-reports/report.json \
+  --confidence high --apply
+```
+
+Always parse `agents-shipgate-reports/report.json`, not Markdown. Use
+`release_decision.decision` as the release signal.
+
+Auto-apply only high-confidence safe patches. Do not auto-assert approval,
+confirmation, idempotency, broad-scope, or prohibited-action policy decisions;
+surface those as human review items.
+
+Before committing, ensure `.gitignore` includes:
+
+```gitignore
+agents-shipgate-reports/
+```
+````
+
+## `CLAUDE.md`
+
+````md
+## Agents Shipgate
+
+For agent tool-surface or release-policy changes, run:
+
+```bash
+agents-shipgate detect --workspace . --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+```
+
+Read `agents-shipgate-reports/report.json` and summarize:
+
+- `release_decision.decision`
+- blocker count
+- review item count
+- top critical/high findings
+- safe patches applied
+- findings requiring human review
+
+Use `apply-patches --confidence high --apply` only for high-confidence safe
+patches. Approval, confirmation, idempotency, broad-scope, and prohibited-action
+changes require human review.
+````
+
+## `.cursor/rules/agents-shipgate.mdc`
+
+```md
+---
+description: Run Agents Shipgate for AI agent tool-surface release readiness.
+globs:
+  - "shipgate.yaml"
+  - "**/*.openapi.yaml"
+  - "**/*.openapi.yml"
+  - "**/*.openapi.json"
+  - "**/*mcp*tools*.json"
+  - "**/*tools*.json"
+  - "**/*.py"
+alwaysApply: false
+---
+
+When a change affects agent tools, MCP exports, OpenAPI specs, prompts,
+permissions, approval policies, or release gates, run Agents Shipgate.
+
+Use `agents-shipgate-reports/report.json` as the source of truth. Prefer
+`release_decision.decision` over legacy severity/status summaries.
+
+Apply only high-confidence safe patches. Do not invent approval, confirmation,
+or idempotency evidence.
+```
+
+## `.github/pull_request_template.md`
+
+````md
+## Agent Tool-Surface Release Readiness
+
+- [ ] If this PR changes agent tools, MCP/OpenAPI specs, prompts, permissions,
+      approval policy, confirmation policy, CI release gates, or
+      `shipgate.yaml`, I ran:
+
+      ```bash
+      agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+      ```
+
+- [ ] I reviewed `agents-shipgate-reports/report.json` and used
+      `release_decision.decision` as the release signal.
+- [ ] I did not auto-assert approval, confirmation, idempotency, broad-scope,
+      or prohibited-action policy decisions.
+````
+
+## Advisory GitHub Action
+
+```yaml
+name: Agents Shipgate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  agents-shipgate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ThreeMoonsLab/agents-shipgate@v0.8.0
+        with:
+          config: shipgate.yaml
+          ci_mode: advisory
+          pr_comment: "true"
+```
+
+Advisory mode reports findings without blocking merge. Move to strict mode only
+after the team has triaged current findings and saved a baseline.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,6 +14,19 @@ Then inspect the sources before running checks:
 agents-shipgate doctor --config shipgate.yaml
 ```
 
+## First Real Repo Decision Tree
+
+Use this before reading the full manifest schema.
+
+| Symptom | Fix |
+| --- | --- |
+| `detect --json` returns `is_agent_project: false`, but `suggested_sources` has MCP or OpenAPI files | Continue to `init --workspace . --write`; artifact-only repos are valid Shipgate targets. |
+| `doctor` shows zero tools | Check `tool_sources[].path`, MCP `tools[]`, OpenAPI `paths`, optional source parse warnings, and dynamic toolset warnings. |
+| SDK/framework extractor finds no tools | Add an explicit MCP export, OpenAPI spec, or local tool inventory instead of relying on dynamic code discovery. |
+| `shipgate.yaml` still has `CHANGE_ME` | Replace `agent.name` and `agent.declared_purpose` from prompt, main agent file, or README context before scanning. |
+| Install fails in an older project environment | Agents Shipgate requires Python 3.12+. Install with `pipx` or `uv` using a Python 3.12+ interpreter. |
+| Reports show up as untracked files | Add `agents-shipgate-reports/` to `.gitignore`; do not commit reports by default. |
+
 ## `doctor` Shows Zero Tools
 
 Common causes:

--- a/examples/golden-prs/README.md
+++ b/examples/golden-prs/README.md
@@ -1,0 +1,21 @@
+# Golden PR Examples
+
+These examples show the full advisory loop a human reviewer or coding agent
+should imitate:
+
+1. Identify a risky tool surface.
+2. Run Agents Shipgate.
+3. Read `agents-shipgate-reports/report.json`.
+4. Use `release_decision.decision`.
+5. Separate safe patches from human release decisions.
+6. Post an advisory PR summary.
+
+Examples:
+
+- [`openai-agents-sdk-refund-agent`](openai-agents-sdk-refund-agent/) - SDK
+  Python tools plus OpenAPI support tools.
+- [`mcp-only-tool-server`](mcp-only-tool-server/) - MCP inventory/export only.
+- [`openapi-support-agent`](openapi-support-agent/) - OpenAPI support/refund
+  API surface.
+
+These are documentation examples, not new framework adapters.

--- a/examples/golden-prs/README.md
+++ b/examples/golden-prs/README.md
@@ -8,7 +8,7 @@ should imitate:
 3. Read `agents-shipgate-reports/report.json`.
 4. Use `release_decision.decision`.
 5. Separate safe patches from human release decisions.
-6. Post an advisory PR summary.
+6. Post a recommended coding-agent PR summary.
 
 Examples:
 

--- a/examples/golden-prs/mcp-only-tool-server/README.md
+++ b/examples/golden-prs/mcp-only-tool-server/README.md
@@ -1,0 +1,62 @@
+# Golden PR: MCP-Only Tool Server
+
+Reference sample: [`samples/support_refund_agent/.agents-shipgate/mcp-tools.json`](../../../samples/support_refund_agent/.agents-shipgate/mcp-tools.json).
+
+## Initial Risky Surface
+
+The repo exposes an MCP tool inventory without Python framework code. In this
+shape, `detect --json` may report `is_agent_project: false`, but
+`suggested_sources` should still be treated as a valid Shipgate onboarding
+signal.
+
+## Commands
+
+```bash
+agents-shipgate detect --workspace . --json
+agents-shipgate init --workspace . --write --ci --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+```
+
+Then read:
+
+```bash
+agents-shipgate-reports/report.json
+```
+
+## Release Decision
+
+Use `release_decision.decision` from JSON. Do not scrape Markdown or infer
+release status from severity counts alone.
+
+## Top Findings To Expect
+
+Depending on the inventory, likely findings include:
+
+- missing tool descriptions
+- missing auth scopes
+- missing approval or confirmation policy for side-effecting tools
+- missing idempotency evidence for retryable writes
+
+## Safe Patch vs Human-Review Boundary
+
+Safe patches are limited to high-confidence mechanical manifest cleanup.
+
+Do not auto-invent MCP scopes, approval policies, or idempotency guarantees.
+Those are release decisions that must come from the tool owner.
+
+## Advisory PR Comment Shape
+
+```md
+## Agents Shipgate
+
+Release decision: `<blocked|review_required|passed>`
+Blockers: <n>
+Review items: <n>
+
+MCP-only note:
+- This repo can be a valid Shipgate target even without Python framework detection.
+- Review `suggested_sources` from `detect --json` and `tool_sources` in `shipgate.yaml`.
+
+Human review:
+- Confirm auth scopes and control policies for side-effecting MCP tools.
+```

--- a/examples/golden-prs/mcp-only-tool-server/README.md
+++ b/examples/golden-prs/mcp-only-tool-server/README.md
@@ -44,7 +44,7 @@ Safe patches are limited to high-confidence mechanical manifest cleanup.
 Do not auto-invent MCP scopes, approval policies, or idempotency guarantees.
 Those are release decisions that must come from the tool owner.
 
-## Advisory PR Comment Shape
+## Recommended Agent PR Summary
 
 ```md
 ## Agents Shipgate

--- a/examples/golden-prs/openai-agents-sdk-refund-agent/README.md
+++ b/examples/golden-prs/openai-agents-sdk-refund-agent/README.md
@@ -30,10 +30,13 @@ Expected advisory summary:
 - Review items: 16
 - Fail policy: advisory mode does not fail CI
 
-## Top Findings
+## Blockers
 
 - `SHIP-POLICY-APPROVAL-MISSING` on `stripe.create_refund`
 - `SHIP-SIDEFX-IDEMPOTENCY-MISSING` on `stripe.create_refund`
+
+## Top Review Items
+
 - `SHIP-AUTH-MANIFEST-BROAD-SCOPE` on manifest scopes
 
 ## Safe Patch vs Human-Review Boundary
@@ -45,7 +48,7 @@ Do not auto-add approval, confirmation, or idempotency evidence. A human owner
 must decide whether the runtime approval gate exists, how it is enforced, and
 which evidence belongs in `shipgate.yaml`.
 
-## Advisory PR Comment Shape
+## Recommended Agent PR Summary
 
 ```md
 ## Agents Shipgate
@@ -59,6 +62,7 @@ Review items: 16
 Top findings:
 1. `SHIP-POLICY-APPROVAL-MISSING` - `stripe.create_refund` needs approval policy evidence.
 2. `SHIP-SIDEFX-IDEMPOTENCY-MISSING` - `stripe.create_refund` needs idempotency evidence.
+3. `SHIP-AUTH-MANIFEST-BROAD-SCOPE` - review manifest scopes before promotion.
 
 Autofix:
 - Applied: 0

--- a/examples/golden-prs/openai-agents-sdk-refund-agent/README.md
+++ b/examples/golden-prs/openai-agents-sdk-refund-agent/README.md
@@ -1,0 +1,66 @@
+# Golden PR: OpenAI Agents SDK Refund Agent
+
+Reference sample: [`samples/support_refund_agent`](../../../samples/support_refund_agent/).
+
+## Initial Risky Surface
+
+The agent includes an SDK entrypoint and release tool sources for support
+refund work. The risky release path includes `stripe.create_refund`, which can
+create an external financial side effect.
+
+## Commands
+
+```bash
+agents-shipgate scan -c samples/support_refund_agent/shipgate.yaml \
+  --suggest-patches --format json
+```
+
+Then read:
+
+```bash
+agents-shipgate-reports/report.json
+```
+
+## Release Decision
+
+Expected advisory summary:
+
+- Decision: `blocked`
+- Blockers: 2
+- Review items: 16
+- Fail policy: advisory mode does not fail CI
+
+## Top Findings
+
+- `SHIP-POLICY-APPROVAL-MISSING` on `stripe.create_refund`
+- `SHIP-SIDEFX-IDEMPOTENCY-MISSING` on `stripe.create_refund`
+- `SHIP-AUTH-MANIFEST-BROAD-SCOPE` on manifest scopes
+
+## Safe Patch vs Human-Review Boundary
+
+Safe patches may clean stale manifest entries when the report marks them
+high-confidence and non-manual.
+
+Do not auto-add approval, confirmation, or idempotency evidence. A human owner
+must decide whether the runtime approval gate exists, how it is enforced, and
+which evidence belongs in `shipgate.yaml`.
+
+## Advisory PR Comment Shape
+
+```md
+## Agents Shipgate
+
+Release decision: `blocked`
+Reason: 2 active findings block release.
+
+Blockers: 2
+Review items: 16
+
+Top findings:
+1. `SHIP-POLICY-APPROVAL-MISSING` - `stripe.create_refund` needs approval policy evidence.
+2. `SHIP-SIDEFX-IDEMPOTENCY-MISSING` - `stripe.create_refund` needs idempotency evidence.
+
+Autofix:
+- Applied: 0
+- Human review required: approval and idempotency controls.
+```

--- a/examples/golden-prs/openapi-support-agent/README.md
+++ b/examples/golden-prs/openapi-support-agent/README.md
@@ -1,0 +1,59 @@
+# Golden PR: OpenAPI Support Agent
+
+Reference sample: [`samples/support_refund_agent/specs/support-tools.openapi.yaml`](../../../samples/support_refund_agent/specs/support-tools.openapi.yaml).
+
+## Initial Risky Surface
+
+The agent calls support/refund APIs described by OpenAPI. The risky path is a
+POST operation that creates a payment refund.
+
+## Commands
+
+```bash
+agents-shipgate scan -c samples/support_refund_agent/shipgate.yaml \
+  --suggest-patches --format json
+```
+
+Then read:
+
+```bash
+agents-shipgate-reports/report.json
+```
+
+## Release Decision
+
+Expected advisory summary when using the support refund sample:
+
+- Decision: `blocked`
+- Blockers: 2
+- Review items: 16
+
+## Top Findings
+
+- `SHIP-SCHEMA-MISSING-BOUNDS` when refund amount lacks a maximum.
+- `SHIP-AUTH-SCOPE-COVERAGE-MISSING` when operation scopes are not covered by the manifest.
+- `SHIP-POLICY-APPROVAL-MISSING` when refund creation lacks approval evidence.
+- `SHIP-SIDEFX-IDEMPOTENCY-MISSING` when retryable writes lack idempotency evidence.
+
+## Safe Patch vs Human-Review Boundary
+
+Schema bounds can often be fixed in the OpenAPI spec by the API owner.
+
+Approval, confirmation, broad-scope, prohibited-action, and idempotency
+findings are human release decisions. The agent may explain the finding and
+point to the relevant operation, but it must not assert a control exists.
+
+## Advisory PR Comment Shape
+
+```md
+## Agents Shipgate
+
+Release decision: `blocked`
+Blockers: 2
+Review items: 16
+
+OpenAPI focus:
+- Add explicit amount bounds to refund parameters.
+- Align operation scopes with `permissions.scopes`.
+- Provide approval and idempotency evidence before promotion.
+```

--- a/examples/golden-prs/openapi-support-agent/README.md
+++ b/examples/golden-prs/openapi-support-agent/README.md
@@ -43,7 +43,7 @@ Approval, confirmation, broad-scope, prohibited-action, and idempotency
 findings are human release decisions. The agent may explain the finding and
 point to the relevant operation, but it must not assert a control exists.
 
-## Advisory PR Comment Shape
+## Recommended Agent PR Summary
 
 ```md
 ## Agents Shipgate

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -1,7 +1,7 @@
 """Docs link integrity tests for the v0.7 agent-facing docs surface.
 
-Per the v0.7 plan §3 verification:
-- The three agent-facing docs exist on disk.
+Per the agent-facing docs verification:
+- The agent-facing docs exist on disk.
 - Each is linked from `docs/INDEX.md` so agents walking the index can
   find them.
 - Internal links inside the agent-facing docs resolve to files that
@@ -22,8 +22,10 @@ INDEX_MD = DOCS_DIR / "INDEX.md"
 
 AGENT_FACING_DOCS = (
     "agent-recipes.md",
+    "agent-adoption-harness.md",
     "autofix-policy.md",
     "minimal-real-configs.md",
+    "target-repo-agent-snippets.md",
 )
 
 
@@ -83,6 +85,57 @@ def test_trust_model_documents_bounded_git_discovery_exception():
     assert "`rev-parse` and `ls-files`" in text
     assert "does not contact remotes" in text
     assert "run framework CLIs" in text
+
+
+def test_target_repo_snippets_pin_advisory_agent_contract():
+    text = (DOCS_DIR / "target-repo-agent-snippets.md").read_text(encoding="utf-8")
+    assert "release_decision.decision" in text
+    assert "agents-shipgate-reports/report.json" in text
+    assert "ci_mode: advisory" in text
+    assert 'pr_comment: "true"' in text
+    assert "apply-patches" in text
+    assert "--confidence high --apply" in text
+    assert "Do not auto-assert approval" in text
+    assert "confirmation" in text
+    assert "idempotency" in text
+    assert "broad-scope" in text
+    assert "prohibited-action" in text
+    assert "pure docs, tests, formatting" in text
+
+
+def test_agent_adoption_harness_is_manual_and_keeps_results_private():
+    text = (DOCS_DIR / "agent-adoption-harness.md").read_text(encoding="utf-8")
+    assert "Do not automate calls" in text
+    assert ".agents-private/adoption-sprint/" in text
+    assert "100-Point Rubric" in text
+    assert "negative-control non-agent repo" in text
+    assert "release_decision.decision" in text
+
+
+def test_golden_pr_examples_exist_and_reference_real_samples():
+    root = REPO_ROOT / "examples" / "golden-prs"
+    expected = {
+        "openai-agents-sdk-refund-agent": REPO_ROOT / "samples" / "support_refund_agent",
+        "mcp-only-tool-server": REPO_ROOT
+        / "samples"
+        / "support_refund_agent"
+        / ".agents-shipgate"
+        / "mcp-tools.json",
+        "openapi-support-agent": REPO_ROOT
+        / "samples"
+        / "support_refund_agent"
+        / "specs"
+        / "support-tools.openapi.yaml",
+    }
+    assert (root / "README.md").is_file()
+    for dirname, sample_path in expected.items():
+        readme = root / dirname / "README.md"
+        assert readme.is_file(), f"Missing golden PR README: {readme}"
+        assert sample_path.exists(), f"Golden PR sample reference is missing: {sample_path}"
+        text = readme.read_text(encoding="utf-8").lower()
+        assert "release decision" in text
+        assert "human" in text
+        assert "pr comment" in text
 
 
 def test_agent_recipes_internal_links_resolve():

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -19,6 +19,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_DIR = REPO_ROOT / "docs"
 INDEX_MD = DOCS_DIR / "INDEX.md"
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)#:][^)#]*)(?:#[^)]*)?\)")
 
 AGENT_FACING_DOCS = (
     "agent-recipes.md",
@@ -27,6 +28,25 @@ AGENT_FACING_DOCS = (
     "minimal-real-configs.md",
     "target-repo-agent-snippets.md",
 )
+
+ADOPTION_DOCS_WITH_LINKS = (
+    DOCS_DIR / "target-repo-agent-snippets.md",
+    DOCS_DIR / "agent-adoption-harness.md",
+    REPO_ROOT / "examples" / "golden-prs" / "README.md",
+    REPO_ROOT / "examples" / "golden-prs" / "openai-agents-sdk-refund-agent" / "README.md",
+    REPO_ROOT / "examples" / "golden-prs" / "mcp-only-tool-server" / "README.md",
+    REPO_ROOT / "examples" / "golden-prs" / "openapi-support-agent" / "README.md",
+)
+
+
+def _assert_internal_links_resolve(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    for href in LINK_RE.findall(text):
+        href = href.strip()
+        if not href or href.startswith(("http://", "https://", "mailto:")):
+            continue
+        target = (path.parent / href).resolve()
+        assert target.exists(), f"{path} links to non-existent {href} (resolved to {target})."
 
 
 def test_agent_facing_docs_exist():
@@ -46,6 +66,11 @@ def test_agent_facing_docs_linked_from_index():
             f"docs/INDEX.md must link to docs/{name}; agents walking "
             "the index would otherwise miss this v0.7 surface."
         )
+
+
+def test_gitignore_keeps_private_agent_notes_out_of_commits():
+    text = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+    assert ".agents-private/" in text
 
 
 def test_index_no_longer_references_v05_schema():
@@ -103,10 +128,22 @@ def test_target_repo_snippets_pin_advisory_agent_contract():
     assert "pure docs, tests, formatting" in text
 
 
+def test_target_repo_cursor_globs_cover_shipgate_discovery_names():
+    text = (DOCS_DIR / "target-repo-agent-snippets.md").read_text(encoding="utf-8")
+    assert '"**/*openapi*.yaml"' in text
+    assert '"**/*openapi*.yml"' in text
+    assert '"**/*openapi*.json"' in text
+    assert '"**/*swagger*.yaml"' in text
+    assert '"**/*swagger*.yml"' in text
+    assert '"**/*swagger*.json"' in text
+    assert '"**/*mcp*.json"' in text
+
+
 def test_agent_adoption_harness_is_manual_and_keeps_results_private():
     text = (DOCS_DIR / "agent-adoption-harness.md").read_text(encoding="utf-8")
     assert "Do not automate calls" in text
     assert ".agents-private/adoption-sprint/" in text
+    assert "`.agents-private/` to `.gitignore`" in text
     assert "100-Point Rubric" in text
     assert "negative-control non-agent repo" in text
     assert "release_decision.decision" in text
@@ -135,7 +172,14 @@ def test_golden_pr_examples_exist_and_reference_real_samples():
         text = readme.read_text(encoding="utf-8").lower()
         assert "release decision" in text
         assert "human" in text
-        assert "pr comment" in text
+        assert "pr summary" in text
+        assert "advisory pr comment shape" not in text
+
+
+def test_new_adoption_docs_internal_links_resolve():
+    for path in ADOPTION_DOCS_WITH_LINKS:
+        assert path.is_file(), f"Expected adoption doc to exist: {path}"
+        _assert_internal_links_resolve(path)
 
 
 def test_agent_recipes_internal_links_resolve():
@@ -143,50 +187,14 @@ def test_agent_recipes_internal_links_resolve():
     likely to grow forward references) must point at files that
     actually exist. Regression for the v0.7 PR 1 review where
     `autofix-policy.md` was linked before it shipped."""
-    text = (DOCS_DIR / "agent-recipes.md").read_text(encoding="utf-8")
-    # Match markdown links of the form [label](relative-path) where
-    # the path is local (no scheme, no anchor-only).
-    link_re = re.compile(r"\[[^\]]+\]\(([^)#:][^)#]*)(?:#[^)]*)?\)")
-    for href in link_re.findall(text):
-        href = href.strip()
-        if not href or href.startswith(("http://", "https://", "mailto:")):
-            continue
-        target = (DOCS_DIR / "agent-recipes.md").parent / href
-        target = target.resolve()
-        assert target.exists(), (
-            f"docs/agent-recipes.md links to non-existent {href} "
-            f"(resolved to {target}). Update the link or land the "
-            "missing file in the same PR."
-        )
+    _assert_internal_links_resolve(DOCS_DIR / "agent-recipes.md")
 
 
 def test_autofix_policy_internal_links_resolve():
     """Same hazard — autofix-policy.md will accumulate references over
     time. Pin them now."""
-    text = (DOCS_DIR / "autofix-policy.md").read_text(encoding="utf-8")
-    link_re = re.compile(r"\[[^\]]+\]\(([^)#:][^)#]*)(?:#[^)]*)?\)")
-    for href in link_re.findall(text):
-        href = href.strip()
-        if not href or href.startswith(("http://", "https://", "mailto:")):
-            continue
-        target = (DOCS_DIR / "autofix-policy.md").parent / href
-        target = target.resolve()
-        assert target.exists(), (
-            f"docs/autofix-policy.md links to non-existent {href} "
-            f"(resolved to {target})."
-        )
+    _assert_internal_links_resolve(DOCS_DIR / "autofix-policy.md")
 
 
 def test_minimal_real_configs_internal_links_resolve():
-    text = (DOCS_DIR / "minimal-real-configs.md").read_text(encoding="utf-8")
-    link_re = re.compile(r"\[[^\]]+\]\(([^)#:][^)#]*)(?:#[^)]*)?\)")
-    for href in link_re.findall(text):
-        href = href.strip()
-        if not href or href.startswith(("http://", "https://", "mailto:")):
-            continue
-        target = (DOCS_DIR / "minimal-real-configs.md").parent / href
-        target = target.resolve()
-        assert target.exists(), (
-            f"docs/minimal-real-configs.md links to non-existent {href} "
-            f"(resolved to {target})."
-        )
+    _assert_internal_links_resolve(DOCS_DIR / "minimal-real-configs.md")


### PR DESCRIPTION
## Summary

Implements the new P0 adoption activation package as public docs/examples, without changing CLI behavior, schemas, manifest format, or GitHub Action interfaces.

Changes:
- Adds target-repo snippets for downstream `AGENTS.md`, `CLAUDE.md`, Cursor rules, PR templates, and advisory GitHub Action setup.
- Adds a manual fresh-repo coding-agent adoption harness spec with a 100-point rubric and private scorecard template guidance.
- Adds golden PR examples for OpenAI Agents SDK, MCP-only, and OpenAPI support-agent adoption loops.
- Hardens first-real-repo guidance for MCP/OpenAPI-only detection, zero tools, dynamic toolsets, `CHANGE_ME`, Python 3.12 runtime friction, and report hygiene.
- Adds docs regression tests for the new adoption contracts and golden example references.

## Validation

- `python -m pytest tests/test_docs_links.py tests/test_prompt_parity.py tests/test_ci_recipes.py tests/test_detect.py tests/test_init_auto.py tests/test_fixture.py -q`
- `python -m pytest` (`340 passed`)
- `python -m ruff check .`

## Notes

No public API changes. Private harness run results remain under ignored `.agents-private/` paths and are not part of this PR.
