### PR TITLE
Add capability intent diff report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,7 @@ Always parse `agents-shipgate-reports/report.json`, not the markdown. Stable fie
 
 - `release_decision.{decision, reason, blockers, review_items, evidence_coverage, baseline_delta, fail_policy}` (v0.8+) — **read this first for release gating**
 - `release_decision.fail_policy.{would_fail_ci, exit_code}` matches the process exit code
+- `capability_facts[]`, `declared_intentions[]`, `misalignments[]`, `release_consequence`, and `suggested_scenarios[]` (v0.9+) — capability/intent diff for release review
 - `summary.{critical_count, high_count, medium_count, status}` (status preserved for v0.7 compat — see note below)
 - `findings[].{id, fingerprint, check_id, severity, tool_name, evidence, recommendation, suppressed}`
 - `findings[].{autofix_safe, requires_human_review, suggested_patch_kind, docs_url}` (v0.7+)
@@ -193,7 +194,7 @@ Always parse `agents-shipgate-reports/report.json`, not the markdown. Stable fie
 - `baseline.{matched_count, new_count, resolved_count}`
 - `tool_inventory[]`
 
-The full schema is at [`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) (current; emitted reports carry `report_schema_version: "0.8"`). Older reports validate against [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) (frozen reference). What's-stable is documented in [STABILITY.md](STABILITY.md).
+The full schema is at [`docs/report-schema.v0.9.json`](docs/report-schema.v0.9.json) (current; emitted reports carry `report_schema_version: "0.9"`). Older reports validate against [`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) (frozen reference). What's-stable is documented in [STABILITY.md](STABILITY.md).
 
 **Release gating signal**: prefer `release_decision.decision` (`"blocked" | "review_required" | "passed"`) over `summary.status`. The new field is **baseline-aware** — a baseline-matched critical surfaces in `release_decision.review_items` (accepted debt), not `release_decision.blockers`. `summary.status` stays baseline-blind for v0.7 compatibility, so a baseline-matched-only critical produces both `summary.status = "release_blockers_detected"` AND `release_decision.decision = "review_required"` (intentional divergence — see [STABILITY.md](STABILITY.md#release_decisiondecision-vs-summarystatus)).
 
@@ -246,9 +247,9 @@ validation and [`docs/manifest-v0.1.md`](docs/manifest-v0.1.md) for prose.
 ### Where is the report schema?
 
 Parse `agents-shipgate-reports/report.json` and validate against
-[`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) (current).
-Older reports (`report_schema_version: "0.7"`) validate against the
-frozen [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json).
+[`docs/report-schema.v0.9.json`](docs/report-schema.v0.9.json) (current).
+Older reports (`report_schema_version: "0.8"`) validate against the
+frozen [`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json).
 Do not scrape Markdown when JSON is available.
 
 ### How do I add a new check?
@@ -282,7 +283,8 @@ glossary: https://threemoonslab.com/glossary/.
 | What | Path | Stable |
 |---|---|---|
 | Manifest schema | [`docs/manifest-v0.1.json`](docs/manifest-v0.1.json) | `0.1` |
-| Report schema (current) | [`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) | `0.8` |
+| Report schema (current) | [`docs/report-schema.v0.9.json`](docs/report-schema.v0.9.json) | `0.9` |
+| Report schema (v0.8 frozen reference) | [`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json) | `0.8` |
 | Report schema (v0.7 frozen reference) | [`docs/report-schema.v0.7.json`](docs/report-schema.v0.7.json) | `0.7` |
 | Report schema (v0.6 frozen reference) | [`docs/report-schema.v0.6.json`](docs/report-schema.v0.6.json) | `0.6` |
 | Check catalog | [`docs/checks.json`](docs/checks.json) | regenerated each release |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Agents Shipgate is designed to be agent-friendly. If you're a coding agent (Clau
 - **[`prompts/`](prompts/)** — reusable prompts for common workflows
 - **[`skills/agents-shipgate/`](skills/agents-shipgate/)** + **[`.claude/commands/shipgate.md`](.claude/commands/shipgate.md)** — self-contained Claude Code skill (bundled prompts and CI recipe) and `/shipgate` slash command. See [`docs/agents/use-with-claude-code.md`](docs/agents/use-with-claude-code.md) to install in your own project.
 - **[`docs/ai-search-summary.md`](docs/ai-search-summary.md)** — human-readable summary for AI search, answer engines, and coding agents
-- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.8.json`](docs/report-schema.v0.8.json)** — JSON Schemas for live editor validation (current; emitted reports carry `report_schema_version: "0.8"`). v0.8 adds the required `release_decision` block — read `release_decision.decision` for release gating in new consumers.
+- **[`docs/manifest-v0.1.json`](docs/manifest-v0.1.json)** + **[`docs/report-schema.v0.9.json`](docs/report-schema.v0.9.json)** — JSON Schemas for live editor validation (current; emitted reports carry `report_schema_version: "0.9"`). v0.9 adds the capability/intent diff fields; read `release_decision.decision` for release gating in new consumers.
 - **[`docs/checks.json`](docs/checks.json)** — machine-readable check catalog
 
 Every command has a `--json` form. Errors emit a structured `next_action` line on stderr when `AGENTS_SHIPGATE_AGENT_MODE=1`.
@@ -341,7 +341,7 @@ Agents Shipgate is a static, manifest-first scanner. It is intentionally narrow:
 - It does not verify runtime behavior, latency, prompt quality, or routing decisions.
 - It does not replace dynamic security testing or human security review of the underlying systems.
 - It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, simple OpenAI API artifacts, optional SDK AST metadata, and static Google ADK/LangChain/CrewAI inputs; tools that are not declared or statically discoverable are not scanned.
-- The manifest remains `version: "0.1"` so existing configs keep working. Current reports carry `report_schema_version: "0.8"` and add the `release_decision` block while preserving the stable payload contract documented in the report schema.
+- The manifest remains `version: "0.1"` so existing configs keep working. Current reports carry `report_schema_version: "0.9"` and add the capability/intent diff fields while preserving the stable payload contract documented in the report schema.
 
 See [ROADMAP.md](ROADMAP.md) for what is planned next.
 
@@ -402,7 +402,7 @@ contact details.
 - [Check catalog](docs/checks.md)
 - [Policy packs](docs/policy-packs.md)
 - [Baseline workflow](docs/baseline.md)
-- [JSON report schema v0.8](docs/report-schema.v0.8.json)
+- [JSON report schema v0.9](docs/report-schema.v0.9.json)
 - [Trust model](docs/trust-model.md)
 - [AI search summary](docs/ai-search-summary.md)
 - [Design partners](docs/design-partners.md)

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -44,6 +44,11 @@ In `agents-shipgate-reports/report.json`, the following are guaranteed:
 - `release_decision.{decision, reason, blockers, review_items, evidence_coverage, baseline_delta, fail_policy}` (v0.8+)
 - `release_decision.fail_policy.{ci_mode, fail_on, new_findings_only, would_fail_ci, exit_code}`
 - `release_decision.blockers[].{id, fingerprint, check_id, severity, title, baseline_status}` and `release_decision.review_items[].{id, fingerprint, check_id, severity, title, baseline_status}` (reference-only — both arrays share the same item shape; full Finding payload is in `findings[]`)
+- `capability_facts[].{id, tool_name, source_type, source_ref, capability, risk_tags, auth_scopes, owner, included_reason, control_status, related_findings}` (v0.9+)
+- `declared_intentions[].{id, kind, text, source, intent_tags}` (v0.9+)
+- `misalignments[].{id, kind, severity, tool_name, capability_refs, intention_refs, finding_refs, policy_requirement, gap, release_implication}` (v0.9+)
+- `release_consequence.{decision, summary, blocker_misalignment_count, review_misalignment_count, fail_policy}` (v0.9+)
+- `suggested_scenarios[].{id, scenario_type, title, given, expected_control, source_misalignments, source_findings}` (v0.9+)
 - `summary.{critical_count, high_count, medium_count, low_count, info_count, suppressed_count, status, human_review_recommended}`
 - `findings[].{id, fingerprint, check_id, severity, category, title, recommendation, suppressed}`
 - `findings[].tool_name` (string or null)

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -127,6 +127,7 @@ The body content of these files may change to reflect new prompts; the entry-poi
 These are not stable — assume they may grow but not shrink:
 
 - **Risk-tag taxonomy.** New tags may appear (e.g. `infrastructure_change`, `code_execution`). Existing tags' meanings will not change.
+- **`capability_facts[].capability` vocabulary.** Values are an open vocabulary seeded from risk tags plus review sentinels such as `wildcard_tool_surface` and `unknown`.
 - **Report `frameworks.{name}` blocks.** New framework summaries (e.g. `frameworks.langchain`) may appear.
 - **Manifest fields.** New optional fields under existing sections.
 - **Check default severities.** May tighten over time. To pin a severity for your repo, use `checks.severity_overrides`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,7 +21,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`checks.md`](checks.md) — full check catalog (human-readable)
 - [`checks.json`](checks.json) — machine-readable check catalog (regenerated each release)
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
-- [`report-schema.v0.8.json`](report-schema.v0.8.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.8"` with the required `release_decision` block)
+- [`report-schema.v0.9.json`](report-schema.v0.9.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.9"` with the required capability/intent diff fields)
+- [`report-schema.v0.8.json`](report-schema.v0.8.json) — frozen v0.8 reference schema; pre-v0.9 reports validate against this
 - [`report-schema.v0.7.json`](report-schema.v0.7.json) — frozen v0.7 reference schema; pre-v0.8 reports validate against this
 - [`report-schema.v0.6.json`](report-schema.v0.6.json) — frozen v0.6 reference schema; pre-v0.7 reports validate against this
 - [`category.md`](category.md) — what an "agent release gate" is, in product terms

--- a/docs/ai-search-summary.md
+++ b/docs/ai-search-summary.md
@@ -84,5 +84,5 @@ shipgate, and Agents-Shipgate.
 - Agent instructions: [`../AGENTS.md`](../AGENTS.md)
 - Machine-readable summary: [`../llms.txt`](../llms.txt)
 - Discovery metadata: [`../.well-known/agents-shipgate.json`](../.well-known/agents-shipgate.json)
-- Report schema: [`report-schema.v0.8.json`](report-schema.v0.8.json)
+- Report schema: [`report-schema.v0.9.json`](report-schema.v0.9.json)
 - Check catalog: [`checks.json`](checks.json)

--- a/docs/autofix-policy.md
+++ b/docs/autofix-policy.md
@@ -198,7 +198,7 @@ from the hash so toggling `--suggest-patches` doesn't shift it.
 - [`checks.md`](checks.md) — full check catalog with rationale.
 - [`minimal-real-configs.md`](minimal-real-configs.md) — per-framework
   minimal manifests to build from.
-- [`report-schema.v0.8.json`](report-schema.v0.8.json) — current JSON
+- [`report-schema.v0.9.json`](report-schema.v0.9.json) — current JSON
   Schema for `report.json`.
 - [`AGENTS.md`](../AGENTS.md) — top-level agent instructions, install,
   trigger table.

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -37,7 +37,7 @@ fail CI.
 
 Reports keep the v0.1 payload contract and add baseline fields:
 
-- `report_schema_version: "0.8"` in current reports
+- `report_schema_version: "0.9"` in current reports
 - `baseline.path`
 - `baseline.matched_count`
 - `baseline.new_count`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -47,5 +47,5 @@ The canonical fixture writes:
 - `agents-shipgate-reports/report.sarif` when requested or when using the GitHub Action
 
 The JSON output is the stable contract for tools and coding agents. See
-[report-schema.v0.8.json](report-schema.v0.8.json) (current; emitted reports
-carry `report_schema_version: "0.8"` and include `release_decision`).
+[report-schema.v0.9.json](report-schema.v0.9.json) (current; emitted reports
+carry `report_schema_version: "0.9"` and include the capability/intent diff).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,6 +40,6 @@ surface before production-like permissions are granted.
 - [Concepts](concepts.md)
 - [Manifest v0.1](manifest-v0.1.md)
 - [Check catalog](checks.md)
-- [Report schema v0.8](report-schema.v0.8.json)
+- [Report schema v0.9](report-schema.v0.9.json)
 - [Trust model](trust-model.md)
 - [Agent instructions](../AGENTS.md)

--- a/docs/report-schema.v0.9.json
+++ b/docs/report-schema.v0.9.json
@@ -1,0 +1,1482 @@
+{
+  "$defs": {
+    "AppendPointerPatch": {
+      "additionalProperties": false,
+      "description": "Append a value to the list at a JSON pointer.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "append_pointer",
+          "default": "append_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "value",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "AppendPointerPatch",
+      "type": "object"
+    },
+    "BaselineDelta": {
+      "properties": {
+        "enabled": {
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "matched_count": {
+          "default": 0,
+          "title": "Matched Count",
+          "type": "integer"
+        },
+        "new_count": {
+          "default": 0,
+          "title": "New Count",
+          "type": "integer"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "resolved_count": {
+          "default": 0,
+          "title": "Resolved Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "matched_count",
+        "new_count",
+        "resolved_count"
+      ],
+      "title": "BaselineDelta",
+      "type": "object"
+    },
+    "BaselineSummary": {
+      "properties": {
+        "matched_count": {
+          "default": 0,
+          "title": "Matched Count",
+          "type": "integer"
+        },
+        "new_count": {
+          "default": 0,
+          "title": "New Count",
+          "type": "integer"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "resolved_count": {
+          "default": 0,
+          "title": "Resolved Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "BaselineSummary",
+      "type": "object"
+    },
+    "CapabilityFact": {
+      "properties": {
+        "auth_scopes": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Auth Scopes",
+          "type": "array"
+        },
+        "capability": {
+          "title": "Capability",
+          "type": "string"
+        },
+        "control_status": {
+          "enum": [
+            "missing",
+            "partial",
+            "present",
+            "unknown"
+          ],
+          "title": "Control Status",
+          "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "included_reason": {
+          "enum": [
+            "high_risk_tag",
+            "wildcard_exposure",
+            "referenced_by_critical_finding",
+            "referenced_by_high_finding",
+            "referenced_by_medium_finding"
+          ],
+          "title": "Included Reason",
+          "type": "string"
+        },
+        "owner": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Owner"
+        },
+        "related_findings": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Related Findings",
+          "type": "array"
+        },
+        "risk_tags": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Risk Tags",
+          "type": "array"
+        },
+        "source_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Ref"
+        },
+        "source_type": {
+          "title": "Source Type",
+          "type": "string"
+        },
+        "tool_name": {
+          "title": "Tool Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "auth_scopes",
+        "capability",
+        "control_status",
+        "id",
+        "included_reason",
+        "owner",
+        "related_findings",
+        "risk_tags",
+        "source_ref",
+        "source_type",
+        "tool_name"
+      ],
+      "title": "CapabilityFact",
+      "type": "object"
+    },
+    "DeclaredIntention": {
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "intent_tags": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Intent Tags",
+          "type": "array"
+        },
+        "kind": {
+          "enum": [
+            "declared_purpose",
+            "prohibited_action",
+            "instruction_preview"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "source": {
+          "title": "Source",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "intent_tags",
+        "kind",
+        "source",
+        "text"
+      ],
+      "title": "DeclaredIntention",
+      "type": "object"
+    },
+    "EvidenceCoverageDecision": {
+      "properties": {
+        "human_review_recommended": {
+          "title": "Human Review Recommended",
+          "type": "boolean"
+        },
+        "level": {
+          "title": "Level",
+          "type": "string"
+        },
+        "low_confidence_tool_count": {
+          "title": "Low Confidence Tool Count",
+          "type": "integer"
+        },
+        "source_warning_count": {
+          "title": "Source Warning Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "human_review_recommended",
+        "level",
+        "low_confidence_tool_count",
+        "source_warning_count"
+      ],
+      "title": "EvidenceCoverageDecision",
+      "type": "object"
+    },
+    "FailPolicy": {
+      "properties": {
+        "ci_mode": {
+          "title": "Ci Mode",
+          "type": "string"
+        },
+        "exit_code": {
+          "title": "Exit Code",
+          "type": "integer"
+        },
+        "fail_on": {
+          "items": {
+            "enum": [
+              "info",
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "type": "string"
+          },
+          "title": "Fail On",
+          "type": "array"
+        },
+        "new_findings_only": {
+          "default": false,
+          "title": "New Findings Only",
+          "type": "boolean"
+        },
+        "would_fail_ci": {
+          "title": "Would Fail Ci",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ci_mode",
+        "exit_code",
+        "fail_on",
+        "new_findings_only",
+        "would_fail_ci"
+      ],
+      "title": "FailPolicy",
+      "type": "object"
+    },
+    "Finding": {
+      "additionalProperties": true,
+      "properties": {
+        "agent_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Agent Id"
+        },
+        "autofix_safe": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Autofix Safe"
+        },
+        "baseline_status": {
+          "anyOf": [
+            {
+              "enum": [
+                "new",
+                "matched",
+                "resolved"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Baseline Status"
+        },
+        "category": {
+          "title": "Category",
+          "type": "string"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "confidence": {
+          "default": "medium",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "docs_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Docs Url"
+        },
+        "evidence": {
+          "additionalProperties": true,
+          "title": "Evidence",
+          "type": "object"
+        },
+        "fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fingerprint"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "patches": {
+          "anyOf": [
+            {
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "append_pointer": "#/$defs/AppendPointerPatch",
+                    "manual": "#/$defs/ManualPatch",
+                    "remove_pointer": "#/$defs/RemovePointerPatch",
+                    "set_pointer": "#/$defs/SetPointerPatch"
+                  },
+                  "propertyName": "kind"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/SetPointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/AppendPointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/RemovePointerPatch"
+                  },
+                  {
+                    "$ref": "#/$defs/ManualPatch"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Patches"
+        },
+        "recommendation": {
+          "title": "Recommendation",
+          "type": "string"
+        },
+        "requires_human_review": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Requires Human Review"
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "suggested_patch_kind": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Suggested Patch Kind"
+        },
+        "suppressed": {
+          "default": false,
+          "title": "Suppressed",
+          "type": "boolean"
+        },
+        "suppression_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Suppression Reason"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Id"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        }
+      },
+      "required": [
+        "baseline_status",
+        "category",
+        "check_id",
+        "confidence",
+        "evidence",
+        "fingerprint",
+        "id",
+        "recommendation",
+        "severity",
+        "suppressed",
+        "title"
+      ],
+      "title": "Finding",
+      "type": "object"
+    },
+    "LoadedPolicyPack": {
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "rule_count": {
+          "title": "Rule Count",
+          "type": "integer"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Version"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "path",
+        "rule_count"
+      ],
+      "title": "LoadedPolicyPack",
+      "type": "object"
+    },
+    "ManualPatch": {
+      "additionalProperties": false,
+      "description": "No machine-applicable change. Carries human-readable instructions.\n\nUsed for every finding whose check ID has no v0.6 non-manual generator\nand for findings (like trace flips, per C6) that are intentionally\nnever auto-patched.",
+      "properties": {
+        "instructions": {
+          "title": "Instructions",
+          "type": "string"
+        },
+        "kind": {
+          "const": "manual",
+          "default": "manual",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "instructions"
+      ],
+      "title": "ManualPatch",
+      "type": "object"
+    },
+    "Misalignment": {
+      "properties": {
+        "capability_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Capability Refs",
+          "type": "array"
+        },
+        "finding_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Finding Refs",
+          "type": "array"
+        },
+        "gap": {
+          "title": "Gap",
+          "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "intention_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Intention Refs",
+          "type": "array"
+        },
+        "kind": {
+          "enum": [
+            "policy_gap",
+            "scope_drift",
+            "prohibited_action_present",
+            "control_missing",
+            "intent_mismatch",
+            "undetected_gap"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "policy_requirement": {
+          "title": "Policy Requirement",
+          "type": "string"
+        },
+        "release_implication": {
+          "title": "Release Implication",
+          "type": "string"
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        }
+      },
+      "required": [
+        "capability_refs",
+        "finding_refs",
+        "gap",
+        "id",
+        "intention_refs",
+        "kind",
+        "policy_requirement",
+        "release_implication",
+        "severity",
+        "tool_name"
+      ],
+      "title": "Misalignment",
+      "type": "object"
+    },
+    "ReleaseConsequence": {
+      "properties": {
+        "blocker_misalignment_count": {
+          "default": 0,
+          "title": "Blocker Misalignment Count",
+          "type": "integer"
+        },
+        "decision": {
+          "enum": [
+            "blocked",
+            "review_required",
+            "passed"
+          ],
+          "title": "Decision",
+          "type": "string"
+        },
+        "fail_policy": {
+          "$ref": "#/$defs/FailPolicy"
+        },
+        "review_misalignment_count": {
+          "default": 0,
+          "title": "Review Misalignment Count",
+          "type": "integer"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blocker_misalignment_count",
+        "decision",
+        "fail_policy",
+        "review_misalignment_count",
+        "summary"
+      ],
+      "title": "ReleaseConsequence",
+      "type": "object"
+    },
+    "ReleaseDecision": {
+      "properties": {
+        "baseline_delta": {
+          "$ref": "#/$defs/BaselineDelta"
+        },
+        "blockers": {
+          "items": {
+            "$ref": "#/$defs/ReleaseDecisionItem"
+          },
+          "title": "Blockers",
+          "type": "array"
+        },
+        "decision": {
+          "enum": [
+            "blocked",
+            "review_required",
+            "passed"
+          ],
+          "title": "Decision",
+          "type": "string"
+        },
+        "evidence_coverage": {
+          "$ref": "#/$defs/EvidenceCoverageDecision"
+        },
+        "fail_policy": {
+          "$ref": "#/$defs/FailPolicy"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "review_items": {
+          "items": {
+            "$ref": "#/$defs/ReleaseDecisionItem"
+          },
+          "title": "Review Items",
+          "type": "array"
+        }
+      },
+      "required": [
+        "baseline_delta",
+        "blockers",
+        "decision",
+        "evidence_coverage",
+        "fail_policy",
+        "reason",
+        "review_items"
+      ],
+      "title": "ReleaseDecision",
+      "type": "object"
+    },
+    "ReleaseDecisionItem": {
+      "properties": {
+        "baseline_status": {
+          "anyOf": [
+            {
+              "enum": [
+                "new",
+                "matched",
+                "resolved"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Baseline Status"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fingerprint"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "baseline_status",
+        "check_id",
+        "fingerprint",
+        "id",
+        "severity",
+        "title"
+      ],
+      "title": "ReleaseDecisionItem",
+      "type": "object"
+    },
+    "RemovePointerPatch": {
+      "additionalProperties": false,
+      "description": "Remove the node at a JSON pointer.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "remove_pointer",
+          "default": "remove_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "RemovePointerPatch",
+      "type": "object"
+    },
+    "ReportSummary": {
+      "properties": {
+        "critical_count": {
+          "default": 0,
+          "title": "Critical Count",
+          "type": "integer"
+        },
+        "evidence_coverage": {
+          "default": "static",
+          "title": "Evidence Coverage",
+          "type": "string"
+        },
+        "high_count": {
+          "default": 0,
+          "title": "High Count",
+          "type": "integer"
+        },
+        "human_review_recommended": {
+          "default": false,
+          "title": "Human Review Recommended",
+          "type": "boolean"
+        },
+        "info_count": {
+          "default": 0,
+          "title": "Info Count",
+          "type": "integer"
+        },
+        "low_count": {
+          "default": 0,
+          "title": "Low Count",
+          "type": "integer"
+        },
+        "medium_count": {
+          "default": 0,
+          "title": "Medium Count",
+          "type": "integer"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        },
+        "suppressed_count": {
+          "default": 0,
+          "title": "Suppressed Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "title": "ReportSummary",
+      "type": "object"
+    },
+    "SetPointerPatch": {
+      "additionalProperties": false,
+      "description": "Set the value at a JSON pointer inside a YAML or JSON file.",
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "kind": {
+          "const": "set_pointer",
+          "default": "set_pointer",
+          "title": "Kind",
+          "type": "string"
+        },
+        "pointer": {
+          "title": "Pointer",
+          "type": "string"
+        },
+        "rationale": {
+          "title": "Rationale",
+          "type": "string"
+        },
+        "target_file": {
+          "title": "Target File",
+          "type": "string"
+        },
+        "target_format": {
+          "enum": [
+            "yaml",
+            "json"
+          ],
+          "title": "Target Format",
+          "type": "string"
+        },
+        "target_sha256": {
+          "title": "Target Sha256",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value"
+        }
+      },
+      "required": [
+        "target_file",
+        "pointer",
+        "value",
+        "target_format",
+        "confidence",
+        "rationale",
+        "target_sha256"
+      ],
+      "title": "SetPointerPatch",
+      "type": "object"
+    },
+    "SourceReference": {
+      "additionalProperties": true,
+      "properties": {
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ref"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "SourceReference",
+      "type": "object"
+    },
+    "SuggestedScenario": {
+      "properties": {
+        "expected_control": {
+          "title": "Expected Control",
+          "type": "string"
+        },
+        "given": {
+          "title": "Given",
+          "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "scenario_type": {
+          "enum": [
+            "approval",
+            "confirmation",
+            "idempotency_retry",
+            "least_privilege_scope",
+            "prohibited_action",
+            "wildcard_inventory",
+            "schema_boundary",
+            "prompt_scope_alignment",
+            "test_case_coverage"
+          ],
+          "title": "Scenario Type",
+          "type": "string"
+        },
+        "source_findings": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Source Findings",
+          "type": "array"
+        },
+        "source_misalignments": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Source Misalignments",
+          "type": "array"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expected_control",
+        "given",
+        "id",
+        "scenario_type",
+        "source_findings",
+        "source_misalignments",
+        "title"
+      ],
+      "title": "SuggestedScenario",
+      "type": "object"
+    },
+    "ToolSurfaceSummary": {
+      "properties": {
+        "high_risk_tools": {
+          "title": "High Risk Tools",
+          "type": "integer"
+        },
+        "missing_descriptions": {
+          "default": 0,
+          "title": "Missing Descriptions",
+          "type": "integer"
+        },
+        "sources": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Sources",
+          "type": "object"
+        },
+        "total_tools": {
+          "title": "Total Tools",
+          "type": "integer"
+        },
+        "wildcard_tools": {
+          "default": 0,
+          "title": "Wildcard Tools",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "total_tools",
+        "high_risk_tools"
+      ],
+      "title": "ToolSurfaceSummary",
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/report-schema.v0.9.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "JSON Schema for the Agents Shipgate Tool-Use Readiness Report. Generated from agents_shipgate.core.models.ReadinessReport with post-processing to preserve the v0.5 public contract. Do not edit by hand.",
+  "properties": {
+    "agent": {
+      "additionalProperties": true,
+      "title": "Agent",
+      "type": "object"
+    },
+    "anthropic_surface": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Anthropic Surface"
+    },
+    "api_surface": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Api Surface"
+    },
+    "baseline": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaselineSummary"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "capability_facts": {
+      "items": {
+        "$ref": "#/$defs/CapabilityFact"
+      },
+      "title": "Capability Facts",
+      "type": "array"
+    },
+    "declared_intentions": {
+      "items": {
+        "$ref": "#/$defs/DeclaredIntention"
+      },
+      "title": "Declared Intentions",
+      "type": "array"
+    },
+    "environment": {
+      "additionalProperties": true,
+      "title": "Environment",
+      "type": "object"
+    },
+    "findings": {
+      "items": {
+        "$ref": "#/$defs/Finding"
+      },
+      "title": "Findings",
+      "type": "array"
+    },
+    "frameworks": {
+      "additionalProperties": true,
+      "properties": {
+        "crewai": {
+          "additionalProperties": true,
+          "required": [
+            "agent_count",
+            "class_tool_count",
+            "crew_count",
+            "dynamic_tool_surface_count",
+            "function_tool_count",
+            "prebuilt_tool_count",
+            "python_entrypoint_count",
+            "tool_inventory_file_count",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "google_adk": {
+          "additionalProperties": true,
+          "required": [
+            "agent_config_count",
+            "agent_count",
+            "callback_count",
+            "dynamic_toolset_count",
+            "eval_file_count",
+            "function_tool_count",
+            "long_running_tool_count",
+            "plugin_count",
+            "python_entrypoint_count",
+            "sub_agent_count",
+            "tool_inventory_file_count",
+            "toolset_count",
+            "trace_sample_count",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "langchain": {
+          "additionalProperties": true,
+          "required": [
+            "agent_tool_binding_count",
+            "dynamic_tool_surface_count",
+            "function_tool_count",
+            "python_entrypoint_count",
+            "structured_tool_count",
+            "tool_inventory_file_count",
+            "tool_node_count",
+            "warnings"
+          ],
+          "type": "object"
+        }
+      },
+      "title": "Frameworks",
+      "type": "object"
+    },
+    "generated_reports": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Generated Reports",
+      "type": "object"
+    },
+    "loaded_plugins": {
+      "items": {
+        "additionalProperties": true,
+        "required": [
+          "check_id",
+          "distribution",
+          "name",
+          "value",
+          "version"
+        ],
+        "type": "object"
+      },
+      "title": "Loaded Plugins",
+      "type": "array"
+    },
+    "loaded_policy_packs": {
+      "items": {
+        "$ref": "#/$defs/LoadedPolicyPack"
+      },
+      "title": "Loaded Policy Packs",
+      "type": "array"
+    },
+    "manifest_dir": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Manifest Dir"
+    },
+    "misalignments": {
+      "items": {
+        "$ref": "#/$defs/Misalignment"
+      },
+      "title": "Misalignments",
+      "type": "array"
+    },
+    "project": {
+      "additionalProperties": true,
+      "title": "Project",
+      "type": "object"
+    },
+    "recommended_actions": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Recommended Actions",
+      "type": "array"
+    },
+    "release_consequence": {
+      "$ref": "#/$defs/ReleaseConsequence"
+    },
+    "release_decision": {
+      "$ref": "#/$defs/ReleaseDecision"
+    },
+    "report_schema_version": {
+      "const": "0.9"
+    },
+    "run_id": {
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "0.1"
+    },
+    "source_warnings": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Source Warnings",
+      "type": "array"
+    },
+    "suggested_scenarios": {
+      "items": {
+        "$ref": "#/$defs/SuggestedScenario"
+      },
+      "title": "Suggested Scenarios",
+      "type": "array"
+    },
+    "summary": {
+      "$ref": "#/$defs/ReportSummary"
+    },
+    "tool_inventory": {
+      "items": {
+        "additionalProperties": true,
+        "required": [
+          "auth_scopes",
+          "confidence",
+          "name",
+          "risk_tags",
+          "source_type"
+        ],
+        "type": "object"
+      },
+      "title": "Tool Inventory",
+      "type": "array"
+    },
+    "tool_surface": {
+      "$ref": "#/$defs/ToolSurfaceSummary"
+    }
+  },
+  "required": [
+    "agent",
+    "capability_facts",
+    "declared_intentions",
+    "environment",
+    "findings",
+    "frameworks",
+    "generated_reports",
+    "loaded_plugins",
+    "loaded_policy_packs",
+    "misalignments",
+    "project",
+    "recommended_actions",
+    "release_consequence",
+    "release_decision",
+    "report_schema_version",
+    "run_id",
+    "schema_version",
+    "source_warnings",
+    "suggested_scenarios",
+    "summary",
+    "tool_inventory",
+    "tool_surface"
+  ],
+  "title": "Agents Shipgate Readiness Report v0.9",
+  "type": "object"
+}

--- a/samples/simple_crewai_agent/expected/report.json
+++ b/samples/simple_crewai_agent/expected/report.json
@@ -85,13 +85,11 @@
   "capability_facts": [],
   "declared_intentions": [
     {
-      "id": "int_22f9d1520e437d19",
+      "id": "int_1e66352dfe9cac9f",
       "kind": "declared_purpose",
       "text": "look up and summarize read-only support case metadata",
       "source": "agent.declared_purpose",
-      "intent_tags": [
-        "read_only"
-      ]
+      "intent_tags": []
     }
   ],
   "misalignments": [],

--- a/samples/simple_crewai_agent/expected/report.json
+++ b/samples/simple_crewai_agent/expected/report.json
@@ -95,7 +95,7 @@
   "misalignments": [],
   "release_consequence": {
     "decision": "review_required",
-    "summary": "0 capability/intent misalignment(s) require release review before shipping.",
+    "summary": "0 release-relevant finding(s) require release review before shipping.",
     "blocker_misalignment_count": 0,
     "review_misalignment_count": 0,
     "fail_policy": {

--- a/samples/simple_crewai_agent/expected/report.json
+++ b/samples/simple_crewai_agent/expected/report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.8",
+  "report_schema_version": "0.9",
   "run_id": "agents_shipgate_1c4577c21998a147",
   "manifest_dir": "<REPO>/samples/simple_crewai_agent",
   "project": {
@@ -82,6 +82,33 @@
       "exit_code": 0
     }
   },
+  "capability_facts": [],
+  "declared_intentions": [
+    {
+      "id": "int_22f9d1520e437d19",
+      "kind": "declared_purpose",
+      "text": "look up and summarize read-only support case metadata",
+      "source": "agent.declared_purpose",
+      "intent_tags": [
+        "read_only"
+      ]
+    }
+  ],
+  "misalignments": [],
+  "release_consequence": {
+    "decision": "review_required",
+    "summary": "0 capability/intent misalignment(s) require release review before shipping.",
+    "blocker_misalignment_count": 0,
+    "review_misalignment_count": 0,
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
+  "suggested_scenarios": [],
   "tool_surface": {
     "total_tools": 3,
     "high_risk_tools": 0,
@@ -114,7 +141,8 @@
   "findings": [],
   "recommended_actions": [],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpca_apmad/report.json"
+    "markdown": "<TMP>/report.md",
+    "json": "<TMP>/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_crewai_agent/expected/report.md
+++ b/samples/simple_crewai_agent/expected/report.md
@@ -32,6 +32,10 @@ Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fa
 
 No critical or high findings.
 
+## Capability <-> Intent Diff
+
+No capability/intent misalignments detected from static evidence.
+
 ## Recommended Next Actions
 
 No action required from static findings.

--- a/samples/simple_langchain_agent/expected/report.json
+++ b/samples/simple_langchain_agent/expected/report.json
@@ -94,7 +94,7 @@
   "misalignments": [],
   "release_consequence": {
     "decision": "review_required",
-    "summary": "0 capability/intent misalignment(s) require release review before shipping.",
+    "summary": "0 release-relevant finding(s) require release review before shipping.",
     "blocker_misalignment_count": 0,
     "review_misalignment_count": 0,
     "fail_policy": {

--- a/samples/simple_langchain_agent/expected/report.json
+++ b/samples/simple_langchain_agent/expected/report.json
@@ -84,13 +84,11 @@
   "capability_facts": [],
   "declared_intentions": [
     {
-      "id": "int_22f9d1520e437d19",
+      "id": "int_1e66352dfe9cac9f",
       "kind": "declared_purpose",
       "text": "look up and summarize read-only support case metadata",
       "source": "agent.declared_purpose",
-      "intent_tags": [
-        "read_only"
-      ]
+      "intent_tags": []
     }
   ],
   "misalignments": [],

--- a/samples/simple_langchain_agent/expected/report.json
+++ b/samples/simple_langchain_agent/expected/report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.8",
+  "report_schema_version": "0.9",
   "run_id": "agents_shipgate_09ab0114a3ecb63a",
   "manifest_dir": "<REPO>/samples/simple_langchain_agent",
   "project": {
@@ -81,6 +81,33 @@
       "exit_code": 0
     }
   },
+  "capability_facts": [],
+  "declared_intentions": [
+    {
+      "id": "int_22f9d1520e437d19",
+      "kind": "declared_purpose",
+      "text": "look up and summarize read-only support case metadata",
+      "source": "agent.declared_purpose",
+      "intent_tags": [
+        "read_only"
+      ]
+    }
+  ],
+  "misalignments": [],
+  "release_consequence": {
+    "decision": "review_required",
+    "summary": "0 capability/intent misalignment(s) require release review before shipping.",
+    "blocker_misalignment_count": 0,
+    "review_misalignment_count": 0,
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
+  "suggested_scenarios": [],
   "tool_surface": {
     "total_tools": 2,
     "high_risk_tools": 0,
@@ -109,7 +136,8 @@
   "findings": [],
   "recommended_actions": [],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpzx40if7x/report.json"
+    "markdown": "<TMP>/report.md",
+    "json": "<TMP>/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_langchain_agent/expected/report.md
+++ b/samples/simple_langchain_agent/expected/report.md
@@ -32,6 +32,10 @@ Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fa
 
 No critical or high findings.
 
+## Capability <-> Intent Diff
+
+No capability/intent misalignments detected from static evidence.
+
 ## Recommended Next Actions
 
 No action required from static findings.

--- a/samples/simple_openai_api_agent/expected/report.json
+++ b/samples/simple_openai_api_agent/expected/report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.8",
+  "report_schema_version": "0.9",
   "run_id": "agents_shipgate_d07e1421099084ae",
   "manifest_dir": "<REPO>/samples/simple_openai_api_agent",
   "project": {
@@ -244,6 +244,671 @@
       "exit_code": 0
     }
   },
+  "capability_facts": [
+    {
+      "id": "cap_1936b581aee1c411",
+      "tool_name": "create_refund",
+      "source_type": "openai_api",
+      "source_ref": "tools/openai-tools.json#0",
+      "capability": "financial_action",
+      "risk_tags": [
+        "financial_action",
+        "write"
+      ],
+      "auth_scopes": [],
+      "owner": null,
+      "included_reason": "referenced_by_high_finding",
+      "control_status": "missing",
+      "related_findings": [
+        "fp_1b64e136ace3472a_dacf6678",
+        "fp_1b64e136ace3472a_fe9f9e46",
+        "fp_245bcdb96d8220e2",
+        "fp_28483a22a9ed40cb",
+        "fp_2bf957380e89863f",
+        "fp_58b3202c0a4d9793",
+        "fp_9675d1799680d81d",
+        "fp_a8a615b5a4f2597b",
+        "fp_b8df99c94ef3aa60",
+        "fp_c2d773062468ceac",
+        "fp_d9059d0c1f3540af",
+        "fp_e9d63903757dfe07"
+      ]
+    },
+    {
+      "id": "cap_e809417ee4da1160",
+      "tool_name": "send_customer_email",
+      "source_type": "openai_api",
+      "source_ref": "tools/openai-tools.json#1",
+      "capability": "external_write",
+      "risk_tags": [
+        "customer_communication",
+        "external_write",
+        "write"
+      ],
+      "auth_scopes": [],
+      "owner": null,
+      "included_reason": "referenced_by_high_finding",
+      "control_status": "missing",
+      "related_findings": [
+        "fp_07538ba8f9532359",
+        "fp_1b64e136ace3472a_dacf6678",
+        "fp_1b64e136ace3472a_fe9f9e46",
+        "fp_28483a22a9ed40cb",
+        "fp_29e718b3bbde0e7d",
+        "fp_4466eb2871434dc5",
+        "fp_45ef3ff3ce2cf187",
+        "fp_a95adeb6338f8b3e",
+        "fp_cf260ff7c72d64b7",
+        "fp_efb42c5b5aea7be6"
+      ]
+    }
+  ],
+  "declared_intentions": [
+    {
+      "id": "int_495832988b7014f6",
+      "kind": "prohibited_action",
+      "text": "send customer email without confirmation",
+      "source": "agent.prohibited_actions",
+      "intent_tags": [
+        "external_write",
+        "customer_communication",
+        "write"
+      ]
+    },
+    {
+      "id": "int_8e0b56f5f01971bd",
+      "kind": "prohibited_action",
+      "text": "issue refund without approval",
+      "source": "agent.prohibited_actions",
+      "intent_tags": [
+        "financial_action",
+        "write"
+      ]
+    },
+    {
+      "id": "int_788db5032dd9f920",
+      "kind": "instruction_preview",
+      "text": "You are a support refund assistant.\n\nYou should only advise the support representative and prepare a draft response. Do not take action on the customer's account.",
+      "source": "openai_api_prompt_files",
+      "intent_tags": [
+        "financial_action"
+      ]
+    }
+  ],
+  "misalignments": [
+    {
+      "id": "mis_0994ddaf63489d62",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_e9d63903757dfe07"
+      ],
+      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
+      "gap": "create_refund lacks idempotency evidence.",
+      "release_implication": "Retries could duplicate financial, destructive, or external effects."
+    },
+    {
+      "id": "mis_4e9c8774ba1dae34",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_d9059d0c1f3540af"
+      ],
+      "policy_requirement": "Manifest metadata must match the active release surface.",
+      "gap": "create_refund is high-risk but has no owner.",
+      "release_implication": "Release review metadata is incomplete or stale."
+    },
+    {
+      "id": "mis_6108cd9658bdc665",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_c2d773062468ceac"
+      ],
+      "policy_requirement": "Risky numeric parameters must declare a maximum or equivalent limit.",
+      "gap": "create_refund.amount has no maximum bound.",
+      "release_implication": "Release reviewers cannot verify blast-radius limits."
+    },
+    {
+      "id": "mis_7a5ca93c06205292",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_9675d1799680d81d"
+      ],
+      "policy_requirement": "API function schemas must be strict enough for reliable tool calls.",
+      "gap": "create_refund function schema is not strict enough.",
+      "release_implication": "The model may send ambiguous or overbroad tool arguments."
+    },
+    {
+      "id": "mis_3ea7f33003a90845",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_4466eb2871434dc5"
+      ],
+      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
+      "gap": "send_customer_email lacks idempotency evidence.",
+      "release_implication": "Retries could duplicate financial, destructive, or external effects."
+    },
+    {
+      "id": "mis_49c9adfcf549bc49",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_29e718b3bbde0e7d"
+      ],
+      "policy_requirement": "API function schemas must be strict enough for reliable tool calls.",
+      "gap": "send_customer_email function schema is not strict enough.",
+      "release_implication": "The model may send ambiguous or overbroad tool arguments."
+    },
+    {
+      "id": "mis_4f14842e2bbd75d5",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_07538ba8f9532359"
+      ],
+      "policy_requirement": "Action-like tool inputs must constrain high-blast-radius fields.",
+      "gap": "send_customer_email accepts broad free-form action input.",
+      "release_implication": "Release reviewers cannot bound the operation payload safely."
+    },
+    {
+      "id": "mis_e4d84cc22a57dce6",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_a95adeb6338f8b3e"
+      ],
+      "policy_requirement": "Manifest metadata must match the active release surface.",
+      "gap": "send_customer_email is high-risk but has no owner.",
+      "release_implication": "Release review metadata is incomplete or stale."
+    },
+    {
+      "id": "mis_73452c83242300c0",
+      "kind": "intent_mismatch",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_1b64e136ace3472a_dacf6678"
+      ],
+      "policy_requirement": "Prompt scope must align with enabled high-risk tools.",
+      "gap": "Prompt says read-only or advise-only while write/high-risk tools are enabled.",
+      "release_implication": "The agent instructions and actual tool surface disagree."
+    },
+    {
+      "id": "mis_1dd6581e7b2546d8",
+      "kind": "intent_mismatch",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_1b64e136ace3472a_dacf6678"
+      ],
+      "policy_requirement": "Prompt scope must align with enabled high-risk tools.",
+      "gap": "Prompt says read-only or advise-only while write/high-risk tools are enabled.",
+      "release_implication": "The agent instructions and actual tool surface disagree."
+    },
+    {
+      "id": "mis_74f922df9418d364",
+      "kind": "prohibited_action_present",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_a8a615b5a4f2597b"
+      ],
+      "policy_requirement": "Prohibited actions must not be contradicted by enabled capabilities.",
+      "gap": "create_refund appears to overlap with a prohibited action.",
+      "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
+    },
+    {
+      "id": "mis_6d584cf0a0f075ce",
+      "kind": "prohibited_action_present",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_cf260ff7c72d64b7"
+      ],
+      "policy_requirement": "Prohibited actions must not be contradicted by enabled capabilities.",
+      "gap": "send_customer_email appears to overlap with a prohibited action.",
+      "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
+    },
+    {
+      "id": "mis_2192a08ed2c08bea",
+      "kind": "scope_drift",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_58b3202c0a4d9793"
+      ],
+      "policy_requirement": "Scope-requiring tools must declare operation-specific auth scopes.",
+      "gap": "create_refund lacks declared auth scopes.",
+      "release_implication": "Release reviewers cannot assess least privilege."
+    },
+    {
+      "id": "mis_741fc769ae988e35",
+      "kind": "scope_drift",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_45ef3ff3ce2cf187"
+      ],
+      "policy_requirement": "Scope-requiring tools must declare operation-specific auth scopes.",
+      "gap": "send_customer_email lacks declared auth scopes.",
+      "release_implication": "Release reviewers cannot assess least privilege."
+    },
+    {
+      "id": "mis_9652290d30cdb3fb",
+      "kind": "undetected_gap",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_2bf957380e89863f"
+      ],
+      "policy_requirement": "Static review requires deterministic evidence for release gaps.",
+      "gap": "create_refund may be retried without idempotency evidence.",
+      "release_implication": "Human review is required to interpret this finding."
+    },
+    {
+      "id": "mis_22127d9fe6367d9d",
+      "kind": "undetected_gap",
+      "severity": "high",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_efb42c5b5aea7be6"
+      ],
+      "policy_requirement": "Static review requires deterministic evidence for release gaps.",
+      "gap": "send_customer_email may be retried without idempotency evidence.",
+      "release_implication": "Human review is required to interpret this finding."
+    },
+    {
+      "id": "mis_d797188d34fd667d",
+      "kind": "control_missing",
+      "severity": "medium",
+      "tool_name": null,
+      "capability_refs": [],
+      "intention_refs": [],
+      "finding_refs": [
+        "fp_64f825faa751b7f8"
+      ],
+      "policy_requirement": "API outputs need structured success, failure, and review states.",
+      "gap": "Response format schemas/refund_decision.schema.json is under-specified.",
+      "release_implication": "Downstream release behavior may depend on under-specified output."
+    },
+    {
+      "id": "mis_d23fb0977a8cd94a",
+      "kind": "intent_mismatch",
+      "severity": "medium",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_1b64e136ace3472a_fe9f9e46"
+      ],
+      "policy_requirement": "Prompt scope must align with enabled high-risk tools.",
+      "gap": "Prompt lacks approval/confirmation language for high-risk tools.",
+      "release_implication": "The agent instructions and actual tool surface disagree."
+    },
+    {
+      "id": "mis_5d0ae076f7a65618",
+      "kind": "intent_mismatch",
+      "severity": "medium",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_1b64e136ace3472a_fe9f9e46"
+      ],
+      "policy_requirement": "Prompt scope must align with enabled high-risk tools.",
+      "gap": "Prompt lacks approval/confirmation language for high-risk tools.",
+      "release_implication": "The agent instructions and actual tool surface disagree."
+    },
+    {
+      "id": "mis_5d71f57a15363df7",
+      "kind": "policy_gap",
+      "severity": "medium",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_245bcdb96d8220e2"
+      ],
+      "policy_requirement": "Trace evidence for approval-controlled tools must show approval.",
+      "gap": "Trace sample shows create_refund without approval.",
+      "release_implication": "Observed sample evidence contradicts the approval expectation."
+    },
+    {
+      "id": "mis_322585ba77d6cf95",
+      "kind": "undetected_gap",
+      "severity": "medium",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_28483a22a9ed40cb"
+      ],
+      "policy_requirement": "Static review requires deterministic evidence for release gaps.",
+      "gap": "OpenAI API flow lacks timeout metadata.",
+      "release_implication": "Human review is required to interpret this finding."
+    },
+    {
+      "id": "mis_887c0d751a12ef7c",
+      "kind": "undetected_gap",
+      "severity": "medium",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_788db5032dd9f920",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_b8df99c94ef3aa60"
+      ],
+      "policy_requirement": "Static review requires deterministic evidence for release gaps.",
+      "gap": "create_refund lacks success/failure output modeling.",
+      "release_implication": "Human review is required to interpret this finding."
+    },
+    {
+      "id": "mis_99eccae7e433cb30",
+      "kind": "undetected_gap",
+      "severity": "medium",
+      "tool_name": "send_customer_email",
+      "capability_refs": [
+        "cap_e809417ee4da1160"
+      ],
+      "intention_refs": [
+        "int_495832988b7014f6",
+        "int_8e0b56f5f01971bd"
+      ],
+      "finding_refs": [
+        "fp_28483a22a9ed40cb"
+      ],
+      "policy_requirement": "Static review requires deterministic evidence for release gaps.",
+      "gap": "OpenAI API flow lacks timeout metadata.",
+      "release_implication": "Human review is required to interpret this finding."
+    }
+  ],
+  "release_consequence": {
+    "decision": "review_required",
+    "summary": "23 capability/intent misalignment(s) require release review before shipping.",
+    "blocker_misalignment_count": 0,
+    "review_misalignment_count": 23,
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
+  "suggested_scenarios": [
+    {
+      "id": "scn_9a21ba1e80b17d64",
+      "scenario_type": "idempotency_retry",
+      "title": "Retry behavior for risky write",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "Retries use idempotency evidence or the side effect is not retried.",
+      "source_misalignments": [
+        "mis_0994ddaf63489d62",
+        "mis_3ea7f33003a90845"
+      ],
+      "source_findings": [
+        "fp_4466eb2871434dc5",
+        "fp_e9d63903757dfe07"
+      ]
+    },
+    {
+      "id": "scn_b290aca1d5e64f2e",
+      "scenario_type": "test_case_coverage",
+      "title": "High-risk tool validation case",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "A declared test or review scenario covers the high-risk tool path.",
+      "source_misalignments": [
+        "mis_4e9c8774ba1dae34",
+        "mis_e4d84cc22a57dce6"
+      ],
+      "source_findings": [
+        "fp_a95adeb6338f8b3e",
+        "fp_d9059d0c1f3540af"
+      ]
+    },
+    {
+      "id": "scn_ae2f0094a6876c0b",
+      "scenario_type": "schema_boundary",
+      "title": "Tool schema boundary check",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "The tool accepts bounded structured inputs and returns structured outputs where needed.",
+      "source_misalignments": [
+        "mis_49c9adfcf549bc49",
+        "mis_4f14842e2bbd75d5",
+        "mis_6108cd9658bdc665",
+        "mis_7a5ca93c06205292",
+        "mis_d797188d34fd667d"
+      ],
+      "source_findings": [
+        "fp_07538ba8f9532359",
+        "fp_29e718b3bbde0e7d",
+        "fp_64f825faa751b7f8",
+        "fp_9675d1799680d81d",
+        "fp_c2d773062468ceac"
+      ]
+    },
+    {
+      "id": "scn_cedd66e060123bf7",
+      "scenario_type": "prompt_scope_alignment",
+      "title": "Prompt and tool-surface alignment",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "The agent instructions match the enabled write and high-risk capabilities.",
+      "source_misalignments": [
+        "mis_1dd6581e7b2546d8",
+        "mis_5d0ae076f7a65618",
+        "mis_73452c83242300c0",
+        "mis_d23fb0977a8cd94a"
+      ],
+      "source_findings": [
+        "fp_1b64e136ace3472a_dacf6678",
+        "fp_1b64e136ace3472a_fe9f9e46"
+      ]
+    },
+    {
+      "id": "scn_f51388bf48a8db83",
+      "scenario_type": "prohibited_action",
+      "title": "Prohibited-action guard",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "The prohibited action is blocked, removed, or covered by the stated control.",
+      "source_misalignments": [
+        "mis_6d584cf0a0f075ce",
+        "mis_74f922df9418d364"
+      ],
+      "source_findings": [
+        "fp_a8a615b5a4f2597b",
+        "fp_cf260ff7c72d64b7"
+      ]
+    },
+    {
+      "id": "scn_3de18f6e85c5cbd0",
+      "scenario_type": "least_privilege_scope",
+      "title": "Least-privilege scope review",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "Manifest and tool scopes match the narrow permissions needed for the release.",
+      "source_misalignments": [
+        "mis_2192a08ed2c08bea",
+        "mis_741fc769ae988e35"
+      ],
+      "source_findings": [
+        "fp_45ef3ff3ce2cf187",
+        "fp_58b3202c0a4d9793"
+      ]
+    },
+    {
+      "id": "scn_97e388d166e8e921",
+      "scenario_type": "approval",
+      "title": "Approval gate for high-risk action",
+      "given": "Exercise the release path for create_refund.",
+      "expected_control": "The run records human approval before the tool call and denies calls without approval.",
+      "source_misalignments": [
+        "mis_5d71f57a15363df7"
+      ],
+      "source_findings": [
+        "fp_245bcdb96d8220e2"
+      ]
+    }
+  ],
   "tool_surface": {
     "total_tools": 2,
     "high_risk_tools": 2,
@@ -924,7 +1589,8 @@
     "Declare an owner for each high-risk production tool in risk_overrides.tools."
   ],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmpdb6iza32/report.json"
+    "markdown": "<TMP>/report.md",
+    "json": "<TMP>/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/simple_openai_api_agent/expected/report.json
+++ b/samples/simple_openai_api_agent/expected/report.json
@@ -305,24 +305,22 @@
   ],
   "declared_intentions": [
     {
-      "id": "int_495832988b7014f6",
+      "id": "int_07ec701205b21b96",
+      "kind": "prohibited_action",
+      "text": "issue refund without approval",
+      "source": "agent.prohibited_actions",
+      "intent_tags": [
+        "financial_action"
+      ]
+    },
+    {
+      "id": "int_bf9d4ad9100fcc59",
       "kind": "prohibited_action",
       "text": "send customer email without confirmation",
       "source": "agent.prohibited_actions",
       "intent_tags": [
         "external_write",
-        "customer_communication",
-        "write"
-      ]
-    },
-    {
-      "id": "int_8e0b56f5f01971bd",
-      "kind": "prohibited_action",
-      "text": "issue refund without approval",
-      "source": "agent.prohibited_actions",
-      "intent_tags": [
-        "financial_action",
-        "write"
+        "customer_communication"
       ]
     },
     {
@@ -337,7 +335,7 @@
   ],
   "misalignments": [
     {
-      "id": "mis_0994ddaf63489d62",
+      "id": "mis_0d313eb8b061d7b1",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "create_refund",
@@ -345,49 +343,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
-      ],
-      "finding_refs": [
-        "fp_e9d63903757dfe07"
-      ],
-      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
-      "gap": "create_refund lacks idempotency evidence.",
-      "release_implication": "Retries could duplicate financial, destructive, or external effects."
-    },
-    {
-      "id": "mis_4e9c8774ba1dae34",
-      "kind": "control_missing",
-      "severity": "high",
-      "tool_name": "create_refund",
-      "capability_refs": [
-        "cap_1936b581aee1c411"
-      ],
-      "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
-      ],
-      "finding_refs": [
-        "fp_d9059d0c1f3540af"
-      ],
-      "policy_requirement": "Manifest metadata must match the active release surface.",
-      "gap": "create_refund is high-risk but has no owner.",
-      "release_implication": "Release review metadata is incomplete or stale."
-    },
-    {
-      "id": "mis_6108cd9658bdc665",
-      "kind": "control_missing",
-      "severity": "high",
-      "tool_name": "create_refund",
-      "capability_refs": [
-        "cap_1936b581aee1c411"
-      ],
-      "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_c2d773062468ceac"
@@ -397,7 +354,7 @@
       "release_implication": "Release reviewers cannot verify blast-radius limits."
     },
     {
-      "id": "mis_7a5ca93c06205292",
+      "id": "mis_3b646ab11162db0e",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "create_refund",
@@ -405,9 +362,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_9675d1799680d81d"
@@ -417,7 +373,45 @@
       "release_implication": "The model may send ambiguous or overbroad tool arguments."
     },
     {
-      "id": "mis_3ea7f33003a90845",
+      "id": "mis_926591b01818cf0b",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
+      ],
+      "finding_refs": [
+        "fp_d9059d0c1f3540af"
+      ],
+      "policy_requirement": "Manifest metadata must match the active release surface.",
+      "gap": "create_refund is high-risk but has no owner.",
+      "release_implication": "Release review metadata is incomplete or stale."
+    },
+    {
+      "id": "mis_a9df78c48e082dd0",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "create_refund",
+      "capability_refs": [
+        "cap_1936b581aee1c411"
+      ],
+      "intention_refs": [
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
+      ],
+      "finding_refs": [
+        "fp_e9d63903757dfe07"
+      ],
+      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
+      "gap": "create_refund lacks idempotency evidence.",
+      "release_implication": "Retries could duplicate financial, destructive, or external effects."
+    },
+    {
+      "id": "mis_0170081d6e670785",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -425,8 +419,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_4466eb2871434dc5"
@@ -436,7 +429,7 @@
       "release_implication": "Retries could duplicate financial, destructive, or external effects."
     },
     {
-      "id": "mis_49c9adfcf549bc49",
+      "id": "mis_5b012d4c2ded8ff1",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -444,8 +437,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_29e718b3bbde0e7d"
@@ -455,7 +447,7 @@
       "release_implication": "The model may send ambiguous or overbroad tool arguments."
     },
     {
-      "id": "mis_4f14842e2bbd75d5",
+      "id": "mis_8b69d68758b8cc07",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -463,8 +455,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_07538ba8f9532359"
@@ -474,7 +465,7 @@
       "release_implication": "Release reviewers cannot bound the operation payload safely."
     },
     {
-      "id": "mis_e4d84cc22a57dce6",
+      "id": "mis_ae5603b18a7422ad",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -482,8 +473,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_a95adeb6338f8b3e"
@@ -493,7 +483,7 @@
       "release_implication": "Release review metadata is incomplete or stale."
     },
     {
-      "id": "mis_73452c83242300c0",
+      "id": "mis_d6c4843e01a26cda",
       "kind": "intent_mismatch",
       "severity": "high",
       "tool_name": "create_refund",
@@ -501,9 +491,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_1b64e136ace3472a_dacf6678"
@@ -513,7 +502,7 @@
       "release_implication": "The agent instructions and actual tool surface disagree."
     },
     {
-      "id": "mis_1dd6581e7b2546d8",
+      "id": "mis_b3af478e081484dc",
       "kind": "intent_mismatch",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -521,9 +510,8 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
         "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_1b64e136ace3472a_dacf6678"
@@ -533,7 +521,7 @@
       "release_implication": "The agent instructions and actual tool surface disagree."
     },
     {
-      "id": "mis_74f922df9418d364",
+      "id": "mis_e9e215dcce120491",
       "kind": "prohibited_action_present",
       "severity": "high",
       "tool_name": "create_refund",
@@ -541,9 +529,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_a8a615b5a4f2597b"
@@ -553,7 +540,7 @@
       "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
     },
     {
-      "id": "mis_6d584cf0a0f075ce",
+      "id": "mis_135a15d086cc3e33",
       "kind": "prohibited_action_present",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -561,8 +548,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_cf260ff7c72d64b7"
@@ -572,7 +558,7 @@
       "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
     },
     {
-      "id": "mis_2192a08ed2c08bea",
+      "id": "mis_eaf7fd17e78431d3",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "create_refund",
@@ -580,9 +566,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_58b3202c0a4d9793"
@@ -592,7 +577,7 @@
       "release_implication": "Release reviewers cannot assess least privilege."
     },
     {
-      "id": "mis_741fc769ae988e35",
+      "id": "mis_1dd16feaf65a0e12",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -600,8 +585,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_45ef3ff3ce2cf187"
@@ -611,7 +595,7 @@
       "release_implication": "Release reviewers cannot assess least privilege."
     },
     {
-      "id": "mis_9652290d30cdb3fb",
+      "id": "mis_7e22046a22ee3b36",
       "kind": "undetected_gap",
       "severity": "high",
       "tool_name": "create_refund",
@@ -619,9 +603,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_2bf957380e89863f"
@@ -631,7 +614,7 @@
       "release_implication": "Human review is required to interpret this finding."
     },
     {
-      "id": "mis_22127d9fe6367d9d",
+      "id": "mis_814ae81d339e1ea1",
       "kind": "undetected_gap",
       "severity": "high",
       "tool_name": "send_customer_email",
@@ -639,8 +622,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_efb42c5b5aea7be6"
@@ -664,7 +646,7 @@
       "release_implication": "Downstream release behavior may depend on under-specified output."
     },
     {
-      "id": "mis_d23fb0977a8cd94a",
+      "id": "mis_8e1d935b9d84c71d",
       "kind": "intent_mismatch",
       "severity": "medium",
       "tool_name": "create_refund",
@@ -672,9 +654,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_1b64e136ace3472a_fe9f9e46"
@@ -684,7 +665,7 @@
       "release_implication": "The agent instructions and actual tool surface disagree."
     },
     {
-      "id": "mis_5d0ae076f7a65618",
+      "id": "mis_227dcda26ec582d2",
       "kind": "intent_mismatch",
       "severity": "medium",
       "tool_name": "send_customer_email",
@@ -692,9 +673,8 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
         "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_1b64e136ace3472a_fe9f9e46"
@@ -704,7 +684,7 @@
       "release_implication": "The agent instructions and actual tool surface disagree."
     },
     {
-      "id": "mis_5d71f57a15363df7",
+      "id": "mis_6e98108a40acf1c8",
       "kind": "policy_gap",
       "severity": "medium",
       "tool_name": "create_refund",
@@ -712,9 +692,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_245bcdb96d8220e2"
@@ -724,7 +703,7 @@
       "release_implication": "Observed sample evidence contradicts the approval expectation."
     },
     {
-      "id": "mis_322585ba77d6cf95",
+      "id": "mis_01005def6d0a6158",
       "kind": "undetected_gap",
       "severity": "medium",
       "tool_name": "create_refund",
@@ -732,9 +711,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_28483a22a9ed40cb"
@@ -744,7 +722,7 @@
       "release_implication": "Human review is required to interpret this finding."
     },
     {
-      "id": "mis_887c0d751a12ef7c",
+      "id": "mis_3941e4d6a12739eb",
       "kind": "undetected_gap",
       "severity": "medium",
       "tool_name": "create_refund",
@@ -752,9 +730,8 @@
         "cap_1936b581aee1c411"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_788db5032dd9f920",
-        "int_8e0b56f5f01971bd"
+        "int_07ec701205b21b96",
+        "int_788db5032dd9f920"
       ],
       "finding_refs": [
         "fp_b8df99c94ef3aa60"
@@ -764,7 +741,7 @@
       "release_implication": "Human review is required to interpret this finding."
     },
     {
-      "id": "mis_99eccae7e433cb30",
+      "id": "mis_91bedd6c6ac4d4b8",
       "kind": "undetected_gap",
       "severity": "medium",
       "tool_name": "send_customer_email",
@@ -772,8 +749,7 @@
         "cap_e809417ee4da1160"
       ],
       "intention_refs": [
-        "int_495832988b7014f6",
-        "int_8e0b56f5f01971bd"
+        "int_bf9d4ad9100fcc59"
       ],
       "finding_refs": [
         "fp_28483a22a9ed40cb"
@@ -785,9 +761,9 @@
   ],
   "release_consequence": {
     "decision": "review_required",
-    "summary": "23 capability/intent misalignment(s) require release review before shipping.",
+    "summary": "20 capability/intent misalignment(s) require release review before shipping.",
     "blocker_misalignment_count": 0,
-    "review_misalignment_count": 23,
+    "review_misalignment_count": 20,
     "fail_policy": {
       "ci_mode": "advisory",
       "fail_on": [],
@@ -798,46 +774,16 @@
   },
   "suggested_scenarios": [
     {
-      "id": "scn_9a21ba1e80b17d64",
-      "scenario_type": "idempotency_retry",
-      "title": "Retry behavior for risky write",
-      "given": "Exercise the release path for create_refund, send_customer_email.",
-      "expected_control": "Retries use idempotency evidence or the side effect is not retried.",
-      "source_misalignments": [
-        "mis_0994ddaf63489d62",
-        "mis_3ea7f33003a90845"
-      ],
-      "source_findings": [
-        "fp_4466eb2871434dc5",
-        "fp_e9d63903757dfe07"
-      ]
-    },
-    {
-      "id": "scn_b290aca1d5e64f2e",
-      "scenario_type": "test_case_coverage",
-      "title": "High-risk tool validation case",
-      "given": "Exercise the release path for create_refund, send_customer_email.",
-      "expected_control": "A declared test or review scenario covers the high-risk tool path.",
-      "source_misalignments": [
-        "mis_4e9c8774ba1dae34",
-        "mis_e4d84cc22a57dce6"
-      ],
-      "source_findings": [
-        "fp_a95adeb6338f8b3e",
-        "fp_d9059d0c1f3540af"
-      ]
-    },
-    {
-      "id": "scn_ae2f0094a6876c0b",
+      "id": "scn_157a93e2ab45d326",
       "scenario_type": "schema_boundary",
       "title": "Tool schema boundary check",
       "given": "Exercise the release path for create_refund, send_customer_email.",
       "expected_control": "The tool accepts bounded structured inputs and returns structured outputs where needed.",
       "source_misalignments": [
-        "mis_49c9adfcf549bc49",
-        "mis_4f14842e2bbd75d5",
-        "mis_6108cd9658bdc665",
-        "mis_7a5ca93c06205292",
+        "mis_0d313eb8b061d7b1",
+        "mis_3b646ab11162db0e",
+        "mis_5b012d4c2ded8ff1",
+        "mis_8b69d68758b8cc07",
         "mis_d797188d34fd667d"
       ],
       "source_findings": [
@@ -849,16 +795,46 @@
       ]
     },
     {
-      "id": "scn_cedd66e060123bf7",
+      "id": "scn_fac44131d345d64d",
+      "scenario_type": "test_case_coverage",
+      "title": "High-risk tool validation case",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "A declared test or review scenario covers the high-risk tool path.",
+      "source_misalignments": [
+        "mis_926591b01818cf0b",
+        "mis_ae5603b18a7422ad"
+      ],
+      "source_findings": [
+        "fp_a95adeb6338f8b3e",
+        "fp_d9059d0c1f3540af"
+      ]
+    },
+    {
+      "id": "scn_2271827c06f0eb07",
+      "scenario_type": "idempotency_retry",
+      "title": "Retry behavior for risky write",
+      "given": "Exercise the release path for create_refund, send_customer_email.",
+      "expected_control": "Retries use idempotency evidence or the side effect is not retried.",
+      "source_misalignments": [
+        "mis_0170081d6e670785",
+        "mis_a9df78c48e082dd0"
+      ],
+      "source_findings": [
+        "fp_4466eb2871434dc5",
+        "fp_e9d63903757dfe07"
+      ]
+    },
+    {
+      "id": "scn_291536635b1248f1",
       "scenario_type": "prompt_scope_alignment",
       "title": "Prompt and tool-surface alignment",
       "given": "Exercise the release path for create_refund, send_customer_email.",
       "expected_control": "The agent instructions match the enabled write and high-risk capabilities.",
       "source_misalignments": [
-        "mis_1dd6581e7b2546d8",
-        "mis_5d0ae076f7a65618",
-        "mis_73452c83242300c0",
-        "mis_d23fb0977a8cd94a"
+        "mis_227dcda26ec582d2",
+        "mis_8e1d935b9d84c71d",
+        "mis_b3af478e081484dc",
+        "mis_d6c4843e01a26cda"
       ],
       "source_findings": [
         "fp_1b64e136ace3472a_dacf6678",
@@ -866,14 +842,14 @@
       ]
     },
     {
-      "id": "scn_f51388bf48a8db83",
+      "id": "scn_4e2075de0c05e4a2",
       "scenario_type": "prohibited_action",
       "title": "Prohibited-action guard",
       "given": "Exercise the release path for create_refund, send_customer_email.",
       "expected_control": "The prohibited action is blocked, removed, or covered by the stated control.",
       "source_misalignments": [
-        "mis_6d584cf0a0f075ce",
-        "mis_74f922df9418d364"
+        "mis_135a15d086cc3e33",
+        "mis_e9e215dcce120491"
       ],
       "source_findings": [
         "fp_a8a615b5a4f2597b",
@@ -881,14 +857,14 @@
       ]
     },
     {
-      "id": "scn_3de18f6e85c5cbd0",
+      "id": "scn_a9e280a472723af2",
       "scenario_type": "least_privilege_scope",
       "title": "Least-privilege scope review",
       "given": "Exercise the release path for create_refund, send_customer_email.",
       "expected_control": "Manifest and tool scopes match the narrow permissions needed for the release.",
       "source_misalignments": [
-        "mis_2192a08ed2c08bea",
-        "mis_741fc769ae988e35"
+        "mis_1dd16feaf65a0e12",
+        "mis_eaf7fd17e78431d3"
       ],
       "source_findings": [
         "fp_45ef3ff3ce2cf187",
@@ -896,13 +872,13 @@
       ]
     },
     {
-      "id": "scn_97e388d166e8e921",
+      "id": "scn_1afe05dae5bd9459",
       "scenario_type": "approval",
       "title": "Approval gate for high-risk action",
       "given": "Exercise the release path for create_refund.",
       "expected_control": "The run records human approval before the tool call and denies calls without approval.",
       "source_misalignments": [
-        "mis_5d71f57a15363df7"
+        "mis_6e98108a40acf1c8"
       ],
       "source_findings": [
         "fp_245bcdb96d8220e2"

--- a/samples/simple_openai_api_agent/expected/report.json
+++ b/samples/simple_openai_api_agent/expected/report.json
@@ -761,7 +761,7 @@
   ],
   "release_consequence": {
     "decision": "review_required",
-    "summary": "20 capability/intent misalignment(s) require release review before shipping.",
+    "summary": "20 release-relevant finding(s) require release review before shipping.",
     "blocker_misalignment_count": 0,
     "review_misalignment_count": 20,
     "fail_policy": {

--- a/samples/simple_openai_api_agent/expected/report.md
+++ b/samples/simple_openai_api_agent/expected/report.md
@@ -70,6 +70,54 @@ Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fa
    Evidence: retry\_policy=\{'max\_attempts': 2\}; risk\_tags=\['customer\_communication', 'external\_write', 'write'\]
    Recommendation: Add idempotency evidence for send\_customer\_email or avoid retrying this side effect.
 
+## Capability <-> Intent Diff
+
+Agent intent:
+
+- prohibited\_action: send customer email without confirmation (tags: external\_write, customer\_communication, write)
+- prohibited\_action: issue refund without approval (tags: financial\_action, write)
+- instruction\_preview: You are a support refund assistant.
+
+You should only advise the support representative and prepare a draft response. Do not take action on the customer's account. (tags: financial\_action)
+
+Actual capabilities:
+
+- create\_refund: capability=financial\_action, risk=financial\_action, write, control=missing
+- send\_customer\_email: capability=external\_write, risk=customer\_communication, external\_write, write, control=missing
+
+Policy/control gaps:
+
+- HIGH control\_missing \[create\_refund\]: create\_refund lacks idempotency evidence.
+  Requires: Risky write tools need idempotency evidence before retryable release.
+  Release implication: Retries could duplicate financial, destructive, or external effects.
+- HIGH control\_missing \[create\_refund\]: create\_refund is high-risk but has no owner.
+  Requires: Manifest metadata must match the active release surface.
+  Release implication: Release review metadata is incomplete or stale.
+- HIGH control\_missing \[create\_refund\]: create\_refund.amount has no maximum bound.
+  Requires: Risky numeric parameters must declare a maximum or equivalent limit.
+  Release implication: Release reviewers cannot verify blast-radius limits.
+- HIGH control\_missing \[create\_refund\]: create\_refund function schema is not strict enough.
+  Requires: API function schemas must be strict enough for reliable tool calls.
+  Release implication: The model may send ambiguous or overbroad tool arguments.
+- HIGH control\_missing \[send\_customer\_email\]: send\_customer\_email lacks idempotency evidence.
+  Requires: Risky write tools need idempotency evidence before retryable release.
+  Release implication: Retries could duplicate financial, destructive, or external effects.
+- 18 more in report.json
+
+Release implication:
+
+- Decision: review\_required
+- 23 capability/intent misalignment\(s\) require release review before shipping.
+
+Next validation:
+
+- Retry behavior for risky write: Retries use idempotency evidence or the side effect is not retried.
+- High-risk tool validation case: A declared test or review scenario covers the high-risk tool path.
+- Tool schema boundary check: The tool accepts bounded structured inputs and returns structured outputs where needed.
+- Prompt and tool-surface alignment: The agent instructions match the enabled write and high-risk capabilities.
+- Prohibited-action guard: The prohibited action is blocked, removed, or covered by the stated control.
+- 2 more in report.json
+
 ## Recommended Next Actions
 
 - Make create\_refund a strict function schema: object parameters, additionalProperties=false, complete required list, and bounded risky fields.

--- a/samples/simple_openai_api_agent/expected/report.md
+++ b/samples/simple_openai_api_agent/expected/report.md
@@ -105,7 +105,7 @@ Policy/control gaps:
 Release implication:
 
 - Decision: review\_required
-- 20 capability/intent misalignment\(s\) require release review before shipping.
+- 20 release-relevant finding\(s\) require release review before shipping.
 
 Next validation:
 

--- a/samples/simple_openai_api_agent/expected/report.md
+++ b/samples/simple_openai_api_agent/expected/report.md
@@ -74,8 +74,8 @@ Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fa
 
 Agent intent:
 
-- prohibited\_action: send customer email without confirmation (tags: external\_write, customer\_communication, write)
-- prohibited\_action: issue refund without approval (tags: financial\_action, write)
+- prohibited\_action: issue refund without approval (tags: financial\_action)
+- prohibited\_action: send customer email without confirmation (tags: external\_write, customer\_communication)
 - instruction\_preview: You are a support refund assistant. You should only advise the support representative and prepare a draft response. Do not take action on the customer's account. (tags: financial\_action)
 
 Actual capabilities:
@@ -85,18 +85,18 @@ Actual capabilities:
 
 Policy/control gaps:
 
-- HIGH control\_missing \[create\_refund\]: create\_refund lacks idempotency evidence.
-  Requires: Risky write tools need idempotency evidence before retryable release.
-  Release implication: Retries could duplicate financial, destructive, or external effects.
-- HIGH control\_missing \[create\_refund\]: create\_refund is high-risk but has no owner.
-  Requires: Manifest metadata must match the active release surface.
-  Release implication: Release review metadata is incomplete or stale.
 - HIGH control\_missing \[create\_refund\]: create\_refund.amount has no maximum bound.
   Requires: Risky numeric parameters must declare a maximum or equivalent limit.
   Release implication: Release reviewers cannot verify blast-radius limits.
 - HIGH control\_missing \[create\_refund\]: create\_refund function schema is not strict enough.
   Requires: API function schemas must be strict enough for reliable tool calls.
   Release implication: The model may send ambiguous or overbroad tool arguments.
+- HIGH control\_missing \[create\_refund\]: create\_refund is high-risk but has no owner.
+  Requires: Manifest metadata must match the active release surface.
+  Release implication: Release review metadata is incomplete or stale.
+- HIGH control\_missing \[create\_refund\]: create\_refund lacks idempotency evidence.
+  Requires: Risky write tools need idempotency evidence before retryable release.
+  Release implication: Retries could duplicate financial, destructive, or external effects.
 - HIGH control\_missing \[send\_customer\_email\]: send\_customer\_email lacks idempotency evidence.
   Requires: Risky write tools need idempotency evidence before retryable release.
   Release implication: Retries could duplicate financial, destructive, or external effects.
@@ -105,13 +105,13 @@ Policy/control gaps:
 Release implication:
 
 - Decision: review\_required
-- 23 capability/intent misalignment\(s\) require release review before shipping.
+- 20 capability/intent misalignment\(s\) require release review before shipping.
 
 Next validation:
 
-- Retry behavior for risky write: Retries use idempotency evidence or the side effect is not retried.
-- High-risk tool validation case: A declared test or review scenario covers the high-risk tool path.
 - Tool schema boundary check: The tool accepts bounded structured inputs and returns structured outputs where needed.
+- High-risk tool validation case: A declared test or review scenario covers the high-risk tool path.
+- Retry behavior for risky write: Retries use idempotency evidence or the side effect is not retried.
 - Prompt and tool-surface alignment: The agent instructions match the enabled write and high-risk capabilities.
 - Prohibited-action guard: The prohibited action is blocked, removed, or covered by the stated control.
 - 2 more in report.json

--- a/samples/simple_openai_api_agent/expected/report.md
+++ b/samples/simple_openai_api_agent/expected/report.md
@@ -76,9 +76,7 @@ Agent intent:
 
 - prohibited\_action: send customer email without confirmation (tags: external\_write, customer\_communication, write)
 - prohibited\_action: issue refund without approval (tags: financial\_action, write)
-- instruction\_preview: You are a support refund assistant.
-
-You should only advise the support representative and prepare a draft response. Do not take action on the customer's account. (tags: financial\_action)
+- instruction\_preview: You are a support refund assistant. You should only advise the support representative and prepare a draft response. Do not take action on the customer's account. (tags: financial\_action)
 
 Actual capabilities:
 

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -439,21 +439,20 @@
       ]
     },
     {
-      "id": "int_b4b5365de66c0cdb",
+      "id": "int_fa00e1ae7db0cd81",
       "kind": "prohibited_action",
       "text": "send external email without preview",
       "source": "agent.prohibited_actions",
       "intent_tags": [
         "external_write",
         "customer_communication",
-        "write",
-        "read_only"
+        "write"
       ]
     }
   ],
   "misalignments": [
     {
-      "id": "mis_9fa35b2cab89e30f",
+      "id": "mis_b20759bc15584fb6",
       "kind": "control_missing",
       "severity": "critical",
       "tool_name": "stripe.create_refund",
@@ -465,7 +464,7 @@
         "int_0f762dcf27664a26",
         "int_5f0f3ef33e71dbf1",
         "int_8e0b56f5f01971bd",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_dac8011e14c53777"
@@ -475,7 +474,7 @@
       "release_implication": "Retries could duplicate financial, destructive, or external effects."
     },
     {
-      "id": "mis_ac6ac0b6a14cdc65",
+      "id": "mis_d385027b6bbe4d9a",
       "kind": "policy_gap",
       "severity": "critical",
       "tool_name": "stripe.create_refund",
@@ -487,7 +486,7 @@
         "int_0f762dcf27664a26",
         "int_5f0f3ef33e71dbf1",
         "int_8e0b56f5f01971bd",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_f092940f62fbb012"
@@ -497,7 +496,7 @@
       "release_implication": "Release is blocked until approval is declared or the tool is removed."
     },
     {
-      "id": "mis_b2cf0b98eed048b7",
+      "id": "mis_886dfe311fe202c0",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -505,25 +504,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_b4b5365de66c0cdb"
-      ],
-      "finding_refs": [
-        "fp_0f8aaa912d589cf0"
-      ],
-      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
-      "gap": "gmail.send_customer_email lacks idempotency evidence.",
-      "release_implication": "Retries could duplicate financial, destructive, or external effects."
-    },
-    {
-      "id": "mis_fe4dade5b3f7ccf4",
-      "kind": "control_missing",
-      "severity": "high",
-      "tool_name": "gmail.send_customer_email",
-      "capability_refs": [
-        "cap_3250ca3c56d98471"
-      ],
-      "intention_refs": [
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_acd63b899d49aa1c"
@@ -533,7 +514,25 @@
       "release_implication": "Release reviewers cannot bound the operation payload safely."
     },
     {
-      "id": "mis_be87ecd392dd016f",
+      "id": "mis_dd1098035b357dae",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "gmail.send_customer_email",
+      "capability_refs": [
+        "cap_3250ca3c56d98471"
+      ],
+      "intention_refs": [
+        "int_fa00e1ae7db0cd81"
+      ],
+      "finding_refs": [
+        "fp_0f8aaa912d589cf0"
+      ],
+      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
+      "gap": "gmail.send_customer_email lacks idempotency evidence.",
+      "release_implication": "Retries could duplicate financial, destructive, or external effects."
+    },
+    {
+      "id": "mis_bc0ad7ca831c38c4",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "shopify.cancel_order",
@@ -544,7 +543,7 @@
         "int_0f762dcf27664a26",
         "int_8e0b56f5f01971bd",
         "int_9dd078e191c7bd70",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_fd2577850cef1f87"
@@ -554,7 +553,7 @@
       "release_implication": "Release review metadata is incomplete or stale."
     },
     {
-      "id": "mis_09c4cc31880f873b",
+      "id": "mis_317928709e9f8f80",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "stripe.create_refund",
@@ -566,7 +565,7 @@
         "int_0f762dcf27664a26",
         "int_5f0f3ef33e71dbf1",
         "int_8e0b56f5f01971bd",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_ab60b01cb53cfcbe"
@@ -592,7 +591,7 @@
       "release_implication": "Release review cannot bound which tools may be available at runtime."
     },
     {
-      "id": "mis_45e6daee64343336",
+      "id": "mis_7138f222cf9818e8",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "zendesk.update_ticket",
@@ -602,7 +601,7 @@
       "intention_refs": [
         "int_0f762dcf27664a26",
         "int_8e0b56f5f01971bd",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_ff2f028953d1c220"
@@ -612,7 +611,7 @@
       "release_implication": "Release reviewers cannot bound the operation payload safely."
     },
     {
-      "id": "mis_0a33eb45f2377400",
+      "id": "mis_36b88ddad41620e0",
       "kind": "policy_gap",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -620,7 +619,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_8e08a4fe6b0917f6"
@@ -630,7 +629,7 @@
       "release_implication": "Release review must verify explicit user confirmation before shipping."
     },
     {
-      "id": "mis_0ebffddee4be5876",
+      "id": "mis_ba2b15a6d70dfa9c",
       "kind": "policy_gap",
       "severity": "high",
       "tool_name": "stripe.create_refund",
@@ -642,7 +641,7 @@
         "int_0f762dcf27664a26",
         "int_5f0f3ef33e71dbf1",
         "int_8e0b56f5f01971bd",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_a62ca2fd9a68a1d1"
@@ -652,7 +651,7 @@
       "release_implication": "Release review must verify explicit user confirmation before shipping."
     },
     {
-      "id": "mis_81e8fc6e86aea18d",
+      "id": "mis_cdb0dc4994f27ecc",
       "kind": "prohibited_action_present",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -660,7 +659,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_e090c62e390e70ab"
@@ -670,7 +669,7 @@
       "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
     },
     {
-      "id": "mis_ce098e4c494919ad",
+      "id": "mis_76ba17f3e2dd6921",
       "kind": "prohibited_action_present",
       "severity": "high",
       "tool_name": "stripe.create_refund",
@@ -682,7 +681,7 @@
         "int_0f762dcf27664a26",
         "int_5f0f3ef33e71dbf1",
         "int_8e0b56f5f01971bd",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_12985c36a06026de"
@@ -706,7 +705,7 @@
       "release_implication": "Release may grant broader access than the reviewed capability needs."
     },
     {
-      "id": "mis_2a5e7e414da3b1f5",
+      "id": "mis_dc6502ac3516c43f",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -714,7 +713,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_1f6cfd6b7daa9b7c"
@@ -724,7 +723,7 @@
       "release_implication": "The manifest does not describe the actual permissions needed."
     },
     {
-      "id": "mis_85082ea6795f0f33",
+      "id": "mis_2e65d10ba6180158",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "shopify.cancel_order",
@@ -735,7 +734,7 @@
         "int_0f762dcf27664a26",
         "int_8e0b56f5f01971bd",
         "int_9dd078e191c7bd70",
-        "int_b4b5365de66c0cdb"
+        "int_fa00e1ae7db0cd81"
       ],
       "finding_refs": [
         "fp_83852fbd6b440524"
@@ -745,7 +744,7 @@
       "release_implication": "The manifest does not describe the actual permissions needed."
     },
     {
-      "id": "mis_66535e6f15386e0c",
+      "id": "mis_b59536c79ea4fb8c",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "support.search_kb",
@@ -753,8 +752,7 @@
         "cap_6b87864148184ced"
       ],
       "intention_refs": [
-        "int_5f0f3ef33e71dbf1",
-        "int_b4b5365de66c0cdb"
+        "int_5f0f3ef33e71dbf1"
       ],
       "finding_refs": [
         "fp_d8e6d1865dae97cc"
@@ -764,21 +762,7 @@
       "release_implication": "The manifest does not describe the actual permissions needed."
     },
     {
-      "id": "mis_78f87b7a9d5cc744",
-      "kind": "control_missing",
-      "severity": "medium",
-      "tool_name": null,
-      "capability_refs": [],
-      "intention_refs": [],
-      "finding_refs": [
-        "fp_39b9ae878f343d1b"
-      ],
-      "policy_requirement": "Manifest metadata must match the active release surface.",
-      "gap": "Manifest declares unused permission scope zendesk:tickets:read.",
-      "release_implication": "Release review metadata is incomplete or stale."
-    },
-    {
-      "id": "mis_6dc5740924c5f2f0",
+      "id": "mis_ffc5c8dedf96a397",
       "kind": "control_missing",
       "severity": "medium",
       "tool_name": "send_email_preview",
@@ -786,8 +770,7 @@
         "cap_749e8c123fc42753"
       ],
       "intention_refs": [
-        "int_5f0f3ef33e71dbf1",
-        "int_b4b5365de66c0cdb"
+        "int_5f0f3ef33e71dbf1"
       ],
       "finding_refs": [
         "fp_85f8513ad72cd9ea"
@@ -795,6 +778,20 @@
       "policy_requirement": "Model-consumed tool outputs should be structured.",
       "gap": "send_email_preview returns free-form text output.",
       "release_implication": "Downstream model behavior may depend on unstructured tool output."
+    },
+    {
+      "id": "mis_ed9ce79c45da4d6e",
+      "kind": "scope_drift",
+      "severity": "medium",
+      "tool_name": null,
+      "capability_refs": [],
+      "intention_refs": [],
+      "finding_refs": [
+        "fp_39b9ae878f343d1b"
+      ],
+      "policy_requirement": "Manifest permissions should only include scopes used by loaded tools.",
+      "gap": "Manifest declares unused permission scope zendesk:tickets:read.",
+      "release_implication": "Release may include stale or unnecessary permission grants."
     }
   ],
   "release_consequence": {
@@ -812,14 +809,14 @@
   },
   "suggested_scenarios": [
     {
-      "id": "scn_1d6fb6c4313807a9",
+      "id": "scn_bed3c1eb23ee8d97",
       "scenario_type": "idempotency_retry",
       "title": "Retry behavior for risky write",
       "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
       "expected_control": "Retries use idempotency evidence or the side effect is not retried.",
       "source_misalignments": [
-        "mis_9fa35b2cab89e30f",
-        "mis_b2cf0b98eed048b7"
+        "mis_b20759bc15584fb6",
+        "mis_dd1098035b357dae"
       ],
       "source_findings": [
         "fp_0f8aaa912d589cf0",
@@ -827,29 +824,29 @@
       ]
     },
     {
-      "id": "scn_da30e0b0b7fefcbe",
+      "id": "scn_b2e6f4667917e2f6",
       "scenario_type": "approval",
       "title": "Approval gate for high-risk action",
       "given": "Exercise the release path for stripe.create_refund.",
       "expected_control": "The run records human approval before the tool call and denies calls without approval.",
       "source_misalignments": [
-        "mis_ac6ac0b6a14cdc65"
+        "mis_d385027b6bbe4d9a"
       ],
       "source_findings": [
         "fp_f092940f62fbb012"
       ]
     },
     {
-      "id": "scn_c6c3dbc5a98636af",
+      "id": "scn_e1bfcac8b42a8a90",
       "scenario_type": "schema_boundary",
       "title": "Tool schema boundary check",
       "given": "Exercise the release path for gmail.send_customer_email, send_email_preview, stripe.create_refund, and 1 more tool(s).",
       "expected_control": "The tool accepts bounded structured inputs and returns structured outputs where needed.",
       "source_misalignments": [
-        "mis_09c4cc31880f873b",
-        "mis_45e6daee64343336",
-        "mis_6dc5740924c5f2f0",
-        "mis_fe4dade5b3f7ccf4"
+        "mis_317928709e9f8f80",
+        "mis_7138f222cf9818e8",
+        "mis_886dfe311fe202c0",
+        "mis_ffc5c8dedf96a397"
       ],
       "source_findings": [
         "fp_85f8513ad72cd9ea",
@@ -859,17 +856,15 @@
       ]
     },
     {
-      "id": "scn_01bcaaa9f688b408",
+      "id": "scn_5ea8402dd61e62e7",
       "scenario_type": "test_case_coverage",
       "title": "High-risk tool validation case",
       "given": "Exercise the release path for shopify.cancel_order.",
       "expected_control": "A declared test or review scenario covers the high-risk tool path.",
       "source_misalignments": [
-        "mis_78f87b7a9d5cc744",
-        "mis_be87ecd392dd016f"
+        "mis_bc0ad7ca831c38c4"
       ],
       "source_findings": [
-        "fp_39b9ae878f343d1b",
         "fp_fd2577850cef1f87"
       ]
     },
@@ -887,14 +882,14 @@
       ]
     },
     {
-      "id": "scn_3154e6988f94994a",
+      "id": "scn_7582ad2eedae8dee",
       "scenario_type": "confirmation",
       "title": "Confirmation gate for external or destructive action",
       "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
       "expected_control": "The run records explicit confirmation before the side effect occurs.",
       "source_misalignments": [
-        "mis_0a33eb45f2377400",
-        "mis_0ebffddee4be5876"
+        "mis_36b88ddad41620e0",
+        "mis_ba2b15a6d70dfa9c"
       ],
       "source_findings": [
         "fp_8e08a4fe6b0917f6",
@@ -902,14 +897,14 @@
       ]
     },
     {
-      "id": "scn_f7283a9f3b88aa44",
+      "id": "scn_b8c7df78d58bed64",
       "scenario_type": "prohibited_action",
       "title": "Prohibited-action guard",
       "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
       "expected_control": "The prohibited action is blocked, removed, or covered by the stated control.",
       "source_misalignments": [
-        "mis_81e8fc6e86aea18d",
-        "mis_ce098e4c494919ad"
+        "mis_76ba17f3e2dd6921",
+        "mis_cdb0dc4994f27ecc"
       ],
       "source_findings": [
         "fp_12985c36a06026de",
@@ -917,19 +912,21 @@
       ]
     },
     {
-      "id": "scn_379fcdc7a1a67c63",
+      "id": "scn_8854d797a2416c6a",
       "scenario_type": "least_privilege_scope",
       "title": "Least-privilege scope review",
       "given": "Exercise the release path for gmail.send_customer_email, shopify.cancel_order, support.search_kb.",
       "expected_control": "Manifest and tool scopes match the narrow permissions needed for the release.",
       "source_misalignments": [
-        "mis_2a5e7e414da3b1f5",
-        "mis_66535e6f15386e0c",
-        "mis_85082ea6795f0f33",
-        "mis_a9b10d037a91d1ef"
+        "mis_2e65d10ba6180158",
+        "mis_a9b10d037a91d1ef",
+        "mis_b59536c79ea4fb8c",
+        "mis_dc6502ac3516c43f",
+        "mis_ed9ce79c45da4d6e"
       ],
       "source_findings": [
         "fp_1f6cfd6b7daa9b7c",
+        "fp_39b9ae878f343d1b",
         "fp_83852fbd6b440524",
         "fp_d27325cbdbbf5483",
         "fp_d8e6d1865dae97cc"

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -401,32 +401,38 @@
       ]
     },
     {
-      "id": "int_0f762dcf27664a26",
+      "id": "int_9b588e3cf417aa8f",
       "kind": "declared_purpose",
       "text": "update support ticket notes",
       "source": "agent.declared_purpose",
-      "intent_tags": [
-        "write"
-      ]
+      "intent_tags": []
     },
     {
-      "id": "int_5f0f3ef33e71dbf1",
+      "id": "int_d7bbd0543afdd316",
       "kind": "declared_purpose",
       "text": "answer refund policy questions",
       "source": "agent.declared_purpose",
       "intent_tags": [
-        "financial_action",
-        "read_only"
+        "financial_action"
       ]
     },
     {
-      "id": "int_8e0b56f5f01971bd",
+      "id": "int_07ec701205b21b96",
       "kind": "prohibited_action",
       "text": "issue refund without approval",
       "source": "agent.prohibited_actions",
       "intent_tags": [
-        "financial_action",
-        "write"
+        "financial_action"
+      ]
+    },
+    {
+      "id": "int_1739e168eb9ad398",
+      "kind": "prohibited_action",
+      "text": "send external email without preview",
+      "source": "agent.prohibited_actions",
+      "intent_tags": [
+        "external_write",
+        "customer_communication"
       ]
     },
     {
@@ -437,22 +443,11 @@
       "intent_tags": [
         "destructive"
       ]
-    },
-    {
-      "id": "int_fa00e1ae7db0cd81",
-      "kind": "prohibited_action",
-      "text": "send external email without preview",
-      "source": "agent.prohibited_actions",
-      "intent_tags": [
-        "external_write",
-        "customer_communication",
-        "write"
-      ]
     }
   ],
   "misalignments": [
     {
-      "id": "mis_b20759bc15584fb6",
+      "id": "mis_625d70d30792e6de",
       "kind": "control_missing",
       "severity": "critical",
       "tool_name": "stripe.create_refund",
@@ -461,10 +456,9 @@
       ],
       "intention_refs": [
         "int_004d51021dfae86d",
-        "int_0f762dcf27664a26",
-        "int_5f0f3ef33e71dbf1",
-        "int_8e0b56f5f01971bd",
-        "int_fa00e1ae7db0cd81"
+        "int_07ec701205b21b96",
+        "int_1739e168eb9ad398",
+        "int_d7bbd0543afdd316"
       ],
       "finding_refs": [
         "fp_dac8011e14c53777"
@@ -474,7 +468,7 @@
       "release_implication": "Retries could duplicate financial, destructive, or external effects."
     },
     {
-      "id": "mis_d385027b6bbe4d9a",
+      "id": "mis_dcc110f9c063a92f",
       "kind": "policy_gap",
       "severity": "critical",
       "tool_name": "stripe.create_refund",
@@ -483,10 +477,9 @@
       ],
       "intention_refs": [
         "int_004d51021dfae86d",
-        "int_0f762dcf27664a26",
-        "int_5f0f3ef33e71dbf1",
-        "int_8e0b56f5f01971bd",
-        "int_fa00e1ae7db0cd81"
+        "int_07ec701205b21b96",
+        "int_1739e168eb9ad398",
+        "int_d7bbd0543afdd316"
       ],
       "finding_refs": [
         "fp_f092940f62fbb012"
@@ -496,7 +489,7 @@
       "release_implication": "Release is blocked until approval is declared or the tool is removed."
     },
     {
-      "id": "mis_886dfe311fe202c0",
+      "id": "mis_95cf603d13a240d8",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -504,7 +497,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_fa00e1ae7db0cd81"
+        "int_1739e168eb9ad398"
       ],
       "finding_refs": [
         "fp_acd63b899d49aa1c"
@@ -514,7 +507,7 @@
       "release_implication": "Release reviewers cannot bound the operation payload safely."
     },
     {
-      "id": "mis_dd1098035b357dae",
+      "id": "mis_d4c86ee883988b00",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -522,7 +515,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_fa00e1ae7db0cd81"
+        "int_1739e168eb9ad398"
       ],
       "finding_refs": [
         "fp_0f8aaa912d589cf0"
@@ -532,7 +525,7 @@
       "release_implication": "Retries could duplicate financial, destructive, or external effects."
     },
     {
-      "id": "mis_bc0ad7ca831c38c4",
+      "id": "mis_63049d8f91bd21ae",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "shopify.cancel_order",
@@ -540,10 +533,7 @@
         "cap_fd7aa0505dafb1dc"
       ],
       "intention_refs": [
-        "int_0f762dcf27664a26",
-        "int_8e0b56f5f01971bd",
-        "int_9dd078e191c7bd70",
-        "int_fa00e1ae7db0cd81"
+        "int_9dd078e191c7bd70"
       ],
       "finding_refs": [
         "fp_fd2577850cef1f87"
@@ -553,7 +543,7 @@
       "release_implication": "Release review metadata is incomplete or stale."
     },
     {
-      "id": "mis_317928709e9f8f80",
+      "id": "mis_e6610a213ea2372c",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "stripe.create_refund",
@@ -562,10 +552,9 @@
       ],
       "intention_refs": [
         "int_004d51021dfae86d",
-        "int_0f762dcf27664a26",
-        "int_5f0f3ef33e71dbf1",
-        "int_8e0b56f5f01971bd",
-        "int_fa00e1ae7db0cd81"
+        "int_07ec701205b21b96",
+        "int_1739e168eb9ad398",
+        "int_d7bbd0543afdd316"
       ],
       "finding_refs": [
         "fp_ab60b01cb53cfcbe"
@@ -591,18 +580,14 @@
       "release_implication": "Release review cannot bound which tools may be available at runtime."
     },
     {
-      "id": "mis_7138f222cf9818e8",
+      "id": "mis_18add992533aad5c",
       "kind": "control_missing",
       "severity": "high",
       "tool_name": "zendesk.update_ticket",
       "capability_refs": [
         "cap_0da3f29d7a7c1ee8"
       ],
-      "intention_refs": [
-        "int_0f762dcf27664a26",
-        "int_8e0b56f5f01971bd",
-        "int_fa00e1ae7db0cd81"
-      ],
+      "intention_refs": [],
       "finding_refs": [
         "fp_ff2f028953d1c220"
       ],
@@ -611,7 +596,7 @@
       "release_implication": "Release reviewers cannot bound the operation payload safely."
     },
     {
-      "id": "mis_36b88ddad41620e0",
+      "id": "mis_752222595b2f3407",
       "kind": "policy_gap",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -619,7 +604,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_fa00e1ae7db0cd81"
+        "int_1739e168eb9ad398"
       ],
       "finding_refs": [
         "fp_8e08a4fe6b0917f6"
@@ -629,7 +614,7 @@
       "release_implication": "Release review must verify explicit user confirmation before shipping."
     },
     {
-      "id": "mis_ba2b15a6d70dfa9c",
+      "id": "mis_7c7e84f12ab69da1",
       "kind": "policy_gap",
       "severity": "high",
       "tool_name": "stripe.create_refund",
@@ -638,10 +623,9 @@
       ],
       "intention_refs": [
         "int_004d51021dfae86d",
-        "int_0f762dcf27664a26",
-        "int_5f0f3ef33e71dbf1",
-        "int_8e0b56f5f01971bd",
-        "int_fa00e1ae7db0cd81"
+        "int_07ec701205b21b96",
+        "int_1739e168eb9ad398",
+        "int_d7bbd0543afdd316"
       ],
       "finding_refs": [
         "fp_a62ca2fd9a68a1d1"
@@ -651,7 +635,7 @@
       "release_implication": "Release review must verify explicit user confirmation before shipping."
     },
     {
-      "id": "mis_cdb0dc4994f27ecc",
+      "id": "mis_0cafc4f91c45e5d3",
       "kind": "prohibited_action_present",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -659,7 +643,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_fa00e1ae7db0cd81"
+        "int_1739e168eb9ad398"
       ],
       "finding_refs": [
         "fp_e090c62e390e70ab"
@@ -669,7 +653,7 @@
       "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
     },
     {
-      "id": "mis_76ba17f3e2dd6921",
+      "id": "mis_e4a5afb9dde265df",
       "kind": "prohibited_action_present",
       "severity": "high",
       "tool_name": "stripe.create_refund",
@@ -678,10 +662,9 @@
       ],
       "intention_refs": [
         "int_004d51021dfae86d",
-        "int_0f762dcf27664a26",
-        "int_5f0f3ef33e71dbf1",
-        "int_8e0b56f5f01971bd",
-        "int_fa00e1ae7db0cd81"
+        "int_07ec701205b21b96",
+        "int_1739e168eb9ad398",
+        "int_d7bbd0543afdd316"
       ],
       "finding_refs": [
         "fp_12985c36a06026de"
@@ -705,7 +688,7 @@
       "release_implication": "Release may grant broader access than the reviewed capability needs."
     },
     {
-      "id": "mis_dc6502ac3516c43f",
+      "id": "mis_cca919e04e5e3978",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "gmail.send_customer_email",
@@ -713,7 +696,7 @@
         "cap_3250ca3c56d98471"
       ],
       "intention_refs": [
-        "int_fa00e1ae7db0cd81"
+        "int_1739e168eb9ad398"
       ],
       "finding_refs": [
         "fp_1f6cfd6b7daa9b7c"
@@ -723,7 +706,7 @@
       "release_implication": "The manifest does not describe the actual permissions needed."
     },
     {
-      "id": "mis_2e65d10ba6180158",
+      "id": "mis_d23ee56172b01749",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "shopify.cancel_order",
@@ -731,10 +714,7 @@
         "cap_fd7aa0505dafb1dc"
       ],
       "intention_refs": [
-        "int_0f762dcf27664a26",
-        "int_8e0b56f5f01971bd",
-        "int_9dd078e191c7bd70",
-        "int_fa00e1ae7db0cd81"
+        "int_9dd078e191c7bd70"
       ],
       "finding_refs": [
         "fp_83852fbd6b440524"
@@ -744,16 +724,14 @@
       "release_implication": "The manifest does not describe the actual permissions needed."
     },
     {
-      "id": "mis_b59536c79ea4fb8c",
+      "id": "mis_129f018e1e3c516f",
       "kind": "scope_drift",
       "severity": "high",
       "tool_name": "support.search_kb",
       "capability_refs": [
         "cap_6b87864148184ced"
       ],
-      "intention_refs": [
-        "int_5f0f3ef33e71dbf1"
-      ],
+      "intention_refs": [],
       "finding_refs": [
         "fp_d8e6d1865dae97cc"
       ],
@@ -762,16 +740,14 @@
       "release_implication": "The manifest does not describe the actual permissions needed."
     },
     {
-      "id": "mis_ffc5c8dedf96a397",
+      "id": "mis_3ca3250a83e2d44e",
       "kind": "control_missing",
       "severity": "medium",
       "tool_name": "send_email_preview",
       "capability_refs": [
         "cap_749e8c123fc42753"
       ],
-      "intention_refs": [
-        "int_5f0f3ef33e71dbf1"
-      ],
+      "intention_refs": [],
       "finding_refs": [
         "fp_85f8513ad72cd9ea"
       ],
@@ -809,14 +785,14 @@
   },
   "suggested_scenarios": [
     {
-      "id": "scn_bed3c1eb23ee8d97",
+      "id": "scn_82300b7c5d913d02",
       "scenario_type": "idempotency_retry",
       "title": "Retry behavior for risky write",
       "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
       "expected_control": "Retries use idempotency evidence or the side effect is not retried.",
       "source_misalignments": [
-        "mis_b20759bc15584fb6",
-        "mis_dd1098035b357dae"
+        "mis_625d70d30792e6de",
+        "mis_d4c86ee883988b00"
       ],
       "source_findings": [
         "fp_0f8aaa912d589cf0",
@@ -824,29 +800,29 @@
       ]
     },
     {
-      "id": "scn_b2e6f4667917e2f6",
+      "id": "scn_bc8763eca67e56ab",
       "scenario_type": "approval",
       "title": "Approval gate for high-risk action",
       "given": "Exercise the release path for stripe.create_refund.",
       "expected_control": "The run records human approval before the tool call and denies calls without approval.",
       "source_misalignments": [
-        "mis_d385027b6bbe4d9a"
+        "mis_dcc110f9c063a92f"
       ],
       "source_findings": [
         "fp_f092940f62fbb012"
       ]
     },
     {
-      "id": "scn_e1bfcac8b42a8a90",
+      "id": "scn_2eb8e62c2e32b68d",
       "scenario_type": "schema_boundary",
       "title": "Tool schema boundary check",
       "given": "Exercise the release path for gmail.send_customer_email, send_email_preview, stripe.create_refund, and 1 more tool(s).",
       "expected_control": "The tool accepts bounded structured inputs and returns structured outputs where needed.",
       "source_misalignments": [
-        "mis_317928709e9f8f80",
-        "mis_7138f222cf9818e8",
-        "mis_886dfe311fe202c0",
-        "mis_ffc5c8dedf96a397"
+        "mis_18add992533aad5c",
+        "mis_3ca3250a83e2d44e",
+        "mis_95cf603d13a240d8",
+        "mis_e6610a213ea2372c"
       ],
       "source_findings": [
         "fp_85f8513ad72cd9ea",
@@ -856,13 +832,13 @@
       ]
     },
     {
-      "id": "scn_5ea8402dd61e62e7",
+      "id": "scn_37efebb31c66ffaa",
       "scenario_type": "test_case_coverage",
       "title": "High-risk tool validation case",
       "given": "Exercise the release path for shopify.cancel_order.",
       "expected_control": "A declared test or review scenario covers the high-risk tool path.",
       "source_misalignments": [
-        "mis_bc0ad7ca831c38c4"
+        "mis_63049d8f91bd21ae"
       ],
       "source_findings": [
         "fp_fd2577850cef1f87"
@@ -882,14 +858,14 @@
       ]
     },
     {
-      "id": "scn_7582ad2eedae8dee",
+      "id": "scn_26d5407d7346b15b",
       "scenario_type": "confirmation",
       "title": "Confirmation gate for external or destructive action",
       "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
       "expected_control": "The run records explicit confirmation before the side effect occurs.",
       "source_misalignments": [
-        "mis_36b88ddad41620e0",
-        "mis_ba2b15a6d70dfa9c"
+        "mis_752222595b2f3407",
+        "mis_7c7e84f12ab69da1"
       ],
       "source_findings": [
         "fp_8e08a4fe6b0917f6",
@@ -897,14 +873,14 @@
       ]
     },
     {
-      "id": "scn_b8c7df78d58bed64",
+      "id": "scn_2ccd8a185ed99d5b",
       "scenario_type": "prohibited_action",
       "title": "Prohibited-action guard",
       "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
       "expected_control": "The prohibited action is blocked, removed, or covered by the stated control.",
       "source_misalignments": [
-        "mis_76ba17f3e2dd6921",
-        "mis_cdb0dc4994f27ecc"
+        "mis_0cafc4f91c45e5d3",
+        "mis_e4a5afb9dde265df"
       ],
       "source_findings": [
         "fp_12985c36a06026de",
@@ -912,16 +888,16 @@
       ]
     },
     {
-      "id": "scn_8854d797a2416c6a",
+      "id": "scn_a2914ba20ff3bf86",
       "scenario_type": "least_privilege_scope",
       "title": "Least-privilege scope review",
       "given": "Exercise the release path for gmail.send_customer_email, shopify.cancel_order, support.search_kb.",
       "expected_control": "Manifest and tool scopes match the narrow permissions needed for the release.",
       "source_misalignments": [
-        "mis_2e65d10ba6180158",
+        "mis_129f018e1e3c516f",
         "mis_a9b10d037a91d1ef",
-        "mis_b59536c79ea4fb8c",
-        "mis_dc6502ac3516c43f",
+        "mis_cca919e04e5e3978",
+        "mis_d23ee56172b01749",
         "mis_ed9ce79c45da4d6e"
       ],
       "source_findings": [

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "0.1",
-  "report_schema_version": "0.8",
+  "report_schema_version": "0.9",
   "run_id": "agents_shipgate_3716da0eb0ec2fad",
   "manifest_dir": "<REPO>/samples/support_refund_agent",
   "project": {
@@ -248,6 +248,694 @@
       "exit_code": 0
     }
   },
+  "capability_facts": [
+    {
+      "id": "cap_3250ca3c56d98471",
+      "tool_name": "gmail.send_customer_email",
+      "source_type": "mcp",
+      "source_ref": ".agents-shipgate/mcp-tools.json",
+      "capability": "external_write",
+      "risk_tags": [
+        "customer_communication",
+        "external_write"
+      ],
+      "auth_scopes": [
+        "gmail:send"
+      ],
+      "owner": "support-platform",
+      "included_reason": "referenced_by_high_finding",
+      "control_status": "missing",
+      "related_findings": [
+        "fp_0f8aaa912d589cf0",
+        "fp_1f6cfd6b7daa9b7c",
+        "fp_8e08a4fe6b0917f6",
+        "fp_acd63b899d49aa1c",
+        "fp_e090c62e390e70ab"
+      ]
+    },
+    {
+      "id": "cap_749e8c123fc42753",
+      "tool_name": "send_email_preview",
+      "source_type": "sdk_function",
+      "source_ref": "agents/refund_agent.py",
+      "capability": "read_only",
+      "risk_tags": [
+        "read_only"
+      ],
+      "auth_scopes": [],
+      "owner": null,
+      "included_reason": "referenced_by_medium_finding",
+      "control_status": "partial",
+      "related_findings": [
+        "fp_85f8513ad72cd9ea"
+      ]
+    },
+    {
+      "id": "cap_fd7aa0505dafb1dc",
+      "tool_name": "shopify.cancel_order",
+      "source_type": "openapi",
+      "source_ref": "specs/support-tools.openapi.yaml#/paths/~1orders~1{order_id}~1cancel/post",
+      "capability": "destructive",
+      "risk_tags": [
+        "destructive",
+        "write"
+      ],
+      "auth_scopes": [
+        "shopify:orders:write"
+      ],
+      "owner": null,
+      "included_reason": "referenced_by_high_finding",
+      "control_status": "missing",
+      "related_findings": [
+        "fp_83852fbd6b440524",
+        "fp_fd2577850cef1f87"
+      ]
+    },
+    {
+      "id": "cap_4df422ae44a17657",
+      "tool_name": "stripe.create_refund",
+      "source_type": "openapi",
+      "source_ref": "specs/support-tools.openapi.yaml#/paths/~1refunds/post",
+      "capability": "financial_action",
+      "risk_tags": [
+        "external_write",
+        "financial_action",
+        "write"
+      ],
+      "auth_scopes": [
+        "stripe:refunds:write"
+      ],
+      "owner": "payments-platform",
+      "included_reason": "referenced_by_critical_finding",
+      "control_status": "missing",
+      "related_findings": [
+        "fp_12985c36a06026de",
+        "fp_a62ca2fd9a68a1d1",
+        "fp_ab60b01cb53cfcbe",
+        "fp_dac8011e14c53777",
+        "fp_f092940f62fbb012"
+      ]
+    },
+    {
+      "id": "cap_6b87864148184ced",
+      "tool_name": "support.search_kb",
+      "source_type": "mcp",
+      "source_ref": ".agents-shipgate/mcp-tools.json",
+      "capability": "read_only",
+      "risk_tags": [
+        "read_only"
+      ],
+      "auth_scopes": [
+        "support:kb:read"
+      ],
+      "owner": "support-platform",
+      "included_reason": "referenced_by_high_finding",
+      "control_status": "missing",
+      "related_findings": [
+        "fp_d8e6d1865dae97cc"
+      ]
+    },
+    {
+      "id": "cap_1ee04a89c7e78ddb",
+      "tool_name": "wildcard_mcp_tools.*",
+      "source_type": "mcp",
+      "source_ref": ".agents-shipgate/wildcard-tools.json",
+      "capability": "wildcard_tool_surface",
+      "risk_tags": [],
+      "auth_scopes": [],
+      "owner": null,
+      "included_reason": "referenced_by_high_finding",
+      "control_status": "unknown",
+      "related_findings": [
+        "fp_fc02d8ecd30f2578"
+      ]
+    },
+    {
+      "id": "cap_0da3f29d7a7c1ee8",
+      "tool_name": "zendesk.update_ticket",
+      "source_type": "openapi",
+      "source_ref": "specs/support-tools.openapi.yaml#/paths/~1tickets~1{ticket_id}/patch",
+      "capability": "write",
+      "risk_tags": [
+        "write"
+      ],
+      "auth_scopes": [
+        "zendesk:tickets:write"
+      ],
+      "owner": null,
+      "included_reason": "referenced_by_high_finding",
+      "control_status": "partial",
+      "related_findings": [
+        "fp_ff2f028953d1c220"
+      ]
+    }
+  ],
+  "declared_intentions": [
+    {
+      "id": "int_004d51021dfae86d",
+      "kind": "declared_purpose",
+      "text": "prepare refund requests for human review",
+      "source": "agent.declared_purpose",
+      "intent_tags": [
+        "financial_action"
+      ]
+    },
+    {
+      "id": "int_0f762dcf27664a26",
+      "kind": "declared_purpose",
+      "text": "update support ticket notes",
+      "source": "agent.declared_purpose",
+      "intent_tags": [
+        "write"
+      ]
+    },
+    {
+      "id": "int_5f0f3ef33e71dbf1",
+      "kind": "declared_purpose",
+      "text": "answer refund policy questions",
+      "source": "agent.declared_purpose",
+      "intent_tags": [
+        "financial_action",
+        "read_only"
+      ]
+    },
+    {
+      "id": "int_8e0b56f5f01971bd",
+      "kind": "prohibited_action",
+      "text": "issue refund without approval",
+      "source": "agent.prohibited_actions",
+      "intent_tags": [
+        "financial_action",
+        "write"
+      ]
+    },
+    {
+      "id": "int_9dd078e191c7bd70",
+      "kind": "prohibited_action",
+      "text": "cancel order without explicit confirmation",
+      "source": "agent.prohibited_actions",
+      "intent_tags": [
+        "destructive"
+      ]
+    },
+    {
+      "id": "int_b4b5365de66c0cdb",
+      "kind": "prohibited_action",
+      "text": "send external email without preview",
+      "source": "agent.prohibited_actions",
+      "intent_tags": [
+        "external_write",
+        "customer_communication",
+        "write",
+        "read_only"
+      ]
+    }
+  ],
+  "misalignments": [
+    {
+      "id": "mis_9fa35b2cab89e30f",
+      "kind": "control_missing",
+      "severity": "critical",
+      "tool_name": "stripe.create_refund",
+      "capability_refs": [
+        "cap_4df422ae44a17657"
+      ],
+      "intention_refs": [
+        "int_004d51021dfae86d",
+        "int_0f762dcf27664a26",
+        "int_5f0f3ef33e71dbf1",
+        "int_8e0b56f5f01971bd",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_dac8011e14c53777"
+      ],
+      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
+      "gap": "stripe.create_refund lacks idempotency evidence.",
+      "release_implication": "Retries could duplicate financial, destructive, or external effects."
+    },
+    {
+      "id": "mis_ac6ac0b6a14cdc65",
+      "kind": "policy_gap",
+      "severity": "critical",
+      "tool_name": "stripe.create_refund",
+      "capability_refs": [
+        "cap_4df422ae44a17657"
+      ],
+      "intention_refs": [
+        "int_004d51021dfae86d",
+        "int_0f762dcf27664a26",
+        "int_5f0f3ef33e71dbf1",
+        "int_8e0b56f5f01971bd",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_f092940f62fbb012"
+      ],
+      "policy_requirement": "High-risk tools must have a declared approval policy.",
+      "gap": "stripe.create_refund lacks a declared approval policy.",
+      "release_implication": "Release is blocked until approval is declared or the tool is removed."
+    },
+    {
+      "id": "mis_b2cf0b98eed048b7",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "gmail.send_customer_email",
+      "capability_refs": [
+        "cap_3250ca3c56d98471"
+      ],
+      "intention_refs": [
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_0f8aaa912d589cf0"
+      ],
+      "policy_requirement": "Risky write tools need idempotency evidence before retryable release.",
+      "gap": "gmail.send_customer_email lacks idempotency evidence.",
+      "release_implication": "Retries could duplicate financial, destructive, or external effects."
+    },
+    {
+      "id": "mis_fe4dade5b3f7ccf4",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "gmail.send_customer_email",
+      "capability_refs": [
+        "cap_3250ca3c56d98471"
+      ],
+      "intention_refs": [
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_acd63b899d49aa1c"
+      ],
+      "policy_requirement": "Action-like tool inputs must constrain high-blast-radius fields.",
+      "gap": "gmail.send_customer_email accepts broad free-form action input.",
+      "release_implication": "Release reviewers cannot bound the operation payload safely."
+    },
+    {
+      "id": "mis_be87ecd392dd016f",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "shopify.cancel_order",
+      "capability_refs": [
+        "cap_fd7aa0505dafb1dc"
+      ],
+      "intention_refs": [
+        "int_0f762dcf27664a26",
+        "int_8e0b56f5f01971bd",
+        "int_9dd078e191c7bd70",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_fd2577850cef1f87"
+      ],
+      "policy_requirement": "Manifest metadata must match the active release surface.",
+      "gap": "shopify.cancel_order is high-risk but has no owner.",
+      "release_implication": "Release review metadata is incomplete or stale."
+    },
+    {
+      "id": "mis_09c4cc31880f873b",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "stripe.create_refund",
+      "capability_refs": [
+        "cap_4df422ae44a17657"
+      ],
+      "intention_refs": [
+        "int_004d51021dfae86d",
+        "int_0f762dcf27664a26",
+        "int_5f0f3ef33e71dbf1",
+        "int_8e0b56f5f01971bd",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_ab60b01cb53cfcbe"
+      ],
+      "policy_requirement": "Risky numeric parameters must declare a maximum or equivalent limit.",
+      "gap": "stripe.create_refund.amount has no maximum bound.",
+      "release_implication": "Release reviewers cannot verify blast-radius limits."
+    },
+    {
+      "id": "mis_f5aff0ea6d28b3f0",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "wildcard_mcp_tools.*",
+      "capability_refs": [
+        "cap_1ee04a89c7e78ddb"
+      ],
+      "intention_refs": [],
+      "finding_refs": [
+        "fp_fc02d8ecd30f2578"
+      ],
+      "policy_requirement": "Tool exposure must use an explicit reviewed allowlist.",
+      "gap": "Wildcard tool exposure declared.",
+      "release_implication": "Release review cannot bound which tools may be available at runtime."
+    },
+    {
+      "id": "mis_45e6daee64343336",
+      "kind": "control_missing",
+      "severity": "high",
+      "tool_name": "zendesk.update_ticket",
+      "capability_refs": [
+        "cap_0da3f29d7a7c1ee8"
+      ],
+      "intention_refs": [
+        "int_0f762dcf27664a26",
+        "int_8e0b56f5f01971bd",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_ff2f028953d1c220"
+      ],
+      "policy_requirement": "Action-like tool inputs must constrain high-blast-radius fields.",
+      "gap": "zendesk.update_ticket accepts broad free-form action input.",
+      "release_implication": "Release reviewers cannot bound the operation payload safely."
+    },
+    {
+      "id": "mis_0a33eb45f2377400",
+      "kind": "policy_gap",
+      "severity": "high",
+      "tool_name": "gmail.send_customer_email",
+      "capability_refs": [
+        "cap_3250ca3c56d98471"
+      ],
+      "intention_refs": [
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_8e08a4fe6b0917f6"
+      ],
+      "policy_requirement": "Destructive, external, or customer actions require confirmation.",
+      "gap": "gmail.send_customer_email lacks a declared confirmation policy.",
+      "release_implication": "Release review must verify explicit user confirmation before shipping."
+    },
+    {
+      "id": "mis_0ebffddee4be5876",
+      "kind": "policy_gap",
+      "severity": "high",
+      "tool_name": "stripe.create_refund",
+      "capability_refs": [
+        "cap_4df422ae44a17657"
+      ],
+      "intention_refs": [
+        "int_004d51021dfae86d",
+        "int_0f762dcf27664a26",
+        "int_5f0f3ef33e71dbf1",
+        "int_8e0b56f5f01971bd",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_a62ca2fd9a68a1d1"
+      ],
+      "policy_requirement": "Destructive, external, or customer actions require confirmation.",
+      "gap": "stripe.create_refund lacks a declared confirmation policy.",
+      "release_implication": "Release review must verify explicit user confirmation before shipping."
+    },
+    {
+      "id": "mis_81e8fc6e86aea18d",
+      "kind": "prohibited_action_present",
+      "severity": "high",
+      "tool_name": "gmail.send_customer_email",
+      "capability_refs": [
+        "cap_3250ca3c56d98471"
+      ],
+      "intention_refs": [
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_e090c62e390e70ab"
+      ],
+      "policy_requirement": "Prohibited actions must not be contradicted by enabled capabilities.",
+      "gap": "gmail.send_customer_email appears to overlap with a prohibited action.",
+      "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
+    },
+    {
+      "id": "mis_ce098e4c494919ad",
+      "kind": "prohibited_action_present",
+      "severity": "high",
+      "tool_name": "stripe.create_refund",
+      "capability_refs": [
+        "cap_4df422ae44a17657"
+      ],
+      "intention_refs": [
+        "int_004d51021dfae86d",
+        "int_0f762dcf27664a26",
+        "int_5f0f3ef33e71dbf1",
+        "int_8e0b56f5f01971bd",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_12985c36a06026de"
+      ],
+      "policy_requirement": "Prohibited actions must not be contradicted by enabled capabilities.",
+      "gap": "stripe.create_refund appears to overlap with a prohibited action.",
+      "release_implication": "The tool surface appears to enable behavior the manifest prohibits."
+    },
+    {
+      "id": "mis_a9b10d037a91d1ef",
+      "kind": "scope_drift",
+      "severity": "high",
+      "tool_name": null,
+      "capability_refs": [],
+      "intention_refs": [],
+      "finding_refs": [
+        "fp_d27325cbdbbf5483"
+      ],
+      "policy_requirement": "Manifest permissions should declare narrow release scopes.",
+      "gap": "Manifest declares broad permission scopes.",
+      "release_implication": "Release may grant broader access than the reviewed capability needs."
+    },
+    {
+      "id": "mis_2a5e7e414da3b1f5",
+      "kind": "scope_drift",
+      "severity": "high",
+      "tool_name": "gmail.send_customer_email",
+      "capability_refs": [
+        "cap_3250ca3c56d98471"
+      ],
+      "intention_refs": [
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_1f6cfd6b7daa9b7c"
+      ],
+      "policy_requirement": "Manifest permissions must cover tool-required scopes.",
+      "gap": "gmail.send_customer_email requires scopes not declared in the manifest.",
+      "release_implication": "The manifest does not describe the actual permissions needed."
+    },
+    {
+      "id": "mis_85082ea6795f0f33",
+      "kind": "scope_drift",
+      "severity": "high",
+      "tool_name": "shopify.cancel_order",
+      "capability_refs": [
+        "cap_fd7aa0505dafb1dc"
+      ],
+      "intention_refs": [
+        "int_0f762dcf27664a26",
+        "int_8e0b56f5f01971bd",
+        "int_9dd078e191c7bd70",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_83852fbd6b440524"
+      ],
+      "policy_requirement": "Manifest permissions must cover tool-required scopes.",
+      "gap": "shopify.cancel_order requires scopes not declared in the manifest.",
+      "release_implication": "The manifest does not describe the actual permissions needed."
+    },
+    {
+      "id": "mis_66535e6f15386e0c",
+      "kind": "scope_drift",
+      "severity": "high",
+      "tool_name": "support.search_kb",
+      "capability_refs": [
+        "cap_6b87864148184ced"
+      ],
+      "intention_refs": [
+        "int_5f0f3ef33e71dbf1",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_d8e6d1865dae97cc"
+      ],
+      "policy_requirement": "Manifest permissions must cover tool-required scopes.",
+      "gap": "support.search_kb requires scopes not declared in the manifest.",
+      "release_implication": "The manifest does not describe the actual permissions needed."
+    },
+    {
+      "id": "mis_78f87b7a9d5cc744",
+      "kind": "control_missing",
+      "severity": "medium",
+      "tool_name": null,
+      "capability_refs": [],
+      "intention_refs": [],
+      "finding_refs": [
+        "fp_39b9ae878f343d1b"
+      ],
+      "policy_requirement": "Manifest metadata must match the active release surface.",
+      "gap": "Manifest declares unused permission scope zendesk:tickets:read.",
+      "release_implication": "Release review metadata is incomplete or stale."
+    },
+    {
+      "id": "mis_6dc5740924c5f2f0",
+      "kind": "control_missing",
+      "severity": "medium",
+      "tool_name": "send_email_preview",
+      "capability_refs": [
+        "cap_749e8c123fc42753"
+      ],
+      "intention_refs": [
+        "int_5f0f3ef33e71dbf1",
+        "int_b4b5365de66c0cdb"
+      ],
+      "finding_refs": [
+        "fp_85f8513ad72cd9ea"
+      ],
+      "policy_requirement": "Model-consumed tool outputs should be structured.",
+      "gap": "send_email_preview returns free-form text output.",
+      "release_implication": "Downstream model behavior may depend on unstructured tool output."
+    }
+  ],
+  "release_consequence": {
+    "decision": "blocked",
+    "summary": "2 capability/intent misalignment(s) map to active release blockers; resolve required controls or remove the capability.",
+    "blocker_misalignment_count": 2,
+    "review_misalignment_count": 16,
+    "fail_policy": {
+      "ci_mode": "advisory",
+      "fail_on": [],
+      "new_findings_only": false,
+      "would_fail_ci": false,
+      "exit_code": 0
+    }
+  },
+  "suggested_scenarios": [
+    {
+      "id": "scn_1d6fb6c4313807a9",
+      "scenario_type": "idempotency_retry",
+      "title": "Retry behavior for risky write",
+      "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
+      "expected_control": "Retries use idempotency evidence or the side effect is not retried.",
+      "source_misalignments": [
+        "mis_9fa35b2cab89e30f",
+        "mis_b2cf0b98eed048b7"
+      ],
+      "source_findings": [
+        "fp_0f8aaa912d589cf0",
+        "fp_dac8011e14c53777"
+      ]
+    },
+    {
+      "id": "scn_da30e0b0b7fefcbe",
+      "scenario_type": "approval",
+      "title": "Approval gate for high-risk action",
+      "given": "Exercise the release path for stripe.create_refund.",
+      "expected_control": "The run records human approval before the tool call and denies calls without approval.",
+      "source_misalignments": [
+        "mis_ac6ac0b6a14cdc65"
+      ],
+      "source_findings": [
+        "fp_f092940f62fbb012"
+      ]
+    },
+    {
+      "id": "scn_c6c3dbc5a98636af",
+      "scenario_type": "schema_boundary",
+      "title": "Tool schema boundary check",
+      "given": "Exercise the release path for gmail.send_customer_email, send_email_preview, stripe.create_refund, and 1 more tool(s).",
+      "expected_control": "The tool accepts bounded structured inputs and returns structured outputs where needed.",
+      "source_misalignments": [
+        "mis_09c4cc31880f873b",
+        "mis_45e6daee64343336",
+        "mis_6dc5740924c5f2f0",
+        "mis_fe4dade5b3f7ccf4"
+      ],
+      "source_findings": [
+        "fp_85f8513ad72cd9ea",
+        "fp_ab60b01cb53cfcbe",
+        "fp_acd63b899d49aa1c",
+        "fp_ff2f028953d1c220"
+      ]
+    },
+    {
+      "id": "scn_01bcaaa9f688b408",
+      "scenario_type": "test_case_coverage",
+      "title": "High-risk tool validation case",
+      "given": "Exercise the release path for shopify.cancel_order.",
+      "expected_control": "A declared test or review scenario covers the high-risk tool path.",
+      "source_misalignments": [
+        "mis_78f87b7a9d5cc744",
+        "mis_be87ecd392dd016f"
+      ],
+      "source_findings": [
+        "fp_39b9ae878f343d1b",
+        "fp_fd2577850cef1f87"
+      ]
+    },
+    {
+      "id": "scn_feb70134401df433",
+      "scenario_type": "wildcard_inventory",
+      "title": "Explicit tool inventory review",
+      "given": "Exercise the release path for wildcard_mcp_tools.*.",
+      "expected_control": "The release exposes a static allowlist instead of wildcard or unbounded tools.",
+      "source_misalignments": [
+        "mis_f5aff0ea6d28b3f0"
+      ],
+      "source_findings": [
+        "fp_fc02d8ecd30f2578"
+      ]
+    },
+    {
+      "id": "scn_3154e6988f94994a",
+      "scenario_type": "confirmation",
+      "title": "Confirmation gate for external or destructive action",
+      "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
+      "expected_control": "The run records explicit confirmation before the side effect occurs.",
+      "source_misalignments": [
+        "mis_0a33eb45f2377400",
+        "mis_0ebffddee4be5876"
+      ],
+      "source_findings": [
+        "fp_8e08a4fe6b0917f6",
+        "fp_a62ca2fd9a68a1d1"
+      ]
+    },
+    {
+      "id": "scn_f7283a9f3b88aa44",
+      "scenario_type": "prohibited_action",
+      "title": "Prohibited-action guard",
+      "given": "Exercise the release path for gmail.send_customer_email, stripe.create_refund.",
+      "expected_control": "The prohibited action is blocked, removed, or covered by the stated control.",
+      "source_misalignments": [
+        "mis_81e8fc6e86aea18d",
+        "mis_ce098e4c494919ad"
+      ],
+      "source_findings": [
+        "fp_12985c36a06026de",
+        "fp_e090c62e390e70ab"
+      ]
+    },
+    {
+      "id": "scn_379fcdc7a1a67c63",
+      "scenario_type": "least_privilege_scope",
+      "title": "Least-privilege scope review",
+      "given": "Exercise the release path for gmail.send_customer_email, shopify.cancel_order, support.search_kb.",
+      "expected_control": "Manifest and tool scopes match the narrow permissions needed for the release.",
+      "source_misalignments": [
+        "mis_2a5e7e414da3b1f5",
+        "mis_66535e6f15386e0c",
+        "mis_85082ea6795f0f33",
+        "mis_a9b10d037a91d1ef"
+      ],
+      "source_findings": [
+        "fp_1f6cfd6b7daa9b7c",
+        "fp_83852fbd6b440524",
+        "fp_d27325cbdbbf5483",
+        "fp_d8e6d1865dae97cc"
+      ]
+    }
+  ],
   "tool_surface": {
     "total_tools": 8,
     "high_risk_tools": 3,
@@ -861,7 +1549,8 @@
     "Declare an owner for each high-risk production tool in risk_overrides.tools."
   ],
   "generated_reports": {
-    "json": "/private/var/folders/_n/xw32gm0n7f957mtdq1mwfl3c0000gn/T/tmp94ljt4m7/report.json"
+    "markdown": "<TMP>/report.md",
+    "json": "<TMP>/report.json"
   },
   "loaded_policy_packs": [],
   "loaded_plugins": [],

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -772,7 +772,7 @@
   ],
   "release_consequence": {
     "decision": "blocked",
-    "summary": "2 capability/intent misalignment(s) map to active release blockers; resolve required controls or remove the capability.",
+    "summary": "2 release-relevant finding(s) map to active release blockers; resolve required controls or remove the capability.",
     "blocker_misalignment_count": 2,
     "review_misalignment_count": 16,
     "fail_policy": {

--- a/samples/support_refund_agent/expected/report.md
+++ b/samples/support_refund_agent/expected/report.md
@@ -72,12 +72,12 @@ Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fa
 
 Agent intent:
 
-- prohibited\_action: issue refund without approval (tags: financial\_action, write)
+- prohibited\_action: issue refund without approval (tags: financial\_action)
+- prohibited\_action: send external email without preview (tags: external\_write, customer\_communication)
 - prohibited\_action: cancel order without explicit confirmation (tags: destructive)
-- prohibited\_action: send external email without preview (tags: external\_write, customer\_communication, write)
 - declared\_purpose: prepare refund requests for human review (tags: financial\_action)
-- declared\_purpose: update support ticket notes (tags: write)
-- declared\_purpose: answer refund policy questions (tags: financial\_action, read\_only)
+- declared\_purpose: update support ticket notes (tags: none)
+- declared\_purpose: answer refund policy questions (tags: financial\_action)
 
 Actual capabilities:
 

--- a/samples/support_refund_agent/expected/report.md
+++ b/samples/support_refund_agent/expected/report.md
@@ -110,7 +110,7 @@ Policy/control gaps:
 Release implication:
 
 - Decision: blocked
-- 2 capability/intent misalignment\(s\) map to active release blockers; resolve required controls or remove the capability.
+- 2 release-relevant finding\(s\) map to active release blockers; resolve required controls or remove the capability.
 
 Next validation:
 

--- a/samples/support_refund_agent/expected/report.md
+++ b/samples/support_refund_agent/expected/report.md
@@ -72,10 +72,12 @@ Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fa
 
 Agent intent:
 
+- prohibited\_action: issue refund without approval (tags: financial\_action, write)
+- prohibited\_action: cancel order without explicit confirmation (tags: destructive)
+- prohibited\_action: send external email without preview (tags: external\_write, customer\_communication, write)
 - declared\_purpose: prepare refund requests for human review (tags: financial\_action)
 - declared\_purpose: update support ticket notes (tags: write)
 - declared\_purpose: answer refund policy questions (tags: financial\_action, read\_only)
-- 3 more in report.json
 
 Actual capabilities:
 
@@ -94,12 +96,12 @@ Policy/control gaps:
 - CRITICAL policy\_gap \[stripe.create\_refund\]: stripe.create\_refund lacks a declared approval policy.
   Requires: High-risk tools must have a declared approval policy.
   Release implication: Release is blocked until approval is declared or the tool is removed.
-- HIGH control\_missing \[gmail.send\_customer\_email\]: gmail.send\_customer\_email lacks idempotency evidence.
-  Requires: Risky write tools need idempotency evidence before retryable release.
-  Release implication: Retries could duplicate financial, destructive, or external effects.
 - HIGH control\_missing \[gmail.send\_customer\_email\]: gmail.send\_customer\_email accepts broad free-form action input.
   Requires: Action-like tool inputs must constrain high-blast-radius fields.
   Release implication: Release reviewers cannot bound the operation payload safely.
+- HIGH control\_missing \[gmail.send\_customer\_email\]: gmail.send\_customer\_email lacks idempotency evidence.
+  Requires: Risky write tools need idempotency evidence before retryable release.
+  Release implication: Retries could duplicate financial, destructive, or external effects.
 - HIGH control\_missing \[shopify.cancel\_order\]: shopify.cancel\_order is high-risk but has no owner.
   Requires: Manifest metadata must match the active release surface.
   Release implication: Release review metadata is incomplete or stale.

--- a/samples/support_refund_agent/expected/report.md
+++ b/samples/support_refund_agent/expected/report.md
@@ -68,6 +68,57 @@ Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fa
    Evidence: tool\_scopes=\['support:kb:read'\]; manifest\_scopes=\['zendesk:tickets:read', 'zendesk:tickets:write', 'stripe:\*'\]; missing\_scopes=\['support:kb:read'\]
    Recommendation: Add the required scopes for support.search\_kb to permissions.scopes or narrow the tool's declared auth requirements.
 
+## Capability <-> Intent Diff
+
+Agent intent:
+
+- declared\_purpose: prepare refund requests for human review (tags: financial\_action)
+- declared\_purpose: update support ticket notes (tags: write)
+- declared\_purpose: answer refund policy questions (tags: financial\_action, read\_only)
+- 3 more in report.json
+
+Actual capabilities:
+
+- gmail.send\_customer\_email: capability=external\_write, risk=customer\_communication, external\_write, control=missing
+- send\_email\_preview: capability=read\_only, risk=read\_only, control=partial
+- shopify.cancel\_order: capability=destructive, risk=destructive, write, control=missing
+- stripe.create\_refund: capability=financial\_action, risk=external\_write, financial\_action, write, control=missing
+- support.search\_kb: capability=read\_only, risk=read\_only, control=missing
+- 2 more in report.json
+
+Policy/control gaps:
+
+- CRITICAL control\_missing \[stripe.create\_refund\]: stripe.create\_refund lacks idempotency evidence.
+  Requires: Risky write tools need idempotency evidence before retryable release.
+  Release implication: Retries could duplicate financial, destructive, or external effects.
+- CRITICAL policy\_gap \[stripe.create\_refund\]: stripe.create\_refund lacks a declared approval policy.
+  Requires: High-risk tools must have a declared approval policy.
+  Release implication: Release is blocked until approval is declared or the tool is removed.
+- HIGH control\_missing \[gmail.send\_customer\_email\]: gmail.send\_customer\_email lacks idempotency evidence.
+  Requires: Risky write tools need idempotency evidence before retryable release.
+  Release implication: Retries could duplicate financial, destructive, or external effects.
+- HIGH control\_missing \[gmail.send\_customer\_email\]: gmail.send\_customer\_email accepts broad free-form action input.
+  Requires: Action-like tool inputs must constrain high-blast-radius fields.
+  Release implication: Release reviewers cannot bound the operation payload safely.
+- HIGH control\_missing \[shopify.cancel\_order\]: shopify.cancel\_order is high-risk but has no owner.
+  Requires: Manifest metadata must match the active release surface.
+  Release implication: Release review metadata is incomplete or stale.
+- 13 more in report.json
+
+Release implication:
+
+- Decision: blocked
+- 2 capability/intent misalignment\(s\) map to active release blockers; resolve required controls or remove the capability.
+
+Next validation:
+
+- Retry behavior for risky write: Retries use idempotency evidence or the side effect is not retried.
+- Approval gate for high-risk action: The run records human approval before the tool call and denies calls without approval.
+- Tool schema boundary check: The tool accepts bounded structured inputs and returns structured outputs where needed.
+- High-risk tool validation case: A declared test or review scenario covers the high-risk tool path.
+- Explicit tool inventory review: The release exposes a static allowlist instead of wildcard or unbounded tools.
+- 3 more in report.json
+
 ## Recommended Next Actions
 
 - Declare an approval policy for stripe.create\_refund or remove this tool from the release.

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -84,12 +84,12 @@ def write_report_schema() -> None:
         "post-processing to preserve the v0.5 public contract. "
         "Do not edit by hand."
     )
-    # Preserve v0.5's stable required list, plus v0.8 additions.
+    # Preserve v0.5's stable required list, plus v0.8/v0.9 additions.
     # Optional intermediate additions (manifest_dir, per-finding patches)
     # are not added here, so they stay optional for additive consumers.
-    # `release_decision` is required at v0.8: every emitted report has it
-    # (build_report always populates it). Marking it required at the
-    # schema level catches drift early.
+    # `release_decision` is required at v0.8, and the v0.9 capability diff
+    # fields are required for every emitted report. Marking them required
+    # at the schema level catches drift early.
     schema["required"] = sorted(
         [
             "schema_version",
@@ -100,6 +100,11 @@ def write_report_schema() -> None:
             "environment",
             "summary",
             "release_decision",
+            "capability_facts",
+            "declared_intentions",
+            "misalignments",
+            "release_consequence",
+            "suggested_scenarios",
             "tool_surface",
             "frameworks",
             "findings",
@@ -125,6 +130,7 @@ def write_report_schema() -> None:
     # `anyOf: [ReleaseDecision, null]`, which would let `null` pass
     # validation and silently violate the v0.8 contract.
     properties["release_decision"] = {"$ref": "#/$defs/ReleaseDecision"}
+    properties["release_consequence"] = {"$ref": "#/$defs/ReleaseConsequence"}
 
     # Preserve nested v0.5 required lists. Pydantic auto-generation marks
     # only fields without defaults as required, but consumers depend on
@@ -198,6 +204,63 @@ def write_report_schema() -> None:
                 "new_findings_only",
                 "would_fail_ci",
                 "exit_code",
+            ]
+        )
+    if "CapabilityFact" in defs:
+        defs["CapabilityFact"]["required"] = sorted(
+            [
+                "id",
+                "tool_name",
+                "source_type",
+                "source_ref",
+                "capability",
+                "risk_tags",
+                "auth_scopes",
+                "owner",
+                "included_reason",
+                "control_status",
+                "related_findings",
+            ]
+        )
+    if "DeclaredIntention" in defs:
+        defs["DeclaredIntention"]["required"] = sorted(
+            ["id", "kind", "text", "source", "intent_tags"]
+        )
+    if "Misalignment" in defs:
+        defs["Misalignment"]["required"] = sorted(
+            [
+                "id",
+                "kind",
+                "severity",
+                "tool_name",
+                "capability_refs",
+                "intention_refs",
+                "finding_refs",
+                "policy_requirement",
+                "gap",
+                "release_implication",
+            ]
+        )
+    if "ReleaseConsequence" in defs:
+        defs["ReleaseConsequence"]["required"] = sorted(
+            [
+                "decision",
+                "summary",
+                "blocker_misalignment_count",
+                "review_misalignment_count",
+                "fail_policy",
+            ]
+        )
+    if "SuggestedScenario" in defs:
+        defs["SuggestedScenario"]["required"] = sorted(
+            [
+                "id",
+                "scenario_type",
+                "title",
+                "given",
+                "expected_control",
+                "source_misalignments",
+                "source_findings",
             ]
         )
 

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -40,6 +40,7 @@ from agents_shipgate.inputs.openai_api import load_openai_api_artifacts
 from agents_shipgate.inputs.openai_sdk_static import load_openai_sdk_static_tools
 from agents_shipgate.inputs.openapi import load_openapi_tools
 from agents_shipgate.inputs.policy_packs import load_policy_packs, run_policy_pack_rules
+from agents_shipgate.report.capability_diff import apply_capability_diff
 from agents_shipgate.report.json_report import write_json_report
 from agents_shipgate.report.markdown import write_markdown_report
 from agents_shipgate.report.sarif import write_sarif_report
@@ -241,6 +242,7 @@ def run_scan(
         frameworks=frameworks_surface,
         baseline=baseline_summary,
     )
+    apply_capability_diff(report, tools)
     _write_reports(report, generated_paths, manifest.output.formats)
     write_github_step_summary(report)
     assert report.release_decision is not None  # build_report always populates it

--- a/src/agents_shipgate/core/models.py
+++ b/src/agents_shipgate/core/models.py
@@ -244,6 +244,93 @@ class ReleaseDecision(BaseModel):
     fail_policy: FailPolicy
 
 
+DeclaredIntentionKind = Literal[
+    "declared_purpose",
+    "prohibited_action",
+    "instruction_preview",
+]
+CapabilityIncludedReason = Literal[
+    "high_risk_tag",
+    "wildcard_exposure",
+    "referenced_by_critical_finding",
+    "referenced_by_high_finding",
+    "referenced_by_medium_finding",
+]
+CapabilityControlStatus = Literal["missing", "partial", "present", "unknown"]
+MisalignmentKind = Literal[
+    "policy_gap",
+    "scope_drift",
+    "prohibited_action_present",
+    "control_missing",
+    "intent_mismatch",
+    "undetected_gap",
+]
+SuggestedScenarioType = Literal[
+    "approval",
+    "confirmation",
+    "idempotency_retry",
+    "least_privilege_scope",
+    "prohibited_action",
+    "wildcard_inventory",
+    "schema_boundary",
+    "prompt_scope_alignment",
+    "test_case_coverage",
+]
+
+
+class CapabilityFact(BaseModel):
+    id: str
+    tool_name: str
+    source_type: str
+    source_ref: str | None = None
+    capability: str
+    risk_tags: list[str] = Field(default_factory=list)
+    auth_scopes: list[str] = Field(default_factory=list)
+    owner: str | None = None
+    included_reason: CapabilityIncludedReason
+    control_status: CapabilityControlStatus
+    related_findings: list[str] = Field(default_factory=list)
+
+
+class DeclaredIntention(BaseModel):
+    id: str
+    kind: DeclaredIntentionKind
+    text: str
+    source: str
+    intent_tags: list[str] = Field(default_factory=list)
+
+
+class Misalignment(BaseModel):
+    id: str
+    kind: MisalignmentKind
+    severity: Severity
+    tool_name: str | None = None
+    capability_refs: list[str] = Field(default_factory=list)
+    intention_refs: list[str] = Field(default_factory=list)
+    finding_refs: list[str] = Field(default_factory=list)
+    policy_requirement: str
+    gap: str
+    release_implication: str
+
+
+class ReleaseConsequence(BaseModel):
+    decision: ReleaseDecisionStatus
+    summary: str
+    blocker_misalignment_count: int = 0
+    review_misalignment_count: int = 0
+    fail_policy: FailPolicy
+
+
+class SuggestedScenario(BaseModel):
+    id: str
+    scenario_type: SuggestedScenarioType
+    title: str
+    given: str
+    expected_control: str
+    source_misalignments: list[str] = Field(default_factory=list)
+    source_findings: list[str] = Field(default_factory=list)
+
+
 class ApiResponseFormat(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
@@ -488,7 +575,7 @@ class ReadinessReport(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     schema_version: str = "0.1"
-    report_schema_version: str = "0.8"
+    report_schema_version: str = "0.9"
     run_id: str
     # v0.6 (per C13): absolute path to the directory containing
     # shipgate.yaml. apply-patches uses this to enforce a containment
@@ -503,6 +590,13 @@ class ReadinessReport(BaseModel):
     # but Python-optional so older test fixtures and SARIF-only callers
     # can construct minimal reports. build_report() always populates it.
     release_decision: ReleaseDecision | None = None
+    # v0.9 capability/intent diff. Populated for emitted scan reports after
+    # release_decision is built; defaults keep older test helpers lightweight.
+    capability_facts: list[CapabilityFact] = Field(default_factory=list)
+    declared_intentions: list[DeclaredIntention] = Field(default_factory=list)
+    misalignments: list[Misalignment] = Field(default_factory=list)
+    release_consequence: ReleaseConsequence | None = None
+    suggested_scenarios: list[SuggestedScenario] = Field(default_factory=list)
     tool_surface: ToolSurfaceSummary
     api_surface: dict[str, Any] | None = None
     anthropic_surface: dict[str, Any] | None = None

--- a/src/agents_shipgate/report/capability_diff.py
+++ b/src/agents_shipgate/report/capability_diff.py
@@ -1,3 +1,5 @@
+"""Build deterministic capability/intent diff facts for report output."""
+
 from __future__ import annotations
 
 import hashlib
@@ -33,6 +35,9 @@ RISK_TAG_PRIORITY = (
     "read_only",
 )
 
+# P0.1 intentionally covers the common release-review vocabulary first.
+# Additional aliases for infrastructure/code-exec/data-access intents can
+# be added without changing the report contract.
 INTENT_TAG_ALIASES: dict[str, tuple[str, ...]] = {
     "answer": ("read_only",),
     "billing": ("financial_action",),
@@ -63,11 +68,16 @@ INTENT_TAG_ALIASES: dict[str, tuple[str, ...]] = {
     "view": ("read_only",),
     "write": ("write",),
 }
+NEGATION_TOKENS = {"without", "no", "not", "never", "non"}
 
 RELEASE_RELEVANT_CATEGORIES = {
+    "adk",
     "api",
     "auth",
+    "crewai",
+    "documentation",
     "inventory",
+    "langchain",
     "manifest",
     "policy",
     "schema",
@@ -108,7 +118,6 @@ MISSING_CONTROL_CHECKS = {
 class DiffSpec:
     kind: MisalignmentKind
     policy_requirement: str
-    gap: str
     release_implication: str
     scenario_type: SuggestedScenarioType | None
 
@@ -123,147 +132,181 @@ CHECK_DIFF_MAP: dict[str, DiffSpec] = {
     "SHIP-INVENTORY-NOT-ENUMERABLE": DiffSpec(
         kind="control_missing",
         policy_requirement="Tool surface must be statically enumerable before release review.",
-        gap="{title}.",
         release_implication="Release review cannot verify the agent's actual tool surface.",
         scenario_type="wildcard_inventory",
     ),
     "SHIP-INVENTORY-WILDCARD-TOOLS": DiffSpec(
         kind="control_missing",
         policy_requirement="Tool exposure must use an explicit reviewed allowlist.",
-        gap="{title}.",
         release_implication="Release review cannot bound which tools may be available at runtime.",
+        scenario_type="wildcard_inventory",
+    ),
+    "SHIP-ADK-DYNAMIC-TOOLSET-NOT-ENUMERABLE": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Framework toolsets must be statically enumerable before release review.",
+        release_implication="Release review cannot verify the Google ADK toolset surface.",
+        scenario_type="wildcard_inventory",
+    ),
+    "SHIP-ADK-MCP-TOOLSET-UNFILTERED": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Framework MCP toolsets must use static tool filters or explicit inventory.",
+        release_implication="Release review cannot bound the Google ADK MCP toolset surface.",
+        scenario_type="wildcard_inventory",
+    ),
+    "SHIP-ADK-FUNCTION-TOOL-METADATA-MISSING": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Framework function tools must expose static metadata for review.",
+        release_implication="Release reviewers cannot verify the ADK function tool boundary.",
+        scenario_type="schema_boundary",
+    ),
+    "SHIP-ADK-LONGRUNNING-CONTRACT-MISSING": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Long-running framework tools need operation status and progress contracts.",
+        release_implication="Release review cannot verify continuation and retry behavior.",
+        scenario_type="schema_boundary",
+    ),
+    "SHIP-ADK-GUARDRAIL-EVIDENCE-MISSING": DiffSpec(
+        kind="control_missing",
+        policy_requirement="High-risk framework tools must include static guardrail evidence.",
+        release_implication="Release lacks deterministic evidence for high-risk framework controls.",
+        scenario_type="test_case_coverage",
+    ),
+    "SHIP-ADK-EVAL-COVERAGE-MISSING": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Production-like framework releases should declare eval coverage.",
+        release_implication="Release lacks validation evidence for production-like ADK behavior.",
+        scenario_type="test_case_coverage",
+    ),
+    "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Framework tool surfaces must be statically enumerable before release review.",
+        release_implication="Release review cannot verify the LangChain tool surface.",
+        scenario_type="wildcard_inventory",
+    ),
+    "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Framework tool surfaces must be statically enumerable before release review.",
+        release_implication="Release review cannot verify the CrewAI tool surface.",
         scenario_type="wildcard_inventory",
     ),
     "SHIP-SCHEMA-BROAD-FREE-TEXT": DiffSpec(
         kind="control_missing",
         policy_requirement="Action-like tool inputs must constrain high-blast-radius fields.",
-        gap="{title}.",
         release_implication="Release reviewers cannot bound the operation payload safely.",
         scenario_type="schema_boundary",
     ),
     "SHIP-SCHEMA-MISSING-BOUNDS": DiffSpec(
         kind="control_missing",
         policy_requirement="Risky numeric parameters must declare a maximum or equivalent limit.",
-        gap="{title}.",
         release_implication="Release reviewers cannot verify blast-radius limits.",
         scenario_type="schema_boundary",
     ),
     "SHIP-SCHEMA-FREEFORM-OUTPUT": DiffSpec(
         kind="control_missing",
         policy_requirement="Model-consumed tool outputs should be structured.",
-        gap="{title}.",
         release_implication="Downstream model behavior may depend on unstructured tool output.",
         scenario_type="schema_boundary",
     ),
     "SHIP-AUTH-MISSING-SCOPE": DiffSpec(
         kind="scope_drift",
         policy_requirement="Scope-requiring tools must declare operation-specific auth scopes.",
-        gap="{title}.",
         release_implication="Release reviewers cannot assess least privilege.",
         scenario_type="least_privilege_scope",
     ),
     "SHIP-AUTH-MANIFEST-BROAD-SCOPE": DiffSpec(
         kind="scope_drift",
         policy_requirement="Manifest permissions should declare narrow release scopes.",
-        gap="{title}.",
         release_implication="Release may grant broader access than the reviewed capability needs.",
         scenario_type="least_privilege_scope",
     ),
     "SHIP-AUTH-TOOL-BROAD-SCOPE": DiffSpec(
         kind="scope_drift",
         policy_requirement="Tool auth metadata should use narrow operation-specific scopes.",
-        gap="{title}.",
         release_implication="The tool may require broader credentials than review can justify.",
         scenario_type="least_privilege_scope",
     ),
     "SHIP-AUTH-SCOPE-COVERAGE-MISSING": DiffSpec(
         kind="scope_drift",
         policy_requirement="Manifest permissions must cover tool-required scopes.",
-        gap="{title}.",
         release_implication="The manifest does not describe the actual permissions needed.",
+        scenario_type="least_privilege_scope",
+    ),
+    "SHIP-MANIFEST-UNUSED-SCOPE": DiffSpec(
+        kind="scope_drift",
+        policy_requirement="Manifest permissions should only include scopes used by loaded tools.",
+        release_implication="Release may include stale or unnecessary permission grants.",
         scenario_type="least_privilege_scope",
     ),
     "SHIP-SCOPE-TOOL-OUTSIDE-PURPOSE": DiffSpec(
         kind="intent_mismatch",
         policy_requirement="Declared purpose must match the attached tool surface.",
-        gap="{title}.",
         release_implication="The release scope is broader than the declared agent intent.",
         scenario_type="prompt_scope_alignment",
     ),
     "SHIP-SCOPE-PROHIBITED-TOOL-PRESENT": DiffSpec(
         kind="prohibited_action_present",
         policy_requirement="Prohibited actions must not be contradicted by enabled capabilities.",
-        gap="{title}.",
         release_implication="The tool surface appears to enable behavior the manifest prohibits.",
         scenario_type="prohibited_action",
     ),
     "SHIP-POLICY-APPROVAL-MISSING": DiffSpec(
         kind="policy_gap",
         policy_requirement="High-risk tools must have a declared approval policy.",
-        gap="{title}.",
         release_implication="Release is blocked until approval is declared or the tool is removed.",
         scenario_type="approval",
     ),
     "SHIP-POLICY-CONFIRMATION-MISSING": DiffSpec(
         kind="policy_gap",
         policy_requirement="Destructive, external, or customer actions require confirmation.",
-        gap="{title}.",
         release_implication="Release review must verify explicit user confirmation before shipping.",
         scenario_type="confirmation",
     ),
     "SHIP-SIDEFX-IDEMPOTENCY-MISSING": DiffSpec(
         kind="control_missing",
         policy_requirement="Risky write tools need idempotency evidence before retryable release.",
-        gap="{title}.",
         release_implication="Retries could duplicate financial, destructive, or external effects.",
         scenario_type="idempotency_retry",
     ),
     "SHIP-API-FUNCTION-SCHEMA-STRICTNESS": DiffSpec(
         kind="control_missing",
         policy_requirement="API function schemas must be strict enough for reliable tool calls.",
-        gap="{title}.",
         release_implication="The model may send ambiguous or overbroad tool arguments.",
         scenario_type="schema_boundary",
     ),
     "SHIP-API-STRUCTURED-OUTPUT-READINESS": DiffSpec(
         kind="control_missing",
         policy_requirement="API outputs need structured success, failure, and review states.",
-        gap="{title}.",
         release_implication="Downstream release behavior may depend on under-specified output.",
         scenario_type="schema_boundary",
     ),
     "SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH": DiffSpec(
         kind="intent_mismatch",
         policy_requirement="Prompt scope must align with enabled high-risk tools.",
-        gap="{title}.",
         release_implication="The agent instructions and actual tool surface disagree.",
         scenario_type="prompt_scope_alignment",
     ),
     "SHIP-API-TEST-CASES-MISSING": DiffSpec(
         kind="control_missing",
         policy_requirement="High-risk API tool-call flows should include declared test cases.",
-        gap="{title}.",
         release_implication="Release lacks validation evidence for high-risk tool paths.",
         scenario_type="test_case_coverage",
     ),
     "SHIP-API-TRACE-APPROVAL-MISSING": DiffSpec(
         kind="policy_gap",
         policy_requirement="Trace evidence for approval-controlled tools must show approval.",
-        gap="{title}.",
         release_implication="Observed sample evidence contradicts the approval expectation.",
         scenario_type="approval",
     ),
     "SHIP-API-TRACE-CONFIRMATION-MISSING": DiffSpec(
         kind="policy_gap",
         policy_requirement="Trace evidence for confirmation-controlled tools must show confirmation.",
-        gap="{title}.",
         release_implication="Observed sample evidence contradicts the confirmation expectation.",
         scenario_type="confirmation",
     ),
 }
 
 
-def apply_capability_diff(report: ReadinessReport, tools: list[Tool]) -> ReadinessReport:
+def apply_capability_diff(report: ReadinessReport, tools: list[Tool]) -> None:
     capability_facts, declared_intentions, records = _build_diff_records(report, tools)
     misalignments = [record.misalignment for record in records]
     report.capability_facts = capability_facts
@@ -271,7 +314,6 @@ def apply_capability_diff(report: ReadinessReport, tools: list[Tool]) -> Readine
     report.misalignments = misalignments
     report.suggested_scenarios = _suggested_scenarios(records)
     report.release_consequence = _release_consequence(report, misalignments)
-    return report
 
 
 def _build_diff_records(
@@ -432,7 +474,10 @@ def _intention(kind: str, text: str, source: str) -> DeclaredIntention:
 
 def _intent_tags(text: str) -> list[str]:
     tags: set[str] = set()
-    for token in _tokens(text):
+    tokens = _ordered_tokens(text)
+    for index, token in enumerate(tokens):
+        if index > 0 and tokens[index - 1] in NEGATION_TOKENS:
+            continue
         tags.update(INTENT_TAG_ALIASES.get(token, ()))
     return sorted(tags, key=lambda tag: RISK_TAG_PRIORITY.index(tag) if tag in RISK_TAG_PRIORITY else 99)
 
@@ -468,9 +513,9 @@ def _misalignment_records(
                 capability_refs=sorted(capability_refs),
                 intention_refs=sorted(intention_refs),
                 finding_refs=sorted(finding_refs),
-                policy_requirement=_render_template(spec.policy_requirement, finding, tool_name),
-                gap=_render_template(spec.gap, finding, tool_name),
-                release_implication=_render_template(spec.release_implication, finding, tool_name),
+                policy_requirement=spec.policy_requirement,
+                gap=f"{finding.title}.",
+                release_implication=spec.release_implication,
             )
             records.append(MisalignmentRecord(misalignment, spec.scenario_type))
     return records
@@ -483,7 +528,6 @@ def _diff_spec(finding: Finding) -> DiffSpec:
         return DiffSpec(
             kind="policy_gap",
             policy_requirement="Policy-controlled tools must declare matching controls.",
-            gap="{title}.",
             release_implication="Release review must resolve the missing policy evidence.",
             scenario_type="approval",
         )
@@ -491,7 +535,6 @@ def _diff_spec(finding: Finding) -> DiffSpec:
         return DiffSpec(
             kind="scope_drift",
             policy_requirement="Auth scopes must match the reviewed release surface.",
-            gap="{title}.",
             release_implication="Least-privilege review is incomplete.",
             scenario_type="least_privilege_scope",
         )
@@ -499,7 +542,6 @@ def _diff_spec(finding: Finding) -> DiffSpec:
         return DiffSpec(
             kind="intent_mismatch",
             policy_requirement="Declared intent must align with tool capabilities.",
-            gap="{title}.",
             release_implication="The reviewed purpose does not fully cover the tool surface.",
             scenario_type="prompt_scope_alignment",
         )
@@ -507,7 +549,6 @@ def _diff_spec(finding: Finding) -> DiffSpec:
         return DiffSpec(
             kind="control_missing",
             policy_requirement="Tool schemas and metadata must constrain unsafe inputs or outputs.",
-            gap="{title}.",
             release_implication="The release has unresolved tool-boundary risk.",
             scenario_type="schema_boundary",
         )
@@ -515,14 +556,26 @@ def _diff_spec(finding: Finding) -> DiffSpec:
         return DiffSpec(
             kind="control_missing",
             policy_requirement="Manifest metadata must match the active release surface.",
-            gap="{title}.",
             release_implication="Release review metadata is incomplete or stale.",
             scenario_type="test_case_coverage",
+        )
+    if finding.category in {"adk", "langchain", "crewai"}:
+        return DiffSpec(
+            kind="control_missing",
+            policy_requirement="Framework tool surfaces and controls must be statically reviewable.",
+            release_implication="Release review cannot fully verify framework-specific tool behavior.",
+            scenario_type="wildcard_inventory",
+        )
+    if finding.category == "documentation":
+        return DiffSpec(
+            kind="control_missing",
+            policy_requirement="Tool documentation must include enough static metadata for review.",
+            release_implication="Release reviewers lack the static description needed to assess behavior.",
+            scenario_type="schema_boundary",
         )
     return DiffSpec(
         kind="undetected_gap",
         policy_requirement="Static review requires deterministic evidence for release gaps.",
-        gap="{title}.",
         release_implication="Human review is required to interpret this finding.",
         scenario_type=None,
     )
@@ -695,6 +748,8 @@ def _release_summary(decision: str, blocker_count: int, review_count: int) -> st
 def _decision_ref(item: object) -> str | None:
     item_id = getattr(item, "id", None)
     fingerprint = getattr(item, "fingerprint", None)
+    # v0.8 items currently set id == fingerprint; the fingerprint fallback
+    # keeps older test fixtures and hand-built reports defensive.
     return item_id or fingerprint
 
 
@@ -724,16 +779,8 @@ def _evidence_tags(finding: Finding) -> list[str]:
     return [tag for tag in tags if isinstance(tag, str)]
 
 
-def _render_template(template: str, finding: Finding, tool_name: str | None) -> str:
-    return template.format(
-        check_id=finding.check_id,
-        title=finding.title,
-        tool=tool_name or finding.tool_name or "agent",
-    )
-
-
-def _tokens(text: str) -> set[str]:
-    return set(re.findall(r"[a-z]+", text.lower()))
+def _ordered_tokens(text: str) -> list[str]:
+    return re.findall(r"[a-z]+", text.lower())
 
 
 def _string_list(value: object) -> list[str]:

--- a/src/agents_shipgate/report/capability_diff.py
+++ b/src/agents_shipgate/report/capability_diff.py
@@ -455,6 +455,8 @@ def _intent_tags(text: str) -> list[str]:
     tags: set[str] = set()
     tokens = _ordered_tokens(text)
     for index, token in enumerate(tokens):
+        # Adjacent-token negation covers common manifest phrasing such as
+        # "without approval", "do not refund", and "never delete".
         if index > 0 and tokens[index - 1] in NEGATION_TOKENS:
             continue
         tags.update(INTENT_TAG_ALIASES.get(token, ()))
@@ -724,12 +726,12 @@ def _release_consequence(
 def _release_summary(decision: str, blocker_count: int, review_count: int) -> str:
     if decision == "blocked":
         return (
-            f"{blocker_count} capability/intent misalignment(s) map to active "
+            f"{blocker_count} release-relevant finding(s) map to active "
             "release blockers; resolve required controls or remove the capability."
         )
     if decision == "review_required":
         return (
-            f"{review_count} capability/intent misalignment(s) require release review "
+            f"{review_count} release-relevant finding(s) require release review "
             "before shipping."
         )
     return "No capability/intent misalignments require release action from static evidence."

--- a/src/agents_shipgate/report/capability_diff.py
+++ b/src/agents_shipgate/report/capability_diff.py
@@ -11,6 +11,7 @@ from agents_shipgate.core.models import (
     CapabilityFact,
     CapabilityIncludedReason,
     DeclaredIntention,
+    DeclaredIntentionKind,
     FailPolicy,
     Finding,
     Misalignment,
@@ -39,34 +40,22 @@ RISK_TAG_PRIORITY = (
 # Additional aliases for infrastructure/code-exec/data-access intents can
 # be added without changing the report contract.
 INTENT_TAG_ALIASES: dict[str, tuple[str, ...]] = {
-    "answer": ("read_only",),
     "billing": ("financial_action",),
     "cancel": ("destructive",),
-    "create": ("write",),
     "delete": ("destructive",),
     "email": ("external_write", "customer_communication"),
     "external": ("external_write", "customer_communication"),
-    "issue": ("write",),
-    "lookup": ("read_only",),
     "message": ("external_write", "customer_communication"),
     "messages": ("external_write", "customer_communication"),
-    "modify": ("write",),
     "payment": ("financial_action",),
     "payments": ("financial_action",),
-    "preview": ("read_only",),
-    "read": ("read_only",),
     "refund": ("financial_action",),
     "refunds": ("financial_action",),
     "reimbursement": ("financial_action",),
     "reimbursements": ("financial_action",),
     "remove": ("destructive",),
-    "search": ("read_only",),
-    "send": ("external_write", "customer_communication", "write"),
+    "send": ("external_write", "customer_communication"),
     "sms": ("external_write", "customer_communication"),
-    "status": ("read_only",),
-    "update": ("write",),
-    "view": ("read_only",),
-    "write": ("write",),
 }
 NEGATION_TOKENS = {"without", "no", "not", "never", "non"}
 
@@ -94,23 +83,13 @@ INTENTION_KIND_ORDER = {
 SEVERITY_SORT = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
 
 MISSING_CONTROL_CHECKS = {
-    "SHIP-ADK-EVAL-COVERAGE-MISSING",
-    "SHIP-ADK-GUARDRAIL-EVIDENCE-MISSING",
-    "SHIP-ADK-LONGRUNNING-CONTRACT-MISSING",
-    "SHIP-API-RETRY-POLICY-MISSING",
+    "SHIP-ADK-DYNAMIC-TOOLSET-NOT-ENUMERABLE",
+    "SHIP-ADK-MCP-TOOLSET-UNFILTERED",
     "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY",
-    "SHIP-API-TEST-CASES-MISSING",
-    "SHIP-API-TIMEOUT-MISSING",
-    "SHIP-API-TOOL-OUTPUT-SCHEMA-MISSING",
-    "SHIP-AUTH-MISSING-SCOPE",
-    "SHIP-AUTH-SCOPE-COVERAGE-MISSING",
     "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
     "SHIP-INVENTORY-NOT-ENUMERABLE",
+    "SHIP-INVENTORY-WILDCARD-TOOLS",
     "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
-    "SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING",
-    "SHIP-POLICY-APPROVAL-MISSING",
-    "SHIP-POLICY-CONFIRMATION-MISSING",
-    "SHIP-SIDEFX-IDEMPOTENCY-MISSING",
 }
 
 
@@ -461,11 +440,11 @@ def _declared_intentions(report: ReadinessReport) -> list[DeclaredIntention]:
     return intentions
 
 
-def _intention(kind: str, text: str, source: str) -> DeclaredIntention:
+def _intention(kind: DeclaredIntentionKind, text: str, source: str) -> DeclaredIntention:
     tags = _intent_tags(text)
     return DeclaredIntention(
         id=_hash_id("int", kind, source, text, sorted(tags)),
-        kind=kind,  # type: ignore[arg-type]
+        kind=kind,
         text=text,
         source=source,
         intent_tags=tags,
@@ -711,22 +690,33 @@ def _release_consequence(
     decision = report.release_decision
     if decision is None:
         return None
-    blocker_refs = {_decision_ref(item) for item in decision.blockers}
-    review_refs = {_decision_ref(item) for item in decision.review_items}
-    blocker_count = sum(
-        1 for item in misalignments if blocker_refs.intersection(item.finding_refs)
-    )
-    review_count = sum(
-        1
+    blocker_refs = {
+        ref for item in decision.blockers if (ref := _decision_ref(item)) is not None
+    }
+    review_refs = {
+        ref for item in decision.review_items if (ref := _decision_ref(item)) is not None
+    }
+    blocker_finding_refs = {
+        ref
         for item in misalignments
-        if not blocker_refs.intersection(item.finding_refs)
-        and review_refs.intersection(item.finding_refs)
-    )
+        for ref in item.finding_refs
+        if ref in blocker_refs
+    }
+    review_finding_refs = {
+        ref
+        for item in misalignments
+        for ref in item.finding_refs
+        if ref in review_refs and ref not in blocker_refs
+    }
     return ReleaseConsequence(
         decision=decision.decision,
-        summary=_release_summary(decision.decision, blocker_count, review_count),
-        blocker_misalignment_count=blocker_count,
-        review_misalignment_count=review_count,
+        summary=_release_summary(
+            decision.decision,
+            len(blocker_finding_refs),
+            len(review_finding_refs),
+        ),
+        blocker_misalignment_count=len(blocker_finding_refs),
+        review_misalignment_count=len(review_finding_refs),
         fail_policy=FailPolicy.model_validate(decision.fail_policy.model_dump()),
     )
 

--- a/src/agents_shipgate/report/capability_diff.py
+++ b/src/agents_shipgate/report/capability_diff.py
@@ -1,0 +1,756 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+
+from agents_shipgate.core.models import (
+    CapabilityFact,
+    CapabilityIncludedReason,
+    DeclaredIntention,
+    FailPolicy,
+    Finding,
+    Misalignment,
+    MisalignmentKind,
+    ReadinessReport,
+    ReleaseConsequence,
+    SuggestedScenario,
+    SuggestedScenarioType,
+    Tool,
+)
+from agents_shipgate.core.risk_hints import is_high_risk_tool, risk_tags
+
+RISK_TAG_PRIORITY = (
+    "financial_action",
+    "destructive",
+    "external_write",
+    "customer_communication",
+    "sensitive_data_access",
+    "infrastructure_change",
+    "code_execution",
+    "write",
+    "read_only",
+)
+
+INTENT_TAG_ALIASES: dict[str, tuple[str, ...]] = {
+    "answer": ("read_only",),
+    "billing": ("financial_action",),
+    "cancel": ("destructive",),
+    "create": ("write",),
+    "delete": ("destructive",),
+    "email": ("external_write", "customer_communication"),
+    "external": ("external_write", "customer_communication"),
+    "issue": ("write",),
+    "lookup": ("read_only",),
+    "message": ("external_write", "customer_communication"),
+    "messages": ("external_write", "customer_communication"),
+    "modify": ("write",),
+    "payment": ("financial_action",),
+    "payments": ("financial_action",),
+    "preview": ("read_only",),
+    "read": ("read_only",),
+    "refund": ("financial_action",),
+    "refunds": ("financial_action",),
+    "reimbursement": ("financial_action",),
+    "reimbursements": ("financial_action",),
+    "remove": ("destructive",),
+    "search": ("read_only",),
+    "send": ("external_write", "customer_communication", "write"),
+    "sms": ("external_write", "customer_communication"),
+    "status": ("read_only",),
+    "update": ("write",),
+    "view": ("read_only",),
+    "write": ("write",),
+}
+
+RELEASE_RELEVANT_CATEGORIES = {
+    "api",
+    "auth",
+    "inventory",
+    "manifest",
+    "policy",
+    "schema",
+    "scope",
+    "security",
+    "side_effects",
+}
+RELEASE_RELEVANT_SEVERITIES = {"critical", "high", "medium"}
+INTENTION_KIND_ORDER = {
+    "declared_purpose": 0,
+    "prohibited_action": 1,
+    "instruction_preview": 2,
+}
+SEVERITY_SORT = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+
+MISSING_CONTROL_CHECKS = {
+    "SHIP-ADK-EVAL-COVERAGE-MISSING",
+    "SHIP-ADK-GUARDRAIL-EVIDENCE-MISSING",
+    "SHIP-ADK-LONGRUNNING-CONTRACT-MISSING",
+    "SHIP-API-RETRY-POLICY-MISSING",
+    "SHIP-API-RETRY-WITHOUT-IDEMPOTENCY",
+    "SHIP-API-TEST-CASES-MISSING",
+    "SHIP-API-TIMEOUT-MISSING",
+    "SHIP-API-TOOL-OUTPUT-SCHEMA-MISSING",
+    "SHIP-AUTH-MISSING-SCOPE",
+    "SHIP-AUTH-SCOPE-COVERAGE-MISSING",
+    "SHIP-CREWAI-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
+    "SHIP-INVENTORY-NOT-ENUMERABLE",
+    "SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
+    "SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING",
+    "SHIP-POLICY-APPROVAL-MISSING",
+    "SHIP-POLICY-CONFIRMATION-MISSING",
+    "SHIP-SIDEFX-IDEMPOTENCY-MISSING",
+}
+
+
+@dataclass(frozen=True)
+class DiffSpec:
+    kind: MisalignmentKind
+    policy_requirement: str
+    gap: str
+    release_implication: str
+    scenario_type: SuggestedScenarioType | None
+
+
+@dataclass(frozen=True)
+class MisalignmentRecord:
+    misalignment: Misalignment
+    scenario_type: SuggestedScenarioType | None
+
+
+CHECK_DIFF_MAP: dict[str, DiffSpec] = {
+    "SHIP-INVENTORY-NOT-ENUMERABLE": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Tool surface must be statically enumerable before release review.",
+        gap="{title}.",
+        release_implication="Release review cannot verify the agent's actual tool surface.",
+        scenario_type="wildcard_inventory",
+    ),
+    "SHIP-INVENTORY-WILDCARD-TOOLS": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Tool exposure must use an explicit reviewed allowlist.",
+        gap="{title}.",
+        release_implication="Release review cannot bound which tools may be available at runtime.",
+        scenario_type="wildcard_inventory",
+    ),
+    "SHIP-SCHEMA-BROAD-FREE-TEXT": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Action-like tool inputs must constrain high-blast-radius fields.",
+        gap="{title}.",
+        release_implication="Release reviewers cannot bound the operation payload safely.",
+        scenario_type="schema_boundary",
+    ),
+    "SHIP-SCHEMA-MISSING-BOUNDS": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Risky numeric parameters must declare a maximum or equivalent limit.",
+        gap="{title}.",
+        release_implication="Release reviewers cannot verify blast-radius limits.",
+        scenario_type="schema_boundary",
+    ),
+    "SHIP-SCHEMA-FREEFORM-OUTPUT": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Model-consumed tool outputs should be structured.",
+        gap="{title}.",
+        release_implication="Downstream model behavior may depend on unstructured tool output.",
+        scenario_type="schema_boundary",
+    ),
+    "SHIP-AUTH-MISSING-SCOPE": DiffSpec(
+        kind="scope_drift",
+        policy_requirement="Scope-requiring tools must declare operation-specific auth scopes.",
+        gap="{title}.",
+        release_implication="Release reviewers cannot assess least privilege.",
+        scenario_type="least_privilege_scope",
+    ),
+    "SHIP-AUTH-MANIFEST-BROAD-SCOPE": DiffSpec(
+        kind="scope_drift",
+        policy_requirement="Manifest permissions should declare narrow release scopes.",
+        gap="{title}.",
+        release_implication="Release may grant broader access than the reviewed capability needs.",
+        scenario_type="least_privilege_scope",
+    ),
+    "SHIP-AUTH-TOOL-BROAD-SCOPE": DiffSpec(
+        kind="scope_drift",
+        policy_requirement="Tool auth metadata should use narrow operation-specific scopes.",
+        gap="{title}.",
+        release_implication="The tool may require broader credentials than review can justify.",
+        scenario_type="least_privilege_scope",
+    ),
+    "SHIP-AUTH-SCOPE-COVERAGE-MISSING": DiffSpec(
+        kind="scope_drift",
+        policy_requirement="Manifest permissions must cover tool-required scopes.",
+        gap="{title}.",
+        release_implication="The manifest does not describe the actual permissions needed.",
+        scenario_type="least_privilege_scope",
+    ),
+    "SHIP-SCOPE-TOOL-OUTSIDE-PURPOSE": DiffSpec(
+        kind="intent_mismatch",
+        policy_requirement="Declared purpose must match the attached tool surface.",
+        gap="{title}.",
+        release_implication="The release scope is broader than the declared agent intent.",
+        scenario_type="prompt_scope_alignment",
+    ),
+    "SHIP-SCOPE-PROHIBITED-TOOL-PRESENT": DiffSpec(
+        kind="prohibited_action_present",
+        policy_requirement="Prohibited actions must not be contradicted by enabled capabilities.",
+        gap="{title}.",
+        release_implication="The tool surface appears to enable behavior the manifest prohibits.",
+        scenario_type="prohibited_action",
+    ),
+    "SHIP-POLICY-APPROVAL-MISSING": DiffSpec(
+        kind="policy_gap",
+        policy_requirement="High-risk tools must have a declared approval policy.",
+        gap="{title}.",
+        release_implication="Release is blocked until approval is declared or the tool is removed.",
+        scenario_type="approval",
+    ),
+    "SHIP-POLICY-CONFIRMATION-MISSING": DiffSpec(
+        kind="policy_gap",
+        policy_requirement="Destructive, external, or customer actions require confirmation.",
+        gap="{title}.",
+        release_implication="Release review must verify explicit user confirmation before shipping.",
+        scenario_type="confirmation",
+    ),
+    "SHIP-SIDEFX-IDEMPOTENCY-MISSING": DiffSpec(
+        kind="control_missing",
+        policy_requirement="Risky write tools need idempotency evidence before retryable release.",
+        gap="{title}.",
+        release_implication="Retries could duplicate financial, destructive, or external effects.",
+        scenario_type="idempotency_retry",
+    ),
+    "SHIP-API-FUNCTION-SCHEMA-STRICTNESS": DiffSpec(
+        kind="control_missing",
+        policy_requirement="API function schemas must be strict enough for reliable tool calls.",
+        gap="{title}.",
+        release_implication="The model may send ambiguous or overbroad tool arguments.",
+        scenario_type="schema_boundary",
+    ),
+    "SHIP-API-STRUCTURED-OUTPUT-READINESS": DiffSpec(
+        kind="control_missing",
+        policy_requirement="API outputs need structured success, failure, and review states.",
+        gap="{title}.",
+        release_implication="Downstream release behavior may depend on under-specified output.",
+        scenario_type="schema_boundary",
+    ),
+    "SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH": DiffSpec(
+        kind="intent_mismatch",
+        policy_requirement="Prompt scope must align with enabled high-risk tools.",
+        gap="{title}.",
+        release_implication="The agent instructions and actual tool surface disagree.",
+        scenario_type="prompt_scope_alignment",
+    ),
+    "SHIP-API-TEST-CASES-MISSING": DiffSpec(
+        kind="control_missing",
+        policy_requirement="High-risk API tool-call flows should include declared test cases.",
+        gap="{title}.",
+        release_implication="Release lacks validation evidence for high-risk tool paths.",
+        scenario_type="test_case_coverage",
+    ),
+    "SHIP-API-TRACE-APPROVAL-MISSING": DiffSpec(
+        kind="policy_gap",
+        policy_requirement="Trace evidence for approval-controlled tools must show approval.",
+        gap="{title}.",
+        release_implication="Observed sample evidence contradicts the approval expectation.",
+        scenario_type="approval",
+    ),
+    "SHIP-API-TRACE-CONFIRMATION-MISSING": DiffSpec(
+        kind="policy_gap",
+        policy_requirement="Trace evidence for confirmation-controlled tools must show confirmation.",
+        gap="{title}.",
+        release_implication="Observed sample evidence contradicts the confirmation expectation.",
+        scenario_type="confirmation",
+    ),
+}
+
+
+def apply_capability_diff(report: ReadinessReport, tools: list[Tool]) -> ReadinessReport:
+    capability_facts, declared_intentions, records = _build_diff_records(report, tools)
+    misalignments = [record.misalignment for record in records]
+    report.capability_facts = capability_facts
+    report.declared_intentions = declared_intentions
+    report.misalignments = misalignments
+    report.suggested_scenarios = _suggested_scenarios(records)
+    report.release_consequence = _release_consequence(report, misalignments)
+    return report
+
+
+def _build_diff_records(
+    report: ReadinessReport,
+    tools: list[Tool],
+) -> tuple[list[CapabilityFact], list[DeclaredIntention], list[MisalignmentRecord]]:
+    active_findings = _active_relevant_findings(report.findings)
+    tool_lookup = {tool.name: tool for tool in tools}
+    findings_by_tool = _findings_by_tool(active_findings, tool_lookup.keys())
+
+    capability_facts = [
+        _capability_fact(tool, findings_by_tool.get(tool.name, []))
+        for tool in tools
+        if _include_tool(tool, findings_by_tool.get(tool.name, []))
+    ]
+    capability_facts.sort(key=lambda fact: (fact.tool_name, fact.id))
+    capability_by_tool = {fact.tool_name: fact for fact in capability_facts}
+
+    declared_intentions = _declared_intentions(report)
+    records = _misalignment_records(
+        active_findings,
+        tool_lookup,
+        capability_by_tool,
+        declared_intentions,
+    )
+    records.sort(
+        key=lambda record: (
+            SEVERITY_SORT[record.misalignment.severity],
+            record.misalignment.kind,
+            record.misalignment.tool_name or "",
+            record.misalignment.id,
+        )
+    )
+    return capability_facts, declared_intentions, records
+
+
+def _active_relevant_findings(findings: list[Finding]) -> list[Finding]:
+    return [
+        finding
+        for finding in findings
+        if not finding.suppressed
+        and finding.severity in RELEASE_RELEVANT_SEVERITIES
+        and finding.category in RELEASE_RELEVANT_CATEGORIES
+    ]
+
+
+def _findings_by_tool(
+    findings: list[Finding],
+    known_tool_names: set[str] | dict[str, Tool] | list[str],
+) -> dict[str, list[Finding]]:
+    known = set(known_tool_names)
+    by_tool: dict[str, list[Finding]] = defaultdict(list)
+    for finding in findings:
+        for tool_name in _finding_tool_names(finding, known):
+            by_tool[tool_name].append(finding)
+    return dict(by_tool)
+
+
+def _include_tool(tool: Tool, related_findings: list[Finding]) -> bool:
+    return bool(
+        related_findings
+        or tool.annotations.get("wildcard_tools") is True
+        or is_high_risk_tool(tool)
+    )
+
+
+def _capability_fact(tool: Tool, related_findings: list[Finding]) -> CapabilityFact:
+    tags = risk_tags(tool, min_confidence="medium")
+    capability = "wildcard_tool_surface" if tool.annotations.get("wildcard_tools") is True else _capability(tags)
+    related_refs = sorted(_finding_ref(finding) for finding in related_findings)
+    return CapabilityFact(
+        id=_hash_id(
+            "cap",
+            tool.name,
+            tool.source_type,
+            tool.source_ref,
+            capability,
+            sorted(tags),
+        ),
+        tool_name=tool.name,
+        source_type=tool.source_type,
+        source_ref=tool.source_ref,
+        capability=capability,
+        risk_tags=tags,
+        auth_scopes=tool.auth.scopes,
+        owner=tool.owner,
+        included_reason=_included_reason(tool, related_findings),
+        control_status=_control_status(tool, related_findings),
+        related_findings=related_refs,
+    )
+
+
+def _capability(tags: list[str]) -> str:
+    tag_set = set(tags)
+    for tag in RISK_TAG_PRIORITY:
+        if tag in tag_set:
+            return tag
+    return "unknown"
+
+
+def _included_reason(tool: Tool, related_findings: list[Finding]) -> CapabilityIncludedReason:
+    severities = {finding.severity for finding in related_findings}
+    if "critical" in severities:
+        return "referenced_by_critical_finding"
+    if "high" in severities:
+        return "referenced_by_high_finding"
+    if "medium" in severities:
+        return "referenced_by_medium_finding"
+    if tool.annotations.get("wildcard_tools") is True:
+        return "wildcard_exposure"
+    return "high_risk_tag"
+
+
+def _control_status(tool: Tool, related_findings: list[Finding]) -> str:
+    if tool.annotations.get("wildcard_tools") is True:
+        return "unknown"
+    if any(_is_missing_control(finding) for finding in related_findings):
+        return "missing"
+    if related_findings:
+        return "partial"
+    if tool.extraction_confidence == "high":
+        return "present"
+    return "unknown"
+
+
+def _is_missing_control(finding: Finding) -> bool:
+    return finding.check_id in MISSING_CONTROL_CHECKS or finding.check_id.endswith("-MISSING")
+
+
+def _declared_intentions(report: ReadinessReport) -> list[DeclaredIntention]:
+    intentions: list[DeclaredIntention] = []
+    for text in _string_list(report.agent.get("declared_purpose")):
+        intentions.append(_intention("declared_purpose", text, "agent.declared_purpose"))
+    for text in _string_list(report.agent.get("prohibited_actions")):
+        intentions.append(_intention("prohibited_action", text, "agent.prohibited_actions"))
+
+    instructions = report.agent.get("instructions")
+    if isinstance(instructions, dict):
+        preview = instructions.get("value_preview")
+        source = instructions.get("source") or "agent.instructions"
+        if isinstance(preview, str) and preview.strip():
+            intentions.append(_intention("instruction_preview", preview.strip(), str(source)))
+
+    intentions.sort(key=lambda item: (INTENTION_KIND_ORDER[item.kind], item.id))
+    return intentions
+
+
+def _intention(kind: str, text: str, source: str) -> DeclaredIntention:
+    tags = _intent_tags(text)
+    return DeclaredIntention(
+        id=_hash_id("int", kind, source, text, sorted(tags)),
+        kind=kind,  # type: ignore[arg-type]
+        text=text,
+        source=source,
+        intent_tags=tags,
+    )
+
+
+def _intent_tags(text: str) -> list[str]:
+    tags: set[str] = set()
+    for token in _tokens(text):
+        tags.update(INTENT_TAG_ALIASES.get(token, ()))
+    return sorted(tags, key=lambda tag: RISK_TAG_PRIORITY.index(tag) if tag in RISK_TAG_PRIORITY else 99)
+
+
+def _misalignment_records(
+    findings: list[Finding],
+    tool_lookup: dict[str, Tool],
+    capability_by_tool: dict[str, CapabilityFact],
+    intentions: list[DeclaredIntention],
+) -> list[MisalignmentRecord]:
+    records: list[MisalignmentRecord] = []
+    known_tools = set(tool_lookup)
+    for finding in findings:
+        spec = _diff_spec(finding)
+        tool_names = _finding_tool_names(finding, known_tools) or [None]
+        for tool_name in tool_names:
+            capability = capability_by_tool.get(tool_name or "")
+            capability_refs = [capability.id] if capability else []
+            intention_refs = _intention_refs(finding, capability, intentions)
+            finding_refs = [_finding_ref(finding)]
+            misalignment = Misalignment(
+                id=_hash_id(
+                    "mis",
+                    spec.kind,
+                    tool_name,
+                    sorted(capability_refs),
+                    sorted(intention_refs),
+                    sorted(finding_refs),
+                ),
+                kind=spec.kind,
+                severity=finding.severity,
+                tool_name=tool_name,
+                capability_refs=sorted(capability_refs),
+                intention_refs=sorted(intention_refs),
+                finding_refs=sorted(finding_refs),
+                policy_requirement=_render_template(spec.policy_requirement, finding, tool_name),
+                gap=_render_template(spec.gap, finding, tool_name),
+                release_implication=_render_template(spec.release_implication, finding, tool_name),
+            )
+            records.append(MisalignmentRecord(misalignment, spec.scenario_type))
+    return records
+
+
+def _diff_spec(finding: Finding) -> DiffSpec:
+    if finding.check_id in CHECK_DIFF_MAP:
+        return CHECK_DIFF_MAP[finding.check_id]
+    if finding.category == "policy":
+        return DiffSpec(
+            kind="policy_gap",
+            policy_requirement="Policy-controlled tools must declare matching controls.",
+            gap="{title}.",
+            release_implication="Release review must resolve the missing policy evidence.",
+            scenario_type="approval",
+        )
+    if finding.category == "auth":
+        return DiffSpec(
+            kind="scope_drift",
+            policy_requirement="Auth scopes must match the reviewed release surface.",
+            gap="{title}.",
+            release_implication="Least-privilege review is incomplete.",
+            scenario_type="least_privilege_scope",
+        )
+    if finding.category == "scope":
+        return DiffSpec(
+            kind="intent_mismatch",
+            policy_requirement="Declared intent must align with tool capabilities.",
+            gap="{title}.",
+            release_implication="The reviewed purpose does not fully cover the tool surface.",
+            scenario_type="prompt_scope_alignment",
+        )
+    if finding.category in {"schema", "security"}:
+        return DiffSpec(
+            kind="control_missing",
+            policy_requirement="Tool schemas and metadata must constrain unsafe inputs or outputs.",
+            gap="{title}.",
+            release_implication="The release has unresolved tool-boundary risk.",
+            scenario_type="schema_boundary",
+        )
+    if finding.category == "manifest":
+        return DiffSpec(
+            kind="control_missing",
+            policy_requirement="Manifest metadata must match the active release surface.",
+            gap="{title}.",
+            release_implication="Release review metadata is incomplete or stale.",
+            scenario_type="test_case_coverage",
+        )
+    return DiffSpec(
+        kind="undetected_gap",
+        policy_requirement="Static review requires deterministic evidence for release gaps.",
+        gap="{title}.",
+        release_implication="Human review is required to interpret this finding.",
+        scenario_type=None,
+    )
+
+
+def _intention_refs(
+    finding: Finding,
+    capability: CapabilityFact | None,
+    intentions: list[DeclaredIntention],
+) -> list[str]:
+    tags = set(capability.risk_tags if capability else _evidence_tags(finding))
+    refs: set[str] = {
+        intention.id
+        for intention in intentions
+        if tags and tags.intersection(intention.intent_tags)
+    }
+    prohibited_action = finding.evidence.get("prohibited_action")
+    if isinstance(prohibited_action, str):
+        refs.update(
+            intention.id
+            for intention in intentions
+            if intention.kind == "prohibited_action" and intention.text == prohibited_action
+        )
+    if finding.check_id == "SHIP-API-PROMPT-TOOL-SCOPE-MISMATCH":
+        refs.update(
+            intention.id
+            for intention in intentions
+            if intention.kind == "instruction_preview"
+        )
+    return sorted(refs)
+
+
+def _suggested_scenarios(records: list[MisalignmentRecord]) -> list[SuggestedScenario]:
+    grouped: dict[SuggestedScenarioType, list[Misalignment]] = defaultdict(list)
+    for record in records:
+        if record.scenario_type is not None:
+            grouped[record.scenario_type].append(record.misalignment)
+
+    scenarios = [
+        _scenario(scenario_type, misalignments)
+        for scenario_type, misalignments in grouped.items()
+    ]
+    order = {record.misalignment.id: index for index, record in enumerate(records)}
+    scenarios.sort(
+        key=lambda scenario: (
+            min(order[item] for item in scenario.source_misalignments),
+            scenario.scenario_type,
+            scenario.id,
+        )
+    )
+    return scenarios
+
+
+def _scenario(
+    scenario_type: SuggestedScenarioType,
+    misalignments: list[Misalignment],
+) -> SuggestedScenario:
+    source_misalignments = sorted(misalignment.id for misalignment in misalignments)
+    source_findings = sorted(
+        {
+            finding_ref
+            for misalignment in misalignments
+            for finding_ref in misalignment.finding_refs
+        }
+    )
+    scope = _scenario_scope(misalignments)
+    title, expected_control = _scenario_text(scenario_type)
+    return SuggestedScenario(
+        id=_hash_id("scn", scenario_type, sorted(source_misalignments)),
+        scenario_type=scenario_type,
+        title=title,
+        given=f"Exercise the release path for {scope}.",
+        expected_control=expected_control,
+        source_misalignments=source_misalignments,
+        source_findings=source_findings,
+    )
+
+
+def _scenario_text(scenario_type: SuggestedScenarioType) -> tuple[str, str]:
+    return {
+        "approval": (
+            "Approval gate for high-risk action",
+            "The run records human approval before the tool call and denies calls without approval.",
+        ),
+        "confirmation": (
+            "Confirmation gate for external or destructive action",
+            "The run records explicit confirmation before the side effect occurs.",
+        ),
+        "idempotency_retry": (
+            "Retry behavior for risky write",
+            "Retries use idempotency evidence or the side effect is not retried.",
+        ),
+        "least_privilege_scope": (
+            "Least-privilege scope review",
+            "Manifest and tool scopes match the narrow permissions needed for the release.",
+        ),
+        "prohibited_action": (
+            "Prohibited-action guard",
+            "The prohibited action is blocked, removed, or covered by the stated control.",
+        ),
+        "wildcard_inventory": (
+            "Explicit tool inventory review",
+            "The release exposes a static allowlist instead of wildcard or unbounded tools.",
+        ),
+        "schema_boundary": (
+            "Tool schema boundary check",
+            "The tool accepts bounded structured inputs and returns structured outputs where needed.",
+        ),
+        "prompt_scope_alignment": (
+            "Prompt and tool-surface alignment",
+            "The agent instructions match the enabled write and high-risk capabilities.",
+        ),
+        "test_case_coverage": (
+            "High-risk tool validation case",
+            "A declared test or review scenario covers the high-risk tool path.",
+        ),
+    }[scenario_type]
+
+
+def _scenario_scope(misalignments: list[Misalignment]) -> str:
+    tools = sorted({item.tool_name for item in misalignments if item.tool_name})
+    if not tools:
+        return "the agent-level release gap"
+    if len(tools) <= 3:
+        return ", ".join(tools)
+    return f"{', '.join(tools[:3])}, and {len(tools) - 3} more tool(s)"
+
+
+def _release_consequence(
+    report: ReadinessReport,
+    misalignments: list[Misalignment],
+) -> ReleaseConsequence | None:
+    decision = report.release_decision
+    if decision is None:
+        return None
+    blocker_refs = {_decision_ref(item) for item in decision.blockers}
+    review_refs = {_decision_ref(item) for item in decision.review_items}
+    blocker_count = sum(
+        1 for item in misalignments if blocker_refs.intersection(item.finding_refs)
+    )
+    review_count = sum(
+        1
+        for item in misalignments
+        if not blocker_refs.intersection(item.finding_refs)
+        and review_refs.intersection(item.finding_refs)
+    )
+    return ReleaseConsequence(
+        decision=decision.decision,
+        summary=_release_summary(decision.decision, blocker_count, review_count),
+        blocker_misalignment_count=blocker_count,
+        review_misalignment_count=review_count,
+        fail_policy=FailPolicy.model_validate(decision.fail_policy.model_dump()),
+    )
+
+
+def _release_summary(decision: str, blocker_count: int, review_count: int) -> str:
+    if decision == "blocked":
+        return (
+            f"{blocker_count} capability/intent misalignment(s) map to active "
+            "release blockers; resolve required controls or remove the capability."
+        )
+    if decision == "review_required":
+        return (
+            f"{review_count} capability/intent misalignment(s) require release review "
+            "before shipping."
+        )
+    return "No capability/intent misalignments require release action from static evidence."
+
+
+def _decision_ref(item: object) -> str | None:
+    item_id = getattr(item, "id", None)
+    fingerprint = getattr(item, "fingerprint", None)
+    return item_id or fingerprint
+
+
+def _finding_ref(finding: Finding) -> str:
+    return finding.id or finding.fingerprint or finding.check_id
+
+
+def _finding_tool_names(finding: Finding, known_tool_names: set[str]) -> list[str]:
+    names: set[str] = set()
+    if finding.tool_name:
+        names.add(finding.tool_name)
+    for key in ("tool_name", "tool"):
+        value = finding.evidence.get(key)
+        if isinstance(value, str):
+            names.add(value)
+    for key in ("tools", "high_risk_tools"):
+        value = finding.evidence.get(key)
+        if isinstance(value, list):
+            names.update(item for item in value if isinstance(item, str))
+    return sorted(name for name in names if name in known_tool_names)
+
+
+def _evidence_tags(finding: Finding) -> list[str]:
+    tags = finding.evidence.get("risk_tags")
+    if not isinstance(tags, list):
+        return []
+    return [tag for tag in tags if isinstance(tag, str)]
+
+
+def _render_template(template: str, finding: Finding, tool_name: str | None) -> str:
+    return template.format(
+        check_id=finding.check_id,
+        title=finding.title,
+        tool=tool_name or finding.tool_name or "agent",
+    )
+
+
+def _tokens(text: str) -> set[str]:
+    return set(re.findall(r"[a-z]+", text.lower()))
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]
+
+
+def _hash_id(prefix: str, *parts: object) -> str:
+    normalized = [_normalize_hash_part(part) for part in parts]
+    digest = hashlib.sha256("|".join(normalized).encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+def _normalize_hash_part(part: object) -> str:
+    if part is None:
+        return ""
+    if isinstance(part, (list, tuple, set)):
+        return ",".join(sorted(str(item) for item in part))
+    return str(part)

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -31,6 +31,12 @@ MARKDOWN_ESCAPE_CHARS = (
     "<",
     ">",
 )
+CAPABILITY_DIFF_MARKDOWN_LIMITS = {
+    "intentions": 3,
+    "capabilities": 5,
+    "misalignments": 5,
+    "scenarios": 5,
+}
 
 
 def write_markdown_report(report: ReadinessReport, path: Path) -> None:
@@ -69,6 +75,7 @@ def render_markdown_report(report: ReadinessReport) -> str:
         ]
     )
     _append_top_findings(lines, report.findings)
+    _append_capability_intent_diff(lines, report)
     _append_baseline(lines, report)
     _append_recommended_actions(lines, report.recommended_actions)
     _append_source_warnings(lines, report)
@@ -165,6 +172,110 @@ def _append_top_findings(lines: list[str], findings: list[Finding]) -> None:
         lines.append(f"   Evidence: {_compact_evidence(finding.evidence)}")
         lines.append(f"   Recommendation: {_safe_markdown_text(finding.recommendation)}")
         lines.append("")
+
+
+def _append_capability_intent_diff(
+    lines: list[str],
+    report: ReadinessReport,
+) -> None:
+    lines.extend(["## Capability <-> Intent Diff", ""])
+    if not report.misalignments:
+        lines.extend(
+            [
+                "No capability/intent misalignments detected from static evidence.",
+                "",
+            ]
+        )
+        return
+
+    lines.extend(["Agent intent:", ""])
+    if report.declared_intentions:
+        for intention in report.declared_intentions[: CAPABILITY_DIFF_MARKDOWN_LIMITS["intentions"]]:
+            tags = ", ".join(intention.intent_tags) if intention.intent_tags else "none"
+            lines.append(
+                f"- {_safe_markdown_text(intention.kind)}: "
+                f"{_safe_markdown_text(_truncate_text(intention.text))} "
+                f"(tags: {_safe_markdown_text(tags)})"
+            )
+        _append_more_line(
+            lines,
+            len(report.declared_intentions),
+            CAPABILITY_DIFF_MARKDOWN_LIMITS["intentions"],
+        )
+    else:
+        lines.append("- No declared intentions captured.")
+    lines.append("")
+
+    lines.extend(["Actual capabilities:", ""])
+    if report.capability_facts:
+        for fact in report.capability_facts[: CAPABILITY_DIFF_MARKDOWN_LIMITS["capabilities"]]:
+            tags = ", ".join(fact.risk_tags) if fact.risk_tags else "none"
+            lines.append(
+                f"- {_safe_markdown_text(fact.tool_name)}: "
+                f"capability={_safe_markdown_text(fact.capability)}, "
+                f"risk={_safe_markdown_text(tags)}, "
+                f"control={_safe_markdown_text(fact.control_status)}"
+            )
+        _append_more_line(
+            lines,
+            len(report.capability_facts),
+            CAPABILITY_DIFF_MARKDOWN_LIMITS["capabilities"],
+        )
+    else:
+        lines.append("- No high-risk or gap-referenced capabilities selected.")
+    lines.append("")
+
+    lines.extend(["Policy/control gaps:", ""])
+    for misalignment in report.misalignments[: CAPABILITY_DIFF_MARKDOWN_LIMITS["misalignments"]]:
+        tool = f" [{misalignment.tool_name}]" if misalignment.tool_name else ""
+        lines.append(
+            f"- {misalignment.severity.upper()} {_safe_markdown_text(misalignment.kind)}"
+            f"{_safe_markdown_text(tool)}: {_safe_markdown_text(misalignment.gap)}"
+        )
+        lines.append(
+            "  Requires: "
+            f"{_safe_markdown_text(misalignment.policy_requirement)}"
+        )
+        lines.append(
+            "  Release implication: "
+            f"{_safe_markdown_text(misalignment.release_implication)}"
+        )
+    _append_more_line(
+        lines,
+        len(report.misalignments),
+        CAPABILITY_DIFF_MARKDOWN_LIMITS["misalignments"],
+    )
+    lines.append("")
+
+    lines.extend(["Release implication:", ""])
+    consequence = report.release_consequence
+    if consequence is None:
+        lines.append("- No release consequence recorded.")
+    else:
+        lines.append(f"- Decision: {_safe_markdown_text(consequence.decision)}")
+        lines.append(f"- {_safe_markdown_text(consequence.summary)}")
+    lines.append("")
+
+    lines.extend(["Next validation:", ""])
+    if report.suggested_scenarios:
+        for scenario in report.suggested_scenarios[: CAPABILITY_DIFF_MARKDOWN_LIMITS["scenarios"]]:
+            lines.append(
+                f"- {_safe_markdown_text(scenario.title)}: "
+                f"{_safe_markdown_text(scenario.expected_control)}"
+            )
+        _append_more_line(
+            lines,
+            len(report.suggested_scenarios),
+            CAPABILITY_DIFF_MARKDOWN_LIMITS["scenarios"],
+        )
+    else:
+        lines.append("- No additional validation scenarios suggested.")
+    lines.append("")
+
+
+def _append_more_line(lines: list[str], total: int, limit: int) -> None:
+    if total > limit:
+        lines.append(f"- {total - limit} more in report.json")
 
 
 def _append_recommended_actions(lines: list[str], actions: list[str]) -> None:
@@ -410,3 +521,9 @@ def _safe_markdown_text(value: object) -> str:
     text = re.sub(r"(?m)^(\s*)-", r"\1\\-", text)
     text = re.sub(r"(?m)^(\s*\d+)\.", r"\1\\.", text)
     return text
+
+
+def _truncate_text(value: str, limit: int = 220) -> str:
+    if len(value) <= limit:
+        return value
+    return f"{value[: limit - 3]}..."

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from agents_shipgate.core.findings import SEVERITY_ORDER
-from agents_shipgate.core.models import Finding, ReadinessReport
+from agents_shipgate.core.models import DeclaredIntention, Finding, ReadinessReport
 
 DISCLAIMER = (
     "Agents Shipgate is an advisory release-readiness scanner. It does not certify "
@@ -190,18 +190,18 @@ def _append_capability_intent_diff(
 
     lines.extend(["Agent intent:", ""])
     if report.declared_intentions:
-        for intention in report.declared_intentions[: CAPABILITY_DIFF_MARKDOWN_LIMITS["intentions"]]:
+        visible_intentions, hidden_intention_count = _capability_diff_intentions(
+            report.declared_intentions
+        )
+        for intention in visible_intentions:
             tags = ", ".join(intention.intent_tags) if intention.intent_tags else "none"
             lines.append(
                 f"- {_safe_markdown_text(intention.kind)}: "
                 f"{_safe_markdown_text(_truncate_text(intention.text))} "
                 f"(tags: {_safe_markdown_text(tags)})"
             )
-        _append_more_line(
-            lines,
-            len(report.declared_intentions),
-            CAPABILITY_DIFF_MARKDOWN_LIMITS["intentions"],
-        )
+        if hidden_intention_count:
+            lines.append(f"- {hidden_intention_count} more in report.json")
     else:
         lines.append("- No declared intentions captured.")
     lines.append("")
@@ -276,6 +276,18 @@ def _append_capability_intent_diff(
 def _append_more_line(lines: list[str], total: int, limit: int) -> None:
     if total > limit:
         lines.append(f"- {total - limit} more in report.json")
+
+
+def _capability_diff_intentions(
+    intentions: list[DeclaredIntention],
+) -> tuple[list[DeclaredIntention], int]:
+    prohibited = [item for item in intentions if item.kind == "prohibited_action"]
+    instruction_preview = [item for item in intentions if item.kind == "instruction_preview"]
+    declared = [item for item in intentions if item.kind == "declared_purpose"]
+    declared_limit = CAPABILITY_DIFF_MARKDOWN_LIMITS["intentions"]
+    visible = prohibited + declared[:declared_limit] + instruction_preview
+    hidden = max(0, len(declared) - declared_limit)
+    return visible, hidden
 
 
 def _append_recommended_actions(lines: list[str], actions: list[str]) -> None:
@@ -524,6 +536,7 @@ def _safe_markdown_text(value: object) -> str:
 
 
 def _truncate_text(value: str, limit: int = 220) -> str:
+    value = " ".join(value.split())
     if len(value) <= limit:
         return value
     return f"{value[: limit - 3]}..."

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -83,18 +83,18 @@ def test_index_no_longer_references_v05_schema():
     )
 
 
-def test_index_lists_current_v08_schema():
-    """The current schema version moved to v0.8; the index must point
-    agents at v0.8 for fresh report.json validation. v0.7 stays linked
+def test_index_lists_current_v09_schema():
+    """The current schema version moved to v0.9; the index must point
+    agents at v0.9 for fresh report.json validation. v0.8 stays linked
     as the frozen reference for older reports."""
     index_text = INDEX_MD.read_text(encoding="utf-8")
-    assert "report-schema.v0.8.json" in index_text, (
-        "docs/INDEX.md must list report-schema.v0.8.json as the current schema "
-        "since emitted reports carry report_schema_version: \"0.8\"."
+    assert "report-schema.v0.9.json" in index_text, (
+        "docs/INDEX.md must list report-schema.v0.9.json as the current schema "
+        "since emitted reports carry report_schema_version: \"0.9\"."
     )
-    assert "report-schema.v0.7.json" in index_text, (
-        "docs/INDEX.md must keep report-schema.v0.7.json linked as the "
-        "frozen reference for pre-v0.8 reports."
+    assert "report-schema.v0.8.json" in index_text, (
+        "docs/INDEX.md must keep report-schema.v0.8.json linked as the "
+        "frozen reference for pre-v0.9 reports."
     )
 
 

--- a/tests/test_finding_remediation.py
+++ b/tests/test_finding_remediation.py
@@ -352,11 +352,10 @@ def test_report_json_payload_carries_new_fields(tmp_path):
             assert key in finding, f"{finding['check_id']} missing {key} in JSON"
 
 
-def test_report_schema_version_is_v08(tmp_path):
-    """Schema version moved from 0.7 → 0.8 per the additive contract
+def test_report_schema_version_is_v09(tmp_path):
+    """Schema version moved from 0.8 to 0.9 per the additive contract
     in STABILITY.md. Old reports validate against their respective
-    schema files, but new scans emit 0.8 with the required
-    `release_decision` block."""
+    schema files, but new scans emit 0.9 with the capability/intent diff."""
     report, _ = run_scan(
         config_path=SAMPLE_MANIFEST,
         output_dir=tmp_path,
@@ -364,5 +363,6 @@ def test_report_schema_version_is_v08(tmp_path):
         ci_mode="advisory",
     )
     payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
-    assert payload["report_schema_version"] == "0.8"
+    assert payload["report_schema_version"] == "0.9"
     assert "release_decision" in payload
+    assert "misalignments" in payload

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -478,6 +478,20 @@ def test_v07_schema_file_is_frozen():
     assert "release_decision" not in schema.get("required", [])
 
 
+def test_v08_schema_file_is_frozen():
+    """v0.8 schema file stays parseable and excludes v0.9 additive fields."""
+    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
+    assert schema["properties"]["report_schema_version"] == {"const": "0.8"}
+    for field in (
+        "capability_facts",
+        "declared_intentions",
+        "misalignments",
+        "release_consequence",
+        "suggested_scenarios",
+    ):
+        assert field not in schema.get("required", [])
+
+
 def test_v07_schema_preserves_nested_required_lists():
     """Top-level required fields plus nested required lists for Finding,
     tool_inventory[], loaded_plugins[], LoadedPolicyPack, and per-framework

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -21,6 +21,7 @@ REPORT_SCHEMA_V04 = Path("docs/report-schema.v0.4.json")
 REPORT_SCHEMA_V06 = Path("docs/report-schema.v0.6.json")
 REPORT_SCHEMA_V07 = Path("docs/report-schema.v0.7.json")
 REPORT_SCHEMA_V08 = Path("docs/report-schema.v0.8.json")
+REPORT_SCHEMA_V09 = Path("docs/report-schema.v0.9.json")
 
 
 def test_sample_markdown_report_matches_golden(tmp_path):
@@ -98,7 +99,7 @@ def test_json_report_contains_integration_contract_keys(tmp_path):
     assert "loaded_plugins" in payload
     assert payload["loaded_plugins"] == []
     assert payload["schema_version"] == "0.1"
-    assert payload["report_schema_version"] == "0.8"
+    assert payload["report_schema_version"] == "0.9"
     assert "release_decision" in payload
     assert payload["release_decision"]["decision"] in {
         "blocked",
@@ -107,6 +108,14 @@ def test_json_report_contains_integration_contract_keys(tmp_path):
     }
     assert "frameworks" in payload
     assert "loaded_policy_packs" in payload
+    for key in (
+        "capability_facts",
+        "declared_intentions",
+        "misalignments",
+        "release_consequence",
+        "suggested_scenarios",
+    ):
+        assert key in payload
 
 
 def test_markdown_release_summary_is_derived_from_json_contract(tmp_path):
@@ -135,6 +144,131 @@ def test_markdown_release_summary_is_derived_from_json_contract(tmp_path):
         f"would_fail_ci={str(fail_policy['would_fail_ci']).lower()} "
         f"(exit {fail_policy['exit_code']})"
     ) in markdown
+
+
+def test_capability_intent_diff_support_refund_fixture(tmp_path):
+    from agents_shipgate.report.json_report import report_json_payload
+
+    report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    payload = report_json_payload(report)
+
+    stripe = next(
+        fact
+        for fact in payload["capability_facts"]
+        if fact["tool_name"] == "stripe.create_refund"
+    )
+    assert {"financial_action", "external_write"} <= set(stripe["risk_tags"])
+    assert stripe["included_reason"] == "referenced_by_critical_finding"
+    assert stripe["control_status"] == "missing"
+    assert not any(
+        fact["tool_name"] == "refund_status_lookup"
+        for fact in payload["capability_facts"]
+    )
+
+    refund_intentions = [
+        intention
+        for intention in payload["declared_intentions"]
+        if "refund" in intention["text"]
+    ]
+    assert refund_intentions
+    assert any("financial_action" in item["intent_tags"] for item in refund_intentions)
+
+    approval_finding = next(
+        finding
+        for finding in payload["findings"]
+        if finding["check_id"] == "SHIP-POLICY-APPROVAL-MISSING"
+        and finding["tool_name"] == "stripe.create_refund"
+    )
+    idempotency_finding = next(
+        finding
+        for finding in payload["findings"]
+        if finding["check_id"] == "SHIP-SIDEFX-IDEMPOTENCY-MISSING"
+        and finding["tool_name"] == "stripe.create_refund"
+    )
+    assert approval_finding["fingerprint"] == "fp_f092940f62fbb012"
+    assert idempotency_finding["fingerprint"] == "fp_dac8011e14c53777"
+
+    assert any(
+        item["kind"] == "policy_gap"
+        and approval_finding["id"] in item["finding_refs"]
+        for item in payload["misalignments"]
+    )
+    assert any(
+        item["kind"] == "control_missing"
+        and idempotency_finding["id"] in item["finding_refs"]
+        for item in payload["misalignments"]
+    )
+    scenario_types = {item["scenario_type"] for item in payload["suggested_scenarios"]}
+    assert {"approval", "idempotency_retry"} <= scenario_types
+
+
+def test_capability_diff_release_consequence_mirrors_release_decision(tmp_path):
+    from agents_shipgate.report.json_report import report_json_payload
+
+    report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    payload = report_json_payload(report)
+
+    assert payload["release_consequence"]["decision"] == payload["release_decision"]["decision"]
+    assert (
+        payload["release_consequence"]["fail_policy"]
+        == payload["release_decision"]["fail_policy"]
+    )
+    assert payload["release_consequence"]["blocker_misalignment_count"] >= 1
+    assert payload["release_decision"]["blockers"] == [
+        {
+            "id": "fp_f092940f62fbb012",
+            "fingerprint": "fp_f092940f62fbb012",
+            "check_id": "SHIP-POLICY-APPROVAL-MISSING",
+            "severity": "critical",
+            "title": "stripe.create_refund lacks a declared approval policy",
+            "baseline_status": None,
+        },
+        {
+            "id": "fp_dac8011e14c53777",
+            "fingerprint": "fp_dac8011e14c53777",
+            "check_id": "SHIP-SIDEFX-IDEMPOTENCY-MISSING",
+            "severity": "critical",
+            "title": "stripe.create_refund lacks idempotency evidence",
+            "baseline_status": None,
+        },
+    ]
+
+
+def test_capability_diff_blocks_are_reproducible(tmp_path):
+    from agents_shipgate.report.json_report import report_json_payload
+
+    first_report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path / "first",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    second_report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path / "second",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    first = report_json_payload(first_report)
+    second = report_json_payload(second_report)
+    for key in (
+        "capability_facts",
+        "declared_intentions",
+        "misalignments",
+        "release_consequence",
+        "suggested_scenarios",
+    ):
+        assert first[key] == second[key]
 
 
 def test_report_paths_use_absolute_path_when_output_escapes_manifest_base(tmp_path):
@@ -187,9 +321,9 @@ def test_json_schema_is_published():
     } <= set(api_surface["required"])
 
 
-def test_json_report_validates_against_v08_schema(tmp_path):
-    """v0.8 schema adds top-level required `release_decision`. Emitted
-    reports must validate against the v0.8 schema."""
+def test_json_report_validates_against_v09_schema(tmp_path):
+    """v0.9 schema adds top-level capability/intent diff fields. Emitted
+    reports must validate against the v0.9 schema."""
     from agents_shipgate.report.json_report import report_json_payload
 
     report, _ = run_scan(
@@ -198,7 +332,7 @@ def test_json_report_validates_against_v08_schema(tmp_path):
         formats=["json"],
         ci_mode="advisory",
     )
-    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V09.read_text(encoding="utf-8"))
 
     validate(instance=report_json_payload(report), schema=schema)
 
@@ -337,8 +471,70 @@ def test_v08_schema_requires_release_decision():
     }
 
 
-def test_v08_schema_rejects_null_release_decision(tmp_path):
-    """A v0.8 payload with `release_decision: null` MUST fail validation.
+def test_v09_schema_requires_release_decision_and_capability_diff():
+    """Top-level required must include v0.8 release_decision and v0.9
+    capability/intent diff fields."""
+    schema = json.loads(REPORT_SCHEMA_V09.read_text(encoding="utf-8"))
+    assert schema["properties"]["report_schema_version"] == {"const": "0.9"}
+    assert {
+        "release_decision",
+        "capability_facts",
+        "declared_intentions",
+        "misalignments",
+        "release_consequence",
+        "suggested_scenarios",
+    } <= set(schema["required"])
+    assert schema["properties"]["release_decision"] == {
+        "$ref": "#/$defs/ReleaseDecision"
+    }
+    assert schema["properties"]["release_consequence"] == {
+        "$ref": "#/$defs/ReleaseConsequence"
+    }
+
+    capability_required = set(schema["$defs"]["CapabilityFact"]["required"])
+    assert capability_required == {
+        "id",
+        "tool_name",
+        "source_type",
+        "source_ref",
+        "capability",
+        "risk_tags",
+        "auth_scopes",
+        "owner",
+        "included_reason",
+        "control_status",
+        "related_findings",
+    }
+    assert schema["$defs"]["CapabilityFact"]["properties"]["included_reason"]["enum"] == [
+        "high_risk_tag",
+        "wildcard_exposure",
+        "referenced_by_critical_finding",
+        "referenced_by_high_finding",
+        "referenced_by_medium_finding",
+    ]
+    assert schema["$defs"]["Misalignment"]["properties"]["kind"]["enum"] == [
+        "policy_gap",
+        "scope_drift",
+        "prohibited_action_present",
+        "control_missing",
+        "intent_mismatch",
+        "undetected_gap",
+    ]
+    assert schema["$defs"]["SuggestedScenario"]["properties"]["scenario_type"]["enum"] == [
+        "approval",
+        "confirmation",
+        "idempotency_retry",
+        "least_privilege_scope",
+        "prohibited_action",
+        "wildcard_inventory",
+        "schema_boundary",
+        "prompt_scope_alignment",
+        "test_case_coverage",
+    ]
+
+
+def test_v09_schema_rejects_null_release_decision_and_consequence(tmp_path):
+    """A v0.9 payload with null release blocks MUST fail validation.
     Regression for the original schema which emitted
     `anyOf: [ReleaseDecision, null]` and silently accepted null."""
     import jsonschema
@@ -351,7 +547,7 @@ def test_v08_schema_rejects_null_release_decision(tmp_path):
         formats=["json"],
         ci_mode="advisory",
     )
-    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V09.read_text(encoding="utf-8"))
     payload = report_json_payload(report)
 
     # Sanity: real payload validates.
@@ -359,6 +555,11 @@ def test_v08_schema_rejects_null_release_decision(tmp_path):
 
     # Tamper: setting release_decision to null must be rejected.
     payload["release_decision"] = None
+    with pytest.raises(jsonschema.ValidationError):
+        validate(instance=payload, schema=schema)
+
+    payload = report_json_payload(report)
+    payload["release_consequence"] = None
     with pytest.raises(jsonschema.ValidationError):
         validate(instance=payload, schema=schema)
 
@@ -496,3 +697,5 @@ tool_sources:
     markdown = render_markdown_report(report)
     assert "## Release Decision" in markdown
     assert "Decision: passed" in markdown
+    assert "## Capability <-> Intent Diff" in markdown
+    assert "No capability/intent misalignments detected from static evidence." in markdown

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -190,6 +190,11 @@ def test_capability_intent_diff_support_refund_fixture(tmp_path):
         if finding["check_id"] == "SHIP-SIDEFX-IDEMPOTENCY-MISSING"
         and finding["tool_name"] == "stripe.create_refund"
     )
+    unused_scope_finding = next(
+        finding
+        for finding in payload["findings"]
+        if finding["check_id"] == "SHIP-MANIFEST-UNUSED-SCOPE"
+    )
     assert approval_finding["fingerprint"] == "fp_f092940f62fbb012"
     assert idempotency_finding["fingerprint"] == "fp_dac8011e14c53777"
 
@@ -203,8 +208,100 @@ def test_capability_intent_diff_support_refund_fixture(tmp_path):
         and idempotency_finding["id"] in item["finding_refs"]
         for item in payload["misalignments"]
     )
+    assert any(
+        item["kind"] == "scope_drift"
+        and unused_scope_finding["id"] in item["finding_refs"]
+        for item in payload["misalignments"]
+    )
     scenario_types = {item["scenario_type"] for item in payload["suggested_scenarios"]}
     assert {"approval", "idempotency_retry"} <= scenario_types
+    least_privilege = next(
+        item
+        for item in payload["suggested_scenarios"]
+        if item["scenario_type"] == "least_privilege_scope"
+    )
+    assert unused_scope_finding["id"] in least_privilege["source_findings"]
+
+
+def test_capability_intent_markdown_pins_prohibited_actions(tmp_path):
+    report, _ = run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    markdown = render_markdown_report(report)
+
+    assert "- prohibited\\_action: issue refund without approval" in markdown
+    assert "- prohibited\\_action: send external email without preview" in markdown
+    assert (
+        "- prohibited\\_action: cancel order without explicit confirmation"
+        in markdown
+    )
+
+
+def test_capability_intent_markdown_collapses_multiline_instruction_preview(tmp_path):
+    report, _ = run_scan(
+        config_path=OPENAI_API_SAMPLE,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    markdown = render_markdown_report(report)
+
+    assert "assistant.\n\nYou should only advise" not in markdown
+    assert (
+        "- instruction\\_preview: You are a support refund assistant. "
+        "You should only advise the support representative"
+    ) in markdown
+
+
+def test_capability_diff_intent_tags_are_alias_based_and_negation_aware():
+    from agents_shipgate.report.capability_diff import _intent_tags
+
+    tags = _intent_tags("send external email without preview")
+
+    assert {"external_write", "customer_communication", "write"} <= set(tags)
+    assert "read_only" not in tags
+    assert "financial_action" in _intent_tags("process reimbursements")
+
+
+def test_capability_diff_includes_framework_release_blocker_categories():
+    from agents_shipgate.core.models import (
+        Finding,
+        ReadinessReport,
+        ReportSummary,
+        ToolSurfaceSummary,
+    )
+    from agents_shipgate.report.capability_diff import apply_capability_diff
+
+    report = ReadinessReport(
+        run_id="test",
+        project={"name": "framework-test"},
+        agent={"name": "framework-agent", "declared_purpose": ["use framework tools"]},
+        environment={"target": "test"},
+        summary=ReportSummary(status="release_review_required", high_count=1),
+        tool_surface=ToolSurfaceSummary(total_tools=0, high_risk_tools=0),
+        findings=[
+            Finding(
+                id="finding-langchain-dynamic",
+                fingerprint="fp_langchain_dynamic",
+                check_id="SHIP-LANGCHAIN-DYNAMIC-TOOL-SURFACE-NOT-ENUMERABLE",
+                title="LangChain tool surface cannot be statically enumerated",
+                severity="high",
+                category="langchain",
+                confidence="medium",
+                recommendation="Provide explicit inventory metadata.",
+            )
+        ],
+    )
+
+    apply_capability_diff(report, [])
+
+    assert report.misalignments
+    assert report.misalignments[0].kind == "control_missing"
+    assert report.misalignments[0].finding_refs == ["finding-langchain-dynamic"]
+    assert report.suggested_scenarios[0].scenario_type == "wildcard_inventory"
 
 
 def test_capability_diff_release_consequence_mirrors_release_decision(tmp_path):

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -177,6 +177,11 @@ def test_capability_intent_diff_support_refund_fixture(tmp_path):
     ]
     assert refund_intentions
     assert any("financial_action" in item["intent_tags"] for item in refund_intentions)
+    update_ticket_intention = next(
+        intention
+        for intention in payload["declared_intentions"]
+        if intention["text"] == "update support ticket notes"
+    )
 
     approval_finding = next(
         finding
@@ -202,6 +207,11 @@ def test_capability_intent_diff_support_refund_fixture(tmp_path):
         item["kind"] == "policy_gap"
         and approval_finding["id"] in item["finding_refs"]
         for item in payload["misalignments"]
+    )
+    assert all(
+        update_ticket_intention["id"] not in item["intention_refs"]
+        for item in payload["misalignments"]
+        if item["tool_name"] == "stripe.create_refund"
     )
     assert any(
         item["kind"] == "control_missing"
@@ -261,8 +271,13 @@ def test_capability_diff_intent_tags_are_alias_based_and_negation_aware():
 
     tags = _intent_tags("send external email without preview")
 
-    assert {"external_write", "customer_communication", "write"} <= set(tags)
+    assert {"external_write", "customer_communication"} <= set(tags)
+    assert "write" not in tags
     assert "read_only" not in tags
+    assert "financial_action" not in _intent_tags("do not refund customer")
+    assert "destructive" not in _intent_tags("never delete records")
+    assert _intent_tags("update support ticket notes") == []
+    assert _intent_tags("answer ticket status") == []
     assert "financial_action" in _intent_tags("process reimbursements")
 
 
@@ -339,6 +354,26 @@ def test_capability_diff_release_consequence_mirrors_release_decision(tmp_path):
             "baseline_status": None,
         },
     ]
+
+
+def test_release_consequence_counts_distinct_release_decision_findings(tmp_path):
+    from agents_shipgate.report.json_report import report_json_payload
+
+    report, _ = run_scan(
+        config_path=OPENAI_API_SAMPLE,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    payload = report_json_payload(report)
+
+    assert len(payload["misalignments"]) > len(payload["release_decision"]["review_items"])
+    assert payload["release_consequence"]["blocker_misalignment_count"] == len(
+        payload["release_decision"]["blockers"]
+    )
+    assert payload["release_consequence"]["review_misalignment_count"] == len(
+        payload["release_decision"]["review_items"]
+    )
 
 
 def test_capability_diff_blocks_are_reproducible(tmp_path):

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,7 +1,9 @@
 import json
+from pathlib import Path
 
 from jsonschema import validate
 
+from agents_shipgate.cli.scan import run_scan
 from agents_shipgate.core.models import (
     Finding,
     ReadinessReport,
@@ -32,6 +34,7 @@ MINIMAL_SARIF_SCHEMA = {
         },
     },
 }
+SUPPORT_REFUND_SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 
 
 def test_sarif_uses_canonical_rule_metadata_and_help_uri():
@@ -96,6 +99,23 @@ def test_sarif_output_matches_minimal_sarif_shape():
     )
 
     validate(instance=render_sarif_report(report), schema=MINIMAL_SARIF_SCHEMA)
+
+
+def test_sarif_output_stays_findings_only_for_capability_diff_reports(tmp_path):
+    run_scan(
+        config_path=SUPPORT_REFUND_SAMPLE,
+        output_dir=tmp_path,
+        formats=["sarif"],
+        ci_mode="advisory",
+    )
+
+    sarif_text = (tmp_path / "report.sarif").read_text(encoding="utf-8")
+
+    assert "capability_facts" not in sarif_text
+    assert "declared_intentions" not in sarif_text
+    assert "misalignments" not in sarif_text
+    assert "release_consequence" not in sarif_text
+    assert "suggested_scenarios" not in sarif_text
 
 
 def _report_with_findings(findings: list[Finding]) -> ReadinessReport:

--- a/tests/test_v07_metadata_roundtrip.py
+++ b/tests/test_v07_metadata_roundtrip.py
@@ -3,7 +3,7 @@
 Per the v0.7 plan §3 final-polish verification: agents reading
 ``agents-shipgate list-checks --json`` and ``report.json`` should both
 get populated remediation metadata for every check, and the JSON
-   contracts on both endpoints should validate against the current schema.
+contracts on both endpoints should validate against the current schema.
 
 Specifically:
 

--- a/tests/test_v07_metadata_roundtrip.py
+++ b/tests/test_v07_metadata_roundtrip.py
@@ -3,7 +3,7 @@
 Per the v0.7 plan §3 final-polish verification: agents reading
 ``agents-shipgate list-checks --json`` and ``report.json`` should both
 get populated remediation metadata for every check, and the JSON
-contracts on both endpoints should validate against the v0.7 schema.
+   contracts on both endpoints should validate against the current schema.
 
 Specifically:
 
@@ -14,8 +14,7 @@ Specifically:
    active finding from a real scan against
    ``samples/support_refund_agent``, both with and without
    ``--suggest-patches``.
-3. The ``report.json`` validates against
-   ``docs/report-schema.v0.7.json``.
+3. The ``report.json`` validates against the current report schema.
 4. The catalog-vs-Finding contract holds in practice: stale-manifest
    findings whose actual emitted patch is non-manual + high-confidence
    carry ``autofix_safe: True`` even though the catalog stays
@@ -40,6 +39,7 @@ SAMPLES = REPO_ROOT / "samples"
 SAMPLE_MANIFEST = SAMPLES / "support_refund_agent" / "shipgate.yaml"
 REPORT_SCHEMA_V07 = REPO_ROOT / "docs" / "report-schema.v0.7.json"
 REPORT_SCHEMA_V08 = REPO_ROOT / "docs" / "report-schema.v0.8.json"
+REPORT_SCHEMA_V09 = REPO_ROOT / "docs" / "report-schema.v0.9.json"
 
 REQUIRED_REMEDIATION_KEYS = (
     "autofix_safe",
@@ -138,10 +138,10 @@ def test_report_json_populates_metadata_with_suggest_patches(tmp_path):
 # --- v0.7 schema validation ------------------------------------------------
 
 
-def test_report_json_validates_against_v08_schema_with_patches(tmp_path):
+def test_report_json_validates_against_v09_schema_with_patches(tmp_path):
     """v0.7 contract: every active finding has the four remediation
-    fields populated. v0.8 added required `release_decision` on top.
-    Validate against the current v0.8 schema (the v0.7 file stays
+    fields populated. v0.9 adds capability/intent diff fields on top.
+    Validate against the current v0.9 schema (the v0.7 file stays
     frozen — see test_reports.py::test_v07_schema_file_is_frozen)."""
     report, _ = run_scan(
         config_path=SAMPLE_MANIFEST,
@@ -151,11 +151,11 @@ def test_report_json_validates_against_v08_schema_with_patches(tmp_path):
         suggest_patches=True,
     )
     payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
-    schema = json.loads(REPORT_SCHEMA_V08.read_text(encoding="utf-8"))
+    schema = json.loads(REPORT_SCHEMA_V09.read_text(encoding="utf-8"))
     validate(instance=payload, schema=schema)
 
 
-def test_report_schema_version_is_v08_in_emitted_report(tmp_path):
+def test_report_schema_version_is_v09_in_emitted_report(tmp_path):
     report, _ = run_scan(
         config_path=SAMPLE_MANIFEST,
         output_dir=tmp_path,
@@ -163,7 +163,7 @@ def test_report_schema_version_is_v08_in_emitted_report(tmp_path):
         ci_mode="advisory",
     )
     payload = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
-    assert payload["report_schema_version"] == "0.8"
+    assert payload["report_schema_version"] == "0.9"
 
 
 # --- Catalog-vs-Finding contract holds in practice -------------------------


### PR DESCRIPTION
## Summary

Adds the v0.9 Capability <-> Intent Diff report layer so release reviews can see declared intent, actual high-risk capabilities, policy/control gaps, release consequence, and suggested validation scenarios in one deterministic section.

## Changes

- Adds v0.9 report models and generated `docs/report-schema.v0.9.json`.
- Builds deterministic `capability_facts`, `declared_intentions`, `misalignments`, `release_consequence`, and `suggested_scenarios` without LLM/runtime judgment.
- Renders a capped Markdown `Capability <-> Intent Diff` section after Top Findings.
- Updates docs, report goldens, and schema/report tests for the new additive contract.

## Validation

- `python scripts/generate_schemas.py`
- `python -m ruff check .`
- `python -m pytest` -> `347 passed in 19.45s`

## Notes

Unrelated untracked local files were left out of the commit.