### PR TITLE
Add explain-finding CLI + companion prompt for per-finding prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Config error: Config file not found: missing.yaml
 {"error": "config_error", "message": "...", "next_action": "agents-shipgate detect --workspace . --json", "next_actions": [{"kind": "command", "command": "agents-shipgate detect --workspace . --json", "why": "..."}, {"kind": "command", "command": "agents-shipgate init --workspace . --write", "why": "..."}]}
 ```
 
-The full set of error kinds emitted in agent mode: `config_error`, `config_already_exists`, `input_parse_error`, `unknown_check_id`, `other_error`, `internal_error`, `malformed_patch`.
+The full set of error kinds emitted in agent mode: `config_error`, `config_already_exists`, `input_parse_error`, `unknown_check_id`, `unknown_fingerprint`, `other_error`, `internal_error`, `malformed_patch`. `unknown_fingerprint` is emitted by `explain-finding` when the fingerprint doesn't match any entry in the supplied report; the payload includes `suggestion` (a close-match fingerprint, when one exists) and `source_report`.
 
 `detect --json` and each `doctor --json` payload also carry `diagnostics: [...]` and `next_actions: [...]` fields. `next_action` (single string) remains the rank-1 action projected to a string; `next_actions` is the ranked list with `kind`, `command|path`, `why`, and `expects` fields. See [docs/diagnostics.md](docs/diagnostics.md) for the full catalog and schema.
 
@@ -266,13 +266,24 @@ agents-shipgate scan -c shipgate.yaml \
 
 Strict mode fails CI only on **new** findings (those not in the baseline).
 
-### Task 5 · Explain a finding
+### Task 5 · Explain a check or a specific finding
+
+For static catalog metadata about a check ID (rationale, fires-when, recommendation):
 
 ```bash
 agents-shipgate explain SHIP-POLICY-APPROVAL-MISSING --json
 ```
 
 Returns the full `CheckMetadata` with `id`, `category`, `default_severity`, `description`, `rationale`, `fires_when`, `evidence_fields`, `recommendation`.
+
+For a contextual explanation tied to a specific finding from a real scan (catalog metadata + the finding's evidence + a 3–5 sentence templated prose summary):
+
+```bash
+agents-shipgate explain-finding fp_<fingerprint> \
+    --from agents-shipgate-reports/report.json --json
+```
+
+Returns the canonical Finding fields plus `metadata` (CheckMetadata for the check_id) and `explanation` — a deterministic prose summary suitable for direct quotation in a PR comment or chat reply. The companion prompt is [`prompts/explain-finding-to-user.md`](prompts/explain-finding-to-user.md).
 
 ---
 
@@ -356,6 +367,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate doctor` | `-c`, `--workspace`, `--json`, `--verbose` |
 | `agents-shipgate contract` | `--json` |
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
+| `agents-shipgate explain-finding` | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--out` |
 | `agents-shipgate fixture` | `list`, `run`, `copy`, `verify` |
@@ -427,6 +439,7 @@ Prebuilt prompts for common workflows live in [`prompts/`](prompts/):
 - [`add-shipgate-to-repo.md`](prompts/add-shipgate-to-repo.md) — bootstrap a repo
 - [`fix-top-finding.md`](prompts/fix-top-finding.md) — iterate on a single finding
 - [`recommend-fixes.md`](prompts/recommend-fixes.md) — walk all active findings and surface targeted fix recommendations across the four autofix-policy classes
+- [`explain-finding-to-user.md`](prompts/explain-finding-to-user.md) — translate one finding into 3–5 sentences of user-facing prose; companion to `agents-shipgate explain-finding`
 - [`stabilize-strict-mode.md`](prompts/stabilize-strict-mode.md) — tune → baseline → promote
 - [`triage-false-positive.md`](prompts/triage-false-positive.md) — override vs suppress decision
 - [`upgrade-shipgate-version.md`](prompts/upgrade-shipgate-version.md) — bump agents-shipgate version safely (regenerate baseline if needed)

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -21,6 +21,7 @@ These commands and flags are stable across all `0.x.y` releases. They will only 
 | `agents-shipgate doctor` | `-c`, `--config`, `--workspace`, `--json`, `--verbose` |
 | `agents-shipgate contract` | `--json` |
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
+| `agents-shipgate explain-finding` (v0.12+) | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--config`, `--out` |
 | `agents-shipgate fixture list` | `--json` |

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -89,11 +89,13 @@ agents-shipgate explain-finding <FINGERPRINT> \
     --from agents-shipgate-reports/report.json --json
 ```
 
-The payload mirrors the canonical Finding fields plus:
+The payload is the full `Finding` shape (every field on `findings[]` in `report.json`, including `source`, `patches`, `confidence`, `agent_id`, etc.) overlaid with three derived fields:
 
 - `metadata` — full `CheckMetadata` for the check_id (rationale, fires_when, evidence_fields, docs_url) when the check is in the catalog; null for unknown ids (third-party plugins, future checks).
 - `explanation` — a deterministic 3–5 sentence prose summary suitable for direct quotation. Names the affected tool, the severity, the recommended fix, and an action-aware closing sentence keyed to `agent_action`. Same inputs always produce the same output.
-- `source_report` — absolute path to the report file the explanation was sourced from; round-trippable for caching and audit.
+- `source_report` — **absolute** path (always; relative `--from` values are resolved before serialization) to the report file the explanation was sourced from; round-trippable for caching and audit.
+
+`explain-finding` requires `report_schema_version >= 0.12` because the action-aware explanation depends on per-finding `agent_action`. Pre-v0.12 reports are rejected with `input_parse_error` and a `next_action` pointing at the canonical scan command. The Pydantic `ReadinessReport` model is intentionally looser than this command's contract (so test fixtures can construct minimal findings); the version gate is what enforces v0.12 semantics on emitted reports.
 
 Companion prompt: [`prompts/explain-finding-to-user.md`](../prompts/explain-finding-to-user.md). Use it when you need to translate a finding for a human who has never read the Shipgate docs. Keep `agents-shipgate explain <CHECK_ID>` for static catalog metadata (no specific finding); use `explain-finding` whenever you have a fingerprint and want the evidence-tied prose.
 

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -80,6 +80,23 @@ available.
 
 - `summary.status` — preserved for v0.7 callers, **baseline-blind**. A baseline-matched critical flips this to `release_blockers_detected` even though `release_decision.decision` correctly classifies it as `review_required`. New consumers should not gate on `summary.status`. See [STABILITY.md §`release_decision.decision` vs `summary.status`](../STABILITY.md#release_decisiondecision-vs-summarystatus).
 
+## Per-finding contextual explanation (v0.12+)
+
+For prose summaries of a single finding (PR comments, chat replies, commit messages), use:
+
+```bash
+agents-shipgate explain-finding <FINGERPRINT> \
+    --from agents-shipgate-reports/report.json --json
+```
+
+The payload mirrors the canonical Finding fields plus:
+
+- `metadata` — full `CheckMetadata` for the check_id (rationale, fires_when, evidence_fields, docs_url) when the check is in the catalog; null for unknown ids (third-party plugins, future checks).
+- `explanation` — a deterministic 3–5 sentence prose summary suitable for direct quotation. Names the affected tool, the severity, the recommended fix, and an action-aware closing sentence keyed to `agent_action`. Same inputs always produce the same output.
+- `source_report` — absolute path to the report file the explanation was sourced from; round-trippable for caching and audit.
+
+Companion prompt: [`prompts/explain-finding-to-user.md`](../prompts/explain-finding-to-user.md). Use it when you need to translate a finding for a human who has never read the Shipgate docs. Keep `agents-shipgate explain <CHECK_ID>` for static catalog metadata (no specific finding); use `explain-finding` whenever you have a fingerprint and want the evidence-tied prose.
+
 ## Authoritative references
 
 - [STABILITY.md](../STABILITY.md) — full 0.x stability contract. Source of truth for everything above.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -157,7 +157,7 @@ Config error: Config file not found: missing.yaml
 {"error": "config_error", "message": "...", "next_action": "agents-shipgate detect --workspace . --json", "next_actions": [{"kind": "command", "command": "agents-shipgate detect --workspace . --json", "why": "..."}, {"kind": "command", "command": "agents-shipgate init --workspace . --write", "why": "..."}]}
 ```
 
-The full set of error kinds emitted in agent mode: `config_error`, `config_already_exists`, `input_parse_error`, `unknown_check_id`, `other_error`, `internal_error`, `malformed_patch`.
+The full set of error kinds emitted in agent mode: `config_error`, `config_already_exists`, `input_parse_error`, `unknown_check_id`, `unknown_fingerprint`, `other_error`, `internal_error`, `malformed_patch`. `unknown_fingerprint` is emitted by `explain-finding` when the fingerprint doesn't match any entry in the supplied report; the payload includes `suggestion` (a close-match fingerprint, when one exists) and `source_report`.
 
 `detect --json` and each `doctor --json` payload also carry `diagnostics: [...]` and `next_actions: [...]` fields. `next_action` (single string) remains the rank-1 action projected to a string; `next_actions` is the ranked list with `kind`, `command|path`, `why`, and `expects` fields. See [docs/diagnostics.md](docs/diagnostics.md) for the full catalog and schema.
 
@@ -291,13 +291,24 @@ agents-shipgate scan -c shipgate.yaml \
 
 Strict mode fails CI only on **new** findings (those not in the baseline).
 
-### Task 5 · Explain a finding
+### Task 5 · Explain a check or a specific finding
+
+For static catalog metadata about a check ID (rationale, fires-when, recommendation):
 
 ```bash
 agents-shipgate explain SHIP-POLICY-APPROVAL-MISSING --json
 ```
 
 Returns the full `CheckMetadata` with `id`, `category`, `default_severity`, `description`, `rationale`, `fires_when`, `evidence_fields`, `recommendation`.
+
+For a contextual explanation tied to a specific finding from a real scan (catalog metadata + the finding's evidence + a 3–5 sentence templated prose summary):
+
+```bash
+agents-shipgate explain-finding fp_<fingerprint> \
+    --from agents-shipgate-reports/report.json --json
+```
+
+Returns the canonical Finding fields plus `metadata` (CheckMetadata for the check_id) and `explanation` — a deterministic prose summary suitable for direct quotation in a PR comment or chat reply. The companion prompt is [`prompts/explain-finding-to-user.md`](prompts/explain-finding-to-user.md).
 
 ---
 
@@ -381,6 +392,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate doctor` | `-c`, `--workspace`, `--json`, `--verbose` |
 | `agents-shipgate contract` | `--json` |
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
+| `agents-shipgate explain-finding` | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--out` |
 | `agents-shipgate fixture` | `list`, `run`, `copy`, `verify` |
@@ -452,6 +464,7 @@ Prebuilt prompts for common workflows live in [`prompts/`](prompts/):
 - [`add-shipgate-to-repo.md`](prompts/add-shipgate-to-repo.md) — bootstrap a repo
 - [`fix-top-finding.md`](prompts/fix-top-finding.md) — iterate on a single finding
 - [`recommend-fixes.md`](prompts/recommend-fixes.md) — walk all active findings and surface targeted fix recommendations across the four autofix-policy classes
+- [`explain-finding-to-user.md`](prompts/explain-finding-to-user.md) — translate one finding into 3–5 sentences of user-facing prose; companion to `agents-shipgate explain-finding`
 - [`stabilize-strict-mode.md`](prompts/stabilize-strict-mode.md) — tune → baseline → promote
 - [`triage-false-positive.md`](prompts/triage-false-positive.md) — override vs suppress decision
 - [`upgrade-shipgate-version.md`](prompts/upgrade-shipgate-version.md) — bump agents-shipgate version safely (regenerate baseline if needed)
@@ -839,6 +852,23 @@ available.
 ## Don't use for new gating
 
 - `summary.status` — preserved for v0.7 callers, **baseline-blind**. A baseline-matched critical flips this to `release_blockers_detected` even though `release_decision.decision` correctly classifies it as `review_required`. New consumers should not gate on `summary.status`. See [STABILITY.md §`release_decision.decision` vs `summary.status`](../STABILITY.md#release_decisiondecision-vs-summarystatus).
+
+## Per-finding contextual explanation (v0.12+)
+
+For prose summaries of a single finding (PR comments, chat replies, commit messages), use:
+
+```bash
+agents-shipgate explain-finding <FINGERPRINT> \
+    --from agents-shipgate-reports/report.json --json
+```
+
+The payload mirrors the canonical Finding fields plus:
+
+- `metadata` — full `CheckMetadata` for the check_id (rationale, fires_when, evidence_fields, docs_url) when the check is in the catalog; null for unknown ids (third-party plugins, future checks).
+- `explanation` — a deterministic 3–5 sentence prose summary suitable for direct quotation. Names the affected tool, the severity, the recommended fix, and an action-aware closing sentence keyed to `agent_action`. Same inputs always produce the same output.
+- `source_report` — absolute path to the report file the explanation was sourced from; round-trippable for caching and audit.
+
+Companion prompt: [`prompts/explain-finding-to-user.md`](../prompts/explain-finding-to-user.md). Use it when you need to translate a finding for a human who has never read the Shipgate docs. Keep `agents-shipgate explain <CHECK_ID>` for static catalog metadata (no specific finding); use `explain-finding` whenever you have a fingerprint and want the evidence-tied prose.
 
 ## Authoritative references
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -862,11 +862,13 @@ agents-shipgate explain-finding <FINGERPRINT> \
     --from agents-shipgate-reports/report.json --json
 ```
 
-The payload mirrors the canonical Finding fields plus:
+The payload is the full `Finding` shape (every field on `findings[]` in `report.json`, including `source`, `patches`, `confidence`, `agent_id`, etc.) overlaid with three derived fields:
 
 - `metadata` — full `CheckMetadata` for the check_id (rationale, fires_when, evidence_fields, docs_url) when the check is in the catalog; null for unknown ids (third-party plugins, future checks).
 - `explanation` — a deterministic 3–5 sentence prose summary suitable for direct quotation. Names the affected tool, the severity, the recommended fix, and an action-aware closing sentence keyed to `agent_action`. Same inputs always produce the same output.
-- `source_report` — absolute path to the report file the explanation was sourced from; round-trippable for caching and audit.
+- `source_report` — **absolute** path (always; relative `--from` values are resolved before serialization) to the report file the explanation was sourced from; round-trippable for caching and audit.
+
+`explain-finding` requires `report_schema_version >= 0.12` because the action-aware explanation depends on per-finding `agent_action`. Pre-v0.12 reports are rejected with `input_parse_error` and a `next_action` pointing at the canonical scan command. The Pydantic `ReadinessReport` model is intentionally looser than this command's contract (so test fixtures can construct minimal findings); the version gate is what enforces v0.12 semantics on emitted reports.
 
 Companion prompt: [`prompts/explain-finding-to-user.md`](../prompts/explain-finding-to-user.md). Use it when you need to translate a finding for a human who has never read the Shipgate docs. Keep `agents-shipgate explain <CHECK_ID>` for static catalog metadata (no specific finding); use `explain-finding` whenever you have a fingerprint and want the evidence-tied prose.
 

--- a/prompts/explain-finding-to-user.md
+++ b/prompts/explain-finding-to-user.md
@@ -1,0 +1,89 @@
+# Prompt · Explain a single Agents Shipgate finding to a user
+
+You need to translate one `report.json` finding into prose for a human
+who has never read the Shipgate docs. Companion to `agents-shipgate
+explain-finding <fingerprint>`, which gives you the structured payload
+you'll quote.
+
+This is for the moment when an agent has run a scan, identified the top
+finding (via `agent_summary.first_recommended_action.why` or by walking
+`findings[]`), and now has to summarize it for a PR comment, chat
+reply, or commit message. The user shouldn't have to follow a doc link
+to understand what's going on.
+
+## Your task
+
+1. **Get the fingerprint.** Read it from `agent_summary.first_recommended_action.why` if that names a `check_id` and tool, then look up the matching `findings[].fingerprint` in `report.json`. Otherwise pick the highest-severity active finding (`critical > high > medium > low`) and read `fingerprint` directly from that entry.
+
+2. **Run `explain-finding` to get the structured payload.**
+   ```bash
+   agents-shipgate explain-finding <FINGERPRINT> \
+       --from agents-shipgate-reports/report.json --json
+   ```
+   The output carries:
+   - `check_id`, `title`, `severity`, `category` — what the check is.
+   - `tool_name`, `tool_id` — the affected tool (may be null for manifest-level checks).
+   - `evidence` — the structured evidence the check captured.
+   - `recommendation` — the check author's verbatim suggested fix.
+   - `agent_action` — `auto_apply | propose_patch_for_review | escalate_to_human | suppress_with_reason | informational`.
+   - `metadata` — full `CheckMetadata` (rationale, fires_when, evidence_fields, docs_url) when the check is in the catalog.
+   - `explanation` — a deterministic 3–5-sentence prose summary you can quote verbatim or rewrite.
+
+3. **Write the prose for the user.** Three to five sentences, in this order:
+   1. **What.** Name the check (`check_id` is fine), the affected tool (`tool_name`), and the severity in one sentence. If the check has no `tool_name`, name what the check examined (e.g. "the manifest", "permissions").
+   2. **Why it matters.** Pull from `metadata.rationale` or `metadata.fires_when`. If neither exists, paraphrase the `recommendation`. Avoid verbatim verbose catalog text — translate "limited automation review" into plain English.
+   3. **What you'll do (or want).** Map `agent_action` to a concrete next step:
+      - `auto_apply`: "I can apply the fix automatically — say yes and I'll run `apply-patches --confidence high --apply`."
+      - `propose_patch_for_review`: "There's a suggested patch but the confidence is medium/low (or there's a manual sibling). Want me to show the diff before applying?"
+      - `escalate_to_human`: "There's no automatic fix. Here's the recommended remediation: [paraphrase recommendation]. Want me to draft the change for you to review?"
+      - `suppress_with_reason`: "If you want to accept this risk, I can add a suppression with reason. What should the reason say?"
+      - `informational`: "No action needed; flagging for awareness."
+   4. *(Optional)* **Where to learn more.** If `metadata.docs_url` exists, link it.
+   5. *(Optional)* **Suppression status.** If `suppressed` is true, mention that — otherwise omit.
+
+4. **Cite evidence sparingly.** Only quote a specific evidence value when it makes the explanation concrete (e.g. naming the broken parameter, the file path from `source.ref`). Do not dump the whole `evidence` dict.
+
+5. **Format for the surface.** PR comments and chat support markdown — use a code span for `check_id` and `tool_name`. Plain text emails should drop the backticks but keep the structure.
+
+## Example
+
+Input (from `explain-finding fp_f092940f62fbb012 --from ... --json`):
+```json
+{
+  "check_id": "SHIP-POLICY-APPROVAL-MISSING",
+  "severity": "critical",
+  "tool_name": "stripe.create_refund",
+  "agent_action": "escalate_to_human",
+  "recommendation": "Declare an approval policy or remove the tool.",
+  "metadata": {
+    "rationale": "High-risk actions need explicit approval before promotion.",
+    "fires_when": "Financial/destructive risk exists without approval policy."
+  }
+}
+```
+
+Good prose for a PR comment:
+
+> The release-readiness scan flagged a critical issue: `stripe.create_refund` doesn't declare an approval policy in `shipgate.yaml`. High-risk actions like refunds need an explicit human approval gate before they can ship — without one, an agent could trigger a refund on its own without review. There's no automatic fix here. The right remediation is to either add `policies.require_approval_for_tools: [stripe.create_refund]` (with a reviewer-visible approval trace) or remove the tool from this release surface. Want me to draft the manifest change for you?
+
+Bad prose for the same input:
+
+> Finding `fp_f092940f62fbb012`: `SHIP-POLICY-APPROVAL-MISSING` fired with severity `critical` on `stripe.create_refund`. autofix_safe=false, requires_human_review=true. evidence: risk_tags=[financial_action, destructive]. recommendation: "Declare an approval policy or remove the tool."
+
+The bad version is true but unreadable — it dumps the JSON instead of translating it.
+
+## What NOT to do
+
+- Do **not** quote the structured `explanation` field verbatim if it's robotic. It's a deterministic baseline; rewrite for tone when needed.
+- Do **not** fabricate consequences. If the check's `rationale` doesn't say "could trigger a refund," don't say it. Stay grounded in catalog text.
+- Do **not** propose `apply-patches` for `escalate_to_human` findings — the user has to decide on the fix manually.
+- Do **not** propose adding a `checks.ignore` entry as the default response. Suppression is a real choice, but it's the last resort and needs an audit-trail-quality reason. Use the [`triage-false-positive.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/prompts/triage-false-positive.md) prompt for that workflow.
+- Do **not** include the fingerprint string in the user-facing prose unless they specifically asked for it. Fingerprints are agent-to-agent identifiers, not human-friendly labels.
+
+## Verification before sending the message
+
+- The user-facing prose names the affected tool (or what the check examined) at least once.
+- The severity is mentioned somewhere (a word like "critical" or "medium-severity" — not just the JSON token).
+- The action sentence matches the finding's `agent_action`. If the message says "I'll apply this automatically," `agent_action` must be `auto_apply`.
+- No raw JSON dumps in the prose — translate, don't quote.
+- If `metadata.docs_url` exists, include it (or link text equivalent).

--- a/skills/agents-shipgate/SKILL.md
+++ b/skills/agents-shipgate/SKILL.md
@@ -36,6 +36,7 @@ Pick the matching task and follow the linked recipe verbatim. Recipes are bundle
 | Add Shipgate to CI for the first time (advisory, PR comment) | See "First-time CI setup" below; copy [`ci-recipes/advisory-pr-comment.yml`](ci-recipes/advisory-pr-comment.yml) |
 | Fix the highest-severity finding | [`prompts/fix-top-finding.md`](prompts/fix-top-finding.md) |
 | Recommend fixes across all active findings | [`prompts/recommend-fixes.md`](prompts/recommend-fixes.md) |
+| Explain a single finding in user-facing prose (3–5 sentences for a PR comment / chat reply) | [`prompts/explain-finding-to-user.md`](prompts/explain-finding-to-user.md); pair with `agents-shipgate explain-finding <fingerprint> --from agents-shipgate-reports/report.json --json` |
 | Triage a suspected false positive | [`prompts/triage-false-positive.md`](prompts/triage-false-positive.md) |
 | Promote advisory CI to strict CI (assumes advisory is already running) | [`prompts/stabilize-strict-mode.md`](prompts/stabilize-strict-mode.md) |
 | Upgrade agents-shipgate version | [`prompts/upgrade-shipgate-version.md`](prompts/upgrade-shipgate-version.md) |

--- a/skills/agents-shipgate/prompts/explain-finding-to-user.md
+++ b/skills/agents-shipgate/prompts/explain-finding-to-user.md
@@ -1,0 +1,89 @@
+# Prompt · Explain a single Agents Shipgate finding to a user
+
+You need to translate one `report.json` finding into prose for a human
+who has never read the Shipgate docs. Companion to `agents-shipgate
+explain-finding <fingerprint>`, which gives you the structured payload
+you'll quote.
+
+This is for the moment when an agent has run a scan, identified the top
+finding (via `agent_summary.first_recommended_action.why` or by walking
+`findings[]`), and now has to summarize it for a PR comment, chat
+reply, or commit message. The user shouldn't have to follow a doc link
+to understand what's going on.
+
+## Your task
+
+1. **Get the fingerprint.** Read it from `agent_summary.first_recommended_action.why` if that names a `check_id` and tool, then look up the matching `findings[].fingerprint` in `report.json`. Otherwise pick the highest-severity active finding (`critical > high > medium > low`) and read `fingerprint` directly from that entry.
+
+2. **Run `explain-finding` to get the structured payload.**
+   ```bash
+   agents-shipgate explain-finding <FINGERPRINT> \
+       --from agents-shipgate-reports/report.json --json
+   ```
+   The output carries:
+   - `check_id`, `title`, `severity`, `category` — what the check is.
+   - `tool_name`, `tool_id` — the affected tool (may be null for manifest-level checks).
+   - `evidence` — the structured evidence the check captured.
+   - `recommendation` — the check author's verbatim suggested fix.
+   - `agent_action` — `auto_apply | propose_patch_for_review | escalate_to_human | suppress_with_reason | informational`.
+   - `metadata` — full `CheckMetadata` (rationale, fires_when, evidence_fields, docs_url) when the check is in the catalog.
+   - `explanation` — a deterministic 3–5-sentence prose summary you can quote verbatim or rewrite.
+
+3. **Write the prose for the user.** Three to five sentences, in this order:
+   1. **What.** Name the check (`check_id` is fine), the affected tool (`tool_name`), and the severity in one sentence. If the check has no `tool_name`, name what the check examined (e.g. "the manifest", "permissions").
+   2. **Why it matters.** Pull from `metadata.rationale` or `metadata.fires_when`. If neither exists, paraphrase the `recommendation`. Avoid verbatim verbose catalog text — translate "limited automation review" into plain English.
+   3. **What you'll do (or want).** Map `agent_action` to a concrete next step:
+      - `auto_apply`: "I can apply the fix automatically — say yes and I'll run `apply-patches --confidence high --apply`."
+      - `propose_patch_for_review`: "There's a suggested patch but the confidence is medium/low (or there's a manual sibling). Want me to show the diff before applying?"
+      - `escalate_to_human`: "There's no automatic fix. Here's the recommended remediation: [paraphrase recommendation]. Want me to draft the change for you to review?"
+      - `suppress_with_reason`: "If you want to accept this risk, I can add a suppression with reason. What should the reason say?"
+      - `informational`: "No action needed; flagging for awareness."
+   4. *(Optional)* **Where to learn more.** If `metadata.docs_url` exists, link it.
+   5. *(Optional)* **Suppression status.** If `suppressed` is true, mention that — otherwise omit.
+
+4. **Cite evidence sparingly.** Only quote a specific evidence value when it makes the explanation concrete (e.g. naming the broken parameter, the file path from `source.ref`). Do not dump the whole `evidence` dict.
+
+5. **Format for the surface.** PR comments and chat support markdown — use a code span for `check_id` and `tool_name`. Plain text emails should drop the backticks but keep the structure.
+
+## Example
+
+Input (from `explain-finding fp_f092940f62fbb012 --from ... --json`):
+```json
+{
+  "check_id": "SHIP-POLICY-APPROVAL-MISSING",
+  "severity": "critical",
+  "tool_name": "stripe.create_refund",
+  "agent_action": "escalate_to_human",
+  "recommendation": "Declare an approval policy or remove the tool.",
+  "metadata": {
+    "rationale": "High-risk actions need explicit approval before promotion.",
+    "fires_when": "Financial/destructive risk exists without approval policy."
+  }
+}
+```
+
+Good prose for a PR comment:
+
+> The release-readiness scan flagged a critical issue: `stripe.create_refund` doesn't declare an approval policy in `shipgate.yaml`. High-risk actions like refunds need an explicit human approval gate before they can ship — without one, an agent could trigger a refund on its own without review. There's no automatic fix here. The right remediation is to either add `policies.require_approval_for_tools: [stripe.create_refund]` (with a reviewer-visible approval trace) or remove the tool from this release surface. Want me to draft the manifest change for you?
+
+Bad prose for the same input:
+
+> Finding `fp_f092940f62fbb012`: `SHIP-POLICY-APPROVAL-MISSING` fired with severity `critical` on `stripe.create_refund`. autofix_safe=false, requires_human_review=true. evidence: risk_tags=[financial_action, destructive]. recommendation: "Declare an approval policy or remove the tool."
+
+The bad version is true but unreadable — it dumps the JSON instead of translating it.
+
+## What NOT to do
+
+- Do **not** quote the structured `explanation` field verbatim if it's robotic. It's a deterministic baseline; rewrite for tone when needed.
+- Do **not** fabricate consequences. If the check's `rationale` doesn't say "could trigger a refund," don't say it. Stay grounded in catalog text.
+- Do **not** propose `apply-patches` for `escalate_to_human` findings — the user has to decide on the fix manually.
+- Do **not** propose adding a `checks.ignore` entry as the default response. Suppression is a real choice, but it's the last resort and needs an audit-trail-quality reason. Use the [`triage-false-positive.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/prompts/triage-false-positive.md) prompt for that workflow.
+- Do **not** include the fingerprint string in the user-facing prose unless they specifically asked for it. Fingerprints are agent-to-agent identifiers, not human-friendly labels.
+
+## Verification before sending the message
+
+- The user-facing prose names the affected tool (or what the check examined) at least once.
+- The severity is mentioned somewhere (a word like "critical" or "medium-severity" — not just the JSON token).
+- The action sentence matches the finding's `agent_action`. If the message says "I'll apply this automatically," `agent_action` must be `auto_apply`.
+- No raw JSON dumps in the prose — translate, don't quote.
+- If `metadata.docs_url` exists, include it (or link text equivalent).

--- a/src/agents_shipgate/cli/explain_finding.py
+++ b/src/agents_shipgate/cli/explain_finding.py
@@ -31,6 +31,23 @@ from agents_shipgate.core.models import (
     ReadinessReport,
 )
 
+_MIN_SUPPORTED_SCHEMA = "0.12"
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    """Parse a `MAJOR.MINOR` schema version into a comparable tuple.
+
+    Raises ``ValueError`` for malformed strings so the CLI maps the
+    failure to ``input_parse_error`` (exit 3) rather than a 500-style
+    crash."""
+    try:
+        return tuple(int(part) for part in value.split("."))
+    except (AttributeError, ValueError) as exc:
+        raise ValueError(
+            f"invalid report_schema_version: {value!r}"
+        ) from exc
+
+
 _AGENT_ACTION_GUIDANCE: dict[AgentAction, str] = {
     "auto_apply": (
         "This finding has a high-confidence machine-applicable patch "
@@ -57,12 +74,22 @@ _AGENT_ACTION_GUIDANCE: dict[AgentAction, str] = {
 }
 
 
-def _load_report(path: Path) -> ReadinessReport:
-    """Load and validate ``report.json`` from disk.
+def _load_report(path: Path) -> tuple[ReadinessReport, dict[str, Any]]:
+    """Load, version-gate, and validate ``report.json`` from disk.
 
-    Returns a fully-typed :class:`ReadinessReport`. Raises ``ValueError``
-    with a structured message on any failure mode (missing, malformed
-    JSON, schema-invalid).
+    Returns ``(report, raw_payload)``: the typed
+    :class:`ReadinessReport` plus the raw dict (for pass-through fields
+    that the Pydantic model may strip). Raises ``ValueError`` with a
+    structured message on any failure mode (missing, malformed JSON,
+    schema-invalid, or pre-v0.12 schema version).
+
+    Pydantic's ``ReadinessReport`` is intentionally looser than
+    ``docs/report-schema.v0.12.json`` (e.g. ``Finding.agent_action``
+    is ``Optional`` so test fixtures can construct minimal findings).
+    Without the explicit version gate, ``explain-finding`` would
+    silently accept a v0.11 report and return ``"agent_action": null``
+    in the payload, contradicting the v0.12 contract that the
+    explanation is action-aware (#58 review P2.2).
     """
     if not path.is_file():
         raise ValueError(f"report file not found: {path}")
@@ -76,8 +103,24 @@ def _load_report(path: Path) -> ReadinessReport:
         raise ValueError(f"report is not valid JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise ValueError("report JSON must be an object")
+
+    version = payload.get("report_schema_version")
+    if not isinstance(version, str):
+        raise ValueError(
+            "input must be an agents-shipgate report.json with a "
+            "string `report_schema_version`."
+        )
+    if _version_tuple(version) < _version_tuple(_MIN_SUPPORTED_SCHEMA):
+        raise ValueError(
+            f"explain-finding requires report_schema_version "
+            f">= {_MIN_SUPPORTED_SCHEMA} (got {version!r}). The "
+            "v0.12 schema added the per-finding `agent_action` enum "
+            "that this command depends on. Re-scan with the current "
+            "CLI: `agents-shipgate scan -c shipgate.yaml --format json`."
+        )
+
     try:
-        return ReadinessReport.model_validate(payload)
+        return ReadinessReport.model_validate(payload), payload
     except ValidationError as exc:
         raise ValueError(f"report.json failed validation: {exc}") from exc
 
@@ -165,16 +208,32 @@ def explain_finding_payload(
     """Build the deterministic payload for ``explain-finding --json``.
 
     Pure function: takes a fingerprint and a report path, returns a
-    serialisable dict. Raises ``ValueError`` on missing fingerprint
-    or unparseable report. Importable from tests.
+    serialisable dict. Raises ``ValueError`` on missing report or
+    pre-v0.12 schema; raises :class:`FingerprintNotFound` when the
+    fingerprint doesn't match any finding in the report.
+
+    Payload shape: every canonical ``Finding`` field (via
+    :meth:`pydantic.BaseModel.model_dump`) plus three derived fields:
+
+    - ``metadata`` — full :class:`CheckMetadata` for ``check_id``
+      (None for unknown ids, e.g. third-party plugins).
+    - ``explanation`` — deterministic 3–5 sentence prose summary.
+    - ``source_report`` — absolute path to the report file the
+      explanation was sourced from.
+
+    Earlier this function returned only a hand-picked subset of
+    Finding fields, dropping ``source``, ``patches``, ``confidence``,
+    and ``agent_id``. The action-aware sentence in the prose
+    explicitly tells agents to surface manual instructions, but with
+    ``patches`` missing they had to re-fetch the report — so the
+    payload now mirrors the full Finding by default (#58 review P2.1).
     """
-    report = _load_report(report_path)
+    report, _raw_payload = _load_report(report_path)
     target = next(
         (f for f in report.findings if f.fingerprint == fingerprint),
         None,
     )
     if target is None:
-        # Suggest a close match by fingerprint prefix.
         all_fps = [f.fingerprint or "" for f in report.findings]
         close = get_close_matches(fingerprint, all_fps, n=1)
         suggestion = close[0] if close else None
@@ -184,31 +243,21 @@ def explain_finding_payload(
     catalog_lookup = {c.id: c for c in catalog}
     metadata = catalog_lookup.get(target.check_id)
 
-    return {
-        "fingerprint": target.fingerprint,
-        "id": target.id,
-        "check_id": target.check_id,
-        "title": target.title,
-        "severity": target.severity,
-        "category": target.category,
-        "tool_name": target.tool_name,
-        "tool_id": target.tool_id,
-        "evidence": target.evidence,
-        "recommendation": target.recommendation,
-        "agent_action": target.agent_action,
-        "autofix_safe": target.autofix_safe,
-        "requires_human_review": target.requires_human_review,
-        "suggested_patch_kind": target.suggested_patch_kind,
-        "docs_url": target.docs_url,
-        "suppressed": target.suppressed,
-        "suppression_reason": target.suppression_reason,
-        "baseline_status": target.baseline_status,
-        "metadata": (
-            metadata.model_dump(mode="json") if metadata is not None else None
-        ),
-        "explanation": _render_explanation(target, metadata),
-        "source_report": str(report_path),
-    }
+    # Mirror the canonical Finding shape via model_dump so future
+    # additive fields (e.g. v0.13 source-provenance enrichments)
+    # flow through automatically. Overlay the three derived fields.
+    payload = target.model_dump(mode="json")
+    payload["metadata"] = (
+        metadata.model_dump(mode="json") if metadata is not None else None
+    )
+    payload["explanation"] = _render_explanation(target, metadata)
+    # `source_report` is documented as an absolute path. Resolve here
+    # so a relative `--from` value (e.g. the documented default
+    # `agents-shipgate-reports/report.json`) round-trips correctly
+    # for downstream tooling that expects a stable, machine-routable
+    # path (#58 review P3).
+    payload["source_report"] = str(report_path.resolve())
+    return payload
 
 
 class FingerprintNotFound(LookupError):

--- a/src/agents_shipgate/cli/explain_finding.py
+++ b/src/agents_shipgate/cli/explain_finding.py
@@ -1,0 +1,340 @@
+"""``shipgate explain-finding`` — contextual explanation for one finding.
+
+`explain <check-id>` returns the static catalog metadata for a check.
+`explain-finding <fingerprint> --from <report.json>` returns the same
+catalog metadata PLUS the specific finding's evidence PLUS a templated
+prose explanation tied to that evidence — so an agent can produce a
+high-quality summary for a human reviewer without re-implementing the
+templating itself.
+
+The templated explanation is deterministic per (catalog, finding); same
+inputs always produce the same output.
+"""
+
+from __future__ import annotations
+
+import json
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Any
+
+import typer
+from pydantic import ValidationError
+
+from agents_shipgate.checks.registry import check_catalog
+from agents_shipgate.cli.agent_mode import emit_agent_mode_error
+from agents_shipgate.cli.diagnostics import NextAction
+from agents_shipgate.core.models import (
+    AgentAction,
+    CheckMetadata,
+    Finding,
+    ReadinessReport,
+)
+
+_AGENT_ACTION_GUIDANCE: dict[AgentAction, str] = {
+    "auto_apply": (
+        "This finding has a high-confidence machine-applicable patch "
+        "and is safe to auto-apply via `agents-shipgate apply-patches "
+        "--confidence high --apply`."
+    ),
+    "propose_patch_for_review": (
+        "A non-manual patch is attached, but the full patch set is not "
+        "auto-safe. Propose `apply-patches` to the user and surface any "
+        "manual instructions verbatim before they confirm `--apply`."
+    ),
+    "escalate_to_human": (
+        "No machine-applicable patch is available; this needs human "
+        "judgment to resolve."
+    ),
+    "suppress_with_reason": (
+        "This check is marked suppressible; if you accept the risk, "
+        "add an entry to `checks.ignore` with a concrete reason."
+    ),
+    "informational": (
+        "No action required — this finding is informational or already "
+        "suppressed."
+    ),
+}
+
+
+def _load_report(path: Path) -> ReadinessReport:
+    """Load and validate ``report.json`` from disk.
+
+    Returns a fully-typed :class:`ReadinessReport`. Raises ``ValueError``
+    with a structured message on any failure mode (missing, malformed
+    JSON, schema-invalid).
+    """
+    if not path.is_file():
+        raise ValueError(f"report file not found: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"cannot read report at {path}: {exc}") from exc
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"report is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("report JSON must be an object")
+    try:
+        return ReadinessReport.model_validate(payload)
+    except ValidationError as exc:
+        raise ValueError(f"report.json failed validation: {exc}") from exc
+
+
+def _evidence_summary(evidence: dict[str, Any]) -> str:
+    """Render a one-sentence summary of finding evidence.
+
+    Walks the dict in insertion order, keeping it short. Falls back to
+    "(no structured evidence)" when empty.
+    """
+    if not evidence:
+        return "(no structured evidence in this finding)"
+    parts: list[str] = []
+    for key, value in evidence.items():
+        # Prefer compact representations for common field shapes.
+        if isinstance(value, list):
+            if not value:
+                continue
+            preview = ", ".join(str(v) for v in value[:3])
+            if len(value) > 3:
+                preview += f", … (+{len(value) - 3})"
+            parts.append(f"{key}=[{preview}]")
+        elif isinstance(value, dict):
+            sub_keys = list(value)[:3]
+            parts.append(f"{key}={{{', '.join(sub_keys)}}}")
+        else:
+            parts.append(f"{key}={value!r}")
+    return "; ".join(parts) or "(structured evidence present but empty values)"
+
+
+def _render_explanation(
+    finding: Finding,
+    metadata: CheckMetadata | None,
+) -> str:
+    """Render a 3–5 sentence prose explanation of this finding.
+
+    Deterministic projection of (finding, metadata): same inputs always
+    produce the same output. Designed for direct quotation in a PR
+    comment or chat reply — names the affected tool, the risk, the
+    recommended fix, and the action the agent intends to take.
+    """
+    tool = finding.tool_name or "the manifest"
+    sentences: list[str] = []
+
+    sentences.append(
+        f"`{finding.check_id}` ({finding.severity}) fired on {tool}: "
+        f"{finding.title.rstrip('.')}."
+    )
+
+    rationale_parts: list[str] = []
+    if metadata and metadata.fires_when:
+        rationale_parts.append(metadata.fires_when.rstrip("."))
+    if metadata and metadata.rationale:
+        rationale_parts.append(metadata.rationale.rstrip("."))
+    if rationale_parts:
+        sentences.append("Why it matters: " + "; ".join(rationale_parts) + ".")
+
+    evidence_summary = _evidence_summary(finding.evidence)
+    if evidence_summary and not evidence_summary.startswith("(no "):
+        sentences.append(f"Evidence: {evidence_summary}.")
+
+    recommendation = (finding.recommendation or "").rstrip(".")
+    if recommendation:
+        sentences.append(f"Recommended fix: {recommendation}.")
+
+    action: AgentAction | None = finding.agent_action
+    if action and action in _AGENT_ACTION_GUIDANCE:
+        sentences.append(_AGENT_ACTION_GUIDANCE[action])
+
+    if finding.suppressed:
+        reason = finding.suppression_reason or "no reason recorded"
+        sentences.append(
+            f"This finding is currently suppressed in shipgate.yaml ({reason})."
+        )
+
+    return " ".join(sentences)
+
+
+def explain_finding_payload(
+    *,
+    fingerprint: str,
+    report_path: Path,
+    plugins_enabled: bool | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic payload for ``explain-finding --json``.
+
+    Pure function: takes a fingerprint and a report path, returns a
+    serialisable dict. Raises ``ValueError`` on missing fingerprint
+    or unparseable report. Importable from tests.
+    """
+    report = _load_report(report_path)
+    target = next(
+        (f for f in report.findings if f.fingerprint == fingerprint),
+        None,
+    )
+    if target is None:
+        # Suggest a close match by fingerprint prefix.
+        all_fps = [f.fingerprint or "" for f in report.findings]
+        close = get_close_matches(fingerprint, all_fps, n=1)
+        suggestion = close[0] if close else None
+        raise FingerprintNotFound(fingerprint, suggestion=suggestion)
+
+    catalog = check_catalog(plugins_enabled=plugins_enabled)
+    catalog_lookup = {c.id: c for c in catalog}
+    metadata = catalog_lookup.get(target.check_id)
+
+    return {
+        "fingerprint": target.fingerprint,
+        "id": target.id,
+        "check_id": target.check_id,
+        "title": target.title,
+        "severity": target.severity,
+        "category": target.category,
+        "tool_name": target.tool_name,
+        "tool_id": target.tool_id,
+        "evidence": target.evidence,
+        "recommendation": target.recommendation,
+        "agent_action": target.agent_action,
+        "autofix_safe": target.autofix_safe,
+        "requires_human_review": target.requires_human_review,
+        "suggested_patch_kind": target.suggested_patch_kind,
+        "docs_url": target.docs_url,
+        "suppressed": target.suppressed,
+        "suppression_reason": target.suppression_reason,
+        "baseline_status": target.baseline_status,
+        "metadata": (
+            metadata.model_dump(mode="json") if metadata is not None else None
+        ),
+        "explanation": _render_explanation(target, metadata),
+        "source_report": str(report_path),
+    }
+
+
+class FingerprintNotFound(LookupError):
+    """Raised when ``explain-finding`` cannot match the requested
+    fingerprint to a finding in the report."""
+
+    def __init__(self, fingerprint: str, *, suggestion: str | None) -> None:
+        self.fingerprint = fingerprint
+        self.suggestion = suggestion
+        suffix = f" Did you mean {suggestion}?" if suggestion else ""
+        super().__init__(f"Unknown fingerprint: {fingerprint}.{suffix}")
+
+
+def explain_finding(
+    fingerprint: str = typer.Argument(
+        ...,
+        help=(
+            "Finding fingerprint (e.g. `fp_f092940f62fbb012`). Read it "
+            "from `findings[].fingerprint` in `report.json`."
+        ),
+    ),
+    source: Path = typer.Option(
+        Path("agents-shipgate-reports/report.json"),
+        "--from",
+        help=(
+            "Path to the scan's `report.json`. Default mirrors the "
+            "canonical reports directory."
+        ),
+    ),
+    no_plugins: bool = typer.Option(
+        False,
+        "--no-plugins",
+        help=(
+            "Do not load third-party check plugins even when "
+            "AGENTS_SHIPGATE_ENABLE_PLUGINS is set."
+        ),
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit JSON instead of text.",
+    ),
+) -> None:
+    """Explain a specific finding from a `report.json`, with evidence.
+
+    Returns the catalog metadata, the specific finding's evidence, and
+    a 3–5 sentence prose explanation suitable for direct quotation in a
+    PR comment or chat reply. Companion to `explain <check-id>`, which
+    returns only the static catalog metadata for a check ID.
+    """
+    try:
+        payload = explain_finding_payload(
+            fingerprint=fingerprint,
+            report_path=source,
+            plugins_enabled=False if no_plugins else None,
+        )
+    except FingerprintNotFound as exc:
+        suffix = f" Did you mean {exc.suggestion}?" if exc.suggestion else ""
+        typer.echo(
+            f"Unknown fingerprint: {exc.fingerprint}.{suffix}", err=True
+        )
+        emit_agent_mode_error(
+            "unknown_fingerprint",
+            fingerprint=exc.fingerprint,
+            suggestion=exc.suggestion,
+            source_report=str(source),
+            next_action=(
+                f"Read findings[].fingerprint in {source} to find the "
+                "right id."
+            ),
+            next_actions=[
+                NextAction(
+                    kind="review",
+                    path=str(source),
+                    why=(
+                        "Walk findings[] to copy the exact fingerprint "
+                        "string. Fingerprints are stable across scans "
+                        "for the same (check_id, tool_name, evidence) "
+                        "tuple."
+                    ),
+                    expects=(
+                        "A `findings[].fingerprint` value of the form "
+                        "`fp_<16-hex-chars>`."
+                    ),
+                ).model_dump(mode="json")
+            ],
+        )
+        raise typer.Exit(2) from exc
+    except ValueError as exc:
+        typer.echo(f"explain-finding: {exc}", err=True)
+        emit_agent_mode_error(
+            "input_parse_error",
+            message=str(exc),
+            source_report=str(source),
+            next_action="agents-shipgate scan -c shipgate.yaml --format json",
+            next_actions=[
+                NextAction(
+                    kind="command",
+                    command=(
+                        "agents-shipgate scan -c shipgate.yaml --format json"
+                    ),
+                    why=(
+                        f"Could not load {source}. Generate a fresh "
+                        "report.json with the canonical 4-call flow."
+                    ),
+                    expects=(
+                        "agents-shipgate-reports/report.json on disk, "
+                        "validatable against the current report schema."
+                    ),
+                ).model_dump(mode="json")
+            ],
+        )
+        raise typer.Exit(3) from exc
+
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    typer.echo(payload["fingerprint"])
+    typer.echo(f"Check: {payload['check_id']}")
+    typer.echo(f"Severity: {payload['severity']}")
+    if payload["tool_name"]:
+        typer.echo(f"Tool: {payload['tool_name']}")
+    typer.echo(f"Title: {payload['title']}")
+    typer.echo("")
+    typer.echo(payload["explanation"])
+    if payload["docs_url"]:
+        typer.echo("")
+        typer.echo(f"Docs: {payload['docs_url']}")

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -37,6 +37,7 @@ from agents_shipgate.cli.discovery.agent_instructions import (
 from agents_shipgate.cli.discovery.agent_instructions.targets import SPECS as _AI_SPECS
 from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.evidence_packet import evidence_packet as _evidence_packet_command
+from agents_shipgate.cli.explain_finding import explain_finding as _explain_finding_command
 from agents_shipgate.cli.fixture import fixture_app
 from agents_shipgate.cli.scan import inspect_sources, run_scan
 from agents_shipgate.cli.scenario import scenario_app
@@ -80,6 +81,14 @@ app.command(
         "into md, html, and/or pdf."
     ),
 )(_evidence_packet_command)
+app.command(
+    "explain-finding",
+    help=(
+        "Explain a specific finding from a `report.json`, with evidence "
+        "and a 3–5 sentence prose summary. Companion to `explain "
+        "<check-id>`."
+    ),
+)(_explain_finding_command)
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_explain_finding.py
+++ b/tests/test_explain_finding.py
@@ -1,0 +1,252 @@
+"""Pin the v0.12 ``agents-shipgate explain-finding`` CLI surface.
+
+Covers:
+- Happy path: a fingerprint from a real scan resolves to a payload
+  with the canonical keys and a non-empty templated explanation.
+- Bad fingerprint: exit code 2 + structured agent-mode error with a
+  close-match suggestion when one exists.
+- Missing/malformed report path: exit code 3 + structured error.
+- Determinism: identical fingerprint + identical report → identical
+  payload (so callers can cache without surprises).
+- Templated explanation always names the affected tool (when one
+  exists), severity, recommendation, and an action-aware sentence
+  that matches the finding's `agent_action`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.explain_finding import (
+    FingerprintNotFound,
+    _render_explanation,
+    explain_finding_payload,
+)
+from agents_shipgate.cli.main import app
+from agents_shipgate.cli.scan import run_scan
+from agents_shipgate.core.models import Finding
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAMPLE_MANIFEST = REPO_ROOT / "samples" / "support_refund_agent" / "shipgate.yaml"
+
+CANONICAL_PAYLOAD_KEYS = frozenset(
+    {
+        "fingerprint",
+        "id",
+        "check_id",
+        "title",
+        "severity",
+        "category",
+        "tool_name",
+        "tool_id",
+        "evidence",
+        "recommendation",
+        "agent_action",
+        "autofix_safe",
+        "requires_human_review",
+        "suggested_patch_kind",
+        "docs_url",
+        "suppressed",
+        "suppression_reason",
+        "baseline_status",
+        "metadata",
+        "explanation",
+        "source_report",
+    }
+)
+
+
+def _scan_into(tmp_path: Path) -> tuple[Path, list[dict]]:
+    """Run a real scan against the support_refund sample and return
+    (report_path, findings_list)."""
+    out = tmp_path / "reports"
+    run_scan(
+        config_path=SAMPLE_MANIFEST,
+        output_dir=out,
+        formats=["json"],
+        ci_mode="advisory",
+        suggest_patches=True,
+    )
+    payload = json.loads((out / "report.json").read_text("utf-8"))
+    return out / "report.json", payload["findings"]
+
+
+def test_happy_path_payload_shape(tmp_path):
+    """A real scan + fingerprint produces a payload with exactly the
+    documented keys and a non-empty explanation."""
+    report_path, findings = _scan_into(tmp_path)
+    fp = next(f["fingerprint"] for f in findings if not f["suppressed"])
+    payload = explain_finding_payload(fingerprint=fp, report_path=report_path)
+
+    assert set(payload) == CANONICAL_PAYLOAD_KEYS, (
+        f"explain-finding payload diverged from documented keys.\n"
+        f"  expected: {sorted(CANONICAL_PAYLOAD_KEYS)}\n"
+        f"  got:      {sorted(payload)}"
+    )
+    assert payload["fingerprint"] == fp
+    assert payload["explanation"], "Explanation must be non-empty."
+    assert payload["check_id"]
+    assert payload["source_report"] == str(report_path)
+
+
+def test_metadata_populated_for_known_check_ids(tmp_path):
+    """For every finding whose check_id is in the catalog, the
+    `metadata` field is a dict (not None) with the canonical
+    CheckMetadata keys. Catches a regression where the catalog lookup
+    silently drops to None."""
+    report_path, findings = _scan_into(tmp_path)
+    for raw in findings:
+        if not raw["fingerprint"]:
+            continue
+        payload = explain_finding_payload(
+            fingerprint=raw["fingerprint"], report_path=report_path
+        )
+        # Every check_id in the support_refund sample is in the
+        # built-in catalog, so metadata should always populate.
+        assert payload["metadata"] is not None, (
+            f"Metadata missing for {payload['check_id']!r} "
+            f"(fingerprint {payload['fingerprint']!r})."
+        )
+        assert payload["metadata"]["id"] == payload["check_id"]
+
+
+def test_payload_is_deterministic(tmp_path):
+    """Two calls with the same inputs return byte-identical payloads.
+    Cached / repeated lookups must not drift due to dict iteration
+    order or non-deterministic catalog initialization."""
+    report_path, findings = _scan_into(tmp_path)
+    fp = next(f["fingerprint"] for f in findings if not f["suppressed"])
+
+    a = explain_finding_payload(fingerprint=fp, report_path=report_path)
+    b = explain_finding_payload(fingerprint=fp, report_path=report_path)
+
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True), (
+        "explain_finding_payload is not deterministic across calls."
+    )
+
+
+def test_unknown_fingerprint_raises_with_suggestion(tmp_path):
+    """A close-but-wrong fingerprint must raise ``FingerprintNotFound``
+    carrying a suggested correction so the agent can recover without
+    walking findings[] itself."""
+    report_path, findings = _scan_into(tmp_path)
+    real_fp = next(f["fingerprint"] for f in findings if f["fingerprint"])
+    # Mutate one character — close enough for difflib to suggest the original.
+    mutated = real_fp[:-1] + ("0" if real_fp[-1] != "0" else "1")
+
+    with pytest.raises(FingerprintNotFound) as exc_info:
+        explain_finding_payload(fingerprint=mutated, report_path=report_path)
+
+    assert exc_info.value.suggestion == real_fp, (
+        f"Expected suggestion={real_fp!r}; got {exc_info.value.suggestion!r}."
+    )
+
+
+def test_unknown_fingerprint_with_no_close_match(tmp_path):
+    """Completely-unrelated fingerprint string yields suggestion=None."""
+    report_path, _findings = _scan_into(tmp_path)
+    with pytest.raises(FingerprintNotFound) as exc_info:
+        explain_finding_payload(
+            fingerprint="fp_xxxxxxxxxxxxxxxx", report_path=report_path
+        )
+    assert exc_info.value.suggestion is None
+
+
+def test_missing_report_raises_value_error(tmp_path):
+    """A non-existent report path raises ValueError so the CLI maps
+    it to exit 3 (input_parse_error)."""
+    with pytest.raises(ValueError, match="report file not found"):
+        explain_finding_payload(
+            fingerprint="fp_anything",
+            report_path=tmp_path / "nope.json",
+        )
+
+
+def test_malformed_report_raises_value_error(tmp_path):
+    """A path that exists but isn't valid JSON raises ValueError."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        explain_finding_payload(fingerprint="fp_anything", report_path=bad)
+
+
+def test_cli_exit_codes_and_json_shape(tmp_path):
+    """End-to-end: the typer CLI returns exit 0 for a happy path,
+    2 for unknown fingerprint, 3 for unreadable report. The JSON
+    output round-trips through json.loads."""
+    report_path, findings = _scan_into(tmp_path)
+    fp = next(f["fingerprint"] for f in findings if not f["suppressed"])
+    runner = CliRunner()
+
+    happy = runner.invoke(
+        app,
+        ["explain-finding", fp, "--from", str(report_path), "--json"],
+    )
+    assert happy.exit_code == 0, happy.output
+    parsed = json.loads(happy.stdout)
+    assert parsed["fingerprint"] == fp
+
+    bad_fp = runner.invoke(
+        app,
+        ["explain-finding", "fp_xxxxxxxxxxxxxxxx", "--from", str(report_path)],
+    )
+    assert bad_fp.exit_code == 2
+
+    missing = runner.invoke(
+        app,
+        ["explain-finding", fp, "--from", str(tmp_path / "missing.json")],
+    )
+    assert missing.exit_code == 3
+
+
+def test_explanation_names_tool_severity_and_action():
+    """The templated explanation must reliably name the affected tool,
+    the severity, the check_id, and an action-aware closing sentence.
+    Pinned so a refactor doesn't drop one of those signals — the
+    prompt expects all of them when it asks the agent to summarize a
+    finding."""
+    finding = Finding(
+        check_id="SHIP-POLICY-APPROVAL-MISSING",
+        title="High-risk tool lacks a declared approval policy.",
+        severity="critical",
+        category="policy",
+        tool_name="stripe.create_refund",
+        recommendation="Declare an approval policy or remove the tool.",
+        agent_action="escalate_to_human",
+        suppressed=False,
+        evidence={"risk_tags": ["financial_action", "destructive"]},
+        autofix_safe=False,
+        requires_human_review=True,
+    )
+    text = _render_explanation(finding, metadata=None)
+
+    assert "stripe.create_refund" in text
+    assert "critical" in text
+    assert "SHIP-POLICY-APPROVAL-MISSING" in text
+    assert "approval policy" in text  # from recommendation
+    # Action-aware closing sentence
+    assert "human judgment" in text or "human review" in text or "no machine" in text.lower()
+
+
+def test_explanation_handles_suppressed_findings():
+    """Suppressed findings still get a coherent explanation and have
+    the suppression status spelled out."""
+    finding = Finding(
+        check_id="SHIP-DOC-MISSING-DESCRIPTION",
+        title="Tool description is missing or too short.",
+        severity="medium",
+        category="documentation",
+        tool_name="legacy_search",
+        recommendation="Add a clear capability description.",
+        agent_action="informational",
+        suppressed=True,
+        suppression_reason="tool deprecated 2026-Q2",
+        evidence={"description_length": 0},
+    )
+    text = _render_explanation(finding, metadata=None)
+    assert "suppressed" in text.lower()
+    assert "tool deprecated 2026-Q2" in text

--- a/tests/test_explain_finding.py
+++ b/tests/test_explain_finding.py
@@ -33,26 +33,40 @@ from agents_shipgate.core.models import Finding
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SAMPLE_MANIFEST = REPO_ROOT / "samples" / "support_refund_agent" / "shipgate.yaml"
 
-CANONICAL_PAYLOAD_KEYS = frozenset(
+# Core fields the payload MUST contain. The payload is now built from
+# `Finding.model_dump()` plus three derived fields, so the full set
+# expands automatically when Finding gains new fields. Pin the contract
+# as a "must contain" subset rather than an exact match — that's what
+# downstream agents actually depend on.
+REQUIRED_PAYLOAD_KEYS = frozenset(
     {
+        # Core finding identity
         "fingerprint",
         "id",
         "check_id",
         "title",
         "severity",
         "category",
+        # Tool linkage
         "tool_name",
         "tool_id",
+        "agent_id",
+        # Evidence and remediation
         "evidence",
+        "source",
+        "patches",
+        "confidence",
         "recommendation",
         "agent_action",
         "autofix_safe",
         "requires_human_review",
         "suggested_patch_kind",
         "docs_url",
+        # Suppression / baseline
         "suppressed",
         "suppression_reason",
         "baseline_status",
+        # Derived overlay (not in the Finding model)
         "metadata",
         "explanation",
         "source_report",
@@ -76,21 +90,136 @@ def _scan_into(tmp_path: Path) -> tuple[Path, list[dict]]:
 
 
 def test_happy_path_payload_shape(tmp_path):
-    """A real scan + fingerprint produces a payload with exactly the
-    documented keys and a non-empty explanation."""
+    """A real scan + fingerprint produces a payload that contains every
+    documented key and a non-empty explanation. The payload mirrors the
+    full `Finding` shape (via `model_dump`) plus the derived overlay
+    (`metadata`, `explanation`, `source_report`), so future additive
+    Finding fields flow through without a breaking schema change."""
     report_path, findings = _scan_into(tmp_path)
     fp = next(f["fingerprint"] for f in findings if not f["suppressed"])
     payload = explain_finding_payload(fingerprint=fp, report_path=report_path)
 
-    assert set(payload) == CANONICAL_PAYLOAD_KEYS, (
-        f"explain-finding payload diverged from documented keys.\n"
-        f"  expected: {sorted(CANONICAL_PAYLOAD_KEYS)}\n"
+    missing = REQUIRED_PAYLOAD_KEYS - set(payload)
+    assert not missing, (
+        f"explain-finding payload missing required keys: {sorted(missing)}.\n"
+        f"  required: {sorted(REQUIRED_PAYLOAD_KEYS)}\n"
         f"  got:      {sorted(payload)}"
     )
     assert payload["fingerprint"] == fp
     assert payload["explanation"], "Explanation must be non-empty."
     assert payload["check_id"]
-    assert payload["source_report"] == str(report_path)
+
+
+def test_payload_mirrors_full_finding_shape(tmp_path):
+    """The payload must include `source`, `patches`, `confidence`, and
+    `agent_id` — fields that earlier hand-picking dropped. The
+    explain-finding contract says the payload mirrors canonical Finding
+    fields; this pins that promise so a future refactor that
+    re-introduces hand-picking trips a regression (#58 review P2.1)."""
+    report_path, findings = _scan_into(tmp_path)
+    # Pick a finding that actually has patches (the support_refund
+    # sample has several when scanned with --suggest-patches).
+    fp = next(
+        f["fingerprint"] for f in findings if f.get("patches")
+    )
+    payload = explain_finding_payload(fingerprint=fp, report_path=report_path)
+
+    for field in ("source", "patches", "confidence", "agent_id"):
+        assert field in payload, (
+            f"Payload must include `{field}` — earlier hand-picking "
+            f"dropped this field. Got: {sorted(payload)!r}"
+        )
+    # `patches` should round-trip from the original finding (non-empty
+    # for this sample).
+    raw = next(f for f in findings if f["fingerprint"] == fp)
+    assert payload["patches"] == raw["patches"]
+
+
+def test_source_report_is_absolute(tmp_path):
+    """`source_report` is documented as an absolute path. A relative
+    `--from` (e.g. the canonical default
+    `agents-shipgate-reports/report.json`) must resolve to absolute
+    before round-tripping into the payload (#58 review P3)."""
+    report_path, findings = _scan_into(tmp_path)
+    fp = next(f["fingerprint"] for f in findings if f["fingerprint"])
+
+    # Force a relative path that points at the same file.
+    import os
+
+    relative = Path(os.path.relpath(report_path, Path.cwd()))
+    payload = explain_finding_payload(fingerprint=fp, report_path=relative)
+
+    assert Path(payload["source_report"]).is_absolute(), (
+        f"source_report must be absolute; got {payload['source_report']!r}"
+    )
+    # And it should point at the same file (resolved).
+    assert Path(payload["source_report"]).resolve() == report_path.resolve()
+
+
+def test_pre_v012_report_is_rejected(tmp_path):
+    """A v0.11-shaped report (lacking per-finding `agent_action`) must
+    be rejected by `explain-finding` — the v0.12 contract says the
+    explanation is action-aware, and silently accepting a stale report
+    would yield `agent_action: null` and drop that sentence
+    (#58 review P2.2)."""
+    v11_payload = {
+        "schema_version": "0.1",
+        "report_schema_version": "0.11",
+        "run_id": "r",
+        "manifest_dir": "/tmp",
+        "project": {},
+        "agent": {},
+        "environment": {},
+        "summary": {
+            "status": "review_required",
+            "critical_count": 0,
+            "high_count": 1,
+            "medium_count": 0,
+            "low_count": 0,
+            "info_count": 0,
+            "suppressed_count": 0,
+            "human_review_recommended": False,
+            "evidence_coverage": "static",
+        },
+        "tool_surface": {"total_tools": 0, "high_risk_tools": 0},
+        "findings": [
+            {
+                "id": "fp_test",
+                "fingerprint": "fp_test",
+                "check_id": "SHIP-DOC-MISSING-DESCRIPTION",
+                "title": "t",
+                "severity": "medium",
+                "category": "documentation",
+                "evidence": {},
+                "confidence": "medium",
+                "recommendation": "r",
+                "suppressed": False,
+            }
+        ],
+        "recommended_actions": [],
+        "generated_reports": {},
+    }
+    stale_path = tmp_path / "stale.json"
+    stale_path.write_text(json.dumps(v11_payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"requires report_schema_version >= 0\.12"):
+        explain_finding_payload(
+            fingerprint="fp_test", report_path=stale_path
+        )
+
+
+def test_missing_schema_version_is_rejected(tmp_path):
+    """A `report.json` without a `report_schema_version` string fails
+    cleanly — preferable to a downstream KeyError or a Pydantic
+    validation barrage."""
+    bad_payload = {"run_id": "r", "findings": []}
+    path = tmp_path / "no-version.json"
+    path.write_text(json.dumps(bad_payload), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError, match=r"agents-shipgate report\.json"
+    ):
+        explain_finding_payload(fingerprint="fp_x", report_path=path)
 
 
 def test_metadata_populated_for_known_check_ids(tmp_path):


### PR DESCRIPTION
## Summary

- Ships W4-3 / W4-4 of the agent-adoption strategy. Closes the gap between `explain <check-id>` (static catalog metadata) and what coding agents actually need when summarizing one finding for a human reviewer: catalog metadata + the specific finding's evidence + a deterministic 3–5 sentence prose explanation.
- New CLI: `agents-shipgate explain-finding <fingerprint> --from <report.json> [--json]`. Companion prompt: `prompts/explain-finding-to-user.md` (+ skill mirror).

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior _(new `explain-finding` command + new `unknown_fingerprint` agent-mode error kind)_
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest` → 903 passed (was 891 on main; +10 new + parametrization expansion), 3 skipped
- `python -m ruff check .` → clean
- Manual end-to-end: `agents-shipgate explain-finding fp_<...> --from agents-shipgate-reports/report.json --json` against the support_refund sample returns the canonical 21-key payload and a tool-named, severity-named, action-aware prose explanation.

## Release-readiness notes

- [x] No user-code import added to default scan paths _(read-only command — loads `report.json` and the catalog only)_
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` _(no new check IDs)_
- [x] Report/schema changes are additive or documented in `STABILITY.md` _(no schema change; new stable command added to STABILITY.md)_

## Notable design points

- **Determinism**: `explain_finding_payload` is a pure function over `(fingerprint, report_path, plugins_enabled)`. Same inputs always produce byte-identical output (pinned by `test_payload_is_deterministic`). Callers can cache without surprises.
- **Action-aware prose**: every `agent_action` enum value (`auto_apply`, `propose_patch_for_review`, `escalate_to_human`, `suppress_with_reason`, `informational`) maps to a tailored closing sentence. The prompt's "what NOT to do" section forbids the agent from saying "I'll apply this automatically" when `agent_action` isn't `auto_apply`.
- **Error UX**: unknown fingerprint produces a close-match suggestion via `difflib.get_close_matches` (mirroring the existing `explain` command's pattern). Missing/malformed report paths route through `input_parse_error` with a `next_action` pointing at the canonical scan command.
- **No JSON dumps**: the companion prompt explicitly forbids quoting raw JSON in user-facing prose, with paired good/bad-prose examples to make the bar clear.

## What's next per the plan

- W4-5 (re-run benchmark against Codex + Cursor) and W4-6 (W4 retrospective) remain external/manual tasks per the plan; they depend on the W2-4 baseline run that's also still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)