### PR TITLE
Add ranked next-action diagnostics for detect / doctor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,18 @@ The full set of error kinds emitted in agent mode: `config_error`, `config_alrea
 
 ### Doctor behavior change for unresolved tool_sources
 
-When a required `tool_sources[].path` does not resolve under the manifest directory:
+When a required `tool_sources[].path` does not resolve under the manifest directory (file missing OR resolves outside the manifest dir):
 
-- `agents-shipgate doctor --json` exits **0** with a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic and an `unresolved_sources: [{id, declared_path, line}]` field in the payload, so an agent can route to a fix without parsing the error message.
-- `agents-shipgate scan` is unchanged — it still raises `InputParseError(3)`. Once you're past doctor, missing sources are real scan failures.
+- `agents-shipgate doctor --json` exits **0** with a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic and an `unresolved_sources: [{id, declared_path, line, reason}]` field in the payload, so an agent can route to a fix without parsing the error message. `reason` is `"missing"` or `"outside_manifest_dir"`.
+- `agents-shipgate doctor` (no `--json`) prints the same `unresolved_sources` + diagnostic block in human-readable form and **exits 3**, preserving the pre-feature loud failure for interactive users.
+- `agents-shipgate scan` is unchanged — it still raises `InputParseError(3)` regardless of `--json`. Once you're past doctor, missing sources are real scan failures.
+
+### Missing vs invalid manifests
+
+`config_error` covers two distinct shapes — agent-mode emits a different rank-1 action for each:
+
+- **Missing**: file does not exist → `SHIP-DIAG-MISSING-MANIFEST`, rank-1 is `agents-shipgate detect --workspace <dir> --json` (then `init --write`).
+- **Invalid**: file exists but the loader rejected it (invalid YAML, schema validation, unsupported version) → `SHIP-DIAG-INVALID-MANIFEST`, rank-1 is `edit <path>` with the loader error in `why`. Do **not** re-run `init` — it refuses to overwrite an existing file.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,15 +117,24 @@ agents-shipgate self-check --json
 agents-shipgate fixture list --json
 ```
 
-Errors carry a structured `next_action` when run with `AGENTS_SHIPGATE_AGENT_MODE=1`:
+Errors carry a structured `next_action` (single string, back-compat) and `next_actions` (ranked list) when run with `AGENTS_SHIPGATE_AGENT_MODE=1`:
 
 ```bash
 $ AGENTS_SHIPGATE_AGENT_MODE=1 agents-shipgate scan -c missing.yaml
 Config error: Config file not found: missing.yaml
-{"error": "config_error", "message": "Config file not found: missing.yaml", "next_action": "agents-shipgate init --workspace . --write"}
+{"error": "config_error", "message": "...", "next_action": "agents-shipgate detect --workspace . --json", "next_actions": [{"kind": "command", "command": "agents-shipgate detect --workspace . --json", "why": "..."}, {"kind": "command", "command": "agents-shipgate init --workspace . --write", "why": "..."}]}
 ```
 
-The full set of error kinds emitted in agent mode: `config_error`, `config_already_exists`, `input_parse_error`, `unknown_check_id`, `other_error`, `internal_error`.
+The full set of error kinds emitted in agent mode: `config_error`, `config_already_exists`, `input_parse_error`, `unknown_check_id`, `other_error`, `internal_error`, `malformed_patch`.
+
+`detect --json` and each `doctor --json` payload also carry `diagnostics: [...]` and `next_actions: [...]` fields. `next_action` (single string) remains the rank-1 action projected to a string; `next_actions` is the ranked list with `kind`, `command|path`, `why`, and `expects` fields. See [docs/diagnostics.md](docs/diagnostics.md) for the full catalog and schema.
+
+### Doctor behavior change for unresolved tool_sources
+
+When a required `tool_sources[].path` does not resolve under the manifest directory:
+
+- `agents-shipgate doctor --json` exits **0** with a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic and an `unresolved_sources: [{id, declared_path, line}]` field in the payload, so an agent can route to a fix without parsing the error message.
+- `agents-shipgate scan` is unchanged — it still raises `InputParseError(3)`. Once you're past doctor, missing sources are real scan failures.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,15 @@
   three negative-control cases) without consulting human-facing docs. Errors
   emitted under `AGENTS_SHIPGATE_AGENT_MODE=1` carry the same `next_actions`
   array. Diagnostic catalog and schema in [docs/diagnostics.md](docs/diagnostics.md).
-- Behavior change: `agents-shipgate doctor` no longer raises
-  `InputParseError(3)` when a required `tool_sources[].path` does not
-  resolve. It now exits 0 with `unresolved_sources: [...]` and a
-  `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic so an agent gets a routable
-  next action. `agents-shipgate scan` is unchanged — it still raises
-  `InputParseError(3)` on missing required sources.
+- Behavior change: when a required `tool_sources[].path` does not
+  resolve (file missing OR resolves outside the manifest directory),
+  `agents-shipgate doctor --json` exits **0** with
+  `unresolved_sources: [...]` and a `SHIP-DIAG-MISSING-SOURCE-FILE`
+  diagnostic so an agent gets a routable next action. The non-JSON
+  `agents-shipgate doctor` form prints the same diagnostic in
+  human-readable form and exits **3** so interactive users still see a
+  loud failure. `agents-shipgate scan` is unchanged — it still raises
+  `InputParseError(3)` on the same condition regardless of `--json`.
 - `DetectResult` gains a `workspace_signals` block (Python file count,
   `pyproject.toml`/`requirements.txt` presence, conventional dir hits) used
   by the new diagnostic resolvers to discriminate negative-control cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@
 - Add `agents-shipgate scenario suggest` (target: `0.9.1`), a YAML export that
   fans out `report.json.suggested_scenarios[]` into concrete
   per-finding/per-tool dynamic validation steps.
+- Added ranked next-action diagnostics: `detect --json` and `doctor --json`
+  now emit `diagnostics: [...]` and `next_actions: [...]` blocks alongside
+  the existing single-string `next_action` field. Coding-agent callers can
+  recover from common first-run failures (missing manifest, zero tools,
+  unresolved `CHANGE_ME`, missing source files, MCP/OpenAPI artifact-only
+  workspaces, dynamic toolsets, production targets without permissions, and
+  three negative-control cases) without consulting human-facing docs. Errors
+  emitted under `AGENTS_SHIPGATE_AGENT_MODE=1` carry the same `next_actions`
+  array. Diagnostic catalog and schema in [docs/diagnostics.md](docs/diagnostics.md).
+- Behavior change: `agents-shipgate doctor` no longer raises
+  `InputParseError(3)` when a required `tool_sources[].path` does not
+  resolve. It now exits 0 with `unresolved_sources: [...]` and a
+  `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic so an agent gets a routable
+  next action. `agents-shipgate scan` is unchanged — it still raises
+  `InputParseError(3)` on missing required sources.
+- `DetectResult` gains a `workspace_signals` block (Python file count,
+  `pyproject.toml`/`requirements.txt` presence, conventional dir hits) used
+  by the new diagnostic resolvers to discriminate negative-control cases.
+  The block is additive; existing fields are unchanged.
 
 ## 0.8.0 - 2026-05-05
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -48,6 +48,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 ## For agents
 
 - [`agent-recipes.md`](agent-recipes.md) — copy-pasteable AI-agent workflows for the canonical 4-call flow (`detect → init → scan → apply-patches`)
+- [`diagnostics.md`](diagnostics.md) — ranked next-action diagnostics surfaced by `detect`, `doctor`, and structured-error JSON
 - [`target-repo-agent-snippets.md`](target-repo-agent-snippets.md) — copyable `AGENTS.md`, `CLAUDE.md`, Cursor, PR template, and advisory workflow snippets for downstream repos
 - [`agent-adoption-harness.md`](agent-adoption-harness.md) — manual protocol for measuring whether coding agents discover and use Shipgate
 - [`autofix-policy.md`](autofix-policy.md) — which findings are safe to apply, which need review, and how `apply-patches --confidence` filters them

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -6,10 +6,25 @@
 action and route to the next command without consulting human-facing
 docs.
 
-Diagnostics are advisory — they do not change exit codes. Exit codes
-are still owned by `ConfigError(2)`, `InputParseError(3)`, and
-the scan policy block (`20`). A diagnostic with `severity: "block"`
-describes a blocking *condition*; the caller decides what to do.
+Diagnostics describe conditions; the catalog itself does not pick exit
+codes. A diagnostic with `severity: "block"` flags a blocking *condition*
+and the caller (a CLI command) decides what to do. The current rules:
+
+- `agents-shipgate scan` always exits non-zero (`ConfigError(2)`,
+  `InputParseError(3)`, or the scan-policy `20`) on any condition that
+  used to fail it. Diagnostics are extra context, not a replacement.
+- `agents-shipgate doctor --json` is the agent contract: it exits **0**
+  on `SHIP-DIAG-MISSING-SOURCE-FILE` so the agent can read
+  `unresolved_sources[]` and route to a fix.
+- `agents-shipgate doctor` (no `--json`) is the human contract: it
+  exits **3** when any payload has `unresolved_sources`, so an
+  interactive user still sees a loud failure. The diagnostic block
+  prints in the human output regardless.
+
+This is the only place a diagnostic affects an exit code, and the
+divergence is bounded to `MISSING-SOURCE-FILE` on `doctor`. Other
+diagnostics (`ZERO-TOOLS`, `CHANGE-ME-PLACEHOLDERS`, etc.) print but
+do not change the exit code.
 
 ## Schema
 
@@ -52,7 +67,8 @@ diagnostics where no command should run.
 
 | ID                                  | Severity | Fires when                                                                                                                                       |
 | ----------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SHIP-DIAG-MISSING-MANIFEST`        | block    | `shipgate.yaml` not found in the working directory.                                                                                              |
+| `SHIP-DIAG-MISSING-MANIFEST`        | block    | The manifest file does not exist on disk. Rank-1 action: `agents-shipgate detect --workspace <dir> --json`.                                       |
+| `SHIP-DIAG-INVALID-MANIFEST`        | block    | The manifest file exists but the loader rejected it (invalid YAML, schema validation failure, unsupported version). Rank-1 action: `edit <path>`. |
 | `SHIP-DIAG-NO-AGENT-SURFACE`        | info     | `is_agent_project=false` AND `suggested_sources=[]` AND no manifest. Catch-all negative control.                                                |
 | `SHIP-DIAG-NON-AGENT-LIBRARY`       | info     | Python project (≥1 .py file + pyproject/requirements) with no agent framework, prompts, or tool surface.                                         |
 | `SHIP-DIAG-PURE-PROMPT-EXPERIMENT`  | info     | Only `prompts/` is present; no Python framework, no tool sources.                                                                                |
@@ -86,13 +102,23 @@ agent no routable next step.
 
 Now `doctor --json` exits **0** with:
 
-- `unresolved_sources: [{id, declared_path, line}]` listing each unresolved entry
+- `unresolved_sources: [{id, declared_path, line, reason}]` listing each
+  unresolved entry. `reason` is `"missing"` (file does not exist) or
+  `"outside_manifest_dir"` (file exists but resolves outside the
+  manifest directory; loaders refuse it on containment grounds).
 - a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic whose rank-1 action is an
-  `edit` pointing at `shipgate.yaml:<line>`
+  `edit` pointing at `<manifest_path>:<line>` (the full path the user
+  invoked `doctor` with, so workspace and nested-manifest runs stay
+  unambiguous).
+
+The non-JSON form (`agents-shipgate doctor` without `--json`) prints
+the same `unresolved_sources` and diagnostic block in human-readable
+form and **exits 3** to preserve the pre-feature loud failure for
+interactive users.
 
 `scan` is unchanged — it still raises `InputParseError(3)` on missing
-required sources, because once an agent moves past doctor, those are real
-scan failures.
+or escaped required sources regardless of `--json`, because once an
+agent moves past doctor, those are real scan failures.
 
 ## Where diagnostics surface
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,111 @@
+# Ranked Next-Action Diagnostics
+
+`agents-shipgate detect`, `doctor`, and structured errors emit a
+`diagnostics[]` and `next_actions[]` block alongside the existing
+`next_action: str` field. A coding-agent caller can read the rank-1
+action and route to the next command without consulting human-facing
+docs.
+
+Diagnostics are advisory — they do not change exit codes. Exit codes
+are still owned by `ConfigError(2)`, `InputParseError(3)`, and
+the scan policy block (`20`). A diagnostic with `severity: "block"`
+describes a blocking *condition*; the caller decides what to do.
+
+## Schema
+
+`Diagnostic` (one per detected condition):
+
+```json
+{
+  "id": "SHIP-DIAG-...",
+  "title": "Human-readable one-liner",
+  "severity": "block | warn | info",
+  "next_actions": [ NextAction, ... ]
+}
+```
+
+`NextAction` (ranked recovery step; ordered list — array position is
+the rank, no separate `rank` field):
+
+| Field    | Type                                      | Notes                                                         |
+| -------- | ----------------------------------------- | ------------------------------------------------------------- |
+| kind     | `command \| edit \| review \| stop`       | Action category.                                              |
+| command  | `string \| null`                          | Required when `kind="command"`. Always `null` when `"stop"`. |
+| path     | `string \| null`                          | Required when `kind="edit"`. May be `shipgate.yaml:<line>`. |
+| why      | `string`                                  | One-sentence rationale.                                       |
+| expects  | `string \| null`                          | Optional: what the next run should output if the action worked. |
+
+The legacy `next_action: str` field on `detect`, `doctor`, and
+agent-mode error JSON is the rank-1 action projected to a single string:
+
+| Rank-1 kind | Legacy projection                  |
+| ----------- | ---------------------------------- |
+| command     | the `command` value verbatim       |
+| edit        | `Edit <path>`                      |
+| review      | `Review: <why>`                    |
+| stop        | `Stop: <why>`                      |
+
+This keeps `next_action` string-typed even for negative-control
+diagnostics where no command should run.
+
+## Catalog
+
+| ID                                  | Severity | Fires when                                                                                                                                       |
+| ----------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SHIP-DIAG-MISSING-MANIFEST`        | block    | `shipgate.yaml` not found in the working directory.                                                                                              |
+| `SHIP-DIAG-NO-AGENT-SURFACE`        | info     | `is_agent_project=false` AND `suggested_sources=[]` AND no manifest. Catch-all negative control.                                                |
+| `SHIP-DIAG-NON-AGENT-LIBRARY`       | info     | Python project (≥1 .py file + pyproject/requirements) with no agent framework, prompts, or tool surface.                                         |
+| `SHIP-DIAG-PURE-PROMPT-EXPERIMENT`  | info     | Only `prompts/` is present; no Python framework, no tool sources.                                                                                |
+| `SHIP-DIAG-MCP-OPENAPI-ARTIFACT-ONLY` | info   | `is_agent_project=false` BUT `suggested_sources` has MCP/OpenAPI entries. Artifact-only repos are valid Shipgate targets.                        |
+| `SHIP-DIAG-ZERO-TOOLS`              | block    | Manifest exists but `doctor` reports `total_tools=0`.                                                                                            |
+| `SHIP-DIAG-DYNAMIC-TOOLSETS-ONLY`   | warn     | `total_tools < 3` AND any of `dynamic_toolset_count` / `dynamic_tool_surface_count` ≥ 1 across ADK / LangChain / CrewAI surfaces.                 |
+| `SHIP-DIAG-MISSING-SOURCE-FILE`     | block    | A required `tool_sources[].path` does not resolve under the manifest directory. (`doctor` no longer raises `InputParseError(3)` for this — see below.) |
+| `SHIP-DIAG-CHANGE-ME-PLACEHOLDERS`  | warn     | Manifest text still contains `CHANGE_ME` markers.                                                                                                |
+| `SHIP-DIAG-NO-PRODUCTION-PERMISSIONS` | warn   | `environment.target: production` AND no permissions / scopes / policies declared.                                                                 |
+
+## Negative-control precedence
+
+When more than one negative-control predicate matches, only the most
+specific diagnostic fires:
+
+```
+SHIP-DIAG-PURE-PROMPT-EXPERIMENT
+    > SHIP-DIAG-NON-AGENT-LIBRARY
+        > SHIP-DIAG-NO-AGENT-SURFACE
+```
+
+A workspace with both a `prompts/` directory and a `pyproject.toml`
+emits only `SHIP-DIAG-PURE-PROMPT-EXPERIMENT`, not the broader
+`SHIP-DIAG-NON-AGENT-LIBRARY`.
+
+## Doctor behavior change
+
+Before this feature, `agents-shipgate doctor` raised `InputParseError(3)`
+when a required `tool_sources[].path` failed to load. That gave a coding
+agent no routable next step.
+
+Now `doctor --json` exits **0** with:
+
+- `unresolved_sources: [{id, declared_path, line}]` listing each unresolved entry
+- a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic whose rank-1 action is an
+  `edit` pointing at `shipgate.yaml:<line>`
+
+`scan` is unchanged — it still raises `InputParseError(3)` on missing
+required sources, because once an agent moves past doctor, those are real
+scan failures.
+
+## Where diagnostics surface
+
+Diagnostics are emitted in three places:
+
+1. `detect --json` — workspace classification + recovery hints.
+2. Each `doctor --json` payload — per-manifest diagnostics.
+3. `AGENTS_SHIPGATE_AGENT_MODE=1` stderr error JSON — alongside the
+   existing `error` and `next_action` fields, errors now also carry
+   `next_actions: list[NextAction]`.
+
+Diagnostics are *not* added to `report.json` (the v0.9 schema is
+unchanged). Per-finding remediation already has its own v0.7 fields
+(`autofix_safe`, `requires_human_review`, `suggested_patch_kind`,
+`docs_url`); diagnostics are pre-scan recovery hints, not post-scan
+remediation.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,14 +18,17 @@ agents-shipgate doctor --config shipgate.yaml
 
 Use this before reading the full manifest schema.
 
-| Symptom | Fix |
-| --- | --- |
-| `detect --json` returns `is_agent_project: false`, but `suggested_sources` has MCP or OpenAPI files | Continue to `init --workspace . --write`; artifact-only repos are valid Shipgate targets. |
-| `doctor` shows zero tools | Check `tool_sources[].path`, MCP `tools[]`, OpenAPI `paths`, optional source parse warnings, and dynamic toolset warnings. |
-| SDK/framework extractor finds no tools | Add an explicit MCP export, OpenAPI spec, or local tool inventory instead of relying on dynamic code discovery. |
-| `shipgate.yaml` still has `CHANGE_ME` | Replace `agent.name` and `agent.declared_purpose` from prompt, main agent file, or README context before scanning. |
-| Install fails in an older project environment | Agents Shipgate requires Python 3.12+. Install with `pipx` or `uv` using a Python 3.12+ interpreter. |
-| Reports show up as untracked files | Add `agents-shipgate-reports/` to `.gitignore`; do not commit reports by default. |
+| Symptom | Diagnostic ID | Fix |
+| --- | --- | --- |
+| `detect --json` returns `is_agent_project: false`, but `suggested_sources` has MCP or OpenAPI files | `SHIP-DIAG-MCP-OPENAPI-ARTIFACT-ONLY` | Continue to `init --workspace . --write`; artifact-only repos are valid Shipgate targets. |
+| `doctor` shows zero tools | `SHIP-DIAG-ZERO-TOOLS` | Check `tool_sources[].path`, MCP `tools[]`, OpenAPI `paths`, optional source parse warnings, and dynamic toolset warnings. |
+| SDK/framework extractor finds no tools | `SHIP-DIAG-DYNAMIC-TOOLSETS-ONLY` | Add an explicit MCP export, OpenAPI spec, or local tool inventory instead of relying on dynamic code discovery. |
+| `shipgate.yaml` still has `CHANGE_ME` | `SHIP-DIAG-CHANGE-ME-PLACEHOLDERS` | Replace `agent.name` and `agent.declared_purpose` from prompt, main agent file, or README context before scanning. |
+| Required `tool_sources[].path` does not resolve | `SHIP-DIAG-MISSING-SOURCE-FILE` | `doctor --json` reports `unresolved_sources: [...]` and a diagnostic with `kind="edit", path="shipgate.yaml:<line>"`. Fix the path. (`scan` still exits 3 on the same condition — fix it before scanning.) |
+| Install fails in an older project environment | — | Agents Shipgate requires Python 3.12+. Install with `pipx` or `uv` using a Python 3.12+ interpreter. |
+| Reports show up as untracked files | — | Add `agents-shipgate-reports/` to `.gitignore`; do not commit reports by default. |
+
+When run under `AGENTS_SHIPGATE_AGENT_MODE=1`, errors carry a `next_actions: [...]` array alongside the legacy `next_action: str`. The full catalog and schema is in [diagnostics.md](diagnostics.md).
 
 ## `doctor` Shows Zero Tools
 

--- a/src/agents_shipgate/cli/apply_patches.py
+++ b/src/agents_shipgate/cli/apply_patches.py
@@ -120,20 +120,21 @@ def apply_patches(
             f"Malformed patch in report at {from_path}: {exc}",
             err=True,
         )
+        import shlex as _shlex
+
+        out_q = _shlex.quote(str(from_path.parent))
+        rerun_command = (
+            f"agents-shipgate scan -c shipgate.yaml --suggest-patches "
+            f"--out {out_q}"
+        )
         _emit_input_error(
             "malformed_patch",
             str(exc),
-            next_action=(
-                f"agents-shipgate scan -c shipgate.yaml --suggest-patches "
-                f"--out {from_path.parent}"
-            ),
+            next_action=rerun_command,
             next_actions=[
                 {
                     "kind": "command",
-                    "command": (
-                        f"agents-shipgate scan -c shipgate.yaml "
-                        f"--suggest-patches --out {from_path.parent}"
-                    ),
+                    "command": rerun_command,
                     "path": None,
                     "why": (
                         "Re-run scan with --suggest-patches to regenerate a "

--- a/src/agents_shipgate/cli/apply_patches.py
+++ b/src/agents_shipgate/cli/apply_patches.py
@@ -120,7 +120,32 @@ def apply_patches(
             f"Malformed patch in report at {from_path}: {exc}",
             err=True,
         )
-        _emit_input_error("malformed_patch", str(exc))
+        _emit_input_error(
+            "malformed_patch",
+            str(exc),
+            next_action=(
+                f"agents-shipgate scan -c shipgate.yaml --suggest-patches "
+                f"--out {from_path.parent}"
+            ),
+            next_actions=[
+                {
+                    "kind": "command",
+                    "command": (
+                        f"agents-shipgate scan -c shipgate.yaml "
+                        f"--suggest-patches --out {from_path.parent}"
+                    ),
+                    "path": None,
+                    "why": (
+                        "Re-run scan with --suggest-patches to regenerate a "
+                        "well-formed patch payload."
+                    ),
+                    "expects": (
+                        f"{from_path} is rewritten with valid patches[] "
+                        "entries."
+                    ),
+                }
+            ],
+        )
         raise typer.Exit(2) from exc
     typed_patches = [p for p in typed_patches if not isinstance(p, ManualPatch)]
 
@@ -160,10 +185,15 @@ def apply_patches(
 # --- Internals --------------------------------------------------------------
 
 
-def _emit_input_error(kind: str, message: str) -> None:
+def _emit_input_error(kind: str, message: str, **fields: object) -> None:
     """Emit a structured one-line JSON error on stderr when
     AGENTS_SHIPGATE_AGENT_MODE=1 is set, matching the convention used by
-    other commands. Silent otherwise."""
+    other commands. Silent otherwise.
+
+    ``fields`` may carry ``next_action`` (legacy single string) and
+    ``next_actions`` (ranked list of NextAction dicts) so callers can
+    attach recovery hints in the same shape as the global agent-mode
+    helper."""
     import os
     import sys
 
@@ -174,7 +204,7 @@ def _emit_input_error(kind: str, message: str) -> None:
         "on",
     }:
         return
-    payload = {"error": kind, "message": message}
+    payload = {"error": kind, "message": message, **fields}
     print(json.dumps(payload, default=str), file=sys.stderr)
 
 

--- a/src/agents_shipgate/cli/detect.py
+++ b/src/agents_shipgate/cli/detect.py
@@ -16,6 +16,11 @@ from pathlib import Path
 
 import typer
 
+from agents_shipgate.cli.diagnostics import (
+    Diagnostic,
+    diagnose_detect,
+    top_next_actions,
+)
 from agents_shipgate.cli.discovery import detect_workspace
 
 
@@ -38,9 +43,25 @@ def detect(
     ),
 ) -> None:
     """Classify a workspace: which agent framework(s), if any."""
-    result = detect_workspace(workspace.resolve(), max_python_files=max_python_files)
+    workspace_resolved = workspace.resolve()
+    result = detect_workspace(workspace_resolved, max_python_files=max_python_files)
+    has_manifest = (workspace_resolved / "shipgate.yaml").is_file()
+    diagnostics: list[Diagnostic] = diagnose_detect(
+        result, has_manifest=has_manifest, workspace=workspace_resolved
+    )
+    flattened = top_next_actions(diagnostics)
+    if diagnostics:
+        # Override the legacy single-string field with the rank-1 projection
+        # so callers that read `next_action` get a routable answer when a
+        # diagnostic fires (otherwise keep the existing classification text).
+        result = result.model_copy(
+            update={"next_action": flattened[0].to_legacy_string()}
+        )
     if json_output:
-        typer.echo(json.dumps(result.model_dump(mode="json"), indent=2))
+        payload = result.model_dump(mode="json")
+        payload["diagnostics"] = [d.model_dump(mode="json") for d in diagnostics]
+        payload["next_actions"] = [a.model_dump(mode="json") for a in flattened]
+        typer.echo(json.dumps(payload, indent=2))
         return
 
     if not result.is_agent_project:

--- a/src/agents_shipgate/cli/diagnostics.py
+++ b/src/agents_shipgate/cli/diagnostics.py
@@ -308,8 +308,8 @@ def diagnose_detect(
                         NextAction(
                             kind="command",
                             command=(
-                                f"agents-shipgate init --workspace {workspace} "
-                                "--write"
+                                f"agents-shipgate init --workspace "
+                                f"{_quote_path(workspace)} --write"
                             ),
                             why=(
                                 "Artifact-only repos are valid Shipgate "

--- a/src/agents_shipgate/cli/diagnostics.py
+++ b/src/agents_shipgate/cli/diagnostics.py
@@ -24,7 +24,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agents_shipgate.cli.discovery.signals import DetectResult
 
-
 # --- Public models ----------------------------------------------------------
 
 
@@ -281,7 +280,10 @@ def diagnose_doctor(
     pure and the placeholder helper is exercised once per command.
     """
     diagnostics: list[Diagnostic] = []
-    manifest_rel = manifest_path.name
+    # Use the manifest path the caller actually invoked, so edit actions
+    # remain unambiguous in workspace runs ("subdir/shipgate.yaml:14")
+    # and absolute-path invocations.
+    manifest_rel = str(manifest_path)
 
     # SHIP-DIAG-MISSING-SOURCE-FILE — required tool_sources path doesn't resolve.
     unresolved = payload.get("unresolved_sources") or []
@@ -292,15 +294,26 @@ def diagnose_doctor(
             target = (
                 f"{manifest_rel}:{line}" if line is not None else manifest_rel
             )
+            reason = entry.get("reason", "missing")
+            if reason == "outside_manifest_dir":
+                why = (
+                    f"tool_sources entry '{entry.get('id')}' points at "
+                    f"{entry.get('declared_path')!r} which resolves outside "
+                    "the manifest directory; the loader would refuse to "
+                    "load it."
+                )
+            else:
+                why = (
+                    f"tool_sources entry '{entry.get('id')}' points at "
+                    f"{entry.get('declared_path')!r} which does not "
+                    "resolve to an existing file under the manifest "
+                    "directory."
+                )
             actions.append(
                 NextAction(
                     kind="edit",
                     path=target,
-                    why=(
-                        f"tool_sources entry '{entry.get('id')}' points at "
-                        f"{entry.get('declared_path')!r} which does not "
-                        "resolve under the manifest directory."
-                    ),
+                    why=why,
                     expects="The path resolves to an existing file.",
                 )
             )

--- a/src/agents_shipgate/cli/diagnostics.py
+++ b/src/agents_shipgate/cli/diagnostics.py
@@ -17,12 +17,25 @@ blocking *condition*; the caller decides what to do.
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agents_shipgate.cli.discovery.signals import DetectResult
+
+
+def _quote_path(value: str | Path) -> str:
+    """POSIX-shell-quote a path for inclusion in a `command` field.
+
+    `next_actions[].command` is a single shell string per the v1 contract,
+    so paths with spaces or shell metacharacters must be quoted before
+    interpolation. ``shlex.quote`` returns the input verbatim when no
+    quoting is needed, which keeps the existing rank-1 commands stable
+    in the common case of simple paths.
+    """
+    return shlex.quote(str(value))
 
 # --- Public models ----------------------------------------------------------
 
@@ -89,6 +102,7 @@ class Diagnostic(BaseModel):
 # docs/diagnostics.md. See tests/test_diagnostics.py for stability checks.
 
 DIAG_MISSING_MANIFEST = "SHIP-DIAG-MISSING-MANIFEST"
+DIAG_INVALID_MANIFEST = "SHIP-DIAG-INVALID-MANIFEST"
 DIAG_NO_AGENT_SURFACE = "SHIP-DIAG-NO-AGENT-SURFACE"
 DIAG_NON_AGENT_LIBRARY = "SHIP-DIAG-NON-AGENT-LIBRARY"
 DIAG_PURE_PROMPT_EXPERIMENT = "SHIP-DIAG-PURE-PROMPT-EXPERIMENT"
@@ -101,6 +115,7 @@ DIAG_NO_PRODUCTION_PERMISSIONS = "SHIP-DIAG-NO-PRODUCTION-PERMISSIONS"
 
 ALL_DIAGNOSTIC_IDS: tuple[str, ...] = (
     DIAG_MISSING_MANIFEST,
+    DIAG_INVALID_MANIFEST,
     DIAG_NO_AGENT_SURFACE,
     DIAG_NON_AGENT_LIBRARY,
     DIAG_PURE_PROMPT_EXPERIMENT,
@@ -118,6 +133,7 @@ ALL_DIAGNOSTIC_IDS: tuple[str, ...] = (
 
 def diagnose_missing_manifest(workspace: Path) -> list[Diagnostic]:
     """``shipgate.yaml`` is absent. The agent should detect, then init."""
+    workspace_q = _quote_path(workspace)
     return [
         Diagnostic(
             id=DIAG_MISSING_MANIFEST,
@@ -126,7 +142,7 @@ def diagnose_missing_manifest(workspace: Path) -> list[Diagnostic]:
             next_actions=[
                 NextAction(
                     kind="command",
-                    command=f"agents-shipgate detect --workspace {workspace} --json",
+                    command=f"agents-shipgate detect --workspace {workspace_q} --json",
                     why=(
                         "Confirm this is an agent project before writing a "
                         "manifest. detect is read-only."
@@ -138,12 +154,62 @@ def diagnose_missing_manifest(workspace: Path) -> list[Diagnostic]:
                 ),
                 NextAction(
                     kind="command",
-                    command=f"agents-shipgate init --workspace {workspace} --write",
+                    command=f"agents-shipgate init --workspace {workspace_q} --write",
                     why=(
                         "Draft a starter manifest from auto-detected "
                         "frameworks and tool sources."
                     ),
                     expects="shipgate.yaml is created at the workspace root.",
+                ),
+            ],
+        )
+    ]
+
+
+def diagnose_invalid_manifest(
+    manifest_path: Path, *, message: str
+) -> list[Diagnostic]:
+    """``shipgate.yaml`` exists on disk but the loader rejected it.
+
+    Distinct from ``SHIP-DIAG-MISSING-MANIFEST``: the manifest is
+    present, so the right rank-1 action is to *edit* it, not to run
+    ``detect`` / ``init`` again. ``message`` is the underlying loader
+    error (invalid YAML, schema validation failure, unsupported version,
+    etc.) so the agent can route to the specific fix.
+    """
+    return [
+        Diagnostic(
+            id=DIAG_INVALID_MANIFEST,
+            title="Manifest exists but failed to load",
+            severity="block",
+            next_actions=[
+                NextAction(
+                    kind="edit",
+                    path=str(manifest_path),
+                    why=(
+                        f"Loader rejected {manifest_path}: {message}. Fix "
+                        "the manifest in place — do not re-run init, which "
+                        "would refuse to overwrite an existing file."
+                    ),
+                    expects=(
+                        "agents-shipgate doctor -c <path> --json runs without "
+                        "raising ConfigError."
+                    ),
+                ),
+                NextAction(
+                    kind="command",
+                    command=(
+                        f"agents-shipgate doctor -c {_quote_path(manifest_path)} "
+                        "--json"
+                    ),
+                    why=(
+                        "Re-run doctor after editing to verify the fix and "
+                        "surface any further diagnostics."
+                    ),
+                    expects=(
+                        "JSON payload with diagnostics[] reflecting current "
+                        "manifest state."
+                    ),
                 ),
             ],
         )
@@ -337,7 +403,7 @@ def diagnose_doctor(
                     NextAction(
                         kind="command",
                         command=(
-                            f"agents-shipgate doctor -c {manifest_path} "
+                            f"agents-shipgate doctor -c {_quote_path(manifest_path)} "
                             "--verbose --json"
                         ),
                         why=(

--- a/src/agents_shipgate/cli/diagnostics.py
+++ b/src/agents_shipgate/cli/diagnostics.py
@@ -1,0 +1,489 @@
+"""Ranked next-action diagnostics for first-run failure modes.
+
+This module turns already-computed signals (``DetectResult``,
+``inspect_sources`` payloads, manifest text) into ranked, structured
+recovery hints a coding-agent caller can route on without reading the
+human-facing docs.
+
+The functions here are pure — they accept already-parsed inputs and
+return Pydantic models. They never hit the filesystem, the network, or
+the typer CLI.
+
+Diagnostics are *advisory*: they do not influence exit codes. Exit codes
+remain owned by ``ConfigError`` (2), ``InputParseError`` (3), and the
+``scan`` policy (20). A diagnostic with ``severity="block"`` describes a
+blocking *condition*; the caller decides what to do.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from agents_shipgate.cli.discovery.signals import DetectResult
+
+
+# --- Public models ----------------------------------------------------------
+
+
+NextActionKind = Literal["command", "edit", "review", "stop"]
+DiagnosticSeverity = Literal["block", "warn", "info"]
+
+
+class NextAction(BaseModel):
+    """One ranked recovery step.
+
+    Ordered list position is the rank — there is no separate ``rank`` field.
+
+    - ``kind="command"`` → ``command`` is a runnable shell string.
+    - ``kind="edit"`` → ``path`` points at a file (optionally
+      ``shipgate.yaml:<line>``).
+    - ``kind="review"`` → no command, just a sentence in ``why``.
+    - ``kind="stop"`` → negative-control; ``command`` is None.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: NextActionKind
+    command: str | None = None
+    path: str | None = None
+    why: str
+    expects: str | None = None
+
+    @model_validator(mode="after")
+    def _check_kind_fields(self) -> NextAction:
+        if self.kind == "command" and not self.command:
+            raise ValueError("kind='command' requires a non-empty command")
+        if self.kind == "edit" and not self.path:
+            raise ValueError("kind='edit' requires a non-empty path")
+        if self.kind == "stop" and self.command is not None:
+            raise ValueError("kind='stop' must not carry a command")
+        return self
+
+    def to_legacy_string(self) -> str:
+        """Project to the back-compat single-string ``next_action`` field."""
+        if self.kind == "command":
+            assert self.command is not None
+            return self.command
+        if self.kind == "edit":
+            return f"Edit {self.path}"
+        if self.kind == "review":
+            return f"Review: {self.why}"
+        return f"Stop: {self.why}"
+
+
+class Diagnostic(BaseModel):
+    """A first-run failure mode with at least one ranked recovery step."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    title: str
+    severity: DiagnosticSeverity
+    next_actions: list[NextAction] = Field(min_length=1)
+
+
+# --- Catalog of diagnostic IDs ---------------------------------------------
+# Stable identifiers; surfaced in JSON and cross-linked from
+# docs/diagnostics.md. See tests/test_diagnostics.py for stability checks.
+
+DIAG_MISSING_MANIFEST = "SHIP-DIAG-MISSING-MANIFEST"
+DIAG_NO_AGENT_SURFACE = "SHIP-DIAG-NO-AGENT-SURFACE"
+DIAG_NON_AGENT_LIBRARY = "SHIP-DIAG-NON-AGENT-LIBRARY"
+DIAG_PURE_PROMPT_EXPERIMENT = "SHIP-DIAG-PURE-PROMPT-EXPERIMENT"
+DIAG_MCP_OPENAPI_ARTIFACT_ONLY = "SHIP-DIAG-MCP-OPENAPI-ARTIFACT-ONLY"
+DIAG_ZERO_TOOLS = "SHIP-DIAG-ZERO-TOOLS"
+DIAG_DYNAMIC_TOOLSETS_ONLY = "SHIP-DIAG-DYNAMIC-TOOLSETS-ONLY"
+DIAG_MISSING_SOURCE_FILE = "SHIP-DIAG-MISSING-SOURCE-FILE"
+DIAG_CHANGE_ME_PLACEHOLDERS = "SHIP-DIAG-CHANGE-ME-PLACEHOLDERS"
+DIAG_NO_PRODUCTION_PERMISSIONS = "SHIP-DIAG-NO-PRODUCTION-PERMISSIONS"
+
+ALL_DIAGNOSTIC_IDS: tuple[str, ...] = (
+    DIAG_MISSING_MANIFEST,
+    DIAG_NO_AGENT_SURFACE,
+    DIAG_NON_AGENT_LIBRARY,
+    DIAG_PURE_PROMPT_EXPERIMENT,
+    DIAG_MCP_OPENAPI_ARTIFACT_ONLY,
+    DIAG_ZERO_TOOLS,
+    DIAG_DYNAMIC_TOOLSETS_ONLY,
+    DIAG_MISSING_SOURCE_FILE,
+    DIAG_CHANGE_ME_PLACEHOLDERS,
+    DIAG_NO_PRODUCTION_PERMISSIONS,
+)
+
+
+# --- Public resolvers -------------------------------------------------------
+
+
+def diagnose_missing_manifest(workspace: Path) -> list[Diagnostic]:
+    """``shipgate.yaml`` is absent. The agent should detect, then init."""
+    return [
+        Diagnostic(
+            id=DIAG_MISSING_MANIFEST,
+            title="No shipgate.yaml in this workspace",
+            severity="block",
+            next_actions=[
+                NextAction(
+                    kind="command",
+                    command=f"agents-shipgate detect --workspace {workspace} --json",
+                    why=(
+                        "Confirm this is an agent project before writing a "
+                        "manifest. detect is read-only."
+                    ),
+                    expects=(
+                        "JSON with is_agent_project, suggested_sources, and "
+                        "diagnostics."
+                    ),
+                ),
+                NextAction(
+                    kind="command",
+                    command=f"agents-shipgate init --workspace {workspace} --write",
+                    why=(
+                        "Draft a starter manifest from auto-detected "
+                        "frameworks and tool sources."
+                    ),
+                    expects="shipgate.yaml is created at the workspace root.",
+                ),
+            ],
+        )
+    ]
+
+
+def diagnose_detect(
+    result: DetectResult, *, has_manifest: bool, workspace: Path
+) -> list[Diagnostic]:
+    """Diagnostics for ``detect --json``.
+
+    Negative-control precedence (most specific wins):
+        PURE_PROMPT_EXPERIMENT > NON_AGENT_LIBRARY > NO_AGENT_SURFACE
+    """
+    diagnostics: list[Diagnostic] = []
+    signals = result.workspace_signals
+    is_agent = result.is_agent_project
+    has_suggested = bool(result.suggested_sources)
+
+    # If a manifest already exists, none of the *workspace-classification*
+    # diagnostics here are interesting — the agent is past detect. Only
+    # surface the artifact-only nudge when relevant.
+    if not has_manifest:
+        if not is_agent and not has_suggested:
+            # Negative-control precedence
+            if (
+                signals.has_prompts_dir
+                and not signals.has_tools_dir
+                and signals.python_file_count == 0
+            ):
+                diagnostics.append(
+                    Diagnostic(
+                        id=DIAG_PURE_PROMPT_EXPERIMENT,
+                        title="Workspace looks like a pure prompt experiment",
+                        severity="info",
+                        next_actions=[
+                            NextAction(
+                                kind="stop",
+                                why=(
+                                    "Only prompts/ is present — no framework "
+                                    "imports, no tool sources. Not a Shipgate "
+                                    "target until tools or a framework appear."
+                                ),
+                            )
+                        ],
+                    )
+                )
+            elif (
+                signals.python_file_count > 0
+                and signals.has_pyproject_or_requirements
+                and not signals.has_prompts_dir
+                and not signals.has_tools_dir
+            ):
+                diagnostics.append(
+                    Diagnostic(
+                        id=DIAG_NON_AGENT_LIBRARY,
+                        title="Workspace looks like a non-agent Python library",
+                        severity="info",
+                        next_actions=[
+                            NextAction(
+                                kind="stop",
+                                why=(
+                                    "Python project with no agent framework, "
+                                    "prompts, or tool surface — not a "
+                                    "Shipgate target."
+                                ),
+                            )
+                        ],
+                    )
+                )
+            else:
+                diagnostics.append(
+                    Diagnostic(
+                        id=DIAG_NO_AGENT_SURFACE,
+                        title="No agent or tool surface detected",
+                        severity="info",
+                        next_actions=[
+                            NextAction(
+                                kind="stop",
+                                why=(
+                                    "Workspace has no framework imports, no "
+                                    "tool artifacts, and no prompt directory."
+                                ),
+                            )
+                        ],
+                    )
+                )
+
+        if not is_agent and has_suggested:
+            diagnostics.append(
+                Diagnostic(
+                    id=DIAG_MCP_OPENAPI_ARTIFACT_ONLY,
+                    title="MCP/OpenAPI artifacts present without Python framework",
+                    severity="info",
+                    next_actions=[
+                        NextAction(
+                            kind="command",
+                            command=(
+                                f"agents-shipgate init --workspace {workspace} "
+                                "--write"
+                            ),
+                            why=(
+                                "Artifact-only repos are valid Shipgate "
+                                "targets; init picks up suggested_sources."
+                            ),
+                            expects=(
+                                "shipgate.yaml is created with tool_sources "
+                                "prefilled."
+                            ),
+                        )
+                    ],
+                )
+            )
+
+    return diagnostics
+
+
+def diagnose_doctor(
+    payload: dict[str, Any],
+    *,
+    manifest_path: Path,
+    manifest_text: str,
+    placeholders: list[dict[str, Any]] | None = None,
+) -> list[Diagnostic]:
+    """Diagnostics for ``doctor --json``.
+
+    ``payload`` is the dict returned by
+    :func:`agents_shipgate.cli.scan.inspect_sources`, including the new
+    ``unresolved_sources`` and ``manifest_summary`` fields.
+
+    ``placeholders`` is the output of
+    :func:`agents_shipgate.cli.discovery.placeholders.collect_placeholders`
+    against ``manifest_text``. Caller passes it in so this resolver stays
+    pure and the placeholder helper is exercised once per command.
+    """
+    diagnostics: list[Diagnostic] = []
+    manifest_rel = manifest_path.name
+
+    # SHIP-DIAG-MISSING-SOURCE-FILE — required tool_sources path doesn't resolve.
+    unresolved = payload.get("unresolved_sources") or []
+    if unresolved:
+        actions: list[NextAction] = []
+        for entry in unresolved:
+            line = entry.get("line")
+            target = (
+                f"{manifest_rel}:{line}" if line is not None else manifest_rel
+            )
+            actions.append(
+                NextAction(
+                    kind="edit",
+                    path=target,
+                    why=(
+                        f"tool_sources entry '{entry.get('id')}' points at "
+                        f"{entry.get('declared_path')!r} which does not "
+                        "resolve under the manifest directory."
+                    ),
+                    expects="The path resolves to an existing file.",
+                )
+            )
+        diagnostics.append(
+            Diagnostic(
+                id=DIAG_MISSING_SOURCE_FILE,
+                title="One or more tool_sources paths do not resolve",
+                severity="block",
+                next_actions=actions,
+            )
+        )
+
+    # SHIP-DIAG-ZERO-TOOLS — manifest exists but inspect_sources returned 0.
+    if payload.get("total_tools", 0) == 0:
+        diagnostics.append(
+            Diagnostic(
+                id=DIAG_ZERO_TOOLS,
+                title="Manifest declares no enumerable tools",
+                severity="block",
+                next_actions=[
+                    NextAction(
+                        kind="command",
+                        command=(
+                            f"agents-shipgate doctor -c {manifest_path} "
+                            "--verbose --json"
+                        ),
+                        why=(
+                            "Re-run with --verbose to see source-load warnings "
+                            "and dynamic-toolset hints."
+                        ),
+                        expects=(
+                            "warnings[] entries explain why each tool_source "
+                            "produced 0 tools."
+                        ),
+                    ),
+                    NextAction(
+                        kind="edit",
+                        path=str(manifest_path),
+                        why=(
+                            "Add an explicit MCP export, OpenAPI spec, or "
+                            "local tool inventory as a new tool_sources entry."
+                        ),
+                        expects=(
+                            "doctor reports total_tools >= 1 on the next run."
+                        ),
+                    ),
+                ],
+            )
+        )
+
+    # SHIP-DIAG-DYNAMIC-TOOLSETS-ONLY — low tools + dynamic count >= 1.
+    if _has_dynamic_toolsets_only(payload):
+        diagnostics.append(
+            Diagnostic(
+                id=DIAG_DYNAMIC_TOOLSETS_ONLY,
+                title="Tool surface is dominated by dynamic toolsets",
+                severity="warn",
+                next_actions=[
+                    NextAction(
+                        kind="edit",
+                        path=str(manifest_path),
+                        why=(
+                            "Static extractors cannot enumerate dynamic "
+                            "ADK/LangChain/CrewAI toolsets. Declare an "
+                            "explicit MCP/OpenAPI source or a local tool "
+                            "inventory artifact."
+                        ),
+                        expects=(
+                            "tool_sources gains a non-dynamic entry; doctor "
+                            "reports a higher total_tools."
+                        ),
+                    )
+                ],
+            )
+        )
+
+    # SHIP-DIAG-CHANGE-ME-PLACEHOLDERS — manifest text still has CHANGE_ME.
+    if placeholders:
+        actions = []
+        for entry in placeholders[:5]:
+            line = entry.get("line")
+            target = (
+                f"{manifest_rel}:{line}" if line is not None else manifest_rel
+            )
+            actions.append(
+                NextAction(
+                    kind="edit",
+                    path=target,
+                    why=(
+                        f"Replace CHANGE_ME at field "
+                        f"{entry.get('path', '<root>')!r}."
+                    ),
+                    expects="The placeholder is replaced with a real value.",
+                )
+            )
+        diagnostics.append(
+            Diagnostic(
+                id=DIAG_CHANGE_ME_PLACEHOLDERS,
+                title="Manifest still contains CHANGE_ME placeholders",
+                severity="warn",
+                next_actions=actions,
+            )
+        )
+
+    # SHIP-DIAG-NO-PRODUCTION-PERMISSIONS — production target with empty perms.
+    summary = payload.get("manifest_summary") or {}
+    if (
+        summary.get("environment_target") == "production"
+        and not summary.get("has_permissions")
+        and not summary.get("has_policies")
+        and (summary.get("scope_count") or 0) == 0
+    ):
+        diagnostics.append(
+            Diagnostic(
+                id=DIAG_NO_PRODUCTION_PERMISSIONS,
+                title="Production target declares no permissions or policies",
+                severity="warn",
+                next_actions=[
+                    NextAction(
+                        kind="edit",
+                        path=str(manifest_path),
+                        why=(
+                            "environment.target is 'production' but the "
+                            "manifest declares no permissions, scopes, or "
+                            "policies — production gates will trigger on "
+                            "scan."
+                        ),
+                        expects=(
+                            "permissions / policies blocks declare at least "
+                            "one scope or rule."
+                        ),
+                    )
+                ],
+            )
+        )
+
+    return diagnostics
+
+
+def top_next_actions(
+    diagnostics: list[Diagnostic], *, limit: int = 3
+) -> list[NextAction]:
+    """Flatten ranked rank-1 actions across diagnostics.
+
+    Severity order: block > warn > info. Within each severity bucket,
+    the input order is preserved so callers can shape the catalog
+    output deterministically.
+    """
+    severity_rank = {"block": 0, "warn": 1, "info": 2}
+    ordered = sorted(
+        enumerate(diagnostics),
+        key=lambda item: (severity_rank[item[1].severity], item[0]),
+    )
+    actions: list[NextAction] = []
+    for _, diag in ordered:
+        actions.append(diag.next_actions[0])
+        if len(actions) >= limit:
+            break
+    return actions
+
+
+# --- Internals --------------------------------------------------------------
+
+
+def _has_dynamic_toolsets_only(payload: dict[str, Any]) -> bool:
+    total_tools = payload.get("total_tools", 0) or 0
+    if total_tools >= 3:
+        return False
+    frameworks = payload.get("frameworks") or {}
+    if not isinstance(frameworks, dict):
+        return False
+    dynamic_total = 0
+    adk = frameworks.get("google_adk") or {}
+    if isinstance(adk, dict):
+        dynamic_total += int(adk.get("dynamic_toolset_count", 0) or 0)
+    langchain = frameworks.get("langchain") or {}
+    if isinstance(langchain, dict):
+        dynamic_total += int(
+            langchain.get("dynamic_tool_surface_count", 0) or 0
+        )
+    crewai = frameworks.get("crewai") or {}
+    if isinstance(crewai, dict):
+        dynamic_total += int(
+            crewai.get("dynamic_tool_surface_count", 0) or 0
+        )
+    return dynamic_total >= 1

--- a/src/agents_shipgate/cli/discovery/__init__.py
+++ b/src/agents_shipgate/cli/discovery/__init__.py
@@ -41,6 +41,7 @@ from agents_shipgate.cli.discovery.signals import (
     DetectResult,
     FrameworkDetection,
     NameCandidate,
+    WorkspaceSignals,
     detect_workspace,
 )
 from agents_shipgate.cli.discovery.template import render_auto_manifest
@@ -63,6 +64,7 @@ __all__ = [
     "TEST_CASE_PATTERNS",
     "TRACE_SAMPLE_PATTERNS",
     "WORKFLOW_RELATIVE_PATH",
+    "WorkspaceSignals",
     "detect_workspace",
     "discover_anthropic_artifacts",
     "discover_manifest_paths",

--- a/src/agents_shipgate/cli/discovery/placeholders.py
+++ b/src/agents_shipgate/cli/discovery/placeholders.py
@@ -1,0 +1,46 @@
+"""Detect ``CHANGE_ME`` placeholders in a rendered manifest.
+
+Pulled out of ``cli/main.py`` so both ``init`` (which has always reported
+placeholders in its JSON output) and the new ``doctor`` diagnostic
+(``SHIP-DIAG-CHANGE-ME-PLACEHOLDERS``) share one implementation.
+
+The ``init`` callers historically saw ``[{path, current}]``; the doctor
+diagnostic also wants the line number to point an ``edit`` action at
+``shipgate.yaml:<line>``. Both are returned in a single richer payload.
+"""
+
+from __future__ import annotations
+
+
+def collect_placeholders(template: str) -> list[dict[str, object]]:
+    """Find ``CHANGE_ME`` markers in ``template`` and return their
+    YAML-pointer-ish location, the original value, and the 1-indexed
+    line number on which the placeholder appears."""
+    placeholders: list[dict[str, object]] = []
+    section_path: list[str] = []
+    last_indent = -1
+    for index, line in enumerate(template.splitlines(), start=1):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        while section_path and last_indent >= indent:
+            section_path.pop()
+            last_indent -= 2
+        stripped = line.strip()
+        if stripped.endswith(":") and "CHANGE_ME" not in stripped:
+            section_path.append(stripped[:-1])
+            last_indent = indent
+            continue
+        if "CHANGE_ME" in line:
+            key = stripped.split(":", 1)[0].lstrip("- ").strip()
+            placeholders.append(
+                {
+                    "path": ".".join(
+                        [*section_path, key] if key else section_path
+                    )
+                    or "<root>",
+                    "current": "CHANGE_ME",
+                    "line": index,
+                }
+            )
+    return placeholders

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -132,6 +132,24 @@ class NameCandidate(BaseModel):
     source: str  # "Agent_name_literal" | "ADK_name_field" | "pyproject" | "workspace_dir"
 
 
+class WorkspaceSignals(BaseModel):
+    """Minimal workspace state used by diagnostics to discriminate
+    negative-control cases (non-agent library, pure-prompt experiment,
+    no surface) from one another.
+
+    Derived inside :func:`detect_workspace` from inputs it already
+    computes; not exposed in the human-readable summary, only in JSON.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    python_file_count: int = 0
+    has_pyproject_or_requirements: bool = False
+    has_prompts_dir: bool = False
+    has_tools_dir: bool = False
+    conventional_dirs: list[str] = Field(default_factory=list)
+
+
 class DetectResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -141,6 +159,7 @@ class DetectResult(BaseModel):
     project_name_candidates: list[NameCandidate] = Field(default_factory=list)
     suggested_sources: list[dict[str, str]] = Field(default_factory=list)
     next_action: str = ""
+    workspace_signals: WorkspaceSignals = Field(default_factory=WorkspaceSignals)
 
 
 # --- Internal scoring state -------------------------------------------------
@@ -241,6 +260,18 @@ def detect_workspace(workspace: Path, *, max_python_files: int = 1000) -> Detect
         else "Workspace does not appear to be an agent project. No action."
     )
 
+    present_dirs = [d for d in CONVENTIONAL_DIRS if (workspace / d).is_dir()]
+    workspace_signals = WorkspaceSignals(
+        python_file_count=len(py_facts),
+        has_pyproject_or_requirements=(
+            (workspace / "pyproject.toml").is_file()
+            or (workspace / "requirements.txt").is_file()
+        ),
+        has_prompts_dir="prompts" in present_dirs,
+        has_tools_dir="tools" in present_dirs,
+        conventional_dirs=present_dirs,
+    )
+
     return DetectResult(
         is_agent_project=is_agent_project,
         frameworks=detections,
@@ -248,6 +279,7 @@ def detect_workspace(workspace: Path, *, max_python_files: int = 1000) -> Detect
         project_name_candidates=project_name_candidates,
         suggested_sources=suggested_sources,
         next_action=next_action,
+        workspace_signals=workspace_signals,
     )
 
 

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -18,6 +18,7 @@ from agents_shipgate.cli.detect import detect as _detect_command
 from agents_shipgate.cli.diagnostics import (
     NextAction,
     diagnose_doctor,
+    diagnose_invalid_manifest,
     diagnose_missing_manifest,
     top_next_actions,
 )
@@ -218,8 +219,8 @@ def scan(
         )
     except ConfigError as exc:
         typer.echo(f"Config error: {exc}", err=True)
-        diagnostics = diagnose_missing_manifest(
-            _missing_manifest_workspace(config=config, workspace=workspace)
+        diagnostics = _diagnose_config_error(
+            config=config, workspace=workspace, exc=exc
         )
         flattened = top_next_actions(diagnostics)
         _emit_agent_mode_error(
@@ -595,8 +596,8 @@ def doctor(
         payloads = [inspect_sources(config_path=path, verbose=verbose) for path in paths]
     except ConfigError as exc:
         typer.echo(f"Config error: {exc}", err=True)
-        diagnostics = diagnose_missing_manifest(
-            _missing_manifest_workspace(config=config, workspace=workspace)
+        diagnostics = _diagnose_config_error(
+            config=config, workspace=workspace, exc=exc
         )
         flattened = top_next_actions(diagnostics)
         _emit_agent_mode_error(
@@ -862,6 +863,28 @@ def _missing_manifest_workspace(
     # `Path.resolve()` works on non-existent paths — and the manifest
     # parent often exists even when the manifest itself is missing.
     return parent.resolve()
+
+
+def _diagnose_config_error(
+    *, config: str, workspace: Path | None, exc: ConfigError
+) -> list:
+    """Pick the right diagnostic for a ``ConfigError``.
+
+    ``ConfigError`` covers two distinct failure shapes:
+    - the manifest file does not exist (``MISSING-MANIFEST``)
+    - the manifest exists but failed to load — invalid YAML, schema
+      validation failure, unsupported version (``INVALID-MANIFEST``)
+
+    The caller's recovery is different in each case. Disambiguate by
+    checking whether the candidate path actually exists on disk.
+    """
+    if not any(char in config for char in "*?[]") and workspace is None:
+        candidate = Path(config)
+        if candidate.is_file():
+            return diagnose_invalid_manifest(candidate, message=str(exc))
+    return diagnose_missing_manifest(
+        _missing_manifest_workspace(config=config, workspace=workspace)
+    )
 
 
 def _run_multi_scan(

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -174,6 +174,10 @@ def scan(
     verbose: bool = typer.Option(False, "--verbose", help="Show debug extraction details."),
 ) -> None:
     """Run a static release-readiness scan."""
+    # Parse CLI options first, in their own try block. ConfigError raised
+    # here is about flag values, not the manifest — emitting a manifest
+    # diagnostic ("edit shipgate.yaml") would route the agent to the
+    # wrong fix.
     try:
         configure_logging(verbose=verbose)
         parsed_formats = _parse_formats(formats)
@@ -181,6 +185,29 @@ def scan(
         if ci_mode and ci_mode not in {"advisory", "strict"}:
             raise ConfigError("--ci-mode must be advisory or strict")
         parsed_fail_on = _parse_fail_on(fail_on)
+    except ConfigError as exc:
+        typer.echo(f"Config error: {exc}", err=True)
+        guidance = (
+            "Fix the invalid CLI flag value referenced in the error and "
+            "re-run scan."
+        )
+        _emit_agent_mode_error(
+            "config_error",
+            message=str(exc),
+            next_action=guidance,
+            next_actions=[
+                NextAction(
+                    kind="review",
+                    why=guidance,
+                    expects=(
+                        "Re-run with a flag value the option parser accepts."
+                    ),
+                ).model_dump(mode="json")
+            ],
+        )
+        raise typer.Exit(2) from exc
+
+    try:
         config_paths = _resolve_config_paths(config=config, workspace=workspace)
         if len(config_paths) == 1:
             report, exit_code = run_scan(
@@ -887,14 +914,15 @@ def _missing_manifest_workspace(
 
     Routes recovery to the directory the user pointed scan/doctor at
     (``-c <path>`` or ``--workspace <dir>``), not whichever directory
-    they happen to be invoking the CLI from. For glob inputs, the parent
-    is itself a glob expression (``*``, ``foo/*``) so we fall back to
-    ``cwd`` rather than emit a non-routable path.
+    they happen to be invoking the CLI from. For glob inputs, walks the
+    path components and uses the longest non-glob prefix — so an
+    invocation like ``scan -c /tmp/repo/*/shipgate.yaml`` from another
+    cwd still routes the agent to ``/tmp/repo``.
     """
     if workspace is not None:
         return workspace.resolve()
     if any(char in config for char in "*?[]"):
-        return Path.cwd()
+        return _glob_non_glob_prefix(config)
     config_path = Path(config)
     parent = config_path.parent
     if not str(parent) or str(parent) == ".":
@@ -902,6 +930,24 @@ def _missing_manifest_workspace(
     # `Path.resolve()` works on non-existent paths — and the manifest
     # parent often exists even when the manifest itself is missing.
     return parent.resolve()
+
+
+def _glob_non_glob_prefix(config: str) -> Path:
+    """Return the longest leading path component sequence with no glob
+    metacharacters, falling back to ``cwd`` for purely-relative globs.
+    """
+    parts = Path(config).parts
+    safe: list[str] = []
+    for part in parts:
+        if any(char in part for char in "*?[]"):
+            break
+        safe.append(part)
+    if not safe:
+        return Path.cwd()
+    candidate = Path(*safe)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate.resolve()
 
 
 def _candidate_manifest_paths(

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -218,7 +218,9 @@ def scan(
         )
     except ConfigError as exc:
         typer.echo(f"Config error: {exc}", err=True)
-        diagnostics = diagnose_missing_manifest(Path.cwd())
+        diagnostics = diagnose_missing_manifest(
+            _missing_manifest_workspace(config=config, workspace=workspace)
+        )
         flattened = top_next_actions(diagnostics)
         _emit_agent_mode_error(
             "config_error",
@@ -593,7 +595,9 @@ def doctor(
         payloads = [inspect_sources(config_path=path, verbose=verbose) for path in paths]
     except ConfigError as exc:
         typer.echo(f"Config error: {exc}", err=True)
-        diagnostics = diagnose_missing_manifest(Path.cwd())
+        diagnostics = diagnose_missing_manifest(
+            _missing_manifest_workspace(config=config, workspace=workspace)
+        )
         flattened = top_next_actions(diagnostics)
         _emit_agent_mode_error(
             "config_error",
@@ -625,7 +629,7 @@ def doctor(
         )
         raise typer.Exit(3) from exc
     enriched_payloads: list[dict[str, object]] = []
-    for path, payload in zip(paths, payloads):
+    for path, payload in zip(paths, payloads, strict=True):
         try:
             manifest_text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
@@ -711,7 +715,42 @@ def doctor(
             typer.echo("Warnings:")
             for warning in payload["warnings"]:
                 typer.echo(f"- {warning}")
+        if payload.get("unresolved_sources"):
+            typer.echo("Unresolved required sources:")
+            config_name = Path(str(payload["config"])).name
+            for entry in payload["unresolved_sources"]:
+                line = entry.get("line")
+                location = (
+                    f"{config_name}:{line}" if line is not None else config_name
+                )
+                typer.echo(
+                    f"- {entry['id']} -> {entry['declared_path']!r} "
+                    f"(declared at {location})"
+                )
+        diagnostics = payload.get("diagnostics") or []
+        if diagnostics:
+            typer.echo("Diagnostics:")
+            for diag in diagnostics:
+                typer.echo(
+                    f"- [{diag['severity']}] {diag['id']}: {diag['title']}"
+                )
+                if diag["next_actions"]:
+                    action = diag["next_actions"][0]
+                    kind = action["kind"]
+                    if kind == "command":
+                        typer.echo(f"    next: {action['command']}")
+                    elif kind == "edit":
+                        typer.echo(f"    edit: {action['path']}")
+                    elif kind == "stop":
+                        typer.echo(f"    stop: {action['why']}")
+                    else:
+                        typer.echo(f"    review: {action['why']}")
         typer.echo("")
+    # Restore pre-PR loud-failure for humans on the missing-required-source
+    # case. JSON consumers (agents) get exit 0 + unresolved_sources earlier in
+    # this function and route on the structured diagnostic instead.
+    if any(payload.get("unresolved_sources") for payload in payloads):
+        raise typer.Exit(3)
 
 
 @baseline_app.command("save")
@@ -803,6 +842,26 @@ def _resolve_config_paths(*, config: str, workspace: Path | None) -> list[Path]:
     if not paths:
         raise ConfigError("No shipgate.yaml files matched")
     return paths
+
+
+def _missing_manifest_workspace(
+    *, config: str, workspace: Path | None
+) -> Path:
+    """Pick the workspace path used by the missing-manifest diagnostic.
+
+    Routes recovery to the directory the user pointed scan/doctor at
+    (``-c <path>`` or ``--workspace <dir>``), not whichever directory
+    they happen to be invoking the CLI from.
+    """
+    if workspace is not None:
+        return workspace.resolve()
+    config_path = Path(config)
+    parent = config_path.parent
+    if not str(parent) or str(parent) == ".":
+        return Path.cwd()
+    # `Path.resolve()` works on non-existent paths — and the manifest
+    # parent often exists even when the manifest itself is missing.
+    return parent.resolve()
 
 
 def _run_multi_scan(

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -593,8 +593,8 @@ def doctor(
     try:
         configure_logging(verbose=verbose)
         paths = _resolve_config_paths(config=config, workspace=workspace)
-        payloads = [inspect_sources(config_path=path, verbose=verbose) for path in paths]
     except ConfigError as exc:
+        # Discovery itself failed — no candidate manifest exists.
         typer.echo(f"Config error: {exc}", err=True)
         diagnostics = _diagnose_config_error(
             config=config, workspace=workspace, exc=exc
@@ -607,6 +607,41 @@ def doctor(
             next_actions=[a.model_dump(mode="json") for a in flattened],
         )
         raise typer.Exit(2) from exc
+    payloads: list[dict[str, object]] = []
+    try:
+        for path in paths:
+            try:
+                payloads.append(inspect_sources(config_path=path, verbose=verbose))
+            except ConfigError as exc:
+                # A specific discovered manifest failed to load. If the
+                # file exists, route the agent to edit it directly
+                # (INVALID-MANIFEST) — `init` refuses to overwrite, so
+                # MISSING-MANIFEST's detect/init hint would loop. If
+                # the file is genuinely absent (only possible in the
+                # bare ``-c missing.yaml`` path, since discovery and
+                # globbing only yield existing files), fall through to
+                # the missing-manifest dispatch.
+                typer.echo(f"Config error: {exc}", err=True)
+                if path.is_file():
+                    diagnostics = diagnose_invalid_manifest(
+                        path, message=str(exc)
+                    )
+                else:
+                    diagnostics = _diagnose_config_error(
+                        config=str(path), workspace=None, exc=exc
+                    )
+                flattened = top_next_actions(diagnostics)
+                _emit_agent_mode_error(
+                    "config_error",
+                    message=str(exc),
+                    next_action=flattened[0].to_legacy_string(),
+                    next_actions=[
+                        a.model_dump(mode="json") for a in flattened
+                    ],
+                )
+                raise typer.Exit(2) from exc
+    except typer.Exit:
+        raise
     except InputParseError as exc:
         typer.echo(f"Input parsing error: {exc}", err=True)
         guidance = (
@@ -852,10 +887,14 @@ def _missing_manifest_workspace(
 
     Routes recovery to the directory the user pointed scan/doctor at
     (``-c <path>`` or ``--workspace <dir>``), not whichever directory
-    they happen to be invoking the CLI from.
+    they happen to be invoking the CLI from. For glob inputs, the parent
+    is itself a glob expression (``*``, ``foo/*``) so we fall back to
+    ``cwd`` rather than emit a non-routable path.
     """
     if workspace is not None:
         return workspace.resolve()
+    if any(char in config for char in "*?[]"):
+        return Path.cwd()
     config_path = Path(config)
     parent = config_path.parent
     if not str(parent) or str(parent) == ".":
@@ -865,6 +904,26 @@ def _missing_manifest_workspace(
     return parent.resolve()
 
 
+def _candidate_manifest_paths(
+    *, config: str, workspace: Path | None
+) -> list[Path]:
+    """Enumerate the manifest paths the user pointed scan/doctor at.
+
+    Mirrors ``_resolve_config_paths`` but does not raise — it's called
+    from inside the ``ConfigError`` handler, where re-raising would
+    obscure the original failure. Returns an empty list when nothing
+    resolves; the dispatcher then falls back to ``MISSING-MANIFEST``.
+    """
+    try:
+        if workspace is not None:
+            return list(discover_manifest_paths(workspace))
+        if any(char in config for char in "*?[]"):
+            return sorted(Path(p) for p in glob.glob(config, recursive=True))
+        return [Path(config)]
+    except Exception:  # noqa: BLE001 — diagnostic dispatch must not fail
+        return []
+
+
 def _diagnose_config_error(
     *, config: str, workspace: Path | None, exc: ConfigError
 ) -> list:
@@ -872,14 +931,18 @@ def _diagnose_config_error(
 
     ``ConfigError`` covers two distinct failure shapes:
     - the manifest file does not exist (``MISSING-MANIFEST``)
-    - the manifest exists but failed to load — invalid YAML, schema
-      validation failure, unsupported version (``INVALID-MANIFEST``)
+    - one or more candidate manifest files exist but the loader rejected
+      them — invalid YAML, schema validation failure, unsupported
+      version (``INVALID-MANIFEST``)
 
-    The caller's recovery is different in each case. Disambiguate by
-    checking whether the candidate path actually exists on disk.
+    Disambiguate by walking every candidate path the CLI invocation
+    points at (direct ``-c <file>``, ``--workspace`` discovery, or a
+    glob pattern). If any candidate is a real file, the loader is
+    choking on it — emit ``INVALID-MANIFEST`` for that file.
     """
-    if not any(char in config for char in "*?[]") and workspace is None:
-        candidate = Path(config)
+    for candidate in _candidate_manifest_paths(
+        config=config, workspace=workspace
+    ):
         if candidate.is_file():
             return diagnose_invalid_manifest(candidate, message=str(exc))
     return diagnose_missing_manifest(

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -15,6 +15,12 @@ from agents_shipgate.checks.registry import check_catalog
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error as _emit_agent_mode_error
 from agents_shipgate.cli.apply_patches import apply_patches as _apply_patches_command
 from agents_shipgate.cli.detect import detect as _detect_command
+from agents_shipgate.cli.diagnostics import (
+    NextAction,
+    diagnose_doctor,
+    diagnose_missing_manifest,
+    top_next_actions,
+)
 from agents_shipgate.cli.discovery import (
     detect_workspace,
     discover_manifest_paths,
@@ -22,6 +28,7 @@ from agents_shipgate.cli.discovery import (
     render_manifest_template,
     write_ci_workflow,
 )
+from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.evidence_packet import evidence_packet as _evidence_packet_command
 from agents_shipgate.cli.fixture import fixture_app
 from agents_shipgate.cli.scan import inspect_sources, run_scan
@@ -211,23 +218,51 @@ def scan(
         )
     except ConfigError as exc:
         typer.echo(f"Config error: {exc}", err=True)
+        diagnostics = diagnose_missing_manifest(Path.cwd())
+        flattened = top_next_actions(diagnostics)
         _emit_agent_mode_error(
             "config_error",
             message=str(exc),
-            next_action="agents-shipgate init --workspace . --write",
+            next_action=flattened[0].to_legacy_string(),
+            next_actions=[a.model_dump(mode="json") for a in flattened],
         )
         raise typer.Exit(2) from exc
     except InputParseError as exc:
         typer.echo(f"Input parsing error: {exc}", err=True)
+        guidance = (
+            "Inspect the file referenced in the error; ensure it exists, "
+            "is valid, and resolves under the manifest directory."
+        )
         _emit_agent_mode_error(
             "input_parse_error",
             message=str(exc),
-            next_action="Inspect the file referenced in the error; ensure it exists, is valid, and resolves under the manifest directory.",
+            next_action=guidance,
+            next_actions=[
+                NextAction(
+                    kind="review",
+                    why=guidance,
+                    expects=(
+                        "Referenced file is present, parseable, and inside "
+                        "the manifest directory."
+                    ),
+                ).model_dump(mode="json")
+            ],
         )
         raise typer.Exit(3) from exc
     except AgentsShipgateError as exc:
         typer.echo(f"Agents Shipgate error: {exc}", err=True)
-        _emit_agent_mode_error("other_error", message=str(exc))
+        guidance = (
+            "Re-run with --verbose for a stack trace, then file an issue if "
+            "the error is not actionable."
+        )
+        _emit_agent_mode_error(
+            "other_error",
+            message=str(exc),
+            next_action=guidance,
+            next_actions=[
+                NextAction(kind="review", why=guidance).model_dump(mode="json")
+            ],
+        )
         raise typer.Exit(4) from exc
     except typer.Exit:
         raise
@@ -235,7 +270,18 @@ def scan(
         if verbose:
             logger.exception("unhandled exception")
         typer.echo(f"Internal error: {exc}", err=True)
-        _emit_agent_mode_error("internal_error", message=str(exc))
+        guidance = (
+            "Re-run with --verbose for a stack trace; this is a bug — please "
+            "file an issue."
+        )
+        _emit_agent_mode_error(
+            "internal_error",
+            message=str(exc),
+            next_action=guidance,
+            next_actions=[
+                NextAction(kind="review", why=guidance).model_dump(mode="json")
+            ],
+        )
         raise typer.Exit(4) from exc
 
     raise typer.Exit(exit_code)
@@ -284,6 +330,19 @@ def explain(
             check_id=check_id,
             suggestion=suggestion,
             next_action="agents-shipgate list-checks --json",
+            next_actions=[
+                NextAction(
+                    kind="command",
+                    command="agents-shipgate list-checks --json",
+                    why=(
+                        "Enumerate the full check catalog so the agent can "
+                        "match by id."
+                    ),
+                    expects=(
+                        "JSON array of CheckMetadata objects with stable ids."
+                    ),
+                ).model_dump(mode="json")
+            ],
         )
         raise typer.Exit(2)
     if json_output:
@@ -348,7 +407,7 @@ def init(
 
     if minimal:
         template = render_manifest_template(workspace_resolved)
-        placeholders = _collect_placeholders(template)
+        placeholders = collect_placeholders(template)
         auto_detected: dict[str, object] = {}
         next_action_create = (
             "Replace placeholders, then run: agents-shipgate scan -c shipgate.yaml"
@@ -366,9 +425,23 @@ def init(
                 "internal_error",
                 message=f"Generated manifest failed validation: {exc}",
                 next_action="agents-shipgate init --minimal",
+                next_actions=[
+                    NextAction(
+                        kind="command",
+                        command="agents-shipgate init --minimal",
+                        why=(
+                            "Auto-detected manifest failed schema validation. "
+                            "Fall back to the legacy CHANGE_ME-heavy template."
+                        ),
+                        expects=(
+                            "shipgate.yaml renders with placeholder fields "
+                            "you fill in manually."
+                        ),
+                    ).model_dump(mode="json")
+                ],
             )
             raise typer.Exit(4) from exc
-        placeholders = _collect_placeholders(template)
+        placeholders = collect_placeholders(template)
         # Mirror the template's selection logic so JSON output never claims
         # a name that the YAML left as CHANGE_ME. Per v0.6 reviewer
         # feedback: workspace_dir is a candidate but NOT chosen for
@@ -418,7 +491,21 @@ def init(
             _emit_agent_mode_error(
                 "config_already_exists",
                 path=str(target),
-                next_action=f"Edit {target} directly or remove it before running init --write.",
+                next_action=f"Edit {target}",
+                next_actions=[
+                    NextAction(
+                        kind="edit",
+                        path=str(target),
+                        why=(
+                            f"{target} already exists. Edit it directly or "
+                            "remove it before re-running init --write."
+                        ),
+                        expects=(
+                            "Manifest reflects the desired tool sources, "
+                            "agent declared_purpose, and policies."
+                        ),
+                    ).model_dump(mode="json")
+                ],
             )
         else:
             target.write_text(template, encoding="utf-8")
@@ -492,36 +579,6 @@ def _validate_manifest_text(text: str) -> None:
     AgentsShipgateManifest.model_validate(data)
 
 
-def _collect_placeholders(template: str) -> list[dict[str, str]]:
-    """Find ``CHANGE_ME`` markers in the rendered template and return their
-    YAML-pointer-ish locations so an agent can fix them programmatically."""
-    placeholders: list[dict[str, str]] = []
-    section_path: list[str] = []
-    last_indent = -1
-    for line in template.splitlines():
-        if not line.strip() or line.lstrip().startswith("#"):
-            continue
-        indent = len(line) - len(line.lstrip())
-        # Adjust the path stack to match indentation level.
-        while section_path and last_indent >= indent:
-            section_path.pop()
-            last_indent -= 2
-        stripped = line.strip()
-        if stripped.endswith(":") and "CHANGE_ME" not in stripped:
-            section_path.append(stripped[:-1])
-            last_indent = indent
-            continue
-        if "CHANGE_ME" in line:
-            key = stripped.split(":", 1)[0].lstrip("- ").strip()
-            placeholders.append(
-                {
-                    "path": ".".join([*section_path, key] if key else section_path) or "<root>",
-                    "current": "CHANGE_ME",
-                }
-            )
-    return placeholders
-
-
 @app.command()
 def doctor(
     config: str = typer.Option("shipgate.yaml", "--config", "-c", help="Path or quoted glob."),
@@ -536,16 +593,59 @@ def doctor(
         payloads = [inspect_sources(config_path=path, verbose=verbose) for path in paths]
     except ConfigError as exc:
         typer.echo(f"Config error: {exc}", err=True)
+        diagnostics = diagnose_missing_manifest(Path.cwd())
+        flattened = top_next_actions(diagnostics)
         _emit_agent_mode_error(
             "config_error",
             message=str(exc),
-            next_action="agents-shipgate init --workspace . --write",
+            next_action=flattened[0].to_legacy_string(),
+            next_actions=[a.model_dump(mode="json") for a in flattened],
         )
         raise typer.Exit(2) from exc
     except InputParseError as exc:
         typer.echo(f"Input parsing error: {exc}", err=True)
-        _emit_agent_mode_error("input_parse_error", message=str(exc))
+        guidance = (
+            "Inspect the file referenced in the error; ensure it exists, "
+            "is valid, and resolves under the manifest directory."
+        )
+        _emit_agent_mode_error(
+            "input_parse_error",
+            message=str(exc),
+            next_action=guidance,
+            next_actions=[
+                NextAction(
+                    kind="review",
+                    why=guidance,
+                    expects=(
+                        "Referenced file is present, parseable, and inside "
+                        "the manifest directory."
+                    ),
+                ).model_dump(mode="json")
+            ],
+        )
         raise typer.Exit(3) from exc
+    enriched_payloads: list[dict[str, object]] = []
+    for path, payload in zip(paths, payloads):
+        try:
+            manifest_text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            manifest_text = ""
+        placeholders = collect_placeholders(manifest_text)
+        diagnostics = diagnose_doctor(
+            payload,
+            manifest_path=path,
+            manifest_text=manifest_text,
+            placeholders=placeholders,
+        )
+        flattened = top_next_actions(diagnostics)
+        enriched = dict(payload)
+        enriched["diagnostics"] = [d.model_dump(mode="json") for d in diagnostics]
+        enriched["next_actions"] = [a.model_dump(mode="json") for a in flattened]
+        enriched["next_action"] = (
+            flattened[0].to_legacy_string() if flattened else ""
+        )
+        enriched_payloads.append(enriched)
+    payloads = enriched_payloads
     if json_output:
         typer.echo(json.dumps(payloads, indent=2, sort_keys=True))
         return

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -409,12 +409,22 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
 def _resolve_source_paths(
     manifest, base_dir: Path, config_path: Path
 ) -> list[dict[str, object]]:
-    """Return required tool_sources whose declared path doesn't resolve.
+    """Return required tool_sources whose declared path is unusable.
 
-    Optional sources are not reported here — the existing ``_load_sources``
-    flow handles them with a warning. Returned entries carry the source
-    id, the declared path string, and the 1-indexed line number in the
-    manifest text where the path appears (best-effort).
+    Two failure modes are flagged so doctor can surface them as a
+    ``SHIP-DIAG-MISSING-SOURCE-FILE`` diagnostic instead of crashing in
+    a downstream loader:
+
+    - ``reason="missing"`` — the file does not exist.
+    - ``reason="outside_manifest_dir"`` — the file exists but escapes the
+      manifest's containment boundary (loaders mirror this check and
+      would raise ``InputParseError``).
+
+    Optional sources are not reported here — the existing
+    ``_load_sources`` flow handles them with a warning. Returned entries
+    carry the source id, the declared path string, the 1-indexed line
+    number in the manifest text where the path appears (best-effort),
+    and the failure reason.
     """
     unresolved: list[dict[str, object]] = []
     try:
@@ -422,14 +432,25 @@ def _resolve_source_paths(
     except (OSError, UnicodeDecodeError):
         manifest_text = ""
     text_lines = manifest_text.splitlines()
+    base_resolved = base_dir.resolve()
     for source in manifest.tool_sources:
         if source.optional:
             continue
         if source.path is None:
             continue
-        candidate = (base_dir / source.path).resolve()
-        if candidate.exists():
-            continue
+        raw_path = Path(source.path)
+        candidate = (
+            raw_path if raw_path.is_absolute() else base_resolved / raw_path
+        ).resolve()
+        if not candidate.exists():
+            reason = "missing"
+        else:
+            try:
+                candidate.relative_to(base_resolved)
+            except ValueError:
+                reason = "outside_manifest_dir"
+            else:
+                continue
         line_no: int | None = None
         needle = f"path: {source.path}"
         for index, line in enumerate(text_lines, start=1):
@@ -441,6 +462,7 @@ def _resolve_source_paths(
                 "id": source.id,
                 "declared_path": source.path,
                 "line": line_no,
+                "reason": reason,
             }
         )
     return unresolved

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -319,6 +319,21 @@ def run_scan(
 def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, object]:
     manifest = load_manifest(config_path)
     base_dir = config_path.resolve().parent
+    unresolved_sources = _resolve_source_paths(manifest, base_dir, config_path)
+    if unresolved_sources:
+        # Drop unresolved-required sources from the manifest before loading
+        # so doctor returns a structured payload with `unresolved_sources`
+        # instead of raising InputParseError. scan() does not use this path
+        # — its `_load_sources` call is unchanged and still raises.
+        unresolved_ids = {entry["id"] for entry in unresolved_sources}
+        manifest = manifest.model_copy(
+            update={
+                "tool_sources": [
+                    src for src in manifest.tool_sources
+                    if src.id not in unresolved_ids
+                ]
+            }
+        )
     loaded_sources = _load_sources(manifest, base_dir, verbose=verbose)
     framework_result = load_framework_artifacts(manifest, base_dir)
     adk_artifacts = framework_result.adk_artifacts
@@ -375,7 +390,60 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
         "policy_packs": [pack.model_dump(mode="json") for pack in policy_packs.loaded],
         "baseline": _default_baseline_status(base_dir),
         "warnings": warnings,
+        "unresolved_sources": unresolved_sources,
+        "manifest_summary": {
+            "environment_target": manifest.environment.target,
+            "has_permissions": bool(
+                manifest.permissions.scopes or manifest.permissions.credential_mode
+            ),
+            "has_policies": bool(
+                manifest.policies.require_approval_for_tools
+                or manifest.policies.require_confirmation_for_tools
+                or manifest.policies.require_idempotency_for_tools
+            ),
+            "scope_count": len(manifest.permissions.scopes),
+        },
     }
+
+
+def _resolve_source_paths(
+    manifest, base_dir: Path, config_path: Path
+) -> list[dict[str, object]]:
+    """Return required tool_sources whose declared path doesn't resolve.
+
+    Optional sources are not reported here — the existing ``_load_sources``
+    flow handles them with a warning. Returned entries carry the source
+    id, the declared path string, and the 1-indexed line number in the
+    manifest text where the path appears (best-effort).
+    """
+    unresolved: list[dict[str, object]] = []
+    try:
+        manifest_text = config_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        manifest_text = ""
+    text_lines = manifest_text.splitlines()
+    for source in manifest.tool_sources:
+        if source.optional:
+            continue
+        if source.path is None:
+            continue
+        candidate = (base_dir / source.path).resolve()
+        if candidate.exists():
+            continue
+        line_no: int | None = None
+        needle = f"path: {source.path}"
+        for index, line in enumerate(text_lines, start=1):
+            if needle in line:
+                line_no = index
+                break
+        unresolved.append(
+            {
+                "id": source.id,
+                "declared_path": source.path,
+                "line": line_no,
+            }
+        )
+    return unresolved
 
 
 def _load_sources(manifest, base_dir: Path, *, verbose: bool) -> list[LoadedToolSource]:

--- a/src/agents_shipgate/cli/scenario.py
+++ b/src/agents_shipgate/cli/scenario.py
@@ -82,10 +82,25 @@ def scenario_suggest(
         payload = scenario_yaml_payload(report)
     except ScenarioInputError as exc:
         typer.echo(f"Invalid input: {exc}", err=True)
+        guidance = (
+            "Inspect the error message and adjust --from or --out accordingly."
+        )
         emit_agent_mode_error(
             "input_parse_error",
             message=str(exc),
-            next_action="Inspect the error message and adjust --from or --out accordingly.",
+            next_action=guidance,
+            next_actions=[
+                {
+                    "kind": "review",
+                    "command": None,
+                    "path": None,
+                    "why": guidance,
+                    "expects": (
+                        "--from points at a valid v0.9+ report.json and --out "
+                        "is a writable file path."
+                    ),
+                }
+            ],
         )
         raise typer.Exit(2) from exc
 
@@ -94,7 +109,23 @@ def scenario_suggest(
         out_path.write_text(render_scenario_yaml(payload), encoding="utf-8")
     except OSError as exc:
         typer.echo(f"Agents Shipgate error: cannot write {out_path}: {exc}", err=True)
-        emit_agent_mode_error("other_error", message=str(exc))
+        emit_agent_mode_error(
+            "other_error",
+            message=str(exc),
+            next_action=f"Verify {out_path.parent} is writable, then retry.",
+            next_actions=[
+                {
+                    "kind": "review",
+                    "command": None,
+                    "path": None,
+                    "why": (
+                        "Output directory is not writable. Confirm the path "
+                        "exists and your process has write permission."
+                    ),
+                    "expects": None,
+                }
+            ],
+        )
         raise typer.Exit(4) from exc
 
     typer.echo(f"Wrote {out_path}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -633,3 +633,134 @@ tool_sources:
 
     result = runner.invoke(app, ["scan", "--config", str(config)])
     assert result.exit_code == 3
+
+
+# Regression coverage for PR #47 reviewer findings -----------------------------
+
+
+_MISSING_SOURCE_MANIFEST = """
+version: "0.1"
+project:
+  name: missing-source
+agent:
+  name: missing-source-agent
+  declared_purpose:
+    - test
+environment:
+  target: local
+tool_sources:
+  - id: missing
+    type: mcp
+    path: missing.json
+"""
+
+
+def test_doctor_human_output_fails_loudly_on_missing_required_source(tmp_path):
+    """P1-1 regression: the human (non-JSON) doctor output must not silently
+    pass when a required tool_sources path doesn't resolve. It used to raise
+    InputParseError(3); now it surfaces the diagnostic and exits 3."""
+    config = tmp_path / "shipgate.yaml"
+    config.write_text(_MISSING_SOURCE_MANIFEST, encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "--config", str(config)])
+
+    assert result.exit_code == 3, result.output
+    assert "Unresolved required sources:" in result.output
+    assert "missing.json" in result.output
+    assert "SHIP-DIAG-MISSING-SOURCE-FILE" in result.output
+
+
+def test_missing_manifest_recovery_uses_config_workspace(tmp_path, monkeypatch):
+    """P2-1 regression: agent-mode rank-1 command must point at the config's
+    parent dir, not whichever cwd the CLI was invoked from."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    foreign_cwd = tmp_path / "elsewhere"
+    foreign_cwd.mkdir()
+    monkeypatch.chdir(foreign_cwd)
+
+    config = tmp_path / "repo" / "shipgate.yaml"
+    config.parent.mkdir()
+
+    result = runner.invoke(app, ["scan", "--config", str(config)])
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    assert payloads, result.output
+    rank_one = payloads[-1]["next_actions"][0]
+    assert "agents-shipgate detect --workspace" in rank_one["command"]
+    # Routes recovery to the config's parent directory, not the foreign cwd.
+    assert str(tmp_path / "repo") in rank_one["command"]
+    assert str(foreign_cwd) not in rank_one["command"]
+
+
+def test_doctor_flags_outside_manifest_dir_source_as_diagnostic(tmp_path):
+    """P2-2 regression: a required tool_sources path that resolves outside
+    the manifest directory must surface as SHIP-DIAG-MISSING-SOURCE-FILE
+    with reason="outside_manifest_dir" — not crash the loader."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # The "outside" file genuinely exists, so the existence check alone
+    # would pass it through. Containment must catch it.
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"tools": []}', encoding="utf-8")
+
+    config = repo / "shipgate.yaml"
+    config.write_text(
+        """
+version: "0.1"
+project:
+  name: outside-source
+agent:
+  name: outside-source-agent
+  declared_purpose:
+    - test
+environment:
+  target: local
+tool_sources:
+  - id: escaped
+    type: mcp
+    path: ../outside.json
+""",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "--config", str(config), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)[0]
+    unresolved = payload["unresolved_sources"]
+    assert len(unresolved) == 1
+    assert unresolved[0]["id"] == "escaped"
+    assert unresolved[0]["reason"] == "outside_manifest_dir"
+    diag = next(
+        d
+        for d in payload["diagnostics"]
+        if d["id"] == "SHIP-DIAG-MISSING-SOURCE-FILE"
+    )
+    assert "outside" in diag["next_actions"][0]["why"].lower()
+
+
+def test_doctor_edit_action_paths_include_manifest_directory(tmp_path):
+    """P2-3 regression: edit-action paths must include the manifest's
+    directory so workspace and nested-manifest runs route the agent to
+    the correct file, not just `shipgate.yaml:<line>`."""
+    repo = tmp_path / "subdir"
+    repo.mkdir()
+    config = repo / "shipgate.yaml"
+    config.write_text(_MISSING_SOURCE_MANIFEST, encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "--config", str(config), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)[0]
+    diag = next(
+        d
+        for d in payload["diagnostics"]
+        if d["id"] == "SHIP-DIAG-MISSING-SOURCE-FILE"
+    )
+    edit_path = diag["next_actions"][0]["path"]
+    # Edit target carries the directory the user pointed doctor at.
+    assert str(config) in edit_path
+    assert edit_path != "shipgate.yaml" and not edit_path.startswith(
+        "shipgate.yaml:"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -740,6 +740,83 @@ tool_sources:
     assert "outside" in diag["next_actions"][0]["why"].lower()
 
 
+def test_invalid_manifest_dispatches_to_invalid_diagnostic(
+    tmp_path, monkeypatch
+):
+    """P1 regression: ConfigError where the file exists but is invalid must
+    surface SHIP-DIAG-INVALID-MANIFEST with an `edit` rank-1 action — NOT
+    SHIP-DIAG-MISSING-MANIFEST with a detect/init command. Otherwise the
+    coding agent runs `init`, which refuses to overwrite, and loops."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    config = tmp_path / "shipgate.yaml"
+    # Valid YAML structure but schema-invalid (missing required project, etc.)
+    config.write_text("not: a valid manifest\n", encoding="utf-8")
+
+    for command in (["scan", "--config", str(config)],
+                     ["doctor", "--config", str(config)]):
+        result = runner.invoke(app, command)
+        assert result.exit_code == 2, result.output
+        payloads = _stderr_json_lines(result.output)
+        assert payloads, result.output
+        rank_one = payloads[-1]["next_actions"][0]
+        assert rank_one["kind"] == "edit", (
+            f"{command[0]} dispatched to {rank_one!r}, expected kind=edit"
+        )
+        assert str(config) in rank_one["path"]
+        # And the next_action string must NOT advertise a detect command —
+        # that would route the agent away from the actual fix.
+        assert not payloads[-1]["next_action"].startswith(
+            "agents-shipgate detect"
+        )
+
+
+def test_invalid_yaml_manifest_dispatches_to_invalid_diagnostic(
+    tmp_path, monkeypatch
+):
+    """Companion to the schema-invalid case: an unparseable YAML file is
+    also "exists but invalid" — same dispatch."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    config = tmp_path / "shipgate.yaml"
+    config.write_text("version: '0.1\nproject:\n  name: \"x", encoding="utf-8")
+
+    result = runner.invoke(app, ["scan", "--config", str(config)])
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    rank_one = payloads[-1]["next_actions"][0]
+    assert rank_one["kind"] == "edit"
+    assert str(config) in rank_one["path"]
+
+
+def test_missing_manifest_command_quotes_workspace_with_spaces(
+    tmp_path, monkeypatch
+):
+    """P2 regression: dynamic `command` strings must POSIX-shell-quote
+    paths so a coding-agent shell runner doesn't word-split a workspace
+    containing spaces."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    spaced = tmp_path / "space path" / "repo dir"
+    spaced.mkdir(parents=True)
+    config = spaced / "shipgate.yaml"
+    # File does not exist → MISSING-MANIFEST path → command embeds workspace.
+
+    result = runner.invoke(app, ["scan", "--config", str(config)])
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    rank_one = payloads[-1]["next_actions"][0]
+    command = rank_one["command"]
+    # Path must round-trip through shlex; the quoted form survives split.
+    import shlex
+
+    parts = shlex.split(command)
+    assert parts[0] == "agents-shipgate"
+    assert parts[1] == "detect"
+    assert "--workspace" in parts
+    workspace_arg = parts[parts.index("--workspace") + 1]
+    assert workspace_arg == str(spaced)
+
+
 def test_doctor_edit_action_paths_include_manifest_directory(tmp_path):
     """P2-3 regression: edit-action paths must include the manifest's
     directory so workspace and nested-manifest runs route the agent to

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -817,6 +817,112 @@ def test_missing_manifest_command_quotes_workspace_with_spaces(
     assert workspace_arg == str(spaced)
 
 
+def test_doctor_workspace_dispatches_invalid_manifest(tmp_path, monkeypatch):
+    """P1 regression (round 3): doctor --workspace with an existing-but-invalid
+    shipgate.yaml must surface SHIP-DIAG-INVALID-MANIFEST pointing at the
+    actual file, not SHIP-DIAG-MISSING-MANIFEST with a detect command."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = repo / "shipgate.yaml"
+    # Schema-invalid (missing required project block) but valid YAML.
+    config.write_text("not: a manifest\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "--workspace", str(repo)])
+
+    assert result.exit_code == 2, result.output
+    payloads = _stderr_json_lines(result.output)
+    assert payloads, result.output
+    rank_one = payloads[-1]["next_actions"][0]
+    assert rank_one["kind"] == "edit", (
+        f"--workspace mode dispatched to {rank_one!r}, "
+        "expected SHIP-DIAG-INVALID-MANIFEST edit action"
+    )
+    assert str(config) in rank_one["path"]
+    assert not payloads[-1]["next_action"].startswith(
+        "agents-shipgate detect"
+    )
+
+
+def test_scan_glob_dispatches_invalid_manifest(tmp_path, monkeypatch):
+    """P1 regression (round 3): same dispatch must work for glob configs."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    repo = tmp_path / "subdir"
+    repo.mkdir()
+    config = repo / "shipgate.yaml"
+    config.write_text("not: a manifest\n", encoding="utf-8")
+    glob_pattern = str(tmp_path / "*" / "shipgate.yaml")
+
+    result = runner.invoke(app, ["scan", "--config", glob_pattern])
+
+    assert result.exit_code == 2, result.output
+    payloads = _stderr_json_lines(result.output)
+    rank_one = payloads[-1]["next_actions"][0]
+    assert rank_one["kind"] == "edit"
+    assert str(config) in rank_one["path"]
+
+
+def test_glob_with_no_matches_yields_workspace_cwd_not_glob_chars(
+    tmp_path, monkeypatch
+):
+    """P1 regression (round 3): a glob with no matches must produce a
+    missing-manifest hint targeting cwd, not a workspace argument
+    containing literal `*` characters."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app, ["scan", "--config", "no_such_dir/*/shipgate.yaml"]
+    )
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    rank_one = payloads[-1]["next_actions"][0]
+    assert rank_one["kind"] == "command"
+    # No literal glob metacharacter ends up in the workspace argument.
+    import shlex as _shlex
+
+    parts = _shlex.split(rank_one["command"])
+    workspace_arg = parts[parts.index("--workspace") + 1]
+    assert "*" not in workspace_arg
+    assert "?" not in workspace_arg
+
+
+def test_artifact_only_command_quotes_workspace_with_spaces(
+    tmp_path, monkeypatch
+):
+    """P2 regression (round 3): SHIP-DIAG-MCP-OPENAPI-ARTIFACT-ONLY's rank-1
+    command must shell-quote the workspace path."""
+    spaced = tmp_path / "space dir" / "artifact only"
+    spaced.mkdir(parents=True)
+    # Plant an MCP file matching MCP_PATTERNS so the artifact-only
+    # diagnostic fires.
+    (spaced / "mcp-tools.json").write_text(
+        '{"tools": [{"name": "x"}]}', encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        app, ["detect", "--workspace", str(spaced), "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    diag_ids = [d["id"] for d in payload["diagnostics"]]
+    assert "SHIP-DIAG-MCP-OPENAPI-ARTIFACT-ONLY" in diag_ids
+    artifact_only = next(
+        d
+        for d in payload["diagnostics"]
+        if d["id"] == "SHIP-DIAG-MCP-OPENAPI-ARTIFACT-ONLY"
+    )
+    command = artifact_only["next_actions"][0]["command"]
+    import shlex as _shlex
+
+    parts = _shlex.split(command)
+    assert parts[0] == "agents-shipgate"
+    workspace_arg = parts[parts.index("--workspace") + 1]
+    assert workspace_arg == str(spaced)
+
+
 def test_doctor_edit_action_paths_include_manifest_directory(tmp_path):
     """P2-3 regression: edit-action paths must include the manifest's
     directory so workspace and nested-manifest runs route the agent to

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import click
+import pytest
 from typer.main import get_command
 from typer.testing import CliRunner
 
@@ -921,6 +922,117 @@ def test_artifact_only_command_quotes_workspace_with_spaces(
     assert parts[0] == "agents-shipgate"
     workspace_arg = parts[parts.index("--workspace") + 1]
     assert workspace_arg == str(spaced)
+
+
+def test_scan_bad_flag_value_does_not_dispatch_to_invalid_manifest(
+    tmp_path, monkeypatch
+):
+    """P1 regression (round 4): a bad CLI flag value (e.g. --fail-on banana)
+    raises ConfigError before the manifest is touched. The error must NOT
+    surface SHIP-DIAG-INVALID-MANIFEST claiming the loader rejected the
+    file — the manifest is fine; the fix is the flag value."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "--config",
+            "samples/clean_read_only_agent/shipgate.yaml",
+            "--fail-on",
+            "banana",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    assert payloads, result.output
+    rank_one = payloads[-1]["next_actions"][0]
+    # Must not advertise an edit action against the manifest, and must
+    # not advertise a detect/init command (this isn't a missing manifest
+    # either — it's a flag-value problem).
+    assert rank_one["kind"] != "edit", (
+        f"flag-value error dispatched to {rank_one!r}; the manifest is fine"
+    )
+    assert "samples/clean_read_only_agent" not in str(
+        rank_one.get("path") or ""
+    )
+
+
+@pytest.mark.parametrize(
+    ("bad_flag", "bad_value"),
+    [
+        ("--format", "txt"),
+        ("--ci-mode", "yolo"),
+        ("--packet-format", "docx"),
+    ],
+)
+def test_scan_other_bad_flag_values_skip_manifest_diagnostic(
+    tmp_path, monkeypatch, bad_flag, bad_value
+):
+    """P1 regression coverage for the rest of the option parsers."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "--config",
+            "samples/clean_read_only_agent/shipgate.yaml",
+            bad_flag,
+            bad_value,
+        ],
+    )
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    rank_one = payloads[-1]["next_actions"][0]
+    assert rank_one["kind"] != "edit"
+
+
+def test_absolute_glob_no_match_targets_glob_prefix(tmp_path, monkeypatch):
+    """P2 regression (round 4): an absolute glob with no matches must route
+    recovery to the longest non-glob prefix (the area the user explicitly
+    pointed at), not the caller's cwd."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    foreign_cwd = tmp_path / "elsewhere"
+    foreign_cwd.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(foreign_cwd)
+
+    glob_pattern = str(repo / "*" / "shipgate.yaml")
+    result = runner.invoke(app, ["scan", "--config", glob_pattern])
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    rank_one = payloads[-1]["next_actions"][0]
+    assert rank_one["kind"] == "command"
+    import shlex as _shlex
+
+    parts = _shlex.split(rank_one["command"])
+    workspace_arg = parts[parts.index("--workspace") + 1]
+    # Routes to the explicit glob prefix, not the foreign cwd.
+    assert workspace_arg == str(repo)
+    assert workspace_arg != str(foreign_cwd)
+
+
+def test_relative_glob_no_match_still_falls_back_to_cwd(tmp_path, monkeypatch):
+    """A purely relative glob (no leading non-glob component) keeps the
+    existing cwd-fallback behavior — there's no useful prefix to route to."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["scan", "--config", "*/shipgate.yaml"])
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    rank_one = payloads[-1]["next_actions"][0]
+    import shlex as _shlex
+
+    parts = _shlex.split(rank_one["command"])
+    workspace_arg = parts[parts.index("--workspace") + 1]
+    assert workspace_arg == str(tmp_path)
 
 
 def test_doctor_edit_action_paths_include_manifest_directory(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -480,3 +480,156 @@ def test_cli_scan_missing_baseline_exits_three(tmp_path):
 
     assert result.exit_code == 3
     assert "Baseline file not found" in result.output
+
+
+# --- Ranked next-action diagnostics integration ----------------------------
+
+
+def _stderr_json_lines(output: str) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in (output or "").splitlines()
+        if line.strip().startswith("{") and '"error"' in line
+    ]
+
+
+def test_agent_mode_scan_missing_config_emits_next_actions(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    result = runner.invoke(
+        app, ["scan", "--config", str(tmp_path / "missing.yaml")]
+    )
+
+    assert result.exit_code == 2
+    payloads = _stderr_json_lines(result.output)
+    assert payloads, f"no agent-mode JSON in output: {result.output!r}"
+    payload = payloads[-1]
+    assert payload["error"] == "config_error"
+    assert isinstance(payload["next_action"], str)
+    assert payload["next_action"]
+    assert isinstance(payload["next_actions"], list)
+    assert payload["next_actions"]
+    rank_one = payload["next_actions"][0]
+    assert payload["next_action"] == rank_one["command"]
+
+
+def test_agent_mode_doctor_missing_config_matches_scan(tmp_path, monkeypatch):
+    """Cross-command consistency: scan and doctor surface the same diagnostic
+    for missing manifest."""
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    scan_result = runner.invoke(
+        app, ["scan", "--config", str(tmp_path / "missing.yaml")]
+    )
+    doctor_result = runner.invoke(
+        app, ["doctor", "--config", str(tmp_path / "missing.yaml")]
+    )
+
+    scan_payload = _stderr_json_lines(scan_result.output)[-1]
+    doctor_payload = _stderr_json_lines(doctor_result.output)[-1]
+    # Same rank-1 next_action whether the agent reached for scan or doctor.
+    assert (
+        scan_payload["next_actions"][0]["command"]
+        == doctor_payload["next_actions"][0]["command"]
+    )
+
+
+def test_detect_emits_negative_control_diagnostic_for_empty_workspace(
+    tmp_path,
+):
+    # Empty workspace — no python, no pyproject, no prompts/tools.
+    result = runner.invoke(
+        app, ["detect", "--workspace", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    diagnostics = payload.get("diagnostics", [])
+    assert any(
+        d["id"] == "SHIP-DIAG-NO-AGENT-SURFACE" for d in diagnostics
+    )
+    assert payload["next_actions"]
+    rank_one = payload["next_actions"][0]
+    assert rank_one["kind"] == "stop"
+    # next_action stays string-typed even when rank-1 is "stop".
+    assert isinstance(payload["next_action"], str)
+    assert payload["next_action"].startswith("Stop:")
+
+
+def test_detect_plain_json_carries_diagnostics_without_agent_mode(tmp_path):
+    """Diagnostics surface in --json output even when AGENTS_SHIPGATE_AGENT_MODE
+    is unset. The env var only gates structured-error stderr emission."""
+    result = runner.invoke(
+        app, ["detect", "--workspace", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "diagnostics" in payload
+    assert "next_actions" in payload
+
+
+def test_doctor_emits_unresolved_source_diagnostic_without_failing(tmp_path):
+    """Deliberate behavior change: a required tool_sources path that doesn't
+    resolve causes ``doctor --json`` to exit 0 with a diagnostic — not the
+    legacy InputParseError(3)."""
+    config = tmp_path / "shipgate.yaml"
+    config.write_text(
+        """
+version: "0.1"
+project:
+  name: missing-source
+agent:
+  name: missing-source-agent
+  declared_purpose:
+    - test
+environment:
+  target: local
+tool_sources:
+  - id: missing
+    type: mcp
+    path: missing.json
+""",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "--config", str(config), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payloads = json.loads(result.output)
+    assert len(payloads) == 1
+    payload = payloads[0]
+    unresolved = payload["unresolved_sources"]
+    assert len(unresolved) == 1
+    assert unresolved[0]["id"] == "missing"
+    assert unresolved[0]["declared_path"] == "missing.json"
+    diag_ids = [d["id"] for d in payload["diagnostics"]]
+    assert "SHIP-DIAG-MISSING-SOURCE-FILE" in diag_ids
+
+
+def test_scan_still_raises_on_missing_required_source(tmp_path):
+    """Regression guard: doctor's behavior change must not leak into scan.
+    scan should still fail with InputParseError(3) when a required
+    tool_sources path doesn't resolve."""
+    config = tmp_path / "shipgate.yaml"
+    config.write_text(
+        """
+version: "0.1"
+project:
+  name: missing-source
+agent:
+  name: missing-source-agent
+  declared_purpose:
+    - test
+environment:
+  target: local
+tool_sources:
+  - id: missing
+    type: mcp
+    path: missing.json
+""",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["scan", "--config", str(config)])
+    assert result.exit_code == 3

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -33,7 +33,6 @@ from agents_shipgate.cli.discovery.signals import (
 )
 from agents_shipgate.cli.main import app as typer_app
 
-
 # --- NextAction model invariants -------------------------------------------
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,574 @@
+"""Tests for the ranked next-action diagnostics module."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.cli import diagnostics as diag_mod
+from agents_shipgate.cli.diagnostics import (
+    ALL_DIAGNOSTIC_IDS,
+    DIAG_CHANGE_ME_PLACEHOLDERS,
+    DIAG_DYNAMIC_TOOLSETS_ONLY,
+    DIAG_MCP_OPENAPI_ARTIFACT_ONLY,
+    DIAG_MISSING_MANIFEST,
+    DIAG_MISSING_SOURCE_FILE,
+    DIAG_NO_AGENT_SURFACE,
+    DIAG_NO_PRODUCTION_PERMISSIONS,
+    DIAG_NON_AGENT_LIBRARY,
+    DIAG_PURE_PROMPT_EXPERIMENT,
+    DIAG_ZERO_TOOLS,
+    Diagnostic,
+    NextAction,
+    diagnose_detect,
+    diagnose_doctor,
+    diagnose_missing_manifest,
+    top_next_actions,
+)
+from agents_shipgate.cli.discovery.signals import (
+    DetectResult,
+    WorkspaceSignals,
+)
+from agents_shipgate.cli.main import app as typer_app
+
+
+# --- NextAction model invariants -------------------------------------------
+
+
+class TestNextActionValidator:
+    def test_command_kind_requires_command(self) -> None:
+        with pytest.raises(ValueError, match="kind='command' requires"):
+            NextAction(kind="command", command=None, why="x")
+
+    def test_edit_kind_requires_path(self) -> None:
+        with pytest.raises(ValueError, match="kind='edit' requires"):
+            NextAction(kind="edit", path=None, why="x")
+
+    def test_stop_kind_forbids_command(self) -> None:
+        with pytest.raises(ValueError, match="kind='stop' must not"):
+            NextAction(kind="stop", command="oops", why="x")
+
+    def test_review_kind_minimal(self) -> None:
+        action = NextAction(kind="review", why="check it")
+        assert action.command is None
+        assert action.path is None
+
+
+class TestNextActionLegacyProjection:
+    def test_command_projects_to_command_string(self) -> None:
+        action = NextAction(kind="command", command="agents-shipgate scan", why="x")
+        assert action.to_legacy_string() == "agents-shipgate scan"
+
+    def test_edit_projects_to_edit_path(self) -> None:
+        action = NextAction(kind="edit", path="shipgate.yaml:14", why="x")
+        assert action.to_legacy_string() == "Edit shipgate.yaml:14"
+
+    def test_review_projects_to_review_why(self) -> None:
+        action = NextAction(kind="review", why="needs human review")
+        assert action.to_legacy_string() == "Review: needs human review"
+
+    def test_stop_projects_to_stop_why(self) -> None:
+        action = NextAction(kind="stop", why="not an agent project")
+        assert action.to_legacy_string() == "Stop: not an agent project"
+
+    def test_legacy_string_is_non_empty_for_every_kind(self) -> None:
+        kinds = ["command", "edit", "review", "stop"]
+        actions = [
+            NextAction(kind="command", command="cmd", why="w"),
+            NextAction(kind="edit", path="p", why="w"),
+            NextAction(kind="review", why="w"),
+            NextAction(kind="stop", why="w"),
+        ]
+        for kind, action in zip(kinds, actions, strict=True):
+            assert action.to_legacy_string(), f"{kind} produced empty string"
+
+
+# --- Diagnostic invariants --------------------------------------------------
+
+
+class TestDiagnosticInvariants:
+    def test_next_actions_min_length_one(self) -> None:
+        with pytest.raises(ValueError):
+            Diagnostic(
+                id="SHIP-DIAG-X",
+                title="t",
+                severity="info",
+                next_actions=[],
+            )
+
+    def test_severity_must_be_known(self) -> None:
+        with pytest.raises(ValueError):
+            Diagnostic(
+                id="SHIP-DIAG-X",
+                title="t",
+                severity="oops",  # type: ignore[arg-type]
+                next_actions=[NextAction(kind="review", why="w")],
+            )
+
+
+# --- Catalog stability ------------------------------------------------------
+
+
+class TestCatalogStability:
+    def test_all_ids_have_diag_prefix(self) -> None:
+        for diag_id in ALL_DIAGNOSTIC_IDS:
+            assert diag_id.startswith("SHIP-DIAG-"), diag_id
+
+    def test_all_ids_unique(self) -> None:
+        assert len(ALL_DIAGNOSTIC_IDS) == len(set(ALL_DIAGNOSTIC_IDS))
+
+    def test_all_ids_listed_in_diagnostics_doc(self) -> None:
+        doc_path = (
+            Path(__file__).resolve().parents[1] / "docs" / "diagnostics.md"
+        )
+        if not doc_path.is_file():
+            pytest.skip("docs/diagnostics.md is added in PR7; skipping")
+        text = doc_path.read_text(encoding="utf-8")
+        for diag_id in ALL_DIAGNOSTIC_IDS:
+            assert diag_id in text, f"{diag_id} not documented in {doc_path}"
+
+
+# --- diagnose_missing_manifest ---------------------------------------------
+
+
+class TestDiagnoseMissingManifest:
+    def test_emits_missing_manifest_diagnostic(self, tmp_path: Path) -> None:
+        diags = diagnose_missing_manifest(tmp_path)
+        assert [d.id for d in diags] == [DIAG_MISSING_MANIFEST]
+        assert diags[0].severity == "block"
+        assert diags[0].next_actions[0].kind == "command"
+        assert "agents-shipgate detect" in diags[0].next_actions[0].command
+
+
+# --- diagnose_detect — negative-control precedence -------------------------
+
+
+def _det(
+    *,
+    is_agent_project: bool = False,
+    suggested_sources: list[dict[str, str]] | None = None,
+    py_files: int = 0,
+    pyproject: bool = False,
+    prompts: bool = False,
+    tools_dir: bool = False,
+    conventional_dirs: list[str] | None = None,
+) -> DetectResult:
+    return DetectResult(
+        is_agent_project=is_agent_project,
+        suggested_sources=suggested_sources or [],
+        workspace_signals=WorkspaceSignals(
+            python_file_count=py_files,
+            has_pyproject_or_requirements=pyproject,
+            has_prompts_dir=prompts,
+            has_tools_dir=tools_dir,
+            conventional_dirs=conventional_dirs or [],
+        ),
+    )
+
+
+class TestDiagnoseDetect:
+    def test_pure_prompt_experiment(self, tmp_path: Path) -> None:
+        result = _det(
+            prompts=True, py_files=0, conventional_dirs=["prompts"]
+        )
+        diags = diagnose_detect(
+            result, has_manifest=False, workspace=tmp_path
+        )
+        assert [d.id for d in diags] == [DIAG_PURE_PROMPT_EXPERIMENT]
+        assert diags[0].next_actions[0].kind == "stop"
+
+    def test_non_agent_library(self, tmp_path: Path) -> None:
+        result = _det(py_files=12, pyproject=True)
+        diags = diagnose_detect(
+            result, has_manifest=False, workspace=tmp_path
+        )
+        assert [d.id for d in diags] == [DIAG_NON_AGENT_LIBRARY]
+        assert diags[0].next_actions[0].kind == "stop"
+
+    def test_no_agent_surface_catchall(self, tmp_path: Path) -> None:
+        # Empty workspace (no python, no prompts, no tools, no pyproject)
+        result = _det()
+        diags = diagnose_detect(
+            result, has_manifest=False, workspace=tmp_path
+        )
+        assert [d.id for d in diags] == [DIAG_NO_AGENT_SURFACE]
+        assert diags[0].next_actions[0].kind == "stop"
+
+    def test_mcp_openapi_artifact_only(self, tmp_path: Path) -> None:
+        result = _det(
+            is_agent_project=False,
+            suggested_sources=[{"type": "mcp", "path": "tools.json"}],
+        )
+        diags = diagnose_detect(
+            result, has_manifest=False, workspace=tmp_path
+        )
+        assert [d.id for d in diags] == [DIAG_MCP_OPENAPI_ARTIFACT_ONLY]
+        action = diags[0].next_actions[0]
+        assert action.kind == "command"
+        assert "init --workspace" in action.command
+        assert "--write" in action.command
+
+    def test_pure_prompt_takes_precedence_over_non_agent(
+        self, tmp_path: Path
+    ) -> None:
+        # Pure prompt: prompts present, py_files=0 — even if pyproject also
+        # present, prompts dir is the most specific signal.
+        result = _det(
+            prompts=True,
+            py_files=0,
+            pyproject=True,
+            conventional_dirs=["prompts"],
+        )
+        diags = diagnose_detect(
+            result, has_manifest=False, workspace=tmp_path
+        )
+        assert DIAG_PURE_PROMPT_EXPERIMENT in [d.id for d in diags]
+        assert DIAG_NON_AGENT_LIBRARY not in [d.id for d in diags]
+        assert DIAG_NO_AGENT_SURFACE not in [d.id for d in diags]
+
+    def test_no_diagnostics_when_manifest_present(
+        self, tmp_path: Path
+    ) -> None:
+        # Even on a non-agent workspace, if a manifest exists, detect's
+        # workspace-classification diagnostics are not interesting.
+        result = _det()
+        diags = diagnose_detect(
+            result, has_manifest=True, workspace=tmp_path
+        )
+        assert diags == []
+
+    def test_agent_project_no_diagnostics(self, tmp_path: Path) -> None:
+        # When detection succeeded, this resolver has nothing to add.
+        result = _det(is_agent_project=True, py_files=20, pyproject=True)
+        diags = diagnose_detect(
+            result, has_manifest=False, workspace=tmp_path
+        )
+        assert diags == []
+
+
+# --- diagnose_doctor --------------------------------------------------------
+
+
+class TestDiagnoseDoctor:
+    def test_zero_tools(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "shipgate.yaml"
+        manifest_path.write_text("version: '0.1'\n", encoding="utf-8")
+        payload = {
+            "total_tools": 0,
+            "frameworks": {},
+            "manifest_summary": {
+                "environment_target": "local",
+                "has_permissions": False,
+                "has_policies": False,
+                "scope_count": 0,
+            },
+            "unresolved_sources": [],
+        }
+        diags = diagnose_doctor(
+            payload,
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=[],
+        )
+        assert any(d.id == DIAG_ZERO_TOOLS for d in diags)
+
+    def test_missing_source_file(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "shipgate.yaml"
+        payload = {
+            "total_tools": 5,
+            "frameworks": {},
+            "manifest_summary": {
+                "environment_target": "local",
+                "has_permissions": False,
+                "has_policies": False,
+                "scope_count": 0,
+            },
+            "unresolved_sources": [
+                {
+                    "id": "support_openapi",
+                    "declared_path": "specs/missing.yaml",
+                    "line": 14,
+                }
+            ],
+        }
+        diags = diagnose_doctor(
+            payload,
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=[],
+        )
+        diag = next(d for d in diags if d.id == DIAG_MISSING_SOURCE_FILE)
+        assert diag.severity == "block"
+        action = diag.next_actions[0]
+        assert action.kind == "edit"
+        assert "shipgate.yaml:14" in action.path
+
+    def test_change_me_placeholders(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "shipgate.yaml"
+        payload = {
+            "total_tools": 1,
+            "frameworks": {},
+            "manifest_summary": {
+                "environment_target": "local",
+                "has_permissions": False,
+                "has_policies": False,
+                "scope_count": 1,
+            },
+            "unresolved_sources": [],
+        }
+        placeholders = [
+            {"path": "agent.name", "current": "CHANGE_ME", "line": 4},
+        ]
+        diags = diagnose_doctor(
+            payload,
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=placeholders,
+        )
+        diag = next(d for d in diags if d.id == DIAG_CHANGE_ME_PLACEHOLDERS)
+        assert diag.severity == "warn"
+        assert diag.next_actions[0].kind == "edit"
+        assert "shipgate.yaml:4" in diag.next_actions[0].path
+
+    def test_dynamic_toolsets_only(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "shipgate.yaml"
+        payload = {
+            "total_tools": 1,
+            "frameworks": {
+                "google_adk": {"dynamic_toolset_count": 2},
+                "langchain": {},
+                "crewai": {},
+            },
+            "manifest_summary": {
+                "environment_target": "local",
+                "has_permissions": True,
+                "has_policies": False,
+                "scope_count": 1,
+            },
+            "unresolved_sources": [],
+        }
+        diags = diagnose_doctor(
+            payload,
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=[],
+        )
+        assert any(d.id == DIAG_DYNAMIC_TOOLSETS_ONLY for d in diags)
+
+    def test_dynamic_toolsets_skipped_when_tools_present(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / "shipgate.yaml"
+        payload = {
+            "total_tools": 5,
+            "frameworks": {
+                "google_adk": {"dynamic_toolset_count": 1},
+            },
+            "manifest_summary": {
+                "environment_target": "local",
+                "has_permissions": True,
+                "has_policies": False,
+                "scope_count": 1,
+            },
+            "unresolved_sources": [],
+        }
+        diags = diagnose_doctor(
+            payload,
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=[],
+        )
+        assert all(
+            d.id != DIAG_DYNAMIC_TOOLSETS_ONLY for d in diags
+        )
+
+    def test_production_no_permissions(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "shipgate.yaml"
+        payload = {
+            "total_tools": 3,
+            "frameworks": {},
+            "manifest_summary": {
+                "environment_target": "production",
+                "has_permissions": False,
+                "has_policies": False,
+                "scope_count": 0,
+            },
+            "unresolved_sources": [],
+        }
+        diags = diagnose_doctor(
+            payload,
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=[],
+        )
+        assert any(
+            d.id == DIAG_NO_PRODUCTION_PERMISSIONS for d in diags
+        )
+
+    def test_no_diagnostics_for_healthy_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / "shipgate.yaml"
+        payload = {
+            "total_tools": 5,
+            "frameworks": {},
+            "manifest_summary": {
+                "environment_target": "production",
+                "has_permissions": True,
+                "has_policies": True,
+                "scope_count": 3,
+            },
+            "unresolved_sources": [],
+        }
+        diags = diagnose_doctor(
+            payload,
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=[],
+        )
+        assert diags == []
+
+
+# --- top_next_actions -------------------------------------------------------
+
+
+class TestTopNextActions:
+    def test_empty_input_returns_empty(self) -> None:
+        assert top_next_actions([]) == []
+
+    def test_severity_ordering_block_warn_info(self) -> None:
+        warn = Diagnostic(
+            id="SHIP-DIAG-W",
+            title="warn",
+            severity="warn",
+            next_actions=[
+                NextAction(kind="command", command="warn-cmd", why="w")
+            ],
+        )
+        block = Diagnostic(
+            id="SHIP-DIAG-B",
+            title="block",
+            severity="block",
+            next_actions=[
+                NextAction(kind="command", command="block-cmd", why="w")
+            ],
+        )
+        info = Diagnostic(
+            id="SHIP-DIAG-I",
+            title="info",
+            severity="info",
+            next_actions=[
+                NextAction(kind="command", command="info-cmd", why="w")
+            ],
+        )
+        # Pass in non-severity order to verify the sort.
+        flattened = top_next_actions([warn, info, block])
+        assert [a.command for a in flattened] == [
+            "block-cmd",
+            "warn-cmd",
+            "info-cmd",
+        ]
+
+    def test_limit_caps_output(self) -> None:
+        diags = [
+            Diagnostic(
+                id=f"SHIP-DIAG-{i}",
+                title="t",
+                severity="warn",
+                next_actions=[
+                    NextAction(kind="command", command=f"c{i}", why="w")
+                ],
+            )
+            for i in range(5)
+        ]
+        assert len(top_next_actions(diags, limit=3)) == 3
+
+
+# --- Cross-check: command actions reference real subcommands ---------------
+
+
+class TestRankOneCommandsAreRoutable:
+    def _typer_subcommands(self) -> set[str]:
+        names: set[str] = set()
+        for command_info in typer_app.registered_commands:
+            if command_info.name:
+                names.add(command_info.name)
+            else:
+                # typer derives the command name from the callback name when
+                # `name=` is not set (e.g. `scan`, `init`, `doctor`).
+                names.add(command_info.callback.__name__)
+        for group in typer_app.registered_groups:
+            if group.name:
+                names.add(group.name)
+        return names
+
+    def test_command_actions_use_known_subcommands(
+        self, tmp_path: Path
+    ) -> None:
+        registered = self._typer_subcommands()
+        # Build every diagnostic by calling each resolver on a triggering
+        # input, then assert each kind="command" rank-1 action parses to a
+        # subcommand the typer app actually exposes.
+        commands_to_check: list[str] = []
+        diags = diagnose_missing_manifest(tmp_path)
+        commands_to_check.extend(
+            a.command for d in diags for a in d.next_actions if a.kind == "command"
+        )
+        result = _det(
+            is_agent_project=False,
+            suggested_sources=[{"type": "mcp", "path": "x.json"}],
+        )
+        diags = diagnose_detect(
+            result, has_manifest=False, workspace=tmp_path
+        )
+        commands_to_check.extend(
+            a.command for d in diags for a in d.next_actions if a.kind == "command"
+        )
+        manifest_path = tmp_path / "shipgate.yaml"
+        diags = diagnose_doctor(
+            {
+                "total_tools": 0,
+                "frameworks": {},
+                "manifest_summary": {
+                    "environment_target": "local",
+                    "has_permissions": False,
+                    "has_policies": False,
+                    "scope_count": 0,
+                },
+                "unresolved_sources": [],
+            },
+            manifest_path=manifest_path,
+            manifest_text="",
+            placeholders=[],
+        )
+        commands_to_check.extend(
+            a.command for d in diags for a in d.next_actions if a.kind == "command"
+        )
+
+        assert commands_to_check, "expected at least one command action"
+        pattern = re.compile(r"^agents-shipgate\s+([\w-]+)")
+        for command in commands_to_check:
+            match = pattern.match(command)
+            assert match, f"command does not start with agents-shipgate: {command!r}"
+            subcommand = match.group(1)
+            assert subcommand in registered, (
+                f"command {command!r} references unknown subcommand "
+                f"{subcommand!r}; registered: {sorted(registered)}"
+            )
+
+
+# --- Module-level guard: catalog tuple is exhaustive -----------------------
+
+
+def test_all_diag_constants_exported_in_all_diagnostic_ids() -> None:
+    """Every ``DIAG_*`` module constant should be in ``ALL_DIAGNOSTIC_IDS``.
+    Catches the bug where a new diagnostic is added but the catalog tuple
+    forgets it (which would silently break the docs-link test)."""
+    constants = {
+        value
+        for name, value in vars(diag_mod).items()
+        if name.startswith("DIAG_") and isinstance(value, str)
+    }
+    assert constants == set(ALL_DIAGNOSTIC_IDS)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -12,6 +12,7 @@ from agents_shipgate.cli.diagnostics import (
     ALL_DIAGNOSTIC_IDS,
     DIAG_CHANGE_ME_PLACEHOLDERS,
     DIAG_DYNAMIC_TOOLSETS_ONLY,
+    DIAG_INVALID_MANIFEST,
     DIAG_MCP_OPENAPI_ARTIFACT_ONLY,
     DIAG_MISSING_MANIFEST,
     DIAG_MISSING_SOURCE_FILE,
@@ -24,6 +25,7 @@ from agents_shipgate.cli.diagnostics import (
     NextAction,
     diagnose_detect,
     diagnose_doctor,
+    diagnose_invalid_manifest,
     diagnose_missing_manifest,
     top_next_actions,
 )
@@ -139,6 +141,39 @@ class TestDiagnoseMissingManifest:
         assert diags[0].severity == "block"
         assert diags[0].next_actions[0].kind == "command"
         assert "agents-shipgate detect" in diags[0].next_actions[0].command
+
+    def test_command_quotes_workspace_with_spaces(
+        self, tmp_path: Path
+    ) -> None:
+        """Paths with spaces must round-trip through shlex.split()."""
+        import shlex
+
+        spaced = tmp_path / "with space"
+        diags = diagnose_missing_manifest(spaced)
+        for action in diags[0].next_actions:
+            parts = shlex.split(action.command)
+            assert parts[0] == "agents-shipgate"
+            ws_idx = parts.index("--workspace")
+            assert parts[ws_idx + 1] == str(spaced)
+
+
+class TestDiagnoseInvalidManifest:
+    def test_emits_edit_action_pointing_at_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        manifest = tmp_path / "shipgate.yaml"
+        diags = diagnose_invalid_manifest(
+            manifest, message="schema validation failed: project required"
+        )
+        assert [d.id for d in diags] == [DIAG_INVALID_MANIFEST]
+        assert diags[0].severity == "block"
+        # Rank-1 action points the agent at the file, not at detect/init —
+        # init refuses to overwrite an existing file, so dispatching there
+        # would loop.
+        rank_one = diags[0].next_actions[0]
+        assert rank_one.kind == "edit"
+        assert str(manifest) in rank_one.path
+        assert "schema validation failed" in rank_one.why
 
 
 # --- diagnose_detect — negative-control precedence -------------------------


### PR DESCRIPTION
## Summary

- Adds a ranked, machine-readable recovery surface so a coding agent that hits a common first-run failure (no `shipgate.yaml`, zero tools, MCP/OpenAPI artifact-only repo, dynamic toolsets, missing source file, unresolved `CHANGE_ME`, non-agent / pure-prompt workspace, production target without permissions) gets a routable next step in JSON without having to consult docs.
- New `cli/diagnostics.py` module: `NextAction` + `Diagnostic` Pydantic models with strict validators, a 10-entry catalog under stable `SHIP-DIAG-*` ids, and pure-functional resolvers (`diagnose_detect`, `diagnose_doctor`, `diagnose_missing_manifest`, `top_next_actions`).
- `detect --json` and each `doctor --json` payload now carry `diagnostics: [...]` and `next_actions: [...]` blocks alongside the existing single-string `next_action`. The legacy field stays string-typed for every kind by projecting from the rank-1 action (`Edit <path>`, `Stop: <why>`, etc.), so consumers that only read `next_action` keep working.
- `AGENTS_SHIPGATE_AGENT_MODE=1` error JSON gains the same `next_actions` array. Audited every emit site: 7 in `main.py`, 2 in `scenario.py`, and the local helper in `apply_patches.py`.

## Type

- [x] CLI or GitHub Action behavior
- [x] Documentation only (also)

## Behavior change (deliberate, one)

`agents-shipgate doctor` no longer raises `InputParseError(3)` when a required `tool_sources[].path` does not resolve. It now exits **0** with:

- `unresolved_sources: [{id, declared_path, line}]` in the per-manifest payload
- a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic whose rank-1 action is an `edit` pointing at `shipgate.yaml:<line>`

`agents-shipgate scan` is unchanged — it still raises `InputParseError(3)` on the same condition. Documented in [`AGENTS.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/claude/gallant-mclean-36d7a4/AGENTS.md), [`CHANGELOG.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/claude/gallant-mclean-36d7a4/CHANGELOG.md), and [`docs/diagnostics.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/claude/gallant-mclean-36d7a4/docs/diagnostics.md). A regression-guard test asserts `scan` still exits 3.

## Notes for reviewers

- **No `report.json` schema bump.** Diagnostics are pre-scan recovery hints; per-finding remediation already lives in v0.7 fields (`autofix_safe`, `suggested_patch_kind`, `docs_url`).
- **`DetectResult` extension is additive** — new `workspace_signals` block (Python file count, pyproject/requirements/prompts/tools dir presence). Existing fields and JSON output are unchanged.
- **`_collect_placeholders` extracted** to `cli/discovery/placeholders.py` so `init` and the new `doctor` diagnostic share one implementation. Now also returns `line` so edit actions can point at `shipgate.yaml:<line>`.
- **Negative-control precedence** is explicit: `PURE_PROMPT_EXPERIMENT > NON_AGENT_LIBRARY > NO_AGENT_SURFACE`. Asserted in tests.
- **`NextAction` validates kind/field correlation** via a `model_validator`: `kind="command"` requires `command`; `kind="edit"` requires `path`; `kind="stop"` rejects `command`. Empty `next_actions` lists are rejected at the Diagnostic level (`min_length=1`).

## Verification

CI is authoritative. Local checks run:

- [x] `python -m pytest -q` — 463 passed (35 new in `tests/test_diagnostics.py`, 6 new integration tests in `tests/test_cli.py`)
- [x] End-to-end smoke against missing-manifest, empty-workspace, zero-tools, missing-source-file, and CHANGE_ME-unresolved scenarios — each produces the expected diagnostic id and rank-1 action
- [x] Cross-command consistency: `scan` and `doctor` produce the same rank-1 next action for the missing-manifest case

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (these are `SHIP-DIAG-*` diagnostics, documented in [`docs/diagnostics.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/claude/gallant-mclean-36d7a4/docs/diagnostics.md))
- [x] Report/schema changes are additive or documented in `STABILITY.md` — `report.json` schema is unchanged. The `DetectResult` and `inspect_sources` payload additions are additive only.

## Test plan

- [ ] Confirm a coding agent receives a routable rank-1 action for each catalogued first-run failure
- [ ] Confirm `next_action` (string) stays present in every JSON output for back-compat
- [ ] Confirm `doctor --json` exits 0 on unresolved required source; `scan` exits 3 on the same input

🤖 Generated with [Claude Code](https://claude.com/claude-code)