### PR TITLE
Add init --agent-instructions for managed agent-facing snippets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,12 @@ agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
 - **`init`** — auto-detects by default. `--ci` writes
   `.github/workflows/agents-shipgate.yml`; orthogonal to `--write`. Use
   `--minimal` for the pre-v0.6 CHANGE_ME-heavy template.
+  `--agent-instructions=all` (or a comma-separated subset of
+  `agents-md,claude-md,cursor,pr-template`) renders agent-facing snippets to
+  stdout; combined with `--write` it commits them to the target repo via
+  managed `<!-- agents-shipgate:start -->` markers (idempotent — safe to
+  rerun). Strict CI and baselines remain opt-in human decisions; the flag
+  emits advisory guidance only.
 - **`scan --suggest-patches`** — attaches Patch objects to every active
   finding. `Finding.patches` is absent without the flag.
 - **`apply-patches`** — file-grouped, dry-run by default. Containment-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ A few Claude-specific notes:
 
 - `agents-shipgate scan`, `init`, `doctor`, `explain`, `list-checks`, `fixture`, `self-check` are **read-only** with respect to user code; safe to run without confirmation.
 - `agents-shipgate init --write` writes `shipgate.yaml` in the workspace. Confirm before running on an unfamiliar repo.
+- `agents-shipgate init --write --agent-instructions=...` writes/updates `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/agents-shipgate.mdc`, and the PR template via managed-block markers. Idempotent; confirm before running on an unfamiliar repo.
 - `agents-shipgate baseline save` writes one JSON file under `.agents-shipgate/`. Safe to run; reversible.
 
 ## Output handling

--- a/docs/target-repo-agent-snippets.md
+++ b/docs/target-repo-agent-snippets.md
@@ -4,6 +4,13 @@ Use these snippets in repos that contain tool-using AI agents. They make
 Agents Shipgate visible to coding agents working in that target repo, not only
 to agents reading the Agents Shipgate source repo.
 
+> The CLI plants these snippets for you. Run
+> `agents-shipgate init --write --agent-instructions=all` (or pass a subset
+> like `--agent-instructions=agents-md,cursor`) to emit them into managed
+> `<!-- agents-shipgate:start -->` blocks. Idempotent — safe to rerun. The raw
+> content below is the canonical reference and the source the renderers in
+> `src/agents_shipgate/cli/discovery/agent_instructions/renderers/` lift from.
+
 ## When To Run
 
 Run Agents Shipgate when a repo or PR changes:

--- a/src/agents_shipgate/cli/discovery/agent_instructions/__init__.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/__init__.py
@@ -1,0 +1,35 @@
+"""Render and apply agent-instruction snippets to a target repo.
+
+Public surface used by ``agents-shipgate init --agent-instructions=...``:
+
+- :data:`BLOCK_VERSION` — current renderer-format version.
+- :data:`TARGETS` — ordered tuple of selectable target names.
+- :func:`parse_selector` — parse the comma-separated selector value.
+- :func:`apply_agent_instructions` — apply the per-target decision tree
+  against a workspace.
+- :class:`TargetOutcome` — per-target result returned by ``apply``.
+"""
+
+from __future__ import annotations
+
+from agents_shipgate.cli.discovery.agent_instructions.apply import (
+    TargetOutcome,
+    apply_agent_instructions,
+    render_targets,
+)
+from agents_shipgate.cli.discovery.agent_instructions.targets import (
+    BLOCK_VERSION,
+    TARGETS,
+    InvalidSelector,
+    parse_selector,
+)
+
+__all__ = [
+    "BLOCK_VERSION",
+    "InvalidSelector",
+    "TARGETS",
+    "TargetOutcome",
+    "apply_agent_instructions",
+    "parse_selector",
+    "render_targets",
+]

--- a/src/agents_shipgate/cli/discovery/agent_instructions/apply.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/apply.py
@@ -73,6 +73,33 @@ _SKIPPED_STATUSES = frozenset(
 )
 
 
+def _first_symlink_in_chain(path: Path, workspace: Path) -> Path | None:
+    """Return the first symlink encountered between ``workspace`` (exclusive)
+    and ``path`` (inclusive), or ``None`` if no existing component is a
+    symlink.
+
+    Walking the parent chain prevents the directory-symlink escape: a
+    workspace where ``.github -> /tmp/outside`` would otherwise route
+    ``.github/pull_request_template.md`` writes outside the workspace even
+    though the file itself is not a symlink. Non-existent intermediates
+    cannot be symlinks, so the walk stops at the first missing component.
+    """
+    workspace_real = workspace.resolve()
+    try:
+        relative_parts = path.relative_to(workspace_real).parts
+    except ValueError:
+        # Caller bug: target was not under workspace lexically. Refuse.
+        return path
+    cur = workspace_real
+    for part in relative_parts:
+        cur = cur / part
+        if cur.is_symlink():
+            return cur
+        if not cur.exists():
+            return None
+    return None
+
+
 @dataclass
 class TargetOutcome:
     """Result of applying or rendering a single target."""
@@ -202,20 +229,24 @@ def _resolve_pr_template_path(workspace: Path) -> tuple[Path, str | None]:
     return lower, None
 
 
-def _apply_managed_block_target(name: str, path: Path) -> TargetOutcome:
+def _apply_managed_block_target(
+    name: str, path: Path, workspace: Path
+) -> TargetOutcome:
     inner = _rendered_inner(name)
     preamble = H1_PREAMBLES.get(name, "")
-    # Refuse to follow symlinks. ``path.exists()`` would follow a dangling
-    # symlink and mutate whatever it points to (potentially outside the
-    # workspace). ``is_symlink()`` checks the link itself, not the target.
-    if path.is_symlink():
+    # Refuse to follow symlinks anywhere in the parent chain. A symlinked
+    # directory above the target file (e.g., ``.github -> /tmp/outside``)
+    # would otherwise route the write outside the workspace.
+    symlink = _first_symlink_in_chain(path, workspace)
+    if symlink is not None:
         return TargetOutcome(
             name=name,
             path=str(path),
             status="skipped_symlink",
             message=(
-                f"{path} is a symlink; refusing to follow it. "
-                "Replace the symlink with a regular file before re-running."
+                f"{symlink} is a symlink; refusing to follow it. "
+                "Replace the symlink with a regular file or directory before "
+                "re-running."
             ),
         )
     if not path.exists():
@@ -294,18 +325,20 @@ def _apply_managed_block_target(name: str, path: Path) -> TargetOutcome:
     )
 
 
-def _apply_cursor(path: Path) -> TargetOutcome:
+def _apply_cursor(path: Path, workspace: Path) -> TargetOutcome:
     rendered = render_cursor_file()
     rendered_bytes = rendered.encode("utf-8")
     rendered_sha = hashlib.sha256(rendered_bytes).hexdigest()
-    if path.is_symlink():
+    symlink = _first_symlink_in_chain(path, workspace)
+    if symlink is not None:
         return TargetOutcome(
             name="cursor",
             path=str(path),
             status="skipped_symlink",
             message=(
-                f"{path} is a symlink; refusing to follow it. "
-                "Replace the symlink with a regular file before re-running."
+                f"{symlink} is a symlink; refusing to follow it. "
+                "Replace the symlink with a regular file or directory before "
+                "re-running."
             ),
         )
     if not path.exists():
@@ -402,8 +435,8 @@ def apply_agent_instructions(
             path = workspace / spec.relative_path
 
         if name == "cursor":
-            outcomes.append(_apply_cursor(path))
+            outcomes.append(_apply_cursor(path, workspace))
         else:
-            outcomes.append(_apply_managed_block_target(name, path))
+            outcomes.append(_apply_managed_block_target(name, path, workspace))
 
     return ApplyResult(requested=requested_list, targets=outcomes)

--- a/src/agents_shipgate/cli/discovery/agent_instructions/apply.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/apply.py
@@ -19,6 +19,8 @@ Status enum:
 - ``skipped_ambiguous`` — multiple/mismatched markers; refused to guess.
 - ``skipped_user_modified`` — cursor MDC file content does not match any
   shipped render; refused to overwrite.
+- ``skipped_symlink`` — the host path is a symlink; refused to follow it
+  outside the workspace.
 - ``skipped_directory_template`` — the directory form
   ``.github/PULL_REQUEST_TEMPLATE/`` exists; v1 only handles the file form.
 
@@ -65,6 +67,7 @@ _SKIPPED_STATUSES = frozenset(
         "skipped_newer_version",
         "skipped_ambiguous",
         "skipped_user_modified",
+        "skipped_symlink",
         "skipped_directory_template",
     }
 )
@@ -140,7 +143,10 @@ def render_targets(workspace: Path, requested: Iterable[str]) -> list[TargetOutc
     outcomes: list[TargetOutcome] = []
     for name in requested:
         spec = SPECS[name]
-        path = (workspace / spec.relative_path).resolve()
+        # Lexical join only — never resolve(). Resolving would follow a
+        # symlink at the host path and report a path outside the workspace,
+        # which would mislead callers in the dry-run JSON.
+        path = workspace / spec.relative_path
         outcomes.append(
             TargetOutcome(
                 name=name,
@@ -160,6 +166,11 @@ def _resolve_pr_template_path(workspace: Path) -> tuple[Path, str | None]:
 
     Returns (path, error_status). On ambiguity the path is the canonical lower
     form and ``error_status`` is the status enum to surface.
+
+    Case-insensitive filesystems (macOS APFS, Windows NTFS) report the same
+    inode for both casings — ``Path.samefile`` collapses them so we do not
+    falsely report ``skipped_ambiguous`` when only one PR template actually
+    exists on disk.
     """
     upper = workspace / PR_TEMPLATE_UPPER
     lower = workspace / PR_TEMPLATE_LOWER
@@ -169,7 +180,16 @@ def _resolve_pr_template_path(workspace: Path) -> tuple[Path, str | None]:
     upper_exists = upper.is_file()
     lower_exists = lower.is_file()
     if upper_exists and lower_exists:
-        # Pick the one that contains our marker; if neither does, ambiguous.
+        try:
+            same = upper.samefile(lower)
+        except OSError:
+            same = False
+        if same:
+            # Same inode (case-insensitive FS) — there is only one file on
+            # disk. Use the lowercase canonical path for output stability.
+            return lower, None
+        # Two genuinely distinct files. Pick the one with our marker; if
+        # neither has it, refuse with skipped_ambiguous.
         for candidate in (lower, upper):
             try:
                 if b"agents-shipgate:start" in candidate.read_bytes():
@@ -185,6 +205,19 @@ def _resolve_pr_template_path(workspace: Path) -> tuple[Path, str | None]:
 def _apply_managed_block_target(name: str, path: Path) -> TargetOutcome:
     inner = _rendered_inner(name)
     preamble = H1_PREAMBLES.get(name, "")
+    # Refuse to follow symlinks. ``path.exists()`` would follow a dangling
+    # symlink and mutate whatever it points to (potentially outside the
+    # workspace). ``is_symlink()`` checks the link itself, not the target.
+    if path.is_symlink():
+        return TargetOutcome(
+            name=name,
+            path=str(path),
+            status="skipped_symlink",
+            message=(
+                f"{path} is a symlink; refusing to follow it. "
+                "Replace the symlink with a regular file before re-running."
+            ),
+        )
     if not path.exists():
         # Compose H1 preamble (if any) + managed block from a virtual empty
         # host. ``upsert`` handles the empty-host case for us.
@@ -265,6 +298,16 @@ def _apply_cursor(path: Path) -> TargetOutcome:
     rendered = render_cursor_file()
     rendered_bytes = rendered.encode("utf-8")
     rendered_sha = hashlib.sha256(rendered_bytes).hexdigest()
+    if path.is_symlink():
+        return TargetOutcome(
+            name="cursor",
+            path=str(path),
+            status="skipped_symlink",
+            message=(
+                f"{path} is a symlink; refusing to follow it. "
+                "Replace the symlink with a regular file before re-running."
+            ),
+        )
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(rendered_bytes)
@@ -328,7 +371,7 @@ def apply_agent_instructions(
                 outcomes.append(
                     TargetOutcome(
                         name=name,
-                        path=str((workspace / PR_TEMPLATE_DIR).resolve()),
+                        path=str(workspace / PR_TEMPLATE_DIR),
                         status="skipped_directory_template",
                         message=(
                             f"{workspace / PR_TEMPLATE_DIR} directory present; "
@@ -342,7 +385,7 @@ def apply_agent_instructions(
                 outcomes.append(
                     TargetOutcome(
                         name=name,
-                        path=str(path.resolve()),
+                        path=str(path),
                         status="skipped_ambiguous",
                         message=(
                             f"Both {workspace / PR_TEMPLATE_LOWER} and "
@@ -353,7 +396,10 @@ def apply_agent_instructions(
                 )
                 continue
         else:
-            path = (workspace / spec.relative_path).resolve()
+            # Lexical join — never resolve(). Resolving a symlink target
+            # would write outside the workspace; the per-target helpers
+            # check ``is_symlink`` and refuse before touching the file.
+            path = workspace / spec.relative_path
 
         if name == "cursor":
             outcomes.append(_apply_cursor(path))

--- a/src/agents_shipgate/cli/discovery/agent_instructions/apply.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/apply.py
@@ -1,0 +1,363 @@
+"""Per-target decision tree for ``--agent-instructions``.
+
+Pure function ``render_targets`` returns the rendered content for each
+requested target without touching the filesystem. ``apply_agent_instructions``
+applies the decision tree against a workspace and returns one
+:class:`TargetOutcome` per requested target.
+
+Status enum:
+
+- ``created_with_block`` — host file did not exist; we created it with an H1
+  preamble (where applicable) plus the managed block.
+- ``appended`` — host file existed without our markers; block appended.
+- ``unchanged`` — markers present, content already current.
+- ``updated`` — markers present, content differed; we rewrote the block.
+- ``migrated`` — markers present at an older version; block + version bumped.
+- ``would_render`` — synthetic dry-run status; emitted when ``write=False``.
+- ``skipped_newer_version`` — markers present at a *newer* version than this
+  CLI; refused to downgrade.
+- ``skipped_ambiguous`` — multiple/mismatched markers; refused to guess.
+- ``skipped_user_modified`` — cursor MDC file content does not match any
+  shipped render; refused to overwrite.
+- ``skipped_directory_template`` — the directory form
+  ``.github/PULL_REQUEST_TEMPLATE/`` exists; v1 only handles the file form.
+
+Every ``skipped_*`` status contributes 2 to the exit code (matching the
+``skipped_existing_target`` precedent in :mod:`ci_workflow`); other statuses
+contribute 0.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from agents_shipgate.cli.discovery.agent_instructions.managed_block import (
+    UpsertStatus,
+    upsert,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers import (
+    CURSOR_PRIOR_RENDER_SHA256,
+    render_agents_md,
+    render_claude_md,
+    render_cursor_file,
+    render_pr_template,
+)
+from agents_shipgate.cli.discovery.agent_instructions.targets import (
+    BLOCK_VERSION,
+    SPECS,
+)
+
+PR_TEMPLATE_LOWER = ".github/pull_request_template.md"
+PR_TEMPLATE_UPPER = ".github/PULL_REQUEST_TEMPLATE.md"
+PR_TEMPLATE_DIR = ".github/PULL_REQUEST_TEMPLATE"
+
+H1_PREAMBLES = {
+    "agents-md": "# Agents\n",
+    "claude-md": "# Claude Code Instructions\n",
+    "pr-template": "",  # PR templates conventionally have no preamble.
+}
+
+_SKIPPED_STATUSES = frozenset(
+    {
+        "skipped_newer_version",
+        "skipped_ambiguous",
+        "skipped_user_modified",
+        "skipped_directory_template",
+    }
+)
+
+
+@dataclass
+class TargetOutcome:
+    """Result of applying or rendering a single target."""
+
+    name: str
+    path: str
+    status: str
+    block_version: int = BLOCK_VERSION
+    message: str = ""
+    rendered: str | None = None  # populated only on dry-run
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "name": self.name,
+            "path": self.path,
+            "status": self.status,
+            "block_version": self.block_version,
+        }
+        if self.message:
+            payload["message"] = self.message
+        if self.rendered is not None:
+            payload["rendered"] = self.rendered
+        return payload
+
+    @property
+    def exit_contribution(self) -> int:
+        return 2 if self.status in _SKIPPED_STATUSES else 0
+
+
+@dataclass
+class ApplyResult:
+    """Aggregate result returned by :func:`apply_agent_instructions`."""
+
+    requested: list[str]
+    targets: list[TargetOutcome]
+    block_version: int = BLOCK_VERSION
+
+    @property
+    def exit_code(self) -> int:
+        return max((t.exit_contribution for t in self.targets), default=0)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "requested": list(self.requested),
+            "block_version": self.block_version,
+            "targets": [t.to_json() for t in self.targets],
+        }
+
+
+# --- rendering -------------------------------------------------------------
+
+
+def _rendered_inner(name: str) -> str:
+    if name == "agents-md":
+        return render_agents_md()
+    if name == "claude-md":
+        return render_claude_md()
+    if name == "pr-template":
+        return render_pr_template()
+    if name == "cursor":
+        return render_cursor_file()
+    raise ValueError(f"unknown target {name!r}")  # pragma: no cover - guarded by selector
+
+
+def render_targets(workspace: Path, requested: Iterable[str]) -> list[TargetOutcome]:
+    """Pure rendering pass for dry-run output. Does not read existing files."""
+    workspace = workspace.resolve()
+    outcomes: list[TargetOutcome] = []
+    for name in requested:
+        spec = SPECS[name]
+        path = (workspace / spec.relative_path).resolve()
+        outcomes.append(
+            TargetOutcome(
+                name=name,
+                path=str(path),
+                status="would_render",
+                rendered=_rendered_inner(name),
+            )
+        )
+    return outcomes
+
+
+# --- applying --------------------------------------------------------------
+
+
+def _resolve_pr_template_path(workspace: Path) -> tuple[Path, str | None]:
+    """Pick the PR template path to use.
+
+    Returns (path, error_status). On ambiguity the path is the canonical lower
+    form and ``error_status`` is the status enum to surface.
+    """
+    upper = workspace / PR_TEMPLATE_UPPER
+    lower = workspace / PR_TEMPLATE_LOWER
+    directory = workspace / PR_TEMPLATE_DIR
+    if directory.is_dir():
+        return lower, "skipped_directory_template"
+    upper_exists = upper.is_file()
+    lower_exists = lower.is_file()
+    if upper_exists and lower_exists:
+        # Pick the one that contains our marker; if neither does, ambiguous.
+        for candidate in (lower, upper):
+            try:
+                if b"agents-shipgate:start" in candidate.read_bytes():
+                    return candidate, None
+            except OSError:
+                continue
+        return lower, "skipped_ambiguous"
+    if upper_exists:
+        return upper, None
+    return lower, None
+
+
+def _apply_managed_block_target(name: str, path: Path) -> TargetOutcome:
+    inner = _rendered_inner(name)
+    preamble = H1_PREAMBLES.get(name, "")
+    if not path.exists():
+        # Compose H1 preamble (if any) + managed block from a virtual empty
+        # host. ``upsert`` handles the empty-host case for us.
+        empty_host = preamble.encode("utf-8")
+        # If the preamble is non-empty, append a blank line separator before
+        # the block so the result reads as "# Heading\n\n<block>".
+        result = upsert(empty_host, inner=inner, version=BLOCK_VERSION)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(result.new_bytes)
+        return TargetOutcome(
+            name=name,
+            path=str(path),
+            status="created_with_block",
+            block_version=result.block_version,
+            message=f"Created {path} with managed block (v{result.block_version}).",
+        )
+
+    host = path.read_bytes()
+    result = upsert(host, inner=inner, version=BLOCK_VERSION)
+    if result.status is UpsertStatus.AMBIGUOUS:
+        return TargetOutcome(
+            name=name,
+            path=str(path),
+            status="skipped_ambiguous",
+            block_version=BLOCK_VERSION,
+            message=(
+                f"{path} contains ambiguous agents-shipgate markers. "
+                "Resolve manually before re-running."
+            ),
+        )
+    if result.status is UpsertStatus.NEWER_VERSION:
+        return TargetOutcome(
+            name=name,
+            path=str(path),
+            status="skipped_newer_version",
+            block_version=result.block_version,
+            message=(
+                f"{path} contains a newer block version (v{result.block_version}); "
+                f"this CLI ships v{BLOCK_VERSION}. Upgrade the CLI."
+            ),
+        )
+    if result.status is UpsertStatus.UNCHANGED:
+        return TargetOutcome(
+            name=name,
+            path=str(path),
+            status="unchanged",
+            block_version=result.block_version,
+            message=f"{path} already up to date (v{result.block_version}).",
+        )
+
+    path.write_bytes(result.new_bytes)
+    if result.status is UpsertStatus.APPENDED:
+        return TargetOutcome(
+            name=name,
+            path=str(path),
+            status="appended",
+            block_version=result.block_version,
+            message=f"Appended managed block (v{result.block_version}) to {path}.",
+        )
+    if result.status is UpsertStatus.MIGRATED:
+        return TargetOutcome(
+            name=name,
+            path=str(path),
+            status="migrated",
+            block_version=result.block_version,
+            message=f"Migrated {path} block to v{result.block_version}.",
+        )
+    return TargetOutcome(
+        name=name,
+        path=str(path),
+        status="updated",
+        block_version=result.block_version,
+        message=f"Updated managed block (v{result.block_version}) in {path}.",
+    )
+
+
+def _apply_cursor(path: Path) -> TargetOutcome:
+    rendered = render_cursor_file()
+    rendered_bytes = rendered.encode("utf-8")
+    rendered_sha = hashlib.sha256(rendered_bytes).hexdigest()
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(rendered_bytes)
+        return TargetOutcome(
+            name="cursor",
+            path=str(path),
+            status="created_with_block",
+            message=f"Created {path}.",
+        )
+    existing = path.read_bytes()
+    existing_sha = hashlib.sha256(existing).hexdigest()
+    if existing_sha == rendered_sha:
+        return TargetOutcome(
+            name="cursor",
+            path=str(path),
+            status="unchanged",
+            message=f"{path} already up to date.",
+        )
+    if existing_sha in CURSOR_PRIOR_RENDER_SHA256:
+        path.write_bytes(rendered_bytes)
+        return TargetOutcome(
+            name="cursor",
+            path=str(path),
+            status="migrated",
+            message=f"Migrated {path} to current renderer (v{BLOCK_VERSION}).",
+        )
+    return TargetOutcome(
+        name="cursor",
+        path=str(path),
+        status="skipped_user_modified",
+        message=(
+            f"{path} differs from any shipped render; not overwriting. "
+            "Delete the file or revert to a shipped version before re-running."
+        ),
+    )
+
+
+def apply_agent_instructions(
+    workspace: Path, requested: Iterable[str], *, write: bool
+) -> ApplyResult:
+    """Apply the per-target decision tree against ``workspace``.
+
+    With ``write=False`` this is a pure rendering pass (no host files read).
+    With ``write=True`` each target is created/appended/updated/skipped per
+    its decision tree and the on-disk file is mutated accordingly.
+    """
+    workspace = workspace.resolve()
+    requested_list = list(requested)
+    if not write:
+        return ApplyResult(
+            requested=requested_list,
+            targets=render_targets(workspace, requested_list),
+        )
+
+    outcomes: list[TargetOutcome] = []
+    for name in requested_list:
+        spec = SPECS[name]
+        if name == "pr-template":
+            path, override_status = _resolve_pr_template_path(workspace)
+            if override_status == "skipped_directory_template":
+                outcomes.append(
+                    TargetOutcome(
+                        name=name,
+                        path=str((workspace / PR_TEMPLATE_DIR).resolve()),
+                        status="skipped_directory_template",
+                        message=(
+                            f"{workspace / PR_TEMPLATE_DIR} directory present; "
+                            "v1 only handles the single-file PR template form. "
+                            "Add the snippet manually to one of the directory templates."
+                        ),
+                    )
+                )
+                continue
+            if override_status == "skipped_ambiguous":
+                outcomes.append(
+                    TargetOutcome(
+                        name=name,
+                        path=str(path.resolve()),
+                        status="skipped_ambiguous",
+                        message=(
+                            f"Both {workspace / PR_TEMPLATE_LOWER} and "
+                            f"{workspace / PR_TEMPLATE_UPPER} exist without an "
+                            "agents-shipgate marker. Delete one before re-running."
+                        ),
+                    )
+                )
+                continue
+        else:
+            path = (workspace / spec.relative_path).resolve()
+
+        if name == "cursor":
+            outcomes.append(_apply_cursor(path))
+        else:
+            outcomes.append(_apply_managed_block_target(name, path))
+
+    return ApplyResult(requested=requested_list, targets=outcomes)

--- a/src/agents_shipgate/cli/discovery/agent_instructions/managed_block.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/managed_block.py
@@ -1,0 +1,178 @@
+"""Parse and render the shipgate-managed block in a co-authored file.
+
+Targets that share host files with the user (AGENTS.md, CLAUDE.md, PR template)
+embed a fenced block:
+
+    <!-- agents-shipgate:start v=1 -->
+    ...rendered content...
+    <!-- agents-shipgate:end -->
+
+This module is byte-pure: callers pass ``bytes`` and receive ``bytes``. Newline
+style (LF vs CRLF) is detected from the host and propagated into the block so
+the rest of the file is preserved byte-for-byte.
+
+The ``v=N`` token is the renderer-format version, not the package version. It
+is bumped only on incompatible content changes; old blocks auto-upgrade on the
+next ``init --write --agent-instructions=...`` run.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+START_PATTERN = re.compile(rb"<!-- agents-shipgate:start v=(\d+) -->")
+END_MARKER = b"<!-- agents-shipgate:end -->"
+END_PATTERN = re.compile(rb"<!-- agents-shipgate:end -->")
+
+
+class BlockState(StrEnum):
+    """Result of parsing a host file for a managed block."""
+
+    NO_MARKERS = "no_markers"
+    PRESENT = "present"
+    AMBIGUOUS = "ambiguous"
+
+
+class UpsertStatus(StrEnum):
+    """Result of computing the new host bytes."""
+
+    APPENDED = "appended"
+    UNCHANGED = "unchanged"
+    UPDATED = "updated"
+    MIGRATED = "migrated"
+    NEWER_VERSION = "newer_version"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass(frozen=True)
+class BlockLocation:
+    """Line-aligned byte offsets of a parsed block.
+
+    ``line_start`` is the first byte of the start-marker LINE (so any
+    indentation before the marker is owned by us, never the user).
+    ``line_end`` is the first byte AFTER the end-marker line — i.e., the
+    trailing newline that follows the end marker is included.
+    """
+
+    line_start: int
+    line_end: int
+    version: int
+
+
+@dataclass(frozen=True)
+class ParsedBlock:
+    state: BlockState
+    location: BlockLocation | None = None
+
+
+@dataclass(frozen=True)
+class UpsertResult:
+    new_bytes: bytes
+    status: UpsertStatus
+    block_version: int  # version of the block that ended up in new_bytes
+
+
+def detect_newline(host: bytes) -> bytes:
+    """Return the host's newline style.
+
+    LF unless any CRLF sequence appears in the host. Empty hosts default to LF.
+    """
+    return b"\r\n" if b"\r\n" in host else b"\n"
+
+
+def parse(host: bytes) -> ParsedBlock:
+    """Locate the managed block in ``host`` bytes."""
+    start_matches = list(START_PATTERN.finditer(host))
+    end_matches = list(END_PATTERN.finditer(host))
+
+    if not start_matches and not end_matches:
+        return ParsedBlock(state=BlockState.NO_MARKERS)
+
+    if len(start_matches) != 1 or len(end_matches) != 1:
+        return ParsedBlock(state=BlockState.AMBIGUOUS)
+
+    start = start_matches[0]
+    end = end_matches[0]
+    if start.start() >= end.start():
+        return ParsedBlock(state=BlockState.AMBIGUOUS)
+
+    line_start = host.rfind(b"\n", 0, start.start()) + 1
+    newline_after_end = host.find(b"\n", end.end())
+    line_end = len(host) if newline_after_end == -1 else newline_after_end + 1
+
+    return ParsedBlock(
+        state=BlockState.PRESENT,
+        location=BlockLocation(
+            line_start=line_start,
+            line_end=line_end,
+            version=int(start.group(1)),
+        ),
+    )
+
+
+def render_block(inner: str, version: int, newline: bytes) -> bytes:
+    """Wrap rendered inner content with start/end markers.
+
+    ``inner`` is the human-readable content between markers. It is normalized
+    to use the host newline style and to end with exactly one newline before
+    the end marker.
+    """
+    if version < 1:
+        raise ValueError(f"block version must be >= 1, got {version}")
+    nl = newline.decode("ascii")
+    body = inner.replace("\r\n", "\n").replace("\n", nl)
+    if not body.endswith(nl):
+        body += nl
+    return (
+        f"<!-- agents-shipgate:start v={version} -->{nl}"
+        f"{body}"
+        f"<!-- agents-shipgate:end -->{nl}"
+    ).encode()
+
+
+def upsert(host: bytes, *, inner: str, version: int) -> UpsertResult:
+    """Compute new host bytes containing the rendered block.
+
+    Pure function. ``host`` may be empty (meaning "no host content yet" —
+    callers writing a new file pass ``b""``). Bytes outside the block region
+    are preserved exactly.
+    """
+    parsed = parse(host)
+    if parsed.state is BlockState.AMBIGUOUS:
+        return UpsertResult(new_bytes=host, status=UpsertStatus.AMBIGUOUS, block_version=version)
+
+    nl = detect_newline(host)
+    block = render_block(inner, version, nl)
+
+    if parsed.state is BlockState.NO_MARKERS:
+        if not host:
+            return UpsertResult(new_bytes=block, status=UpsertStatus.APPENDED, block_version=version)
+        # Ensure exactly one blank line between user content and our block.
+        prefix = host
+        if not prefix.endswith(nl):
+            prefix += nl
+        if not prefix.endswith(nl + nl):
+            prefix += nl
+        return UpsertResult(
+            new_bytes=prefix + block,
+            status=UpsertStatus.APPENDED,
+            block_version=version,
+        )
+
+    assert parsed.location is not None  # type narrowing for the PRESENT branch
+    loc = parsed.location
+    if loc.version > version:
+        return UpsertResult(
+            new_bytes=host,
+            status=UpsertStatus.NEWER_VERSION,
+            block_version=loc.version,
+        )
+
+    new_bytes = host[: loc.line_start] + block + host[loc.line_end :]
+    if new_bytes == host:
+        return UpsertResult(new_bytes=host, status=UpsertStatus.UNCHANGED, block_version=version)
+    if loc.version < version:
+        return UpsertResult(new_bytes=new_bytes, status=UpsertStatus.MIGRATED, block_version=version)
+    return UpsertResult(new_bytes=new_bytes, status=UpsertStatus.UPDATED, block_version=version)

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/__init__.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/__init__.py
@@ -1,0 +1,35 @@
+"""Per-target renderers for ``--agent-instructions``.
+
+Each renderer returns a string. Managed-block targets return only the
+*inner* content (what goes between the markers); the cursor renderer
+returns the full file body since we own the whole file.
+
+Content is sourced from ``docs/target-repo-agent-snippets.md``. A snapshot
+test enforces parity so the doc and renderers cannot drift independently.
+"""
+
+from __future__ import annotations
+
+from agents_shipgate.cli.discovery.agent_instructions.renderers.agents_md import (
+    render_block as render_agents_md,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers.claude_md import (
+    render_block as render_claude_md,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers.cursor import (
+    PRIOR_RENDER_SHA256 as CURSOR_PRIOR_RENDER_SHA256,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers.cursor import (
+    render_file as render_cursor_file,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers.pr_template import (
+    render_block as render_pr_template,
+)
+
+__all__ = [
+    "CURSOR_PRIOR_RENDER_SHA256",
+    "render_agents_md",
+    "render_claude_md",
+    "render_cursor_file",
+    "render_pr_template",
+]

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/_shared.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/_shared.py
@@ -1,0 +1,14 @@
+"""Shared snippets reused across multiple renderers.
+
+Centralizing the wording here keeps surfaces consistent and makes the Rule 3
+guard (``ci_mode: strict`` only appears in the CI-pointer paragraph) easy to
+enforce with a snapshot test.
+"""
+
+from __future__ import annotations
+
+CI_POINTER_PARAGRAPH = (
+    "CI runs via `.github/workflows/agents-shipgate.yml`. Generate it with "
+    "`agents-shipgate init --ci`. The default mode is `ci_mode: advisory`. "
+    "Promotion to `ci_mode: strict` is a human decision after baseline review."
+)

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/agents_md.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/agents_md.py
@@ -1,0 +1,57 @@
+"""Render the inner content for the AGENTS.md managed block.
+
+Content lifted from ``docs/target-repo-agent-snippets.md`` (the `## AGENTS.md`
+section) plus a closing ``### CI`` mini-section with the shared advisory pointer.
+"""
+
+from __future__ import annotations
+
+from agents_shipgate.cli.discovery.agent_instructions.renderers._shared import (
+    CI_POINTER_PARAGRAPH,
+)
+
+
+def render_block() -> str:
+    """Return the inner content (between markers) for AGENTS.md."""
+    return f"""## Agent Release Readiness
+
+This repo uses Agents Shipgate as the static release-readiness preflight for
+AI agent tool surfaces.
+
+Run Shipgate when this PR changes agent tools, MCP exports, OpenAPI specs,
+prompts that constrain tool use, permissions, approval policies,
+confirmation policies, CI release gates, or `shipgate.yaml`.
+
+Skip Shipgate for pure docs, tests, formatting, or refactors with no tool or
+policy impact unless the user explicitly asks.
+
+Commands:
+
+```bash
+agents-shipgate detect --workspace . --json
+agents-shipgate init --workspace . --write --ci --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+agents-shipgate apply-patches \\
+  --from agents-shipgate-reports/report.json \\
+  --confidence high --apply
+```
+
+Always parse `agents-shipgate-reports/report.json`, not Markdown. Use
+`release_decision.decision` as the release signal.
+
+Auto-apply only high-confidence safe patches. Do not auto-assert approval,
+confirmation, idempotency, broad-scope, or prohibited-action policy decisions;
+surface those as human review items.
+
+Before committing, ensure `.gitignore` includes:
+
+```gitignore
+agents-shipgate-reports/
+```
+
+### CI
+
+{CI_POINTER_PARAGRAPH}
+
+<sub>Managed by agents-shipgate; rerun `agents-shipgate init --write --agent-instructions=agents-md` to refresh. If your linter forbids raw HTML, exempt `<!-- agents-shipgate:* -->`.</sub>
+"""

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/claude_md.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/claude_md.py
@@ -1,0 +1,47 @@
+"""Render the inner content for the CLAUDE.md managed block.
+
+Content lifted from ``docs/target-repo-agent-snippets.md`` (the `## CLAUDE.md`
+section). Self-contained — no cross-link to AGENTS.md so generating only this
+target does not produce a dangling reference.
+"""
+
+from __future__ import annotations
+
+from agents_shipgate.cli.discovery.agent_instructions.renderers._shared import (
+    CI_POINTER_PARAGRAPH,
+)
+
+
+def render_block() -> str:
+    """Return the inner content (between markers) for CLAUDE.md."""
+    return f"""## Agents Shipgate
+
+For agent tool-surface or release-policy changes, run:
+
+```bash
+agents-shipgate detect --workspace . --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+```
+
+Read `agents-shipgate-reports/report.json` and summarize:
+
+- `release_decision.decision`
+- blocker count
+- review item count
+- top critical/high findings
+- safe patches applied
+- findings requiring human review
+
+Use `apply-patches --confidence high --apply` only for high-confidence safe
+patches. Approval, confirmation, idempotency, broad-scope, and prohibited-action
+changes require human review.
+
+Set `AGENTS_SHIPGATE_AGENT_MODE=1` so errors emit a `next_action` JSON line on
+stderr.
+
+### CI
+
+{CI_POINTER_PARAGRAPH}
+
+<sub>Managed by agents-shipgate; rerun `agents-shipgate init --write --agent-instructions=claude-md` to refresh.</sub>
+"""

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/cursor.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/cursor.py
@@ -1,0 +1,56 @@
+"""Render the full ``.cursor/rules/agents-shipgate.mdc`` file.
+
+We own the whole file. Content lifted from ``docs/target-repo-agent-snippets.md``
+(the ``## .cursor/rules/agents-shipgate.mdc`` section).
+
+Idempotency: the file is overwritten only if its current SHA-256 matches a hash
+the package has shipped previously (this list grows when ``BLOCK_VERSION`` bumps).
+A user-edited file the CLI has never produced is left alone with status
+``skipped_user_modified``.
+"""
+
+from __future__ import annotations
+
+from agents_shipgate.cli.discovery.agent_instructions.renderers._shared import (
+    CI_POINTER_PARAGRAPH,
+)
+
+
+def render_file() -> str:
+    """Return the full file body for ``.cursor/rules/agents-shipgate.mdc``."""
+    return f"""---
+description: Run Agents Shipgate for AI agent tool-surface release readiness.
+globs:
+  - "shipgate.yaml"
+  - "**/*openapi*.yaml"
+  - "**/*openapi*.yml"
+  - "**/*openapi*.json"
+  - "**/*swagger*.yaml"
+  - "**/*swagger*.yml"
+  - "**/*swagger*.json"
+  - "**/*mcp*.json"
+  - "**/*tools*.json"
+  - "**/*.py"
+alwaysApply: false
+---
+
+When a change affects agent tools, MCP exports, OpenAPI specs, prompts,
+permissions, approval policies, or release gates, run Agents Shipgate.
+
+Use `agents-shipgate-reports/report.json` as the source of truth. Prefer
+`release_decision.decision` over legacy severity/status summaries.
+
+Apply only high-confidence safe patches. Do not invent approval, confirmation,
+or idempotency evidence.
+
+## CI
+
+{CI_POINTER_PARAGRAPH}
+"""
+
+
+# SHA-256 hashes of every prior render of this file. When BLOCK_VERSION bumps
+# and the rendered content changes, the previous current-render hash moves into
+# this tuple so the next CLI run can safely overwrite v(N-1) files. Leave the
+# tuple empty when there is no prior shipped version (v=1 is the initial).
+PRIOR_RENDER_SHA256: tuple[str, ...] = ()

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/pr_template.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/pr_template.py
@@ -1,0 +1,29 @@
+"""Render the inner content for the PR template managed block.
+
+Content lifted from ``docs/target-repo-agent-snippets.md`` (the
+``## .github/pull_request_template.md`` section). The conditional "If this PR
+changes…" wording avoids docs-only false positives.
+"""
+
+from __future__ import annotations
+
+
+def render_block() -> str:
+    """Return the inner content (between markers) for the PR template."""
+    return """## Agent Tool-Surface Release Readiness
+
+- [ ] If this PR changes agent tools, MCP/OpenAPI specs, prompts, permissions,
+      approval policy, confirmation policy, CI release gates, or
+      `shipgate.yaml`, I ran:
+
+      ```bash
+      agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+      ```
+
+- [ ] I reviewed `agents-shipgate-reports/report.json` and used
+      `release_decision.decision` as the release signal.
+- [ ] I did not auto-assert approval, confirmation, idempotency, broad-scope,
+      or prohibited-action policy decisions.
+
+<sub>Managed by agents-shipgate; rerun `agents-shipgate init --write --agent-instructions=pr-template` to refresh.</sub>
+"""

--- a/src/agents_shipgate/cli/discovery/agent_instructions/targets.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/targets.py
@@ -1,0 +1,79 @@
+"""Target registry and selector parsing for ``--agent-instructions=``.
+
+The selector accepts:
+
+- ``all``  — every registered target.
+- ``none`` — no targets (rare; mirrors ``--minimal`` as an explicit opt-out).
+- A comma-separated list of target names, e.g. ``agents-md,cursor``.
+
+Unknown names raise :class:`InvalidSelector`. The CLI converts that into a
+``config_error`` agent-mode error JSON line + a ``next_action`` pointing at
+the valid set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Bumped only on incompatible content changes (e.g., the report.json contract
+# evolves and prior blocks would mislead). Renderer-format version, NOT the
+# package version — package version stamping would rotate hashes every release.
+BLOCK_VERSION: int = 1
+
+# Order is the order targets are applied and printed. AGENTS.md first because
+# it's the agent-facing entry point; CLAUDE.md mirrors it for Claude users;
+# Cursor is a separate IDE rule file; PR template is reviewer-facing.
+TARGETS: tuple[str, ...] = ("agents-md", "claude-md", "cursor", "pr-template")
+
+
+class InvalidSelector(ValueError):
+    """Raised when ``--agent-instructions=<value>`` contains an unknown name."""
+
+
+@dataclass(frozen=True)
+class TargetSpec:
+    name: str
+    relative_path: str  # default; PR template may resolve a different casing
+    is_full_file: bool  # True for cursor (we own the whole file), False for managed-block targets
+
+
+SPECS: dict[str, TargetSpec] = {
+    "agents-md": TargetSpec(name="agents-md", relative_path="AGENTS.md", is_full_file=False),
+    "claude-md": TargetSpec(name="claude-md", relative_path="CLAUDE.md", is_full_file=False),
+    "cursor": TargetSpec(
+        name="cursor",
+        relative_path=".cursor/rules/agents-shipgate.mdc",
+        is_full_file=True,
+    ),
+    "pr-template": TargetSpec(
+        name="pr-template",
+        relative_path=".github/pull_request_template.md",
+        is_full_file=False,
+    ),
+}
+
+
+def parse_selector(value: str) -> list[str]:
+    """Parse a selector string into an ordered, deduplicated list of target names.
+
+    Empty selector is rejected — the CLI must pass ``all`` or ``none`` explicitly.
+    """
+    raw = (value or "").strip()
+    if not raw:
+        raise InvalidSelector(
+            "Empty selector. Pass --agent-instructions=all, --agent-instructions=none, "
+            "or a comma-separated list of: " + ", ".join(TARGETS)
+        )
+    if raw == "all":
+        return list(TARGETS)
+    if raw == "none":
+        return []
+    requested = [item.strip() for item in raw.split(",") if item.strip()]
+    unknown = [name for name in requested if name not in SPECS]
+    if unknown:
+        raise InvalidSelector(
+            f"Unknown agent-instruction target(s): {', '.join(unknown)}. "
+            f"Valid targets: {', '.join(TARGETS)}."
+        )
+    # Preserve the order TARGETS declares so output is stable across selector permutations.
+    return [name for name in TARGETS if name in requested]

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -612,12 +612,16 @@ def init(
         agent_instructions_exit = ai_result.exit_code
         agent_instructions_targets = list(ai_result.targets)
 
-    # Idempotency reconciliation: when --agent-instructions is set and the
-    # manifest already exists, treat the manifest action as already-done so
-    # that `init --write --agent-instructions=<target>` is safe to rerun (the
-    # advertised refresh command). The manifest_status field still reports
-    # "skipped_existing" so callers can detect.
-    if requested_targets is not None and manifest_status == "skipped_existing":
+    # Idempotency reconciliation: when --agent-instructions selects at least
+    # one real target AND the manifest already exists, treat the manifest
+    # action as already-done so `init --write --agent-instructions=<target>`
+    # is safe to rerun (the advertised refresh command). The manifest_status
+    # field still reports "skipped_existing" so callers can detect.
+    #
+    # `=none` parses to an empty list — no instruction action runs, so this
+    # accommodation does NOT apply and manifest skip remains exit 2 (matches
+    # plain `init --write`).
+    if requested_targets and manifest_status == "skipped_existing":
         manifest_exit = 0
         manifest_skip_pending = False
     if manifest_skip_pending:

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -29,6 +29,12 @@ from agents_shipgate.cli.discovery import (
     render_manifest_template,
     write_ci_workflow,
 )
+from agents_shipgate.cli.discovery.agent_instructions import (
+    InvalidSelector,
+    apply_agent_instructions,
+    parse_selector,
+)
+from agents_shipgate.cli.discovery.agent_instructions.targets import SPECS as _AI_SPECS
 from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.evidence_packet import evidence_packet as _evidence_packet_command
 from agents_shipgate.cli.fixture import fixture_app
@@ -432,6 +438,22 @@ def init(
             "calls ThreeMoonsLab/agents-shipgate."
         ),
     ),
+    agent_instructions: str | None = typer.Option(
+        None,
+        "--agent-instructions",
+        help=(
+            "Render or write agent-instruction snippets for the target repo. "
+            "Pass --agent-instructions=all for every target, "
+            "--agent-instructions=agents-md,cursor for a subset, or "
+            "--agent-instructions=none to opt out. "
+            "Without --write, snippets are printed to stdout (or returned in "
+            "--json). With --write, snippets are written to AGENTS.md, "
+            "CLAUDE.md, .cursor/rules/agents-shipgate.mdc, and the PR template "
+            "via managed `<!-- agents-shipgate:start -->` markers (idempotent "
+            "and safe to rerun). Strict CI and baselines remain opt-in human "
+            "decisions; this flag only emits advisory guidance."
+        ),
+    ),
 ) -> None:
     """Draft a starter shipgate.yaml from a workspace.
 
@@ -441,6 +463,37 @@ def init(
     """
     workspace_resolved = workspace.resolve()
     target = workspace / "shipgate.yaml"
+
+    # Parse --agent-instructions selector early so invalid input fails before
+    # any filesystem mutation. ``None`` = flag absent.
+    requested_targets: list[str] | None
+    if agent_instructions is None:
+        requested_targets = None
+    else:
+        try:
+            requested_targets = parse_selector(agent_instructions)
+        except InvalidSelector as exc:
+            typer.echo(str(exc), err=True)
+            _emit_agent_mode_error(
+                "config_error",
+                message=str(exc),
+                next_action=(
+                    "Pass --agent-instructions=all, --agent-instructions=none, "
+                    "or a comma-separated subset."
+                ),
+                next_actions=[
+                    NextAction(
+                        kind="command",
+                        command="agents-shipgate init --agent-instructions=all",
+                        why=str(exc),
+                        expects=(
+                            "Snippets render for every supported target "
+                            "(AGENTS.md, CLAUDE.md, Cursor rule, PR template)."
+                        ),
+                    ).model_dump(mode="json")
+                ],
+            )
+            raise typer.Exit(2) from exc
 
     if minimal:
         template = render_manifest_template(workspace_resolved)
@@ -561,6 +614,18 @@ def init(
         if result.cross_reference_path is not None:
             workflow_outcome["cross_reference_path"] = result.cross_reference_path
 
+    # Agent-instructions action — independent of manifest and workflow actions.
+    agent_instructions_outcome: dict[str, object] | None = None
+    agent_instructions_exit = 0
+    agent_instructions_targets: list[object] = []
+    if requested_targets is not None:
+        ai_result = apply_agent_instructions(
+            workspace_resolved, requested_targets, write=write
+        )
+        agent_instructions_outcome = ai_result.to_json()
+        agent_instructions_exit = ai_result.exit_code
+        agent_instructions_targets = list(ai_result.targets)
+
     # Output
     if json_output:
         payload: dict[str, object] = {
@@ -580,10 +645,23 @@ def init(
             payload["auto_detected"] = auto_detected
         if workflow_outcome is not None:
             payload["workflow"] = workflow_outcome
+        if agent_instructions_outcome is not None:
+            payload["agent_instructions"] = agent_instructions_outcome
         typer.echo(json.dumps(payload, indent=2))
     else:
         if not write:
-            typer.echo(template)
+            if requested_targets is not None:
+                # Manifest + each requested target, separated by section headers
+                # so the output is unambiguous.
+                typer.echo("--- shipgate.yaml ---")
+                typer.echo(template)
+                for outcome in agent_instructions_targets:
+                    relative = _AI_SPECS[outcome.name].relative_path
+                    typer.echo("")
+                    typer.echo(f"--- {relative} ---")
+                    typer.echo(outcome.rendered or "")
+            else:
+                typer.echo(template)
         else:
             if manifest_status == "written":
                 typer.echo(manifest_message)
@@ -601,9 +679,43 @@ def init(
                 else sys.stdout
             )
             print(workflow_outcome["message"], file=stream)
+        if write and agent_instructions_targets:
+            for outcome in agent_instructions_targets:
+                stream = sys.stderr if outcome.status.startswith("skipped") else sys.stdout
+                if outcome.message:
+                    print(outcome.message, file=stream)
 
-    if manifest_exit:
-        raise typer.Exit(manifest_exit)
+    # Surface a structured next_action JSON line for the rank-1 skipped target
+    # so coding-agent callers can route to a fix without scraping stdout. Gated
+    # on AGENTS_SHIPGATE_AGENT_MODE=1 by `_emit_agent_mode_error` itself.
+    if agent_instructions_exit:
+        first_skip = next(
+            (t for t in agent_instructions_targets if t.status.startswith("skipped")),
+            None,
+        )
+        if first_skip is not None:
+            _emit_agent_mode_error(
+                "config_already_exists",
+                path=first_skip.path,
+                message=first_skip.message,
+                next_action=f"Edit {first_skip.path}",
+                next_actions=[
+                    NextAction(
+                        kind="edit",
+                        path=first_skip.path,
+                        why=first_skip.message
+                        or f"{first_skip.path} is in a state we will not overwrite.",
+                        expects=(
+                            "After resolving, re-run "
+                            f"`agents-shipgate init --write --agent-instructions={first_skip.name}`."
+                        ),
+                    ).model_dump(mode="json")
+                ],
+            )
+
+    final_exit = max(manifest_exit, agent_instructions_exit)
+    if final_exit:
+        raise typer.Exit(final_exit)
 
 
 def _validate_manifest_text(text: str) -> None:

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -573,30 +573,16 @@ def init(
     manifest_status = "not_attempted"
     manifest_exit = 0
     manifest_message: str | None = None
+    manifest_skip_pending = False
     if write:
         if target.exists():
             manifest_status = "skipped_existing"
             manifest_exit = 2
             manifest_message = f"Config already exists: {target}"
-            _emit_agent_mode_error(
-                "config_already_exists",
-                path=str(target),
-                next_action=f"Edit {target}",
-                next_actions=[
-                    NextAction(
-                        kind="edit",
-                        path=str(target),
-                        why=(
-                            f"{target} already exists. Edit it directly or "
-                            "remove it before re-running init --write."
-                        ),
-                        expects=(
-                            "Manifest reflects the desired tool sources, "
-                            "agent declared_purpose, and policies."
-                        ),
-                    ).model_dump(mode="json")
-                ],
-            )
+            # Defer the agent-mode error emit. When --agent-instructions is
+            # set the user's primary intent is refreshing snippets, and an
+            # already-existing manifest is informational, not a failure.
+            manifest_skip_pending = True
         else:
             target.write_text(template, encoding="utf-8")
             manifest_status = "written"
@@ -625,6 +611,35 @@ def init(
         agent_instructions_outcome = ai_result.to_json()
         agent_instructions_exit = ai_result.exit_code
         agent_instructions_targets = list(ai_result.targets)
+
+    # Idempotency reconciliation: when --agent-instructions is set and the
+    # manifest already exists, treat the manifest action as already-done so
+    # that `init --write --agent-instructions=<target>` is safe to rerun (the
+    # advertised refresh command). The manifest_status field still reports
+    # "skipped_existing" so callers can detect.
+    if requested_targets is not None and manifest_status == "skipped_existing":
+        manifest_exit = 0
+        manifest_skip_pending = False
+    if manifest_skip_pending:
+        _emit_agent_mode_error(
+            "config_already_exists",
+            path=str(target),
+            next_action=f"Edit {target}",
+            next_actions=[
+                NextAction(
+                    kind="edit",
+                    path=str(target),
+                    why=(
+                        f"{target} already exists. Edit it directly or "
+                        "remove it before re-running init --write."
+                    ),
+                    expects=(
+                        "Manifest reflects the desired tool sources, "
+                        "agent declared_purpose, and policies."
+                    ),
+                ).model_dump(mode="json")
+            ],
+        )
 
     # Output
     if json_output:

--- a/tests/test_agent_instructions_apply.py
+++ b/tests/test_agent_instructions_apply.py
@@ -46,6 +46,11 @@ case_sensitive_fs = pytest.mark.skipif(
     reason="PR-template casing tests require a case-sensitive filesystem.",
 )
 
+case_insensitive_fs = pytest.mark.skipif(
+    _filesystem_is_case_sensitive(Path(__file__).parent),
+    reason="Test asserts case-insensitive samefile collapsing.",
+)
+
 # --- selector parsing ------------------------------------------------------
 
 
@@ -318,3 +323,83 @@ def test_apply_exit_code_is_max_of_target_contributions(tmp_path: Path) -> None:
 def test_block_version_constant_is_one() -> None:
     """v1 is the initial release; bump only on incompatible content changes."""
     assert BLOCK_VERSION == 1
+
+
+# --- symlink safety --------------------------------------------------------
+
+
+def test_apply_refuses_to_follow_symlink_for_managed_block_target(
+    tmp_path: Path,
+) -> None:
+    """A symlink at AGENTS.md must NOT be followed — otherwise an in-repo
+    `AGENTS.md -> ~/.zshrc` would mutate a file outside the workspace."""
+    decoy_target = tmp_path / "real_target.md"
+    decoy_target.write_text("USER PROSE outside the snippet system\n", encoding="utf-8")
+    link = tmp_path / "AGENTS.md"
+    link.symlink_to(decoy_target)
+    result = apply_agent_instructions(tmp_path, ["agents-md"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_symlink"
+    assert result.exit_code == 2
+    # The link target was not mutated.
+    assert decoy_target.read_text(encoding="utf-8") == (
+        "USER PROSE outside the snippet system\n"
+    )
+    # The symlink still points at the original target.
+    assert link.is_symlink()
+    assert link.readlink() == decoy_target
+
+
+def test_apply_refuses_to_follow_symlink_for_cursor_target(
+    tmp_path: Path,
+) -> None:
+    """The full-file cursor target must also refuse symlinks."""
+    decoy_target = tmp_path / "real_cursor_rule.md"
+    decoy_target.write_text("not a cursor rule\n", encoding="utf-8")
+    link_dir = tmp_path / ".cursor" / "rules"
+    link_dir.mkdir(parents=True)
+    link = link_dir / "agents-shipgate.mdc"
+    link.symlink_to(decoy_target)
+    result = apply_agent_instructions(tmp_path, ["cursor"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_symlink"
+    assert result.exit_code == 2
+    assert decoy_target.read_text(encoding="utf-8") == "not a cursor rule\n"
+
+
+def test_apply_does_not_resolve_symlinked_workspace_path(tmp_path: Path) -> None:
+    """When the workspace itself contains a symlink, the relative target
+    path must stay lexical (workspace / relative). We must not resolve()
+    the joined target path or symlinks inside the workspace would route
+    writes outside it."""
+    # Build a workspace with no symlinks; the assertion is structural — the
+    # resulting outcome path is the lexical join, not a resolved one.
+    result = apply_agent_instructions(tmp_path, ["agents-md"], write=True)
+    [outcome] = result.targets
+    expected = tmp_path.resolve() / "AGENTS.md"
+    assert outcome.path == str(expected)
+
+
+# --- case-insensitive PR template -----------------------------------------
+
+
+@case_insensitive_fs
+def test_pr_template_collapses_casings_on_case_insensitive_fs(
+    tmp_path: Path,
+) -> None:
+    """On macOS APFS / Windows NTFS, both casings address the same inode.
+    The CLI must NOT report ``skipped_ambiguous`` when there is only one
+    file on disk — it must treat them as the same path."""
+    # Create the file using the lowercase form. Both `is_file()` calls
+    # return True on a case-insensitive FS.
+    lower = tmp_path / PR_TEMPLATE_LOWER
+    lower.parent.mkdir(parents=True)
+    lower.write_text("# user prose, no marker\n", encoding="utf-8")
+    upper = tmp_path / PR_TEMPLATE_UPPER
+    assert upper.is_file()  # confirms the FS is case-insensitive
+    result = apply_agent_instructions(tmp_path, ["pr-template"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "appended"
+    assert result.exit_code == 0
+    # User content preserved.
+    assert "user prose, no marker" in lower.read_text(encoding="utf-8")

--- a/tests/test_agent_instructions_apply.py
+++ b/tests/test_agent_instructions_apply.py
@@ -1,0 +1,320 @@
+"""Library-level tests for ``apply.py`` and ``targets.py``.
+
+Covers the per-target decision tree (every status in the enum), the selector
+parser, and PR template path resolution edge cases.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.cli.discovery.agent_instructions import (
+    BLOCK_VERSION,
+    TARGETS,
+    InvalidSelector,
+    apply_agent_instructions,
+    parse_selector,
+)
+from agents_shipgate.cli.discovery.agent_instructions.apply import (
+    PR_TEMPLATE_DIR,
+    PR_TEMPLATE_LOWER,
+    PR_TEMPLATE_UPPER,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers import (
+    cursor as cursor_module,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers import (
+    render_agents_md,
+    render_cursor_file,
+)
+
+
+def _filesystem_is_case_sensitive(path: Path) -> bool:
+    probe = path / ".__case_probe__"
+    probe.write_bytes(b"x")
+    try:
+        return not (path / ".__CASE_PROBE__").exists()
+    finally:
+        probe.unlink()
+
+
+case_sensitive_fs = pytest.mark.skipif(
+    not _filesystem_is_case_sensitive(Path(__file__).parent),
+    reason="PR-template casing tests require a case-sensitive filesystem.",
+)
+
+# --- selector parsing ------------------------------------------------------
+
+
+def test_parse_selector_all_returns_every_target() -> None:
+    assert parse_selector("all") == list(TARGETS)
+
+
+def test_parse_selector_none_returns_empty_list() -> None:
+    assert parse_selector("none") == []
+
+
+def test_parse_selector_csv_preserves_canonical_order() -> None:
+    # Selector order is normalized to TARGETS order so JSON output is stable.
+    assert parse_selector("cursor,agents-md") == ["agents-md", "cursor"]
+
+
+def test_parse_selector_strips_whitespace() -> None:
+    assert parse_selector(" agents-md ,  cursor ") == ["agents-md", "cursor"]
+
+
+def test_parse_selector_empty_value_is_invalid() -> None:
+    with pytest.raises(InvalidSelector):
+        parse_selector("")
+
+
+def test_parse_selector_unknown_target_is_invalid() -> None:
+    with pytest.raises(InvalidSelector) as exc:
+        parse_selector("agents-md,bogus")
+    assert "bogus" in str(exc.value)
+    # Error message advertises valid targets so agents can self-correct.
+    for valid in TARGETS:
+        assert valid in str(exc.value)
+
+
+# --- dry-run (write=False) -------------------------------------------------
+
+
+def test_apply_dry_run_does_not_touch_filesystem(tmp_path: Path) -> None:
+    result = apply_agent_instructions(tmp_path, list(TARGETS), write=False)
+    assert result.exit_code == 0
+    assert {t.status for t in result.targets} == {"would_render"}
+    assert all(t.rendered for t in result.targets)
+    # No files created in tmp_path.
+    assert list(tmp_path.iterdir()) == []
+
+
+# --- fresh workspace -------------------------------------------------------
+
+
+def test_apply_write_fresh_workspace_creates_all_targets(tmp_path: Path) -> None:
+    result = apply_agent_instructions(tmp_path, list(TARGETS), write=True)
+    assert result.exit_code == 0
+    assert {t.status for t in result.targets} == {"created_with_block"}
+    # Files exist where expected.
+    assert (tmp_path / "AGENTS.md").exists()
+    assert (tmp_path / "CLAUDE.md").exists()
+    assert (tmp_path / ".cursor/rules/agents-shipgate.mdc").exists()
+    assert (tmp_path / PR_TEMPLATE_LOWER).exists()
+    # AGENTS.md preamble + block.
+    agents_md = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert agents_md.startswith("# Agents")
+    assert "<!-- agents-shipgate:start v=1 -->" in agents_md
+    assert "<!-- agents-shipgate:end -->" in agents_md
+
+
+def test_apply_write_idempotent_repeat(tmp_path: Path) -> None:
+    """Re-running with no changes is a no-op (UNCHANGED, byte-equal)."""
+    apply_agent_instructions(tmp_path, list(TARGETS), write=True)
+    snapshot = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    second = apply_agent_instructions(tmp_path, list(TARGETS), write=True)
+    assert second.exit_code == 0
+    assert {t.status for t in second.targets} == {"unchanged"}
+    after = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    assert snapshot == after
+
+
+# --- AGENTS.md edge cases --------------------------------------------------
+
+
+def test_apply_appends_to_existing_agents_md_without_markers(tmp_path: Path) -> None:
+    original = "# My Project\n\nExisting content.\n"
+    (tmp_path / "AGENTS.md").write_text(original, encoding="utf-8")
+    result = apply_agent_instructions(tmp_path, ["agents-md"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "appended"
+    after = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    # User content preserved byte-for-byte at the start.
+    assert after.startswith(original)
+    assert "<!-- agents-shipgate:start v=1 -->" in after
+
+
+def test_apply_updates_existing_block_when_content_differs(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text(
+        "<!-- agents-shipgate:start v=1 -->\n"
+        "outdated body\n"
+        "<!-- agents-shipgate:end -->\n",
+        encoding="utf-8",
+    )
+    result = apply_agent_instructions(tmp_path, ["agents-md"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "updated"
+    # New block matches current renderer output.
+    after = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert render_agents_md().splitlines()[0] in after
+
+
+def test_apply_skips_when_block_version_is_newer(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text(
+        "<!-- agents-shipgate:start v=99 -->\n"
+        "future content\n"
+        "<!-- agents-shipgate:end -->\n",
+        encoding="utf-8",
+    )
+    result = apply_agent_instructions(tmp_path, ["agents-md"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_newer_version"
+    assert outcome.exit_contribution == 2
+    assert result.exit_code == 2
+    # File untouched.
+    assert "future content" in (tmp_path / "AGENTS.md").read_text()
+
+
+def test_apply_skips_when_markers_are_ambiguous(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text(
+        "<!-- agents-shipgate:start v=1 -->\n"
+        "a\n"
+        "<!-- agents-shipgate:start v=1 -->\n"
+        "b\n"
+        "<!-- agents-shipgate:end -->\n",
+        encoding="utf-8",
+    )
+    result = apply_agent_instructions(tmp_path, ["agents-md"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_ambiguous"
+    assert result.exit_code == 2
+
+
+# --- cursor edge cases -----------------------------------------------------
+
+
+def test_cursor_unchanged_when_file_matches_current_render(tmp_path: Path) -> None:
+    target = tmp_path / ".cursor/rules/agents-shipgate.mdc"
+    target.parent.mkdir(parents=True)
+    target.write_text(render_cursor_file(), encoding="utf-8")
+    result = apply_agent_instructions(tmp_path, ["cursor"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "unchanged"
+
+
+def test_cursor_skipped_when_user_modified(tmp_path: Path) -> None:
+    target = tmp_path / ".cursor/rules/agents-shipgate.mdc"
+    target.parent.mkdir(parents=True)
+    target.write_text("# my own cursor rule, hands off\n", encoding="utf-8")
+    result = apply_agent_instructions(tmp_path, ["cursor"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_user_modified"
+    assert outcome.exit_contribution == 2
+    # File untouched.
+    assert target.read_text(encoding="utf-8") == "# my own cursor rule, hands off\n"
+
+
+def test_cursor_migrated_when_file_matches_prior_render(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Simulate a prior shipped render whose hash is registered."""
+    prior_text = "stub-prior-render\n"
+    prior_sha = hashlib.sha256(prior_text.encode("utf-8")).hexdigest()
+    monkeypatch.setattr(cursor_module, "PRIOR_RENDER_SHA256", (prior_sha,))
+    # Reload the symbol that apply imported at module load.
+    from agents_shipgate.cli.discovery.agent_instructions import renderers as _r
+    monkeypatch.setattr(_r, "CURSOR_PRIOR_RENDER_SHA256", (prior_sha,))
+    from agents_shipgate.cli.discovery.agent_instructions import apply as apply_module
+    monkeypatch.setattr(apply_module, "CURSOR_PRIOR_RENDER_SHA256", (prior_sha,))
+
+    target = tmp_path / ".cursor/rules/agents-shipgate.mdc"
+    target.parent.mkdir(parents=True)
+    target.write_text(prior_text, encoding="utf-8")
+
+    result = apply_agent_instructions(tmp_path, ["cursor"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "migrated"
+    # File now matches current render.
+    assert target.read_text(encoding="utf-8") == render_cursor_file()
+
+
+# --- PR template path discovery -------------------------------------------
+
+
+def test_pr_template_creates_lowercase_when_neither_exists(tmp_path: Path) -> None:
+    result = apply_agent_instructions(tmp_path, ["pr-template"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "created_with_block"
+    assert (tmp_path / PR_TEMPLATE_LOWER).exists()
+    # Resolved path uses the lowercase form per GitHub's documented convention.
+    assert outcome.path.endswith("pull_request_template.md")
+
+
+@case_sensitive_fs
+def test_pr_template_uses_uppercase_when_only_uppercase_exists(tmp_path: Path) -> None:
+    upper = tmp_path / PR_TEMPLATE_UPPER
+    upper.parent.mkdir(parents=True)
+    upper.write_text("# Existing\n", encoding="utf-8")
+    result = apply_agent_instructions(tmp_path, ["pr-template"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "appended"
+    assert outcome.path.endswith("PULL_REQUEST_TEMPLATE.md")
+    assert not (tmp_path / PR_TEMPLATE_LOWER).exists()
+
+
+@case_sensitive_fs
+def test_pr_template_picks_marked_one_when_both_exist(tmp_path: Path) -> None:
+    upper = tmp_path / PR_TEMPLATE_UPPER
+    upper.parent.mkdir(parents=True)
+    upper.write_text("# Untouched\n", encoding="utf-8")
+    lower = tmp_path / PR_TEMPLATE_LOWER
+    lower.write_text(
+        "# With marker\n"
+        "<!-- agents-shipgate:start v=1 -->\n"
+        "stale\n"
+        "<!-- agents-shipgate:end -->\n",
+        encoding="utf-8",
+    )
+    result = apply_agent_instructions(tmp_path, ["pr-template"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "updated"
+    # Used the marked file, ignored the unmarked one.
+    assert outcome.path.endswith("pull_request_template.md")
+    assert upper.read_text(encoding="utf-8") == "# Untouched\n"
+
+
+@case_sensitive_fs
+def test_pr_template_ambiguous_when_both_exist_without_marker(tmp_path: Path) -> None:
+    upper = tmp_path / PR_TEMPLATE_UPPER
+    lower = tmp_path / PR_TEMPLATE_LOWER
+    upper.parent.mkdir(parents=True)
+    upper.write_text("# upper\n", encoding="utf-8")
+    lower.write_text("# lower\n", encoding="utf-8")
+    result = apply_agent_instructions(tmp_path, ["pr-template"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_ambiguous"
+    assert result.exit_code == 2
+
+
+def test_pr_template_skips_when_directory_form_exists(tmp_path: Path) -> None:
+    directory = tmp_path / PR_TEMPLATE_DIR
+    directory.mkdir(parents=True)
+    (directory / "feature.md").write_text("# template a\n", encoding="utf-8")
+    result = apply_agent_instructions(tmp_path, ["pr-template"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_directory_template"
+    assert result.exit_code == 2
+
+
+# --- aggregate exit code ---------------------------------------------------
+
+
+def test_apply_exit_code_is_max_of_target_contributions(tmp_path: Path) -> None:
+    """Mix one success and one skip; result.exit_code must be 2."""
+    # Force cursor into skipped_user_modified.
+    cursor_path = tmp_path / ".cursor/rules/agents-shipgate.mdc"
+    cursor_path.parent.mkdir(parents=True)
+    cursor_path.write_text("custom cursor content\n", encoding="utf-8")
+    result = apply_agent_instructions(tmp_path, ["agents-md", "cursor"], write=True)
+    statuses = {t.name: t.status for t in result.targets}
+    assert statuses["agents-md"] == "created_with_block"
+    assert statuses["cursor"] == "skipped_user_modified"
+    assert result.exit_code == 2
+
+
+def test_block_version_constant_is_one() -> None:
+    """v1 is the initial release; bump only on incompatible content changes."""
+    assert BLOCK_VERSION == 1

--- a/tests/test_agent_instructions_apply.py
+++ b/tests/test_agent_instructions_apply.py
@@ -380,6 +380,60 @@ def test_apply_does_not_resolve_symlinked_workspace_path(tmp_path: Path) -> None
     assert outcome.path == str(expected)
 
 
+def test_apply_refuses_symlinked_parent_directory_for_pr_template(
+    tmp_path: Path,
+) -> None:
+    """Parent-directory symlink escape: `.github -> /tmp/outside` would
+    otherwise route `.github/pull_request_template.md` writes to the
+    outside directory. The chain check must reject this."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / ".github").symlink_to(outside)
+    result = apply_agent_instructions(workspace, ["pr-template"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_symlink"
+    assert result.exit_code == 2
+    # No file written to the outside directory.
+    assert list(outside.iterdir()) == []
+
+
+def test_apply_refuses_symlinked_parent_directory_for_cursor(
+    tmp_path: Path,
+) -> None:
+    """Same chain check applies to the cursor full-file target — the
+    `.cursor` parent must not be a symlink."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / ".cursor").symlink_to(outside)
+    result = apply_agent_instructions(workspace, ["cursor"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_symlink"
+    assert result.exit_code == 2
+    assert list(outside.iterdir()) == []
+
+
+def test_apply_refuses_intermediate_symlinked_subdirectory_for_cursor(
+    tmp_path: Path,
+) -> None:
+    """A symlink one level deeper (`.cursor/rules -> /tmp/outside`) must
+    also be rejected — the chain walk runs through every existing
+    component, not just the immediate parent."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    workspace = tmp_path / "ws"
+    cursor_dir = workspace / ".cursor"
+    cursor_dir.mkdir(parents=True)
+    (cursor_dir / "rules").symlink_to(outside)
+    result = apply_agent_instructions(workspace, ["cursor"], write=True)
+    [outcome] = result.targets
+    assert outcome.status == "skipped_symlink"
+    assert list(outside.iterdir()) == []
+
+
 # --- case-insensitive PR template -----------------------------------------
 
 

--- a/tests/test_agent_instructions_renderers.py
+++ b/tests/test_agent_instructions_renderers.py
@@ -1,0 +1,91 @@
+"""Renderer-level tests for ``--agent-instructions`` content.
+
+Includes the Rule 3 strict-mode safety guard: ``ci_mode: strict`` must only
+appear inside the shared CI-pointer paragraph's "promotion is a human
+decision" sentence, never in any other rendered content.
+"""
+
+from __future__ import annotations
+
+import re
+
+from agents_shipgate.cli.discovery.agent_instructions.renderers import (
+    render_agents_md,
+    render_claude_md,
+    render_cursor_file,
+    render_pr_template,
+)
+from agents_shipgate.cli.discovery.agent_instructions.renderers._shared import (
+    CI_POINTER_PARAGRAPH,
+)
+
+ALL_RENDERERS = {
+    "agents-md": render_agents_md,
+    "claude-md": render_claude_md,
+    "cursor": render_cursor_file,
+    "pr-template": render_pr_template,
+}
+
+
+def test_each_renderer_returns_nonempty_string() -> None:
+    for name, fn in ALL_RENDERERS.items():
+        out = fn()
+        assert isinstance(out, str), name
+        assert out.strip(), name
+
+
+def test_cursor_renders_full_mdc_with_frontmatter() -> None:
+    out = render_cursor_file()
+    assert out.startswith("---\n")
+    assert "alwaysApply: false" in out
+    assert "globs:" in out
+    # Broad globs (per docs/target-repo-agent-snippets.md): OpenAPI, MCP, tools, Python.
+    for token in ("openapi", "swagger", "mcp", "tools", "*.py"):
+        assert token in out
+
+
+def test_pr_template_uses_conditional_wording() -> None:
+    out = render_pr_template()
+    # Conditional avoids docs-only false positives.
+    assert "If this PR changes" in out
+
+
+def test_agents_md_includes_report_json_contract() -> None:
+    out = render_agents_md()
+    assert "agents-shipgate-reports/report.json" in out
+    assert "release_decision.decision" in out
+
+
+def test_claude_md_is_self_contained_no_dangling_link() -> None:
+    """Generating only --agent-instructions=claude-md must not produce a
+    dangling reference to AGENTS.md."""
+    out = render_claude_md()
+    # Self-contained means it lists its own commands and report.json contract.
+    assert "agents-shipgate detect" in out
+    assert "release_decision.decision" in out
+    # Cross-link to AGENTS.md is intentionally omitted.
+    assert "AGENTS.md" not in out
+
+
+def test_strict_mode_token_only_in_ci_pointer_paragraph() -> None:
+    """Rule 3: ``ci_mode: strict`` (or `strict mode`/`strict CI`) must only
+    appear inside the shared CI-pointer paragraph and only in the
+    "promotion is a human decision" framing."""
+    assert "ci_mode: strict" in CI_POINTER_PARAGRAPH
+    pattern = re.compile(r"ci_mode:\s*strict|strict\s+mode|strict\s+CI", re.IGNORECASE)
+    for name, fn in ALL_RENDERERS.items():
+        rendered = fn()
+        # Strip the CI_POINTER_PARAGRAPH out and assert no match in remainder.
+        without_pointer = rendered.replace(CI_POINTER_PARAGRAPH, "")
+        assert not pattern.search(without_pointer), (
+            f"{name} mentions strict CI outside the shared pointer paragraph"
+        )
+
+
+def test_advisory_default_appears_in_agent_facing_targets() -> None:
+    """The agent-facing targets (AGENTS.md, CLAUDE.md, Cursor rule) should
+    communicate advisory-by-default. The PR template intentionally omits the
+    CI-pointer paragraph — it's a reviewer checklist, not CI documentation."""
+    for name in ("agents-md", "claude-md", "cursor"):
+        rendered = ALL_RENDERERS[name]()
+        assert "advisory" in rendered.lower(), name

--- a/tests/test_init_agent_instructions.py
+++ b/tests/test_init_agent_instructions.py
@@ -1,0 +1,337 @@
+"""CLI matrix tests for ``agents-shipgate init --agent-instructions=<selector>``.
+
+Mirrors :mod:`tests.test_init_ci` for the orthogonal-flag matrix. Verifies
+dry-run output, write semantics, idempotent re-runs, composability with
+``--write`` and ``--ci``, structured errors under ``AGENTS_SHIPGATE_AGENT_MODE``,
+and the Rule 3 strict-CI safety guard at the rendered-content level.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.discovery.agent_instructions import TARGETS
+from agents_shipgate.cli.discovery.agent_instructions.targets import SPECS
+from agents_shipgate.cli.discovery.ci_workflow import WORKFLOW_RELATIVE_PATH
+from agents_shipgate.cli.main import app
+
+SAMPLES = Path(__file__).resolve().parent.parent / "samples"
+runner = CliRunner()
+
+
+def _seed_workspace(tmp_path: Path, sample: str) -> Path:
+    dst = tmp_path / "ws"
+    shutil.copytree(SAMPLES / sample, dst)
+    target = dst / "shipgate.yaml"
+    if target.exists():
+        target.unlink()
+    reports = dst / "agents-shipgate-reports"
+    if reports.exists():
+        shutil.rmtree(reports)
+    return dst
+
+
+# --- dry-run ---------------------------------------------------------------
+
+
+def test_dry_run_all_targets_emits_section_headers(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--agent-instructions=all"],
+    )
+    assert result.exit_code == 0, result.output
+    # Manifest section header.
+    assert "--- shipgate.yaml ---" in result.output
+    # Per-target section headers.
+    for name in TARGETS:
+        assert f"--- {SPECS[name].relative_path} ---" in result.output
+
+
+def test_dry_run_all_targets_json_has_rendered_content(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--agent-instructions=all", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ai = payload["agent_instructions"]
+    assert ai["requested"] == list(TARGETS)
+    assert ai["block_version"] == 1
+    statuses = {t["name"]: t["status"] for t in ai["targets"]}
+    assert statuses == {name: "would_render" for name in TARGETS}
+    for entry in ai["targets"]:
+        assert entry["rendered"]
+    # No filesystem changes.
+    for name in TARGETS:
+        assert not (workspace / SPECS[name].relative_path).exists()
+
+
+def test_dry_run_subset_selector(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--agent-instructions=agents-md,cursor",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    names = [t["name"] for t in payload["agent_instructions"]["targets"]]
+    assert names == ["agents-md", "cursor"]
+
+
+def test_dry_run_none_selector_emits_empty_targets_list(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--agent-instructions=none", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["agent_instructions"] == {
+        "requested": [],
+        "block_version": 1,
+        "targets": [],
+    }
+
+
+def test_invalid_selector_exits_two_with_human_error(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--agent-instructions=bogus"],
+    )
+    assert result.exit_code == 2
+    # Human-readable error mentions the bad selector.
+    combined = result.output + (result.stderr if result.stderr_bytes is not None else "")
+    assert "bogus" in combined
+
+
+def test_invalid_selector_emits_structured_error_under_agent_mode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    result = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--agent-instructions=nope"],
+    )
+    assert result.exit_code == 2
+    # Structured stderr line — runner mixes streams; search for the JSON.
+    output = result.output
+    assert '"error": "config_error"' in output
+    assert '"next_action"' in output
+
+
+# --- --write -------------------------------------------------------------
+
+
+def test_write_all_targets_on_fresh_workspace(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--agent-instructions=all",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ai = payload["agent_instructions"]
+    assert {t["status"] for t in ai["targets"]} == {"created_with_block"}
+    # Files exist.
+    for name in TARGETS:
+        path = workspace / SPECS[name].relative_path
+        assert path.exists()
+    # AGENTS.md has the H1 preamble + managed block.
+    agents_md = (workspace / "AGENTS.md").read_text(encoding="utf-8")
+    assert agents_md.startswith("# Agents")
+    assert "<!-- agents-shipgate:start v=1 -->" in agents_md
+
+
+def test_write_idempotent_rerun_is_noop(tmp_path: Path) -> None:
+    """Repeat ``--write --agent-instructions=all`` is a no-op for the
+    instruction files (byte-equal). Manifest action exits 2 on the second run
+    because shipgate.yaml already exists; that is the expected behavior for the
+    manifest action and is independent of agent-instructions idempotency."""
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    first = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--agent-instructions=all",
+            "--json",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    snapshot = {
+        rel: (workspace / rel).read_bytes()
+        for rel in (SPECS[name].relative_path for name in TARGETS)
+    }
+    second = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--agent-instructions=all",
+            "--json",
+        ],
+    )
+    payload = json.loads(second.output)
+    # Agent-instructions specifically: every target reports unchanged.
+    assert {t["status"] for t in payload["agent_instructions"]["targets"]} == {"unchanged"}
+    after = {
+        rel: (workspace / rel).read_bytes()
+        for rel in (SPECS[name].relative_path for name in TARGETS)
+    }
+    # Byte-equal across the run — the canonical "safe to run repeatedly" proof.
+    assert snapshot == after
+
+
+def test_write_appends_to_existing_agents_md_without_markers(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    original = "# Project AGENTS.md\n\nUser-authored prose.\n"
+    (workspace / "AGENTS.md").write_text(original, encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--agent-instructions=agents-md",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    [outcome] = payload["agent_instructions"]["targets"]
+    assert outcome["status"] == "appended"
+    # User content preserved at the start.
+    after = (workspace / "AGENTS.md").read_text(encoding="utf-8")
+    assert after.startswith(original)
+
+
+def test_write_cursor_skipped_when_user_modified_exits_two(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    cursor = workspace / ".cursor/rules/agents-shipgate.mdc"
+    cursor.parent.mkdir(parents=True)
+    cursor.write_text("# user-authored cursor rule\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--agent-instructions=cursor",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    [outcome] = payload["agent_instructions"]["targets"]
+    assert outcome["status"] == "skipped_user_modified"
+    # File untouched.
+    assert cursor.read_text(encoding="utf-8") == "# user-authored cursor rule\n"
+
+
+def test_skipped_target_emits_structured_stderr_under_agent_mode(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Hand-edited cursor + AGENTS_SHIPGATE_AGENT_MODE=1 produces a structured
+    next_action JSON line on stderr so coding-agent callers can route to a fix
+    without scraping stdout."""
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    cursor = workspace / ".cursor/rules/agents-shipgate.mdc"
+    cursor.parent.mkdir(parents=True)
+    cursor.write_text("# user-authored cursor rule\n", encoding="utf-8")
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--agent-instructions=cursor",
+        ],
+    )
+    assert result.exit_code == 2
+    output = result.output
+    assert '"error": "config_already_exists"' in output
+    assert '"next_action"' in output
+    # The next_action should reference the affected target and re-run command.
+    assert "agent-instructions=cursor" in output
+
+
+# --- composability with --ci ---------------------------------------------
+
+
+def test_triple_combo_init_write_ci_agent_instructions(tmp_path: Path) -> None:
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--ci",
+            "--agent-instructions=all",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    # All three orthogonal actions present.
+    assert payload["manifest_status"] == "written"
+    assert payload["workflow"]["status"] == "written"
+    assert payload["agent_instructions"]["block_version"] == 1
+    # Files on disk.
+    assert (workspace / "shipgate.yaml").exists()
+    assert (workspace / WORKFLOW_RELATIVE_PATH).exists()
+    for name in TARGETS:
+        assert (workspace / SPECS[name].relative_path).exists()
+
+
+def test_help_text_documents_agent_instructions(tmp_path: Path) -> None:
+    """The help string should advertise the new flag and call out advisory-only."""
+    result = runner.invoke(app, ["init", "--help"])
+    assert result.exit_code == 0
+    assert "--agent-instructions" in result.output
+    # Advisory-only safety language for Rule 3.
+    assert "advisory" in result.output.lower()
+
+
+def test_existing_init_tests_unaffected_by_default(tmp_path: Path) -> None:
+    """Without --agent-instructions, the JSON payload must NOT include
+    ``agent_instructions`` (matches the workflow precedent: presence-only)."""
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    result = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--write", "--json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "agent_instructions" not in payload

--- a/tests/test_init_agent_instructions.py
+++ b/tests/test_init_agent_instructions.py
@@ -165,10 +165,11 @@ def test_write_all_targets_on_fresh_workspace(tmp_path: Path) -> None:
 
 
 def test_write_idempotent_rerun_is_noop(tmp_path: Path) -> None:
-    """Repeat ``--write --agent-instructions=all`` is a no-op for the
-    instruction files (byte-equal). Manifest action exits 2 on the second run
-    because shipgate.yaml already exists; that is the expected behavior for the
-    manifest action and is independent of agent-instructions idempotency."""
+    """The advertised refresh command — `init --write --agent-instructions=all`
+    — must be idempotent at the process level. A re-run reports every target as
+    ``unchanged``, exits 0 (even though shipgate.yaml already exists, because
+    the user's primary intent under --agent-instructions is the snippet
+    refresh, not manifest creation), and the workspace is byte-equal."""
     workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
     first = runner.invoke(
         app,
@@ -197,8 +198,12 @@ def test_write_idempotent_rerun_is_noop(tmp_path: Path) -> None:
             "--json",
         ],
     )
+    # Idempotent at the process level: exit 0 even though shipgate.yaml exists.
+    assert second.exit_code == 0, second.output
     payload = json.loads(second.output)
-    # Agent-instructions specifically: every target reports unchanged.
+    # Manifest action reports the skip informationally; agent-instructions
+    # all unchanged.
+    assert payload["manifest_status"] == "skipped_existing"
     assert {t["status"] for t in payload["agent_instructions"]["targets"]} == {"unchanged"}
     after = {
         rel: (workspace / rel).read_bytes()
@@ -206,6 +211,23 @@ def test_write_idempotent_rerun_is_noop(tmp_path: Path) -> None:
     }
     # Byte-equal across the run — the canonical "safe to run repeatedly" proof.
     assert snapshot == after
+
+
+def test_manifest_skip_still_exits_two_without_agent_instructions(
+    tmp_path: Path,
+) -> None:
+    """Backwards compatibility: `init --write` (no --agent-instructions)
+    against an existing shipgate.yaml still exits 2. The idempotency
+    accommodation only applies when --agent-instructions is set."""
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    (workspace / "shipgate.yaml").write_text("# user manifest\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--write", "--json"],
+    )
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["manifest_status"] == "skipped_existing"
 
 
 def test_write_appends_to_existing_agents_md_without_markers(tmp_path: Path) -> None:
@@ -315,8 +337,17 @@ def test_triple_combo_init_write_ci_agent_instructions(tmp_path: Path) -> None:
         assert (workspace / SPECS[name].relative_path).exists()
 
 
-def test_help_text_documents_agent_instructions(tmp_path: Path) -> None:
-    """The help string should advertise the new flag and call out advisory-only."""
+def test_help_text_documents_agent_instructions(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The help string should advertise the new flag and call out advisory-only.
+
+    Force a wide terminal so Rich's renderer does not truncate ``--agent-
+    instructions`` into ``--agent-in…`` on narrow CI runners (default
+    COLUMNS=80). The CliRunner does not propagate env to Rich's console;
+    setting it on the parent process via monkeypatch is the reliable way."""
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setenv("TERMINAL_WIDTH", "200")
     result = runner.invoke(app, ["init", "--help"])
     assert result.exit_code == 0
     assert "--agent-instructions" in result.output

--- a/tests/test_init_agent_instructions.py
+++ b/tests/test_init_agent_instructions.py
@@ -230,6 +230,31 @@ def test_manifest_skip_still_exits_two_without_agent_instructions(
     assert payload["manifest_status"] == "skipped_existing"
 
 
+def test_manifest_skip_exits_two_with_agent_instructions_none(
+    tmp_path: Path,
+) -> None:
+    """`--agent-instructions=none` runs no instruction action, so the
+    idempotency accommodation should NOT apply — manifest skip still exits 2,
+    matching plain `init --write` behavior."""
+    workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
+    (workspace / "shipgate.yaml").write_text("# user manifest\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(workspace),
+            "--write",
+            "--agent-instructions=none",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["manifest_status"] == "skipped_existing"
+    assert payload["agent_instructions"]["targets"] == []
+
+
 def test_write_appends_to_existing_agents_md_without_markers(tmp_path: Path) -> None:
     workspace = _seed_workspace(tmp_path, "simple_langchain_agent")
     original = "# Project AGENTS.md\n\nUser-authored prose.\n"
@@ -337,22 +362,25 @@ def test_triple_combo_init_write_ci_agent_instructions(tmp_path: Path) -> None:
         assert (workspace / SPECS[name].relative_path).exists()
 
 
-def test_help_text_documents_agent_instructions(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """The help string should advertise the new flag and call out advisory-only.
+def test_init_command_documents_agent_instructions() -> None:
+    """The init command must expose ``--agent-instructions`` and the help
+    string must call out advisory-only behavior (Rule 3).
 
-    Force a wide terminal so Rich's renderer does not truncate ``--agent-
-    instructions`` into ``--agent-in…`` on narrow CI runners (default
-    COLUMNS=80). The CliRunner does not propagate env to Rich's console;
-    setting it on the parent process via monkeypatch is the reliable way."""
-    monkeypatch.setenv("COLUMNS", "200")
-    monkeypatch.setenv("TERMINAL_WIDTH", "200")
-    result = runner.invoke(app, ["init", "--help"])
-    assert result.exit_code == 0
-    assert "--agent-instructions" in result.output
-    # Advisory-only safety language for Rule 3.
-    assert "advisory" in result.output.lower()
+    Existence is checked via Click param introspection — terminal-width
+    rendering varies across CI runners (Rich truncates option names on
+    narrow terminals even with COLUMNS set), and we should not gate merge
+    on whether the rendered string fits."""
+    from typer.main import get_command
+
+    click_app = get_command(app)
+    init_cmd = click_app.commands["init"]
+    param_names = {p.name for p in init_cmd.params}
+    assert "agent_instructions" in param_names
+
+    init_param = next(p for p in init_cmd.params if p.name == "agent_instructions")
+    # Decls include the long-form flag; help text mentions advisory.
+    assert any("--agent-instructions" in opt for opt in init_param.opts)
+    assert "advisory" in (init_param.help or "").lower()
 
 
 def test_existing_init_tests_unaffected_by_default(tmp_path: Path) -> None:

--- a/tests/test_managed_block.py
+++ b/tests/test_managed_block.py
@@ -1,0 +1,277 @@
+"""Library-level tests for the agent-instructions managed-block helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from agents_shipgate.cli.discovery.agent_instructions.managed_block import (
+    BlockState,
+    UpsertStatus,
+    detect_newline,
+    parse,
+    render_block,
+    upsert,
+)
+
+# --- detect_newline --------------------------------------------------------
+
+
+def test_detect_newline_lf_default() -> None:
+    assert detect_newline(b"") == b"\n"
+    assert detect_newline(b"hello\nworld\n") == b"\n"
+
+
+def test_detect_newline_crlf_when_any_present() -> None:
+    assert detect_newline(b"hello\r\nworld\n") == b"\r\n"
+    assert detect_newline(b"\r\n") == b"\r\n"
+
+
+# --- parse -----------------------------------------------------------------
+
+
+def test_parse_no_markers() -> None:
+    assert parse(b"# heading\nhello\n").state is BlockState.NO_MARKERS
+    assert parse(b"").state is BlockState.NO_MARKERS
+
+
+def test_parse_present_returns_line_offsets() -> None:
+    host = (
+        b"# heading\n"
+        b"prelude\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"body line 1\n"
+        b"body line 2\n"
+        b"<!-- agents-shipgate:end -->\n"
+        b"trailer\n"
+    )
+    parsed = parse(host)
+    assert parsed.state is BlockState.PRESENT
+    assert parsed.location is not None
+    assert parsed.location.version == 1
+    # line_start should be at the start of the start-marker LINE (not mid-line).
+    assert host[parsed.location.line_start :].startswith(b"<!-- agents-shipgate:start")
+    # line_end should be just after the end marker's trailing newline.
+    assert host[parsed.location.line_end :] == b"trailer\n"
+
+
+def test_parse_present_handles_eof_without_trailing_newline() -> None:
+    host = (
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"body\n"
+        b"<!-- agents-shipgate:end -->"
+    )
+    parsed = parse(host)
+    assert parsed.state is BlockState.PRESENT
+    assert parsed.location is not None
+    assert parsed.location.line_end == len(host)
+
+
+def test_parse_ambiguous_two_start_markers() -> None:
+    host = (
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"a\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"b\n"
+        b"<!-- agents-shipgate:end -->\n"
+    )
+    assert parse(host).state is BlockState.AMBIGUOUS
+
+
+def test_parse_ambiguous_end_before_start() -> None:
+    host = (
+        b"<!-- agents-shipgate:end -->\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+    )
+    assert parse(host).state is BlockState.AMBIGUOUS
+
+
+def test_parse_ambiguous_unmatched_end() -> None:
+    host = b"<!-- agents-shipgate:start v=1 -->\nbody\n"
+    assert parse(host).state is BlockState.AMBIGUOUS
+
+
+# --- render_block ----------------------------------------------------------
+
+
+def test_render_block_lf_normalizes_newlines_in_inner() -> None:
+    out = render_block("a\nb\n", version=1, newline=b"\n")
+    assert out == (
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"a\n"
+        b"b\n"
+        b"<!-- agents-shipgate:end -->\n"
+    )
+
+
+def test_render_block_crlf_propagates_to_inner() -> None:
+    out = render_block("a\nb\n", version=1, newline=b"\r\n")
+    assert out == (
+        b"<!-- agents-shipgate:start v=1 -->\r\n"
+        b"a\r\nb\r\n"
+        b"<!-- agents-shipgate:end -->\r\n"
+    )
+
+
+def test_render_block_inner_without_trailing_newline_gets_one() -> None:
+    out = render_block("body", version=1, newline=b"\n")
+    assert out == (
+        b"<!-- agents-shipgate:start v=1 -->\nbody\n<!-- agents-shipgate:end -->\n"
+    )
+
+
+def test_render_block_rejects_zero_or_negative_version() -> None:
+    with pytest.raises(ValueError):
+        render_block("body\n", version=0, newline=b"\n")
+    with pytest.raises(ValueError):
+        render_block("body\n", version=-1, newline=b"\n")
+
+
+# --- upsert ----------------------------------------------------------------
+
+
+def test_upsert_empty_host_writes_just_block() -> None:
+    out = upsert(b"", inner="hello\n", version=1)
+    assert out.status is UpsertStatus.APPENDED
+    assert out.new_bytes == (
+        b"<!-- agents-shipgate:start v=1 -->\nhello\n<!-- agents-shipgate:end -->\n"
+    )
+
+
+def test_upsert_appends_with_blank_line_separator() -> None:
+    host = b"# Heading\nExisting line.\n"
+    out = upsert(host, inner="block body\n", version=1)
+    assert out.status is UpsertStatus.APPENDED
+    # Original two lines preserved byte-for-byte.
+    assert out.new_bytes.startswith(host)
+    # Exactly one blank line between user content and block.
+    assert out.new_bytes == (
+        b"# Heading\n"
+        b"Existing line.\n"
+        b"\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"block body\n"
+        b"<!-- agents-shipgate:end -->\n"
+    )
+
+
+def test_upsert_appends_when_host_lacks_trailing_newline() -> None:
+    host = b"# Heading\nNo newline at EOF"
+    out = upsert(host, inner="body\n", version=1)
+    assert out.status is UpsertStatus.APPENDED
+    assert out.new_bytes == (
+        b"# Heading\n"
+        b"No newline at EOF\n"
+        b"\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"body\n"
+        b"<!-- agents-shipgate:end -->\n"
+    )
+
+
+def test_upsert_unchanged_when_block_matches_exactly() -> None:
+    host = (
+        b"prelude\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"body\n"
+        b"<!-- agents-shipgate:end -->\n"
+        b"trailer\n"
+    )
+    out = upsert(host, inner="body\n", version=1)
+    assert out.status is UpsertStatus.UNCHANGED
+    assert out.new_bytes == host
+
+
+def test_upsert_updated_replaces_only_block_region() -> None:
+    host = (
+        b"prelude\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"old body\n"
+        b"<!-- agents-shipgate:end -->\n"
+        b"trailer\n"
+    )
+    out = upsert(host, inner="new body\n", version=1)
+    assert out.status is UpsertStatus.UPDATED
+    assert out.new_bytes == (
+        b"prelude\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"new body\n"
+        b"<!-- agents-shipgate:end -->\n"
+        b"trailer\n"
+    )
+
+
+def test_upsert_migrated_bumps_version_and_replaces_block() -> None:
+    host = (
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"old\n"
+        b"<!-- agents-shipgate:end -->\n"
+    )
+    out = upsert(host, inner="new\n", version=2)
+    assert out.status is UpsertStatus.MIGRATED
+    assert out.block_version == 2
+    assert b"v=2" in out.new_bytes
+    assert b"new\n" in out.new_bytes
+
+
+def test_upsert_newer_version_refuses() -> None:
+    host = (
+        b"<!-- agents-shipgate:start v=99 -->\n"
+        b"future\n"
+        b"<!-- agents-shipgate:end -->\n"
+    )
+    out = upsert(host, inner="body\n", version=1)
+    assert out.status is UpsertStatus.NEWER_VERSION
+    assert out.new_bytes == host
+
+
+def test_upsert_ambiguous_returns_unchanged_bytes() -> None:
+    host = (
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"a\n"
+        b"<!-- agents-shipgate:start v=1 -->\n"
+        b"b\n"
+        b"<!-- agents-shipgate:end -->\n"
+    )
+    out = upsert(host, inner="body\n", version=1)
+    assert out.status is UpsertStatus.AMBIGUOUS
+    assert out.new_bytes == host
+
+
+# --- CRLF preservation -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("nl_label", "nl"),
+    [("lf", b"\n"), ("crlf", b"\r\n")],
+)
+def test_upsert_preserves_host_newline_style(nl_label: str, nl: bytes) -> None:
+    host = b"# Heading" + nl + b"User line." + nl
+    out = upsert(host, inner="block body\n", version=1)
+    assert out.status is UpsertStatus.APPENDED
+    # Host prefix must be byte-equal to the original.
+    assert out.new_bytes.startswith(host)
+    # Only the host newline byte sequence appears in the inserted block.
+    inserted = out.new_bytes[len(host) :]
+    if nl == b"\r\n":
+        assert b"\r\n" in inserted
+        # Stray bare LFs are not allowed when host is CRLF (they would mix line endings).
+        assert b"\n" not in inserted.replace(b"\r\n", b"")
+    else:
+        assert b"\r\n" not in inserted
+
+
+def test_upsert_round_trip_preserves_user_bytes_outside_block(
+) -> None:
+    """Repeated upsert with the same content must be a no-op (UNCHANGED)
+    and must preserve user bytes outside the block exactly."""
+    user_prefix = b"# My Doc\n\nPara 1.\nPara 2.\n\n"
+    user_suffix = b"\nMore prose after.\n"
+    inner = "managed body line 1\nmanaged body line 2\n"
+    first = upsert(user_prefix.rstrip(b"\n") + b"\n", inner=inner, version=1)
+    # Insert block, then add user suffix back to simulate user editing AFTER us.
+    composed = first.new_bytes + user_suffix
+    second = upsert(composed, inner=inner, version=1)
+    assert second.status is UpsertStatus.UNCHANGED
+    assert second.new_bytes == composed
+    # User suffix is intact.
+    assert second.new_bytes.endswith(user_suffix)


### PR DESCRIPTION
## Summary

- Turns the snippet copy in [`docs/target-repo-agent-snippets.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/target-repo-agent-snippets.md) into a first-class CLI output. `agents-shipgate init --agent-instructions=all` (or a `agents-md,claude-md,cursor,pr-template` subset; or `none`) renders the snippets to stdout; combined with `--write`, the CLI plants them in the target repo via managed `<!-- agents-shipgate:start v=1 -->` markers.
- Idempotent and byte-preserving: re-running with no changes is a no-op, host newline style (LF/CRLF) is preserved, surrounding bytes are byte-equal across runs. Exit 2 when a target is in a state we will not overwrite (hand-edited cursor file, ambiguous markers, newer block version, directory-form PR template) — including a structured `next_action` JSON line on stderr under `AGENTS_SHIPGATE_AGENT_MODE=1`.
- Composes orthogonally with `--write` and `--ci` (third action, exit code = `max(manifest_exit, agent_instructions_exit)`); JSON output gains a top-level `agent_instructions` key. Strict CI and baselines remain opt-in human decisions — a snapshot test asserts `ci_mode: strict` does not appear in any rendered target outside the shared CI-pointer paragraph.

## Why

Adopters previously had to read [`docs/target-repo-agent-snippets.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/target-repo-agent-snippets.md) and paste copy into their repos by hand. This makes the existing copy executable: one CLI flag plants the right guidance into AGENTS.md, CLAUDE.md, the Cursor rule, and the PR template — so any agent or reviewer working in the target repo discovers Shipgate without leaving the repo.

## Notable design points

- **Selector requires an explicit value.** `--agent-instructions` alone would fail Typer's argument parsing; `=all` / `=<csv>` / `=none` is unambiguous and explicit in scripts.
- **Managed-block markers, silent overwrite of hand edits inside the block.** Block carries a footer pointing back at the refresh command; `v=N` token is the renderer-format version (not the package version) so the cursor `PRIOR_RENDER_SHA256` list stays small.
- **Renderer content lifted from the existing doc** (no redesign). Cursor globs include OpenAPI/Swagger/MCP/tools/Python so the rule activates while editing real tool surfaces. PR template uses the conditional \"If this PR changes…\" wording so docs-only PRs aren't false positives.
- **PR template path resolution** probes both `.github/pull_request_template.md` and `.github/PULL_REQUEST_TEMPLATE.md`; refuses ambiguous-both-without-marker; explicitly out-of-scope-skips when the directory form `.github/PULL_REQUEST_TEMPLATE/` exists (status enum reserves `skipped_directory_template` so future support is non-breaking).

## Test plan

- [x] `python -m pytest` — 602 passed, 3 skipped (case-sensitivity-only PR-template tests skip on macOS APFS; Linux CI exercises them).
- [x] `python -m ruff check .` — clean.
- [x] End-to-end smoke against `samples/simple_langchain_agent`: `init --write --agent-instructions=all --json` creates all 4 files; re-run is byte-equal (`git status --porcelain` empty).
- [x] Triple combo `init --write --ci --agent-instructions=all` succeeds; JSON has `manifest_status`, `workflow`, `agent_instructions` keys.
- [x] Hand-edited cursor MDC under `AGENTS_SHIPGATE_AGENT_MODE=1` exits 2 with `{\"error\": \"config_already_exists\", \"next_action\": ...}` on stderr; on-disk file untouched.
- [ ] Reviewer: confirm the renderer copy in `src/agents_shipgate/cli/discovery/agent_instructions/renderers/` matches your intent (especially the `## CI` mini-section that adds the advisory pointer to AGENTS.md / CLAUDE.md / cursor — the doc didn't carry that paragraph inline).
- [ ] Reviewer: confirm exit-2-on-skip is the right default, vs. exit 0 (workflow precedent). Manifest precedent is exit 2; this PR follows the manifest model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)