### PR TITLE
Add agent-action-guide, upstream-integrations, golden-pr-from-coding-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Top findings:
 The fastest way to understand what changes for a reviewer: walk through a Golden PR. Each one ships a sample manifest, the resulting report, the release decision, and the recommended PR-comment summary an agent should post.
 
 - [`openai-agents-sdk-refund-agent`](examples/golden-prs/openai-agents-sdk-refund-agent/README.md) — refund agent adds `stripe.create_refund`. Shipgate decides `blocked` because approval policy and idempotency evidence are missing. Includes the recommended Markdown PR-comment template.
+- [`golden-pr-from-coding-agent.md`](examples/golden-prs/golden-pr-from-coding-agent.md) — the *artifact* a coding agent should produce after running the canonical 4-call flow: PR comment, structured `agent_summary`, applied diff, review-item table.
 - [`mcp-only-tool-server`](examples/golden-prs/mcp-only-tool-server/README.md) — MCP server with no Python framework imports; demonstrates the MCP-only adoption path.
 - [`openapi-support-agent`](examples/golden-prs/openapi-support-agent/README.md) — OpenAPI-described tool surface; shows scope-coverage findings.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,8 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`checks.json`](checks.json) — machine-readable check catalog (regenerated each release)
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
 - [`report-schema.v0.12.json`](report-schema.v0.12.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.12"`, which adds the per-finding `agent_action` enum and the top-level `agent_summary` block)
+- [`agent-action-guide.md`](agent-action-guide.md) — per-category recipe for what to do with a finding (canonical fix per check category, last-resort suppression rules)
+- [`upstream-integrations.md`](upstream-integrations.md) — per-framework 60-second drop-in for adding Shipgate to an existing project (OpenAI Agents SDK, LangChain, CrewAI, ADK, MCP-only, OpenAPI-only, OpenAI Messages API, Anthropic Messages API)
 - [`report-schema.v0.11.json`](report-schema.v0.11.json) — frozen v0.11 reference schema; pre-v0.12 reports validate against this
 - [`report-schema.v0.10.json`](report-schema.v0.10.json) — frozen v0.10 reference schema; pre-v0.11 reports validate against this
 - [`report-schema.v0.9.json`](report-schema.v0.9.json) — frozen v0.9 reference schema; pre-v0.10 reports validate against this

--- a/docs/agent-action-guide.md
+++ b/docs/agent-action-guide.md
@@ -1,0 +1,143 @@
+# Agent Action Guide
+
+Per-category recipe for what a coding agent should DO when it sees a Shipgate finding. Companion to [`autofix-policy.md`](autofix-policy.md) (which describes the four-class autofix model) and [`agent-recipes.md`](agent-recipes.md) (the canonical 4-call flow). This doc is the lookup table for "I have a finding with `check_id: SHIP-X-Y`; what's the right move?"
+
+> **Audience.** AI coding agents reading a specific finding from `agents-shipgate-reports/report.json`. Drives the routing inside [`prompts/recommend-fixes.md`](../prompts/recommend-fixes.md) and [`prompts/fix-top-finding.md`](../prompts/fix-top-finding.md).
+
+## How to use this doc
+
+1. Open the finding in `report.json`. Read its `check_id`, `category`, and `agent_action`.
+2. Find the category row in the table below.
+3. Apply the recipe **only after** confirming `agent_action` matches the recipe's expected action. If it doesn't, the per-finding fields override this doc — use [`explain-finding`](../README.md#for-coding-agents) to get the canonical projection.
+4. Surface the recommended fix to the user. Use [`prompts/explain-finding-to-user.md`](../prompts/explain-finding-to-user.md) when you need to translate it into prose.
+
+The recipes assume the user owns the manifest and the tool sources. For checks against third-party tools (e.g. an MCP server you didn't write), the recipe usually shifts from "fix the spec" to "narrow the surface or add a wrapper."
+
+## Quick reference
+
+| Category | Typical `agent_action` | One-line recipe | Last-resort suppression |
+|---|---|---|---|
+| `manifest` | `auto_apply` | Run `apply-patches --confidence high --apply`; the patch is a stale-entry removal | Don't suppress — fix the stale entry instead |
+| `inventory` | `escalate_to_human` | Replace wildcard tools with an explicit allowlist; declare MCP/OpenAPI sources for high-confidence inventory | Acceptable if tool surface is intentionally broad and audited externally |
+| `documentation` | `escalate_to_human` | Add a 20+ char description to the tool definition (in OpenAPI / MCP / SDK source) | Acceptable for tools slated for imminent removal — record the deletion ticket in the `reason` |
+| `schema` | `escalate_to_human` | Tighten the parameter schema (add `maximum`, replace free-form strings with enums, structure free-form output) | Almost never — broad schemas are the actual risk |
+| `auth` | `propose_patch_for_review` for scope-coverage; `escalate_to_human` for broad-scope | Append the missing scope to `permissions.scopes` (medium-confidence patch attached) OR replace `*`/`admin` with operation-specific scopes | Suppress only if a wrapper enforces narrower scope at runtime |
+| `scope` | `escalate_to_human` | Either remove the offending tool from this release or update `agent.declared_purpose` / `prohibited_actions` to match | Don't suppress — the contradiction will surface again |
+| `policy` | `escalate_to_human` | Add the tool to `policies.require_approval_for_tools` / `require_confirmation_for_tools` / `require_idempotency_for_tools` with a reviewer-visible reason | Acceptable for purely-internal tools with explicit ADR linking the suppression |
+| `side_effects` | `escalate_to_human` | Constrain blast-radius parameters (max amount, target allowlist) or split into separate tools per scope | Don't suppress — the risk is the action surface, not the check |
+| `evidence` | `escalate_to_human` | Add the missing local HITL evidence file (approval trace / override log / promotion criteria); fix `validation.required_evidence` flags if intentionally lower posture | Acceptable when the deployment legitimately doesn't have HITL evidence — explicitly document the review posture |
+| `security` | `escalate_to_human` | Rewrite the offending text — secrets out of descriptions, neutralize prompt-like directives | Almost never — these are real findings |
+| `api` (OpenAI) | `escalate_to_human` | Tighten response schemas, add decision/refusal/error fields, align prompt scope with enabled tools | Suppress only when the artifact is being deprecated |
+| `adk` / `langchain` / `crewai` | `escalate_to_human` | Provide explicit MCP/OpenAPI inputs OR declare a local tool inventory (`tool_inventories[]`); add eval files for production targets | Suppress when the framework's static surface is intentionally limited and runtime evidence is provided separately |
+
+## Per-category prescriptions
+
+### `manifest` — auto-applicable in most cases
+
+Stale-suppression / stale-policy / stale-risk-override findings emit a high-confidence `remove_pointer` patch when the match is unique. The recipe is:
+
+```bash
+agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
+    --confidence high --apply
+```
+
+**Caveat**: when multiple suppressions match the same stale check, the generator falls back to `ManualPatch` and `agent_action` becomes `escalate_to_human` — the agent should surface which entries were ambiguous and ask the user to pick.
+
+### `inventory` — narrow the surface
+
+`SHIP-INVENTORY-WILDCARD-TOOLS` and friends fire when the agent exposes "all tools" via a wildcard. There's no patch — fix the source:
+
+- **MCP-only repos**: replace the wildcard with an explicit `tools` array in the export.
+- **ADK / LangChain / CrewAI**: declare `tool_inventories[]` with a static JSON listing the resolved tools.
+- **OpenAPI**: ensure all paths are documented; the wildcard usually means a path glob that's broader than reality.
+
+`SHIP-INVENTORY-LOW-CONFIDENCE-PRODUCTION-SURFACE` fires when the production target depends on best-effort SDK inference. Either move the target to staging while the inventory matures, or provide an MCP/OpenAPI source.
+
+### `documentation` — fix the source
+
+Most documentation findings are pure source-side fixes. Add a description (20+ chars), remove instruction-override-like language, remove secrets. **Do not** add the description to `shipgate.yaml` — descriptions live with the tool itself.
+
+### `schema` — constrain the parameter
+
+`SHIP-SCHEMA-MISSING-BOUNDS` on a numeric field: add `maximum` (and optionally `minimum`). `SHIP-SCHEMA-BROAD-FREE-TEXT`: replace `type: string` with an `enum`, or split the field into structured sub-fields. `SHIP-SCHEMA-FREEFORM-OUTPUT`: add a `response_format` (OpenAI) or structured output schema.
+
+### `auth` — scope coverage gets a medium-confidence patch
+
+`SHIP-AUTH-SCOPE-COVERAGE-MISSING` emits an `append_pointer` patch at `medium` confidence. The recipe is:
+
+1. Show the user the patch's `value` (the proposed scope) and `pointer` (`/permissions/scopes/-`).
+2. Ask whether the proposed scope is the right one — scope strings encode policy choices and shouldn't be auto-appended.
+3. After confirmation, apply with `--confidence medium`:
+   ```bash
+   agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
+       --confidence medium --apply
+   ```
+
+`SHIP-AUTH-MANIFEST-BROAD-SCOPE` (`*` / `admin` declared at manifest level) is `escalate_to_human` — the agent must NOT auto-pick a narrower scope. Surface the broad scope to the user with a list of alternatives and let them choose.
+
+### `scope` — purpose vs. capability mismatch
+
+`SHIP-SCOPE-TOOL-OUTSIDE-PURPOSE` and `SHIP-SCOPE-PROHIBITED-TOOL-PRESENT` are contradiction findings. There's no automatic resolution; the user has to decide whether the tool is in scope (then update `agent.declared_purpose` / drop the entry from `prohibited_actions`) or out of scope (then remove the tool from the release surface). Suppression is wrong because the contradiction will keep surfacing on every scan.
+
+### `policy` — declare approval / confirmation / idempotency
+
+The most common "release_decision: blocked" cause. Recipe:
+
+```yaml
+# shipgate.yaml
+policies:
+  require_approval_for_tools:
+    - stripe.create_refund
+  require_confirmation_for_tools:
+    - gmail.send_customer_email
+  require_idempotency_for_tools:
+    - stripe.create_refund
+```
+
+**Trace findings (`SHIP-API-TRACE-APPROVAL-MISSING`, `SHIP-API-TRACE-CONFIRMATION-MISSING`) are class-four "never auto-fix"** per [`autofix-policy.md`](autofix-policy.md). Do NOT edit the trace recording to flip `approved: true`/`confirmed: true` — that patches the evidence, not the runtime gate. The fix is to implement the runtime gate and let it produce a real trace.
+
+### `side_effects` — narrow blast radius
+
+Add bounds to risky parameters (max refund amount, max email recipients), or split the tool into per-scope variants (`refund_small` / `refund_admin`). The check fires precisely when the surface is too broad to reason about; the recipe is to make the surface narrower, not to suppress.
+
+### `evidence` — add or document the HITL files
+
+`SHIP-EVIDENCE-APPROVAL-TRACE-MISSING` and friends fire when `validation.required_evidence` declares a posture but the local artifact files are missing or empty. Recipe:
+
+1. If the posture is correct: add the missing approval trace / override log / promotion criteria file at the path declared in the manifest.
+2. If the posture is wrong: lower the `validation.target_review_posture` and clear the `required_evidence` flags that don't apply.
+3. Either way, **don't fabricate evidence**. The `ManualPatch.instructions` for these checks include explicit anti-pattern language to that effect.
+
+### `security` — fix the offending text
+
+`SHIP-DOC-SECRET-IN-DESCRIPTION` (description carries an API key shape): rotate the secret, then remove from the description. `SHIP-DOC-INJECTION-RISK`: rewrite the text to be neutral metadata without instruction-override directives.
+
+### `api` (OpenAI Messages API artifacts)
+
+The OpenAI API category covers checks against `tools/openai-tools.json`, `prompts/`, `policies/openai-*.yaml`, and `tests/openai-cases.json`. Most are about response-format strictness and prompt-tool alignment. Recipe per check is in [`docs/checks.md`](checks.md).
+
+### `adk` / `langchain` / `crewai` — provide static evidence
+
+Framework-specific findings usually fire because the agent has dynamic toolsets / factory wrappers / runtime-loaded tools that the static AST extractor can't see. Recipe:
+
+- **ADK dynamic toolsets**: provide a static MCP export, an OpenAPI spec, OR a local tool inventory file (`google_adk.tool_inventories[]`). Eval coverage findings need eval files declared in `google_adk.eval_sets`.
+- **LangChain / CrewAI**: declare `langchain.tool_inventories[]` / `crewai.tool_inventories[]` pointing at JSON files listing the resolved tools.
+
+## What NOT to do
+
+- Do **not** treat `agent_action: auto_apply` as universal. Even auto-applicable findings should preview the diff before mutation in this guide's recipes — surface the patch to the user before `--apply`.
+- Do **not** suppress to silence — every `checks.ignore` entry must have a `reason` that names the audit trail (ADR link, ticket, deprecation date). Empty or vague reasons fail manifest validation.
+- Do **not** add `risk_overrides` as a default response. Overrides change the underlying risk classification; suppressions accept a specific finding. Use [`triage-false-positive.md`](../prompts/triage-false-positive.md) to decide between them.
+- Do **not** edit trace files (approval_trace, override_log) to silence trace findings. The trace is evidence; flip the runtime gate, not the recording.
+- Do **not** apply `--confidence medium` patches without showing the user the proposed `value` first. Scope strings, prompts, and policy entries encode decisions that shouldn't be auto-picked.
+
+## See also
+
+- [`autofix-policy.md`](autofix-policy.md) — the four-class autofix model and the catalog/Finding contract.
+- [`agent-recipes.md`](agent-recipes.md) — the canonical 4-call flow.
+- [`agent-contract-current.md`](agent-contract-current.md) — current schema versions and the `agent_action` enum.
+- [`upstream-integrations.md`](upstream-integrations.md) — per-framework drop-in instructions.
+- [`prompts/recommend-fixes.md`](../prompts/recommend-fixes.md) — coordinated remediation pass across all active findings.
+- [`prompts/fix-top-finding.md`](../prompts/fix-top-finding.md) — single-finding deep dive.
+- [`prompts/explain-finding-to-user.md`](../prompts/explain-finding-to-user.md) — translate a finding into user-facing prose.
+- [`prompts/triage-false-positive.md`](../prompts/triage-false-positive.md) — override vs. suppress decision tree.

--- a/docs/upstream-integrations.md
+++ b/docs/upstream-integrations.md
@@ -77,9 +77,6 @@ tool_sources:
   - id: lc
     type: langchain
     path: agent.py
-langchain:
-  tool_inventories:
-    - inventories/langchain-tools.json
 policies:
   require_approval_for_tools: []
   require_confirmation_for_tools: []
@@ -90,7 +87,7 @@ ci:
 **Working fixture**: [`samples/simple_langchain_agent/`](../samples/simple_langchain_agent/).
 
 **Pitfalls**:
-- LangGraph subgraphs and dynamically-built nodes aren't fully visible. Add a `langchain.tool_inventories[]` JSON listing the resolved tools so the inventory check stops failing.
+- LangGraph subgraphs and dynamically-built nodes aren't fully visible. Add `langchain.tool_inventories[]` only after you have written a local JSON inventory; missing non-optional artifact files stop the scan before findings are produced.
 - LangChain ≤ 0.2 patterns (`AgentExecutor` with prebuilt tools) are partially supported; the static surface may show low-confidence extractions.
 
 ## CrewAI (`@tool`, `Agent` / `Crew` / `Task`)
@@ -109,9 +106,6 @@ tool_sources:
   - id: crew
     type: crewai
     path: crew.py
-crewai:
-  tool_inventories:
-    - inventories/crewai-tools.json
 policies:
   require_approval_for_tools: []
 ci:
@@ -121,7 +115,7 @@ ci:
 **Working fixture**: [`samples/simple_crewai_agent/`](../samples/simple_crewai_agent/).
 
 **Pitfalls**:
-- CrewAI's prebuilt-tool registry isn't visible to AST extraction. The `tool_inventories[]` file is the recommended path to high-confidence inventory.
+- CrewAI's prebuilt-tool registry isn't visible to AST extraction. Add `crewai.tool_inventories[]` only after you have written a local JSON inventory; missing non-optional artifact files stop the scan before findings are produced.
 - Multi-agent crews need each `Agent(role=…)` to be statically introspectable; runtime config-driven roles fall back to low confidence.
 
 ## Google ADK (Python + Agent Config YAML)
@@ -140,11 +134,6 @@ tool_sources:
   - id: adk
     type: google_adk
     path: agent.py
-google_adk:
-  eval_sets:
-    - evals/support.eval.json
-  tool_inventories:
-    - inventories/adk-mcp-tools.json
 policies:
   require_approval_for_tools: []
 ci:
@@ -155,7 +144,7 @@ ci:
 
 **Pitfalls**:
 - `OpenAPIToolset(...)` and `McpToolset(...)` need `tool_filter` declared; without it, the toolset counts as "unfiltered" and `SHIP-ADK-MCP-TOOLSET-UNFILTERED` fires high. Add the filter, then point `inventory_path` at a local tool inventory.
-- Production targets need `eval_sets` declared; otherwise `SHIP-ADK-EVAL-COVERAGE-MISSING` fires.
+- Production targets need `google_adk.eval_sets` declared; otherwise `SHIP-ADK-EVAL-COVERAGE-MISSING` fires. Add the block only after the eval file exists, or mark the artifact `optional: true` during bring-up.
 
 ## MCP-only (no Python framework)
 

--- a/docs/upstream-integrations.md
+++ b/docs/upstream-integrations.md
@@ -1,0 +1,341 @@
+# Upstream Integrations
+
+Per-framework, 60-second instructions for dropping Agents Shipgate into a project that already uses one of the supported tool surfaces. This is the "coding agent's adoption checklist" — paste the minimal `shipgate.yaml`, run the canonical 4-call flow, and you're scanning.
+
+> **Audience.** Coding agents adding Shipgate to a target repo for the first time, or repo maintainers picking up Shipgate. If you want the full architectural reference, see [`docs/manifest-v0.1.md`](manifest-v0.1.md) and [`docs/minimal-real-configs.md`](minimal-real-configs.md). This doc is the speedrun.
+
+## The flow (every framework)
+
+```bash
+pipx install agents-shipgate
+agents-shipgate detect --json                                          # 1. classify
+agents-shipgate init --write --ci --json                               # 2. manifest + workflow
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json  # 3. scan + suggest
+agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
+    --confidence high --apply                                          # 4. apply safe trivial fixes
+```
+
+Per-framework guidance below differs only in step 2's manifest shape and which `tool_sources` you declare. Step 1 (`detect`) auto-classifies and tells you which framework rows fired; step 3 reads them.
+
+If you want a zero-install first step (just to confirm Shipgate is relevant), see [`docs/zero-install.md`](zero-install.md).
+
+## OpenAI Agents SDK (`@function_tool`)
+
+Drop-in for projects that decorate Python functions with `@function_tool` from `openai-agents`. Static AST extraction reads the decorators without importing the framework.
+
+```yaml
+# shipgate.yaml
+version: "0.1"
+project:
+  name: refund-agent
+agent:
+  name: support-refund-agent
+  declared_purpose:
+    - issue refunds for verified support cases
+  prohibited_actions:
+    - send personal data to external services
+environment:
+  target: production_like
+tool_sources:
+  - id: agent
+    type: openai_agents_sdk
+    path: agent.py
+policies:
+  require_approval_for_tools: []
+  require_confirmation_for_tools: []
+  require_idempotency_for_tools: []
+permissions:
+  scopes: []
+ci:
+  mode: advisory
+output:
+  directory: agents-shipgate-reports
+  formats: [markdown, json]
+```
+
+**Working fixture**: [`samples/support_refund_agent/`](../samples/support_refund_agent/) (this one combines OpenAI Agents SDK + OpenAPI + MCP). Run `agents-shipgate fixture run support_refund_agent` to scan it without writing any YAML.
+
+**Pitfalls**:
+- Tool factories (`make_tool(name=...)`) and decorators applied dynamically aren't visible to AST extraction. Provide an explicit MCP/OpenAPI export or a local tool inventory.
+- `Agent(name="…")` literals get auto-detected; runtime `Agent(name=os.environ[...])` doesn't.
+
+## LangChain / LangGraph (`@tool`, `create_agent`)
+
+For projects using LangChain Core 0.3+ `@tool` decorators or `create_agent` / `create_react_agent` patterns.
+
+```yaml
+version: "0.1"
+project:
+  name: support-agent
+agent:
+  name: langchain-support-agent
+  declared_purpose:
+    - answer support questions and escalate to humans for refunds
+environment:
+  target: production_like
+tool_sources:
+  - id: lc
+    type: langchain
+    path: agent.py
+langchain:
+  tool_inventories:
+    - inventories/langchain-tools.json
+policies:
+  require_approval_for_tools: []
+  require_confirmation_for_tools: []
+ci:
+  mode: advisory
+```
+
+**Working fixture**: [`samples/simple_langchain_agent/`](../samples/simple_langchain_agent/).
+
+**Pitfalls**:
+- LangGraph subgraphs and dynamically-built nodes aren't fully visible. Add a `langchain.tool_inventories[]` JSON listing the resolved tools so the inventory check stops failing.
+- LangChain ≤ 0.2 patterns (`AgentExecutor` with prebuilt tools) are partially supported; the static surface may show low-confidence extractions.
+
+## CrewAI (`@tool`, `Agent` / `Crew` / `Task`)
+
+```yaml
+version: "0.1"
+project:
+  name: research-crew
+agent:
+  name: research-agent
+  declared_purpose:
+    - research a topic and produce a structured brief
+environment:
+  target: local
+tool_sources:
+  - id: crew
+    type: crewai
+    path: crew.py
+crewai:
+  tool_inventories:
+    - inventories/crewai-tools.json
+policies:
+  require_approval_for_tools: []
+ci:
+  mode: advisory
+```
+
+**Working fixture**: [`samples/simple_crewai_agent/`](../samples/simple_crewai_agent/).
+
+**Pitfalls**:
+- CrewAI's prebuilt-tool registry isn't visible to AST extraction. The `tool_inventories[]` file is the recommended path to high-confidence inventory.
+- Multi-agent crews need each `Agent(role=…)` to be statically introspectable; runtime config-driven roles fall back to low confidence.
+
+## Google ADK (Python + Agent Config YAML)
+
+```yaml
+version: "0.1"
+project:
+  name: adk-support-agent
+agent:
+  name: support-agent
+  declared_purpose:
+    - handle support cases
+environment:
+  target: production_like
+tool_sources:
+  - id: adk
+    type: google_adk
+    path: agent.py
+google_adk:
+  eval_sets:
+    - evals/support.eval.json
+  tool_inventories:
+    - inventories/adk-mcp-tools.json
+policies:
+  require_approval_for_tools: []
+ci:
+  mode: advisory
+```
+
+**Working fixture**: [`samples/google_adk_agent/`](../samples/google_adk_agent/).
+
+**Pitfalls**:
+- `OpenAPIToolset(...)` and `McpToolset(...)` need `tool_filter` declared; without it, the toolset counts as "unfiltered" and `SHIP-ADK-MCP-TOOLSET-UNFILTERED` fires high. Add the filter, then point `inventory_path` at a local tool inventory.
+- Production targets need `eval_sets` declared; otherwise `SHIP-ADK-EVAL-COVERAGE-MISSING` fires.
+
+## MCP-only (no Python framework)
+
+For repositories that ship an MCP server and nothing else — no Python wrapper, no SDK decorators. Detection registers as `is_agent_project: false`, but `suggested_sources` will list the MCP export, so adoption proceeds.
+
+```yaml
+version: "0.1"
+project:
+  name: refund-mcp-server
+agent:
+  name: refund-mcp
+  declared_purpose:
+    - expose refund operations over MCP
+environment:
+  target: production_like
+tool_sources:
+  - id: mcp
+    type: mcp
+    path: mcp/tools.json
+policies:
+  require_approval_for_tools: []
+ci:
+  mode: advisory
+```
+
+**Working fixture**: [`examples/golden-prs/mcp-only-tool-server/`](../examples/golden-prs/mcp-only-tool-server/) — golden PR with a complete walkthrough.
+
+**Pitfalls**:
+- `*` / wildcard tool entries in the MCP export trigger `SHIP-INVENTORY-WILDCARD-TOOLS` high. Replace with an explicit allowlist.
+- The MCP export must be the resolved tool list, not a server config that points at runtime-loaded tools.
+
+## OpenAPI-only (HTTP tool surface)
+
+```yaml
+version: "0.1"
+project:
+  name: support-api
+agent:
+  name: support-api-agent
+  declared_purpose:
+    - operate support tickets via the documented API
+environment:
+  target: production_like
+tool_sources:
+  - id: api
+    type: openapi
+    path: openapi.yaml
+policies:
+  require_approval_for_tools: []
+permissions:
+  scopes: []
+ci:
+  mode: advisory
+```
+
+**Working fixture**: [`examples/golden-prs/openapi-support-agent/`](../examples/golden-prs/openapi-support-agent/).
+
+**Pitfalls**:
+- OpenAPI specs without `security` blocks don't declare auth scopes; `SHIP-AUTH-MISSING-SCOPE` fires high on every write operation. Add `security` per operation.
+- Spec files larger than 10 MB are rejected. Split or downsample.
+
+## OpenAI Messages API artifacts
+
+For projects that drive a Messages API model with `tools/openai-tools.json`, `prompts/`, `policies/openai-*.yaml`, and `tests/openai-cases.json` artifacts. No Python framework needed.
+
+```yaml
+version: "0.1"
+project:
+  name: support-messages-agent
+agent:
+  name: support-messages-agent
+  declared_purpose:
+    - handle tier-1 support over the Messages API
+environment:
+  target: production_like
+openai_api:
+  prompt_files:
+    - prompts/system.md
+  tools:
+    - path: tools/openai-tools.json
+  response_formats:
+    - path: schemas/response.schema.json
+      downstream_critical_fields: [decision, status]
+  model_config:
+    path: openai-config.json
+  test_cases:
+    - path: tests/cases.openai.cases.json
+  trace_samples:
+    - path: traces/sample.jsonl
+  policy_rules:
+    - path: policies/openai-policy.yaml
+ci:
+  mode: advisory
+```
+
+**Working fixture**: [`samples/simple_openai_api_agent/`](../samples/simple_openai_api_agent/).
+
+**Pitfalls**:
+- The `response_formats[].downstream_critical_fields` array names the JSON keys that downstream code branches on. Listing them lets `SHIP-API-STRUCTURED-OUTPUT-READINESS` validate that those keys are constrained (enum, oneOf) rather than free-form.
+- Trace samples must be JSON Lines with `approved` / `confirmed` / `decision` fields when the matching policy rule requires them — see [`docs/api-trace-evidence.md`](api-trace-evidence.md) for the canonical shape.
+
+## Anthropic Messages API artifacts
+
+```yaml
+version: "0.1"
+project:
+  name: support-anthropic-agent
+agent:
+  name: support-anthropic-agent
+  declared_purpose:
+    - tier-1 support over Anthropic Messages API
+environment:
+  target: production_like
+anthropic:
+  prompt_files:
+    - prompts/system.md
+  tools:
+    - path: tools/anthropic-tools.json
+  policy_rules:
+    - path: policies/anthropic-policy.yaml
+ci:
+  mode: advisory
+```
+
+**Working fixture**: [`samples/simple_anthropic_agent/`](../samples/simple_anthropic_agent/).
+
+**Pitfalls**:
+- Server-side built-in tool types (`computer_*`, `bash_*`, `web_search*`, `text_editor_*`) are skipped by checks like `SHIP-DOC-MISSING-DESCRIPTION` because the user can't fix the schema. A source warning surfaces instead.
+- Tool names must match `^[a-zA-Z0-9_-]{1,64}$`; violations are warnings, not errors.
+
+## Multi-framework projects (combined surface)
+
+Real production agents often combine surfaces — Python SDK plus an external MCP server plus an OpenAPI API. Just declare each `tool_source`:
+
+```yaml
+tool_sources:
+  - id: agent_sdk
+    type: openai_agents_sdk
+    path: agent.py
+  - id: refund_api
+    type: openapi
+    path: refund-api.yaml
+  - id: mcp_inventory
+    type: mcp
+    path: .agents-shipgate/mcp-export.json
+```
+
+Tool inventory and policy checks deduplicate across sources by `tool_name`, so the same tool surfaced via the SDK and the MCP export gets one finding, not two.
+
+## CI integration (the same for every framework)
+
+```yaml
+# .github/workflows/agents-shipgate.yml
+name: Agents Shipgate
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  shipgate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+        with:
+          ci_mode: advisory
+          diff_base: target
+          pr_comment: 'true'
+```
+
+`init --ci` writes a similar workflow into `.github/workflows/agents-shipgate.yml`. Switch to `ci_mode: strict` only after the team has reviewed the advisory output and saved a baseline (see [`baseline.md`](baseline.md)).
+
+## See also
+
+- [`zero-install.md`](zero-install.md) — verify relevance without installing anything.
+- [`agent-recipes.md`](agent-recipes.md) — programmatic 4-call flow for coding agents.
+- [`agent-action-guide.md`](agent-action-guide.md) — per-category recipe when you have a finding to act on.
+- [`minimal-real-configs.md`](minimal-real-configs.md) — fuller per-framework configs with rationale.
+- [`integrations.md`](integrations.md) — CI provider recipes (CircleCI, GitLab) beyond GitHub Actions.
+- [`docs/manifest-v0.1.md`](manifest-v0.1.md) — full manifest schema reference.

--- a/examples/golden-prs/README.md
+++ b/examples/golden-prs/README.md
@@ -18,4 +18,8 @@ Examples:
 - [`openapi-support-agent`](openapi-support-agent/) - OpenAPI support/refund
   API surface.
 
+For the **artifact** a coding agent produces after running the flow (the
+PR comment / chat reply, not the recipe to run Shipgate), see
+[`golden-pr-from-coding-agent.md`](golden-pr-from-coding-agent.md).
+
 These are documentation examples, not new framework adapters.

--- a/examples/golden-prs/golden-pr-from-coding-agent.md
+++ b/examples/golden-prs/golden-pr-from-coding-agent.md
@@ -139,7 +139,7 @@ The agent should also be ready to surface the structured form when asked. This m
 
 - **Severity counts** in the headline come from `agent_summary.{blocker_count, review_item_count, auto_appliable_patches, needs_human_review}`.
 - **Top blockers** come from `release_decision.blockers[]`. For each, run `agents-shipgate explain-finding <FINGERPRINT> --json` to get the metadata + evidence + templated explanation; quote the explanation or rewrite for tone.
-- **Diff blocks** come from the `apply-patches --apply --json` output's `files` array. Render with standard `+`/`-` markers.
+- **Diff blocks** come from the `apply-patches --apply --json` output's `files` object — keyed by file path, with each entry exposing `status`, `patches`, `diff`, `error`. Iterate `Object.entries(out.files)` (or `out["files"].items()` in Python) and render each `diff` with standard `+`/`-` markers.
 - **Review-item table** comes from walking `findings[]` filtered by `release_decision.review_items[].fingerprint`.
 
 ## When the verdict is different

--- a/examples/golden-prs/golden-pr-from-coding-agent.md
+++ b/examples/golden-prs/golden-pr-from-coding-agent.md
@@ -1,0 +1,157 @@
+# Golden PR — what a coding agent's output looks like
+
+A worked example of the **artifact** a coding agent produces after running Agents Shipgate end-to-end. Sibling examples ([`mcp-only-tool-server`](mcp-only-tool-server/), [`openai-agents-sdk-refund-agent`](openai-agents-sdk-refund-agent/), [`openapi-support-agent`](openapi-support-agent/)) document the *recipe* for adopting Shipgate; this doc documents the *output* — the diff, the PR comment, and the structured summary an agent should generate.
+
+> **Audience.** Coding agents (Claude Code, Codex, Cursor) running Shipgate inside a host repo. Use this as the template for the message you post back to the user once the canonical 4-call flow finishes.
+
+## Setup (the agent's actions before the PR)
+
+The agent has just completed the canonical 4-call flow on a target repo:
+
+```bash
+agents-shipgate detect --json
+agents-shipgate init --write --ci --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
+    --confidence high --apply
+```
+
+`scan` produced `agents-shipgate-reports/report.json` with:
+
+- `release_decision.decision: "blocked"`
+- 2 blockers on `stripe.create_refund` (missing approval policy, missing idempotency)
+- 14 high / 2 medium review items
+- 1 auto-applicable patch (a stale suppression removed by `apply-patches`)
+
+The agent now has to summarize this for the user.
+
+## The expected artifact (PR comment / chat reply)
+
+```markdown
+## Agents Shipgate — release blocked
+
+**Decision**: `blocked` (2 active findings block release; 14 high + 2
+medium review items also flagged.)
+
+**Top blockers**:
+1. `stripe.create_refund` — `SHIP-POLICY-APPROVAL-MISSING` (critical).
+   The refund tool ships without a declared approval policy. High-risk
+   actions need an explicit human approval gate before promotion. I
+   can draft `policies.require_approval_for_tools: [stripe.create_refund]`
+   for you; want me to add it with a placeholder reason you can edit?
+2. `stripe.create_refund` — `SHIP-SIDEFX-IDEMPOTENCY-MISSING` (critical).
+   The tool has no `idempotency_key` parameter and no policy entry.
+   Without idempotency, retried refunds duplicate. The fix is either
+   adding a parameter to the tool spec or declaring
+   `policies.require_idempotency_for_tools: [stripe.create_refund]`
+   with an external idempotency-key generator. Same draft offer.
+
+**What I already applied** (high-confidence, no manual review needed):
+- Removed 1 stale suppression entry that referenced a check ID that
+  no longer exists in the catalog. Diff shown below.
+
+**What needs your review** (14 high + 2 medium review items): I can
+walk these one-by-one if you want, or you can read
+`agents-shipgate-reports/report.md`. The full machine-readable list
+is at `agents-shipgate-reports/report.json`; the top-level
+`agent_summary` block carries the headline counts.
+
+**Reports**:
+- Markdown: `agents-shipgate-reports/report.md`
+- JSON: `agents-shipgate-reports/report.json` (schema v0.12)
+- Release Evidence Packet: `agents-shipgate-reports/packet.{md,json,html}`
+
+**CI**: `.github/workflows/agents-shipgate.yml` already wires
+`agents-shipgate@v0.10.0` in advisory mode; this PR will get a
+sticky-marker comment from the Action on every push.
+
+<details>
+<summary>Diff applied by <code>apply-patches --confidence high --apply</code></summary>
+
+```diff
+--- shipgate.yaml
++++ shipgate.yaml
+@@ -42,7 +42,3 @@
+ checks:
+   ignore:
+     - check_id: SHIP-RETIRED-CHECK-ID
+       tool: legacy_search
+       reason: removed in v0.10
+-    - check_id: SHIP-MANIFEST-STALE-SUPPRESSION
+-      tool: ghost_tool
+-      reason: tool removed
+```
+
+The removal is safe: the suppressed check ID either doesn't exist in
+the loaded catalog (orphaned) or matches no loaded tool (ghost). Either
+way, leaving the entry in place misleads future review.
+</details>
+
+<details>
+<summary>Top human-review items (full list in <code>report.json</code>)</summary>
+
+| # | Severity | Check | Tool | Action |
+|---|---|---|---|---|
+| 1 | high | `SHIP-AUTH-SCOPE-COVERAGE-MISSING` | `stripe.create_refund` | propose_patch_for_review (medium-confidence patch attached; I can show the diff) |
+| 2 | high | `SHIP-DOC-MISSING-DESCRIPTION` | `wildcard_mcp_tools.*` | escalate_to_human (no patch; description belongs with the tool spec) |
+| 3 | high | `SHIP-INVENTORY-WILDCARD-TOOLS` | `wildcard_mcp_tools.*` | escalate_to_human (replace wildcard with explicit allowlist) |
+| ... | ... | ... | ... | ... |
+</details>
+```
+
+## The structured summary (for downstream automation)
+
+The agent should also be ready to surface the structured form when asked. This mirrors `agent_summary` from `report.json`:
+
+```json
+{
+  "verdict": "blocked",
+  "headline": "2 active finding(s) block release; 16 review item(s) accepted as debt.",
+  "blocker_count": 2,
+  "review_item_count": 16,
+  "auto_appliable_patches": 1,
+  "needs_human_review": 15,
+  "first_recommended_action": {
+    "kind": "command",
+    "command": "agents-shipgate apply-patches --from /abs/path/agents-shipgate-reports/report.json --confidence high --apply",
+    "why": "1 finding(s) carry high-confidence patches safe to apply without human review."
+  }
+}
+```
+
+## What the agent did NOT do (and shouldn't have)
+
+- ❌ Apply medium-confidence patches without showing the diff and getting confirmation. Scope strings encode policy decisions; the user has to pick.
+- ❌ Add a `checks.ignore` entry to silence the approval-policy blocker. Suppression isn't a fix; the `triage-false-positive.md` workflow names the (rare) case for it.
+- ❌ Edit the trace recording (`approval_trace.jsonl`) to flip `approved: true`. Trace findings are class-four "never auto-fix" — patching the trace patches the evidence, not the runtime gate.
+- ❌ Fabricate a recommendation that wasn't grounded in `recommendation`, `evidence`, `patches[].instructions`, or `docs_url`.
+- ❌ Dump the raw JSON in the PR comment. The structured summary above is the agent-to-agent form; the PR comment translates each finding into prose for the human reviewer.
+
+## What to copy from this template
+
+- **Lead with the verdict.** `blocked` / `review_required` / `passed`, with the headline counts on the same line.
+- **Top blockers** named by `check_id` and `tool_name`, with a one-sentence "why it matters" pulled from `metadata.rationale` (use `agents-shipgate explain-finding <FINGERPRINT> --json`).
+- **Apply / review split**. What you applied automatically, what needs human review. Always show the auto-applied diff.
+- **Reports paths**. The agent shouldn't hide where the reports landed; the user may want to read them.
+- **CI status**. Mention whether `init --ci` wrote a workflow.
+
+## What to vary per scan
+
+- **Severity counts** in the headline come from `agent_summary.{blocker_count, review_item_count, auto_appliable_patches, needs_human_review}`.
+- **Top blockers** come from `release_decision.blockers[]`. For each, run `agents-shipgate explain-finding <FINGERPRINT> --json` to get the metadata + evidence + templated explanation; quote the explanation or rewrite for tone.
+- **Diff blocks** come from the `apply-patches --apply --json` output's `files` array. Render with standard `+`/`-` markers.
+- **Review-item table** comes from walking `findings[]` filtered by `release_decision.review_items[].fingerprint`.
+
+## When the verdict is different
+
+- **`review_required` (no blockers)**: replace the headline with "review required; N review item(s)". Still split by `agent_action`. Still cite the auto-applied diff if there was one.
+- **`passed`**: a one-liner is fine ("Agents Shipgate is green; advisory CI is wired."). Mention the report paths so the user can verify.
+- **Evidence-only `review_required`** (no findings; the scan saw only low-confidence/static evidence): the headline IS the `release_decision.reason`. Surface it verbatim with a follow-up question about whether to gather more evidence (MCP/OpenAPI inputs, eval traces).
+
+## See also
+
+- [`prompts/add-shipgate-to-repo.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/prompts/add-shipgate-to-repo.md) — the recipe that produces this artifact.
+- [`prompts/recommend-fixes.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/prompts/recommend-fixes.md) — coordinated remediation pass.
+- [`prompts/explain-finding-to-user.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/prompts/explain-finding-to-user.md) — translate one finding into user-facing prose.
+- [`docs/agent-action-guide.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/agent-action-guide.md) — per-category recipes.
+- [`mcp-only-tool-server/`](mcp-only-tool-server/), [`openai-agents-sdk-refund-agent/`](openai-agents-sdk-refund-agent/), [`openapi-support-agent/`](openapi-support-agent/) — sibling golden PRs with full manifests.

--- a/examples/golden-prs/golden-pr-from-coding-agent.md
+++ b/examples/golden-prs/golden-pr-from-coding-agent.md
@@ -20,7 +20,7 @@ agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
 
 - `release_decision.decision: "blocked"`
 - 2 blockers on `stripe.create_refund` (missing approval policy, missing idempotency)
-- 14 high / 2 medium review items
+- 14 high / 2 medium release review items; 15 need human review
 - 1 auto-applicable patch (a stale suppression removed by `apply-patches`)
 
 The agent now has to summarize this for the user.
@@ -30,8 +30,8 @@ The agent now has to summarize this for the user.
 ```markdown
 ## Agents Shipgate — release blocked
 
-**Decision**: `blocked` (2 active findings block release; 14 high + 2
-medium review items also flagged.)
+**Decision**: `blocked` (2 active findings block release; 16 review
+items also flagged, 15 of those need human review.)
 
 **Top blockers**:
 1. `stripe.create_refund` — `SHIP-POLICY-APPROVAL-MISSING` (critical).
@@ -50,11 +50,11 @@ medium review items also flagged.)
 - Removed 1 stale suppression entry that referenced a check ID that
   no longer exists in the catalog. Diff shown below.
 
-**What needs your review** (14 high + 2 medium review items): I can
+**What needs your review next** (15 non-blocker review findings): I can
 walk these one-by-one if you want, or you can read
 `agents-shipgate-reports/report.md`. The full machine-readable list
 is at `agents-shipgate-reports/report.json`; the top-level
-`agent_summary` block carries the headline counts.
+`agent_summary` block carries the headline/action counts.
 
 **Reports**:
 - Markdown: `agents-shipgate-reports/report.md`
@@ -101,7 +101,10 @@ way, leaving the entry in place misleads future review.
 
 ## The structured summary (for downstream automation)
 
-The agent should also be ready to surface the structured form when asked. This mirrors `agent_summary` from `report.json`:
+The agent should also be ready to surface the structured form when asked.
+In a real run, copy these fields directly from `agent_summary` in
+`report.json`; the object below shows the expected shape and internally
+consistent counts:
 
 ```json
 {
@@ -110,7 +113,7 @@ The agent should also be ready to surface the structured form when asked. This m
   "blocker_count": 2,
   "review_item_count": 16,
   "auto_appliable_patches": 1,
-  "needs_human_review": 15,
+  "needs_human_review": 17,
   "first_recommended_action": {
     "kind": "command",
     "command": "agents-shipgate apply-patches --from /abs/path/agents-shipgate-reports/report.json --confidence high --apply",
@@ -118,6 +121,11 @@ The agent should also be ready to surface the structured form when asked. This m
   }
 }
 ```
+
+Here, `needs_human_review` includes the 2 blockers plus the 15 review
+items whose `agent_action` requires human input. It is intentionally not
+the same number as `review_item_count`, which mirrors
+`release_decision.review_items`.
 
 ## What the agent did NOT do (and shouldn't have)
 
@@ -137,7 +145,7 @@ The agent should also be ready to surface the structured form when asked. This m
 
 ## What to vary per scan
 
-- **Severity counts** in the headline come from `agent_summary.{blocker_count, review_item_count, auto_appliable_patches, needs_human_review}`.
+- **Summary counts** in the headline come from `agent_summary.{blocker_count, review_item_count, auto_appliable_patches, needs_human_review}`.
 - **Top blockers** come from `release_decision.blockers[]`. For each, run `agents-shipgate explain-finding <FINGERPRINT> --json` to get the metadata + evidence + templated explanation; quote the explanation or rewrite for tone.
 - **Diff blocks** come from the `apply-patches --apply --json` output's `files` object — keyed by file path, with each entry exposing `status`, `patches`, `diff`, `error`. Iterate `Object.entries(out.files)` (or `out["files"].items()` in Python) and render each `diff` with standard `+`/`-` markers.
 - **Review-item table** comes from walking `findings[]` filtered by `release_decision.review_items[].fingerprint`.


### PR DESCRIPTION
## Summary

- Ships **P1-1**, **P1-2**, **P1-4** of the agent-adoption strategy backlog. Three pure-documentation additions targeting the "what does a coding agent do next?" gap.
- Tries to make the existing prompt suite + report contract self-sufficient: an agent reading `report.json` should be able to find a per-category recipe (P1-1), a per-framework drop-in (P1-2), and a worked output template (P1-4) without leaving the repo.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest` → 907 passed (unchanged from main; this PR adds no test code)
- `python -m ruff check .` → clean
- New docs cross-linked from `docs/INDEX.md`, `examples/golden-prs/README.md`, and the `README.md` Findings Gallery so `test_index_links_*` style guards keep passing as the doc set grows

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` _(no new check IDs)_
- [x] Report/schema changes are additive or documented in `STABILITY.md` _(no schema changes)_

## What's in each new doc

### `docs/agent-action-guide.md` (P1-1)

Per-category lookup table for "I have a finding with `category: X`; what's the right move?" Each row maps to a typical `agent_action`, a one-line recipe, and the last-resort suppression rule. Per-category prose handles nuance: trace findings are class-four "never auto-fix"; scope-coverage emits a medium-confidence patch that needs user confirmation; evidence findings can be addressed by lowering the review posture. Companion to `autofix-policy.md` (the four-class model) and `agent-recipes.md` (the 4-call flow).

### `docs/upstream-integrations.md` (P1-2)

60-second drop-in per framework: minimal `shipgate.yaml`, working sample fixture link, common pitfalls. Covers OpenAI Agents SDK, LangChain/LangGraph, CrewAI, Google ADK, MCP-only, OpenAPI-only, OpenAI Messages API, Anthropic Messages API, plus a multi-framework section for combined surfaces. Each framework's pitfalls list names the actual extraction-friction cases (factory wrappers, dynamic toolsets, server-side built-ins) so the agent doesn't end up debugging extraction silently.

### `examples/golden-prs/golden-pr-from-coding-agent.md` (P1-4)

The **artifact** a coding agent produces after the canonical 4-call flow — not another adoption recipe. Sibling docs (mcp-only, openai-agents-sdk-refund, openapi-support) describe how to set up Shipgate; this one shows what the PR comment / chat reply should look like once the flow finishes. Includes a worked PR comment, the corresponding `agent_summary` JSON, an applied-diff block, a review-item table, and explicit "what NOT to do" callouts (no medium-confidence apply without confirmation, no trace edits, no raw JSON in user-facing prose).

## Reviewer notes

- The agent-action-guide is per-category by design; there are 14 check categories and ~40 check IDs, so going per-category keeps the doc readable while still covering every check.
- The upstream-integrations pitfalls lists are intentionally short — full extraction details live in `docs/manifest-v0.1.md` and `docs/minimal-real-configs.md`. This doc is the speedrun, not the architectural reference.
- The golden-PR artifact uses concrete numbers (2 blockers / 14 high / 2 medium / 1 auto-applied) drawn from the support_refund_agent fixture so reviewers can scan that fixture's `expected/report.json` and confirm shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)