### PR TITLE
Add agents-shipgate bootstrap super-command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,14 @@ agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
     --confidence high --apply
 ```
 
+Or chain all four in one call:
+
+```bash
+agents-shipgate bootstrap --json
+```
+
+`bootstrap` runs `detect → init --write --ci → scan --suggest-patches → apply-patches --confidence high` against the current workspace, stopping on the first non-recoverable error and emitting a structured per-step summary. Use it for first-time adoption; for ongoing CI keep using the GitHub Action. Flags: `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json`.
+
 - **`detect`** — read-only; classifies the workspace. `is_agent_project: false`
   means stop early.
 - **`init`** — auto-detects by default. `--ci` writes
@@ -368,6 +376,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate contract` | `--json` |
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
 | `agents-shipgate explain-finding` | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
+| `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--out` |
 | `agents-shipgate fixture` | `list`, `run`, `copy`, `verify` |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -22,6 +22,7 @@ These commands and flags are stable across all `0.x.y` releases. They will only 
 | `agents-shipgate contract` | `--json` |
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
 | `agents-shipgate explain-finding` (v0.12+) | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
+| `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--config`, `--out` |
 | `agents-shipgate fixture list` | `--json` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -110,6 +110,14 @@ agents-shipgate apply-patches --from agents-shipgate-reports/report.json \
     --confidence high --apply
 ```
 
+Or chain all four in one call:
+
+```bash
+agents-shipgate bootstrap --json
+```
+
+`bootstrap` runs `detect → init --write --ci → scan --suggest-patches → apply-patches --confidence high` against the current workspace, stopping on the first non-recoverable error and emitting a structured per-step summary. Use it for first-time adoption; for ongoing CI keep using the GitHub Action. Flags: `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json`.
+
 - **`detect`** — read-only; classifies the workspace. `is_agent_project: false`
   means stop early.
 - **`init`** — auto-detects by default. `--ci` writes
@@ -393,6 +401,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate contract` | `--json` |
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
 | `agents-shipgate explain-finding` | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
+| `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--out` |
 | `agents-shipgate fixture` | `list`, `run`, `copy`, `verify` |

--- a/src/agents_shipgate/cli/bootstrap.py
+++ b/src/agents_shipgate/cli/bootstrap.py
@@ -112,6 +112,22 @@ def bootstrap_run(
     """
     if env is None:
         env = dict(os.environ)
+    # Pre-flight: workspace must exist and be a directory. Without
+    # this, _run_step's subprocess.run(cwd=...) blows up with
+    # FileNotFoundError before bootstrap can produce a structured
+    # result, leaving callers with a traceback instead of a
+    # routable verdict (#64 review P2).
+    if not workspace.exists() or not workspace.is_dir():
+        return {
+            "verdict": "failed_at_preflight",
+            "stopped": True,
+            "stop_reason": (
+                f"workspace {workspace} does not exist or is not a "
+                "directory. Bootstrap cannot run."
+            ),
+            "steps": [],
+            "release_decision": None,
+        }
     workspace = workspace.resolve()
     manifest_path = workspace / "shipgate.yaml"
 
@@ -129,6 +145,15 @@ def bootstrap_run(
         parse_json=True,
     )
     steps.append(detect_step)
+
+    # Check detect exit code BEFORE the no-agent-surface heuristic.
+    # A nonzero detect with empty stdout yields detect_payload == {},
+    # which trips the heuristic (is_agent_project=false, suggested=[])
+    # and gets reported as "nothing to do" — masking the real failure
+    # (#64 review P2). Check the exit code first so genuine detect
+    # failures route to failed_at_detect.
+    if detect_step["exit_code"] != 0:
+        return _stop_with_failure(steps, detect_step, "detect")
 
     detect_payload = detect_step["payload"] or {}
     is_agent_project = bool(detect_payload.get("is_agent_project"))
@@ -150,9 +175,6 @@ def bootstrap_run(
             "steps": steps,
             "release_decision": None,
         }
-
-    if detect_step["exit_code"] != 0:
-        return _stop_with_failure(steps, detect_step, "detect")
 
     # --- 2. init -----------------------------------------------------
     init_argv = ["init", "--workspace", str(workspace), "--write", "--json"]
@@ -246,9 +268,13 @@ def bootstrap_run(
             parse_json=True,
         )
         steps.append(apply_step)
-        if apply_step["exit_code"] not in (0, 5):
-            # 5 = containment violation in some apply-patches paths;
-            # treat 0 as success, 5 as recoverable-but-noted.
+        if apply_step["exit_code"] != 0:
+            # Any non-zero apply-patches exit is a stop. Exit 5 in
+            # particular is a containment violation — the safety layer
+            # refused to mutate files (e.g. a patch targeted a path
+            # outside the workspace). Letting bootstrap proceed to a
+            # `complete_*` verdict would let an agent claim completion
+            # after the safety gate said NO (#64 review P2).
             return _stop_with_failure(steps, apply_step, "apply-patches")
 
     # --- Verdict -----------------------------------------------------

--- a/src/agents_shipgate/cli/bootstrap.py
+++ b/src/agents_shipgate/cli/bootstrap.py
@@ -1,0 +1,408 @@
+"""``shipgate bootstrap`` — chain detect → init → scan → apply-patches in one call.
+
+The strategy doc's "Single-turn agent flow" calls four commands in
+sequence; that's the canonical 4-call adoption flow and most coding
+agents type it out manually. ``bootstrap`` is the keyboard shortcut:
+one command, sensible defaults, structured per-step output.
+
+This is intentionally a thin orchestrator. Each step shells out to
+the same ``agents-shipgate`` binary so the underlying behaviour
+(error messages, exit codes, ``--json`` shape) stays identical to a
+manual invocation. No reimplementation, no behavior fork — that's
+the contract.
+
+Stop conditions:
+
+- ``detect`` says no agent surface AND no manifest already exists
+  AND ``suggested_sources`` is empty. Bootstrap exits 0 with a
+  ``stop`` action — the workspace isn't an agent project; there's
+  nothing to do.
+- Any step exits with a non-zero, non-recoverable code.
+  ``init`` returning ``manifest_status: "skipped_existing"`` is
+  recoverable (we move on with the existing manifest); a missing
+  manifest after init is not.
+- ``scan`` raises a config or input error: surface the error, stop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from agents_shipgate.cli.agent_mode import emit_agent_mode_error
+
+_ENV_VAR = "AGENTS_SHIPGATE_AGENT_MODE"
+
+
+def _binary_command(extra_args: list[str], *, json_output: bool = True) -> list[str]:
+    """Build the argv for invoking the same `agents-shipgate` binary
+    via ``python -m agents_shipgate``. Path-independent — works inside
+    a venv, a pipx install, or a source checkout."""
+    cmd = [sys.executable, "-m", "agents_shipgate", *extra_args]
+    if json_output and "--json" not in extra_args:
+        cmd.append("--json")
+    return cmd
+
+
+def _run_step(
+    *,
+    label: str,
+    argv: list[str],
+    cwd: Path,
+    env: dict[str, str],
+    parse_json: bool,
+) -> dict[str, Any]:
+    """Run one step in the chain and return a structured result.
+
+    The returned dict always carries:
+      - ``label`` — human-readable step name (``detect``, ``init``, …)
+      - ``exit_code`` — subprocess exit code
+      - ``argv`` — exact argv used (debuggable)
+      - ``stdout`` — captured stdout (decoded; may be empty)
+      - ``stderr`` — captured stderr (decoded; may be empty)
+      - ``payload`` — parsed JSON dict when ``parse_json=True`` and
+        stdout looked like JSON; otherwise None.
+    """
+    completed = subprocess.run(
+        argv,
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    payload: dict[str, Any] | None = None
+    if parse_json and completed.stdout.strip():
+        try:
+            payload = json.loads(completed.stdout)
+        except json.JSONDecodeError:
+            payload = None
+    return {
+        "label": label,
+        "exit_code": completed.returncode,
+        "argv": argv,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "payload": payload,
+    }
+
+
+def bootstrap_run(
+    *,
+    workspace: Path,
+    confidence: str = "high",
+    ci: bool = True,
+    apply: bool = True,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Run the bootstrap chain and return a structured result.
+
+    Pure function: takes a workspace and config, returns a dict
+    summarizing every step. Importable from tests; the typer command
+    is a thin wrapper.
+
+    Returns ``{"verdict": str, "stopped": bool, "stop_reason": str,
+    "steps": [...], "release_decision": ... | None}``.
+    """
+    if env is None:
+        env = dict(os.environ)
+    workspace = workspace.resolve()
+    manifest_path = workspace / "shipgate.yaml"
+
+    steps: list[dict[str, Any]] = []
+
+    # --- 1. detect ---------------------------------------------------
+    detect_step = _run_step(
+        label="detect",
+        argv=_binary_command(
+            ["detect", "--workspace", str(workspace), "--json"],
+            json_output=False,  # already set above
+        ),
+        cwd=workspace,
+        env=env,
+        parse_json=True,
+    )
+    steps.append(detect_step)
+
+    detect_payload = detect_step["payload"] or {}
+    is_agent_project = bool(detect_payload.get("is_agent_project"))
+    suggested = detect_payload.get("suggested_sources") or []
+    manifest_already = manifest_path.is_file()
+
+    if (
+        not is_agent_project
+        and not suggested
+        and not manifest_already
+    ):
+        return {
+            "verdict": "no_agent_surface",
+            "stopped": True,
+            "stop_reason": (
+                "detect says is_agent_project=false, suggested_sources=[], "
+                "and no shipgate.yaml exists. Bootstrap has nothing to do."
+            ),
+            "steps": steps,
+            "release_decision": None,
+        }
+
+    if detect_step["exit_code"] != 0:
+        return _stop_with_failure(steps, detect_step, "detect")
+
+    # --- 2. init -----------------------------------------------------
+    init_argv = ["init", "--workspace", str(workspace), "--write", "--json"]
+    if ci:
+        init_argv.append("--ci")
+    init_step = _run_step(
+        label="init",
+        argv=_binary_command(init_argv, json_output=False),
+        cwd=workspace,
+        env=env,
+        parse_json=True,
+    )
+    steps.append(init_step)
+
+    init_payload = init_step["payload"] or {}
+    manifest_status = init_payload.get("manifest_status")
+    # `skipped_existing` is fine — it means a manifest was already
+    # present; we'll scan against it. `not_attempted` shouldn't
+    # happen with --write but we tolerate it.
+    if init_step["exit_code"] != 0 and manifest_status not in (
+        "skipped_existing",
+        "not_attempted",
+    ):
+        return _stop_with_failure(steps, init_step, "init")
+
+    if not manifest_path.is_file():
+        return _stop_with_failure(
+            steps,
+            init_step,
+            "init",
+            override_reason=(
+                f"init returned exit {init_step['exit_code']} but "
+                f"{manifest_path} is still missing. Bootstrap can't continue."
+            ),
+        )
+
+    # --- 3. scan -----------------------------------------------------
+    scan_step = _run_step(
+        label="scan",
+        argv=_binary_command(
+            [
+                "scan",
+                "-c",
+                str(manifest_path),
+                "--suggest-patches",
+                "--format",
+                "json",
+                "--ci-mode",
+                "advisory",
+            ],
+            json_output=False,  # scan emits a status string on stdout, not JSON
+        ),
+        cwd=workspace,
+        env=env,
+        parse_json=False,
+    )
+    steps.append(scan_step)
+
+    if scan_step["exit_code"] not in (0, 20):
+        # 20 = strict-mode gate failure; we ran in advisory so any
+        # 20 here is unusual but routable. Other non-zero codes
+        # (config, input, internal) are hard stops.
+        return _stop_with_failure(steps, scan_step, "scan")
+
+    # The report.json will land in the manifest's output.directory or
+    # the conventional `agents-shipgate-reports/`. Try the conventional
+    # path first; fall back to scanning common directories.
+    report_path = _locate_report(workspace)
+    release_decision = _read_release_decision(report_path) if report_path else None
+
+    # --- 4. apply-patches -------------------------------------------
+    if apply and report_path is not None:
+        apply_step = _run_step(
+            label="apply-patches",
+            argv=_binary_command(
+                [
+                    "apply-patches",
+                    "--from",
+                    str(report_path),
+                    "--confidence",
+                    confidence,
+                    "--apply",
+                    "--json",
+                ],
+                json_output=False,
+            ),
+            cwd=workspace,
+            env=env,
+            parse_json=True,
+        )
+        steps.append(apply_step)
+        if apply_step["exit_code"] not in (0, 5):
+            # 5 = containment violation in some apply-patches paths;
+            # treat 0 as success, 5 as recoverable-but-noted.
+            return _stop_with_failure(steps, apply_step, "apply-patches")
+
+    # --- Verdict -----------------------------------------------------
+    verdict = "complete"
+    if release_decision is None:
+        verdict = "complete_no_report"
+    elif release_decision.get("decision") == "blocked":
+        verdict = "complete_blocked"
+    elif release_decision.get("decision") == "review_required":
+        verdict = "complete_review_required"
+    elif release_decision.get("decision") == "passed":
+        verdict = "complete_passed"
+
+    return {
+        "verdict": verdict,
+        "stopped": False,
+        "stop_reason": "",
+        "steps": steps,
+        "release_decision": release_decision,
+        "report_path": str(report_path) if report_path else None,
+    }
+
+
+def _stop_with_failure(
+    steps: list[dict[str, Any]],
+    step: dict[str, Any],
+    step_label: str,
+    *,
+    override_reason: str | None = None,
+) -> dict[str, Any]:
+    reason = override_reason or (
+        f"{step_label} exited {step['exit_code']}; bootstrap stopped. "
+        f"See stderr for details."
+    )
+    return {
+        "verdict": f"failed_at_{step_label}",
+        "stopped": True,
+        "stop_reason": reason,
+        "steps": steps,
+        "release_decision": None,
+    }
+
+
+def _locate_report(workspace: Path) -> Path | None:
+    """Find the JSON report scan emitted. Tries the conventional
+    `agents-shipgate-reports/report.json` first; returns None if not
+    found (callers route this to a "no report" verdict)."""
+    canonical = workspace / "agents-shipgate-reports" / "report.json"
+    if canonical.is_file():
+        return canonical
+    return None
+
+
+def _read_release_decision(report_path: Path) -> dict[str, Any] | None:
+    """Pull just the `release_decision` block from a report.json so
+    bootstrap can summarize without round-tripping the whole report."""
+    try:
+        text = report_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload.get("release_decision")
+
+
+def bootstrap(
+    workspace: Path = typer.Option(
+        Path("."),
+        "--workspace",
+        help="Workspace to bootstrap. Defaults to the current directory.",
+    ),
+    confidence: str = typer.Option(
+        "high",
+        "--confidence",
+        help=(
+            "Confidence threshold for apply-patches. Default is 'high', "
+            "which only mutates auto-safe patches. Use 'medium' to also "
+            "apply scope-coverage and similar mid-confidence fixes."
+        ),
+    ),
+    no_ci: bool = typer.Option(
+        False,
+        "--no-ci",
+        help="Skip writing .github/workflows/agents-shipgate.yml.",
+    ),
+    no_apply: bool = typer.Option(
+        False,
+        "--no-apply",
+        help=(
+            "Run scan but skip apply-patches. Useful when you want to "
+            "preview what would change before mutating."
+        ),
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a structured per-step JSON summary on stdout.",
+    ),
+) -> None:
+    """Run the canonical 4-call adoption flow in one command.
+
+    Chains: ``detect → init --write --ci → scan --suggest-patches →
+    apply-patches --confidence high``. Each step shells out to the
+    same agents-shipgate binary, so behavior is identical to a manual
+    invocation. Stops on the first non-recoverable error.
+
+    Use this when adopting Shipgate in a fresh repo. For ongoing CI,
+    keep using the GitHub Action — bootstrap is the one-shot
+    convenience layer for first-time setup.
+    """
+    result = bootstrap_run(
+        workspace=workspace,
+        confidence=confidence,
+        ci=not no_ci,
+        apply=not no_apply,
+    )
+
+    if json_output:
+        typer.echo(json.dumps(result, default=str, indent=2))
+    else:
+        _emit_human_summary(result)
+
+    if result["stopped"] and result["verdict"] != "no_agent_surface":
+        emit_agent_mode_error(
+            "other_error",
+            message=result["stop_reason"],
+            verdict=result["verdict"],
+            next_action="Read the failing step's stderr; re-run that step manually.",
+        )
+        # Match the failing step's exit code when possible
+        for step in reversed(result["steps"]):
+            if step["exit_code"] != 0:
+                raise typer.Exit(step["exit_code"])
+        raise typer.Exit(4)
+
+
+def _emit_human_summary(result: dict[str, Any]) -> None:
+    typer.echo("Agents Shipgate · bootstrap")
+    typer.echo("")
+    for step in result["steps"]:
+        status = "OK" if step["exit_code"] == 0 else f"exit={step['exit_code']}"
+        typer.echo(f"  - {step['label']}: {status}")
+    typer.echo("")
+    if result["stopped"]:
+        typer.echo(f"Stopped: {result['stop_reason']}")
+        return
+    rd = result.get("release_decision")
+    if rd:
+        typer.echo(f"Release decision: {rd['decision']}")
+        typer.echo(
+            f"  blockers={len(rd.get('blockers', []))}, "
+            f"review_items={len(rd.get('review_items', []))}"
+        )
+        if result.get("report_path"):
+            typer.echo(f"  report: {result['report_path']}")
+    else:
+        typer.echo("Bootstrap completed but no report.json was found.")

--- a/src/agents_shipgate/cli/bootstrap.py
+++ b/src/agents_shipgate/cli/bootstrap.py
@@ -217,10 +217,12 @@ def bootstrap_run(
         # (config, input, internal) are hard stops.
         return _stop_with_failure(steps, scan_step, "scan")
 
-    # The report.json will land in the manifest's output.directory or
-    # the conventional `agents-shipgate-reports/`. Try the conventional
-    # path first; fall back to scanning common directories.
-    report_path = _locate_report(workspace)
+    # The report.json lands in `manifest.output.directory` when set, or
+    # the conventional `agents-shipgate-reports/` otherwise. Read the
+    # manifest first so custom output directories are honored AND a
+    # stale `agents-shipgate-reports/report.json` from a previous run
+    # doesn't pre-empt the fresh report (#64 review P1).
+    report_path = _locate_report(workspace, manifest_path)
     release_decision = _read_release_decision(report_path) if report_path else None
 
     # --- 4. apply-patches -------------------------------------------
@@ -290,14 +292,111 @@ def _stop_with_failure(
     }
 
 
-def _locate_report(workspace: Path) -> Path | None:
-    """Find the JSON report scan emitted. Tries the conventional
-    `agents-shipgate-reports/report.json` first; returns None if not
-    found (callers route this to a "no report" verdict)."""
+def _locate_report(workspace: Path, manifest_path: Path) -> Path | None:
+    """Find the JSON report scan emitted.
+
+    Priority order matches scan's actual write path:
+
+    1. The directory the manifest declares as `output.directory`.
+       Relative paths resolve against the manifest's parent directory
+       (the standard scan resolves there too).
+    2. The conventional `agents-shipgate-reports/` under the workspace.
+
+    The manifest-aware path comes first because the alternative —
+    checking the conventional path first — would silently pre-empt a
+    fresh custom-output report with a stale one from a prior run
+    (#64 review P1).
+    """
+    manifest_dir = manifest_path.resolve().parent
+    manifest_output_dir = _read_manifest_output_dir(manifest_path)
+    if manifest_output_dir is not None:
+        if not manifest_output_dir.is_absolute():
+            manifest_output_dir = manifest_dir / manifest_output_dir
+        candidate = manifest_output_dir / "report.json"
+        if candidate.is_file():
+            return candidate
+        # When the manifest pins a directory but the file isn't there,
+        # do NOT fall back to the canonical path. The fresh scan should
+        # have written to the pinned dir; a missing file there is a
+        # real signal (e.g. the scan failed silently or wrote elsewhere
+        # because of a --out override). Falling back risks reading a
+        # stale report from the default location.
+        return None
     canonical = workspace / "agents-shipgate-reports" / "report.json"
     if canonical.is_file():
         return canonical
     return None
+
+
+def _read_manifest_output_dir(manifest_path: Path) -> Path | None:
+    """Read `output.directory` from the manifest if set.
+
+    Uses PyYAML (already a runtime dep). Returns ``None`` when the
+    manifest is unreadable, malformed, or doesn't set the field;
+    callers then fall back to the canonical path.
+    """
+    import yaml
+
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    output = data.get("output")
+    if not isinstance(output, dict):
+        return None
+    directory = output.get("directory")
+    if isinstance(directory, str) and directory.strip():
+        return Path(directory.strip())
+    return None
+
+
+def _failed_step_error(step: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Extract the structured `error` kind and forward fields from a
+    failing step's stderr.
+
+    When ``AGENTS_SHIPGATE_AGENT_MODE=1`` is set in the inherited env
+    (bootstrap inherits the parent env by default), every child step
+    emits a single-line JSON object on stderr describing its error
+    kind. Bootstrap captures that stderr and forwards the underlying
+    kind PLUS the routable fields (`message`, `next_action`,
+    `next_actions`, and kind-specific extras like `suggestion`,
+    `source_report`, `path`, `fingerprint`, `check_id`).
+
+    Returns ``(kind, forward_fields)``. Falls back to
+    ``("other_error", {})`` when no structured JSON line is found
+    (e.g. the env var wasn't set or the step printed prose only).
+    """
+    stderr = step.get("stderr") or ""
+    if not stderr.strip():
+        return "other_error", {}
+    # Scan stderr bottom-up because the structured line is emitted
+    # last; a prose error line may precede it.
+    for line in reversed(stderr.splitlines()):
+        line = line.strip()
+        if not (line.startswith("{") and line.endswith("}")):
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        kind = payload.get("error")
+        if not isinstance(kind, str):
+            continue
+        # Forward every routable field except the kind itself (which
+        # we re-emit explicitly) and `verdict` (which bootstrap owns).
+        forward = {
+            k: v
+            for k, v in payload.items()
+            if k not in {"error", "verdict"}
+        }
+        return kind, forward
+    return "other_error", {}
 
 
 def _read_release_decision(report_path: Path) -> dict[str, Any] | None:
@@ -372,11 +471,25 @@ def bootstrap(
         _emit_human_summary(result)
 
     if result["stopped"] and result["verdict"] != "no_agent_surface":
+        # Forward the underlying step's structured error so coding
+        # agents get the same routing they'd get from a manual
+        # invocation (#64 review P2). Bootstrap previously re-emitted
+        # a generic `other_error`, hiding kind-specific next_actions
+        # like input_parse_error's "re-run scan with --suggest-patches"
+        # or unknown_check_id's `suggestion`.
+        failing = next(
+            (s for s in reversed(result["steps"]) if s["exit_code"] != 0),
+            None,
+        )
+        kind, forwarded = (
+            _failed_step_error(failing) if failing else ("other_error", {})
+        )
         emit_agent_mode_error(
-            "other_error",
-            message=result["stop_reason"],
+            kind,
+            failing_step=failing["label"] if failing else None,
             verdict=result["verdict"],
-            next_action="Read the failing step's stderr; re-run that step manually.",
+            stop_reason=result["stop_reason"],
+            **forwarded,
         )
         # Match the failing step's exit code when possible
         for step in reversed(result["steps"]):

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -14,6 +14,7 @@ from agents_shipgate import __version__
 from agents_shipgate.checks.registry import check_catalog
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error as _emit_agent_mode_error
 from agents_shipgate.cli.apply_patches import apply_patches as _apply_patches_command
+from agents_shipgate.cli.bootstrap import bootstrap as _bootstrap_command
 from agents_shipgate.cli.detect import detect as _detect_command
 from agents_shipgate.cli.diagnostics import (
     NextAction,
@@ -81,6 +82,14 @@ app.command(
         "into md, html, and/or pdf."
     ),
 )(_evidence_packet_command)
+app.command(
+    "bootstrap",
+    help=(
+        "Run the canonical 4-call adoption flow in one command: "
+        "detect → init --write --ci → scan --suggest-patches → "
+        "apply-patches --confidence high."
+    ),
+)(_bootstrap_command)
 app.command(
     "explain-finding",
     help=(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,174 @@
+"""Pin the ``agents-shipgate bootstrap`` super-command surface.
+
+Bootstrap chains the canonical 4-call flow (detect → init → scan →
+apply-patches) via subprocess, so the underlying behaviour is identical
+to manual invocation. These tests exercise the chain end-to-end against
+the bundled samples and pin the structured-summary shape.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.bootstrap import bootstrap_run
+from agents_shipgate.cli.main import app
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SIMPLE_OPENAI_API = REPO_ROOT / "samples" / "simple_openai_api_agent"
+
+
+def _copy_sample(sample_dir: Path, into: Path) -> Path:
+    """Copy a sample fixture into a tmp workspace so bootstrap can mutate
+    it without touching the in-tree fixture."""
+    shutil.copytree(sample_dir, into / sample_dir.name)
+    return into / sample_dir.name
+
+
+def test_bootstrap_chains_against_simple_openai_api_sample(tmp_path):
+    """End-to-end happy-path check: bootstrap completes against a real
+    sample fixture, every step lands a structured result, and the
+    release-decision summary is read from the emitted report.json."""
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    result = bootstrap_run(
+        workspace=workspace, ci=False, apply=False, confidence="high"
+    )
+
+    assert result["stopped"] is False, (
+        f"Bootstrap stopped unexpectedly: {result['stop_reason']!r}"
+    )
+    labels = [s["label"] for s in result["steps"]]
+    assert labels == ["detect", "init", "scan"], (
+        f"Bootstrap chain ran unexpected steps: {labels!r}"
+    )
+
+    detect_step = result["steps"][0]
+    assert detect_step["exit_code"] == 0
+    assert detect_step["payload"], "detect must emit a JSON payload"
+
+    rd = result["release_decision"]
+    assert rd is not None, "Bootstrap must read release_decision from report.json"
+    assert rd["decision"] in {"blocked", "review_required", "passed"}
+    assert result["report_path"], "report_path must point at the emitted report"
+
+
+def test_bootstrap_skips_when_no_agent_surface(tmp_path):
+    """A workspace with no agent surface and no existing manifest must
+    stop early with ``verdict: no_agent_surface`` rather than running
+    init/scan against nothing."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    (empty / "README.md").write_text("just a readme\n", encoding="utf-8")
+
+    result = bootstrap_run(workspace=empty, ci=False, apply=False)
+    assert result["verdict"] == "no_agent_surface"
+    assert result["stopped"] is True
+    assert "is_agent_project=false" in result["stop_reason"]
+    # Only detect ran; init/scan/apply skipped.
+    assert [s["label"] for s in result["steps"]] == ["detect"]
+
+
+def test_bootstrap_tolerates_manifest_already_exists(tmp_path):
+    """When the workspace already has shipgate.yaml, init refuses to
+    overwrite (exit 2 with ``manifest_status: skipped_existing``).
+    Bootstrap must continue past this — it's not a hard failure."""
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    assert (workspace / "shipgate.yaml").is_file()
+
+    result = bootstrap_run(workspace=workspace, ci=False, apply=False)
+    init_step = next(s for s in result["steps"] if s["label"] == "init")
+    # init exits non-zero on overwrite refusal
+    assert init_step["exit_code"] == 2, (
+        f"init exit code drifted; expected 2 (skipped_existing), got "
+        f"{init_step['exit_code']}"
+    )
+    # …but bootstrap proceeded to scan anyway
+    assert any(s["label"] == "scan" for s in result["steps"])
+    assert result["stopped"] is False
+
+
+def test_bootstrap_stops_when_scan_fails(tmp_path):
+    """A manifest that points at a missing tool source produces a
+    scan-time `input_parse_error` (exit 3). Bootstrap must stop with
+    `verdict: failed_at_scan` and surface the underlying stderr."""
+    workspace = tmp_path / "broken"
+    workspace.mkdir()
+    (workspace / "shipgate.yaml").write_text(
+        "version: \"0.1\"\n"
+        "project:\n  name: broken\n"
+        "agent:\n  name: broken\n  declared_purpose:\n    - test broken manifest\n"
+        "environment:\n  target: local\n"
+        "tool_sources:\n  - id: missing\n    type: openapi\n    path: missing.yaml\n",
+        encoding="utf-8",
+    )
+    # Create a file so detect sees something — otherwise we hit the
+    # "no agent surface" early-stop branch.
+    (workspace / "missing.yaml").write_text("openapi: 3.1.0\n", encoding="utf-8")
+
+    result = bootstrap_run(workspace=workspace, ci=False, apply=False)
+    # detect should succeed (workspace has an OpenAPI spec), init should
+    # skip (manifest exists), scan should fail.
+    scan_step = next(
+        (s for s in result["steps"] if s["label"] == "scan"),
+        None,
+    )
+    if scan_step is not None and scan_step["exit_code"] not in (0, 20):
+        assert result["verdict"].startswith("failed_at_")
+        assert result["stopped"] is True
+
+
+def test_bootstrap_emits_structured_json_when_requested(tmp_path):
+    """`bootstrap --json` must produce parseable structured output with
+    the canonical top-level keys."""
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    runner = CliRunner()
+    invocation = runner.invoke(
+        app,
+        [
+            "bootstrap",
+            "--workspace",
+            str(workspace),
+            "--no-ci",
+            "--no-apply",
+            "--json",
+        ],
+    )
+    assert invocation.exit_code == 0, invocation.output
+    payload = json.loads(invocation.stdout)
+    for key in ("verdict", "stopped", "stop_reason", "steps", "release_decision"):
+        assert key in payload, f"Missing top-level key {key!r} in bootstrap JSON"
+    assert isinstance(payload["steps"], list)
+    assert all(
+        {"label", "exit_code", "argv", "stdout", "stderr"} <= set(step)
+        for step in payload["steps"]
+    )
+
+
+def test_bootstrap_no_apply_skips_apply_patches_step(tmp_path):
+    """`--no-apply` must skip the apply-patches step entirely. Pinned so
+    a future refactor doesn't accidentally always run apply."""
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    result = bootstrap_run(workspace=workspace, ci=False, apply=False)
+    labels = [s["label"] for s in result["steps"]]
+    assert "apply-patches" not in labels
+
+
+def test_bootstrap_reports_release_decision_verdict_in_summary(tmp_path):
+    """The top-level `verdict` mirrors `release_decision.decision` —
+    `complete_passed` / `complete_review_required` / `complete_blocked`.
+    A coding agent reading `bootstrap --json` should be able to gate on
+    the verdict without re-parsing the report.json."""
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    result = bootstrap_run(workspace=workspace, ci=False, apply=False)
+    rd = result["release_decision"]
+    if rd is None:
+        pytest.skip("Sample produced no release_decision; verdict mirroring skipped.")
+    expected_prefix = f"complete_{rd['decision']}"
+    assert result["verdict"] == expected_prefix, (
+        f"verdict {result['verdict']!r} should mirror "
+        f"release_decision.decision {rd['decision']!r}"
+    )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -318,3 +318,127 @@ def test_bootstrap_reports_release_decision_verdict_in_summary(tmp_path):
         f"verdict {result['verdict']!r} should mirror "
         f"release_decision.decision {rd['decision']!r}"
     )
+
+
+def test_bootstrap_rejects_missing_workspace_with_structured_failure(tmp_path):
+    """Pre-flight: when --workspace points at a path that doesn't exist
+    (typo, deleted dir, wrong cwd), bootstrap must emit a structured
+    `failed_at_preflight` verdict rather than crashing in subprocess.run
+    with FileNotFoundError. Coding agents need a routable signal."""
+    missing = tmp_path / "definitely-missing"
+    assert not missing.exists()
+
+    result = bootstrap_run(workspace=missing, ci=False, apply=False)
+    assert result["verdict"] == "failed_at_preflight"
+    assert result["stopped"] is True
+    assert "does not exist" in result["stop_reason"]
+    # Steps must be empty — we never got to detect.
+    assert result["steps"] == []
+
+
+def test_bootstrap_rejects_workspace_pointing_at_a_file(tmp_path):
+    """Pre-flight also catches the case where --workspace is a real
+    path but points at a file (e.g. user pointed at shipgate.yaml
+    instead of its parent directory)."""
+    not_a_dir = tmp_path / "config.yaml"
+    not_a_dir.write_text("version: 0.1\n", encoding="utf-8")
+
+    result = bootstrap_run(workspace=not_a_dir, ci=False, apply=False)
+    assert result["verdict"] == "failed_at_preflight"
+    assert result["stopped"] is True
+    assert result["steps"] == []
+
+
+def test_bootstrap_routes_nonzero_detect_to_failed_at_detect(tmp_path, monkeypatch):
+    """When detect exits non-zero with empty stdout, bootstrap must
+    route to `failed_at_detect` rather than fall through to the
+    no-agent-surface heuristic (which would mask the failure as
+    "nothing to do"). The check order matters: exit code FIRST,
+    payload heuristic SECOND (#64 review P2)."""
+    # Build a fake binary command that always exits 1 with empty stdout
+    # but a structured agent-mode stderr line. We patch subprocess.run
+    # at the bootstrap module level so only this test sees the override.
+    from agents_shipgate.cli import bootstrap as bs_module
+
+    real_run = bs_module.subprocess.run
+
+    class FakeCompleted:
+        def __init__(self, returncode: int, stdout: str, stderr: str) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(argv, **kwargs):
+        if "detect" in argv:
+            return FakeCompleted(
+                returncode=1,
+                stdout="",
+                stderr=(
+                    '{"error": "other_error", "message": "detector blew up", '
+                    '"next_action": "file an issue"}\n'
+                ),
+            )
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(bs_module.subprocess, "run", fake_run)
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    result = bootstrap_run(workspace=workspace, ci=False, apply=False)
+    assert result["verdict"] == "failed_at_detect", (
+        f"nonzero detect with empty stdout must NOT fall through to "
+        f"no_agent_surface; got {result['verdict']!r}"
+    )
+    assert result["stopped"] is True
+    # And the stderr's structured kind must be discoverable for the
+    # downstream emit_agent_mode_error path.
+    detect_step = next(s for s in result["steps"] if s["label"] == "detect")
+    assert detect_step["exit_code"] == 1
+    kind, forwarded = _failed_step_error(detect_step)
+    assert kind == "other_error"
+    assert forwarded.get("message") == "detector blew up"
+
+
+def test_bootstrap_stops_on_apply_patches_exit_5_containment_violation(
+    tmp_path, monkeypatch
+):
+    """apply-patches exit 5 = containment violation (the safety layer
+    refused to mutate files). Bootstrap must stop with
+    `failed_at_apply-patches`, not return a `complete_*` verdict —
+    otherwise an agent could report completion after the safety gate
+    said NO (#64 review P2)."""
+    from agents_shipgate.cli import bootstrap as bs_module
+
+    real_run = bs_module.subprocess.run
+
+    class FakeCompleted:
+        def __init__(self, returncode: int, stdout: str, stderr: str) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(argv, **kwargs):
+        if "apply-patches" in argv:
+            return FakeCompleted(
+                returncode=5,
+                stdout="",
+                stderr=(
+                    '{"error": "other_error", "message": '
+                    '"refusing: patch path escapes workspace"}\n'
+                ),
+            )
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(bs_module.subprocess, "run", fake_run)
+
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    result = bootstrap_run(workspace=workspace, ci=False, apply=True)
+
+    assert result["verdict"] == "failed_at_apply-patches", (
+        f"apply-patches exit 5 must stop bootstrap; got {result['verdict']!r}"
+    )
+    assert result["stopped"] is True
+    apply_step = next(
+        s for s in result["steps"] if s["label"] == "apply-patches"
+    )
+    assert apply_step["exit_code"] == 5

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -15,7 +15,11 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from agents_shipgate.cli.bootstrap import bootstrap_run
+from agents_shipgate.cli.bootstrap import (
+    _failed_step_error,
+    _locate_report,
+    bootstrap_run,
+)
 from agents_shipgate.cli.main import app
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -155,6 +159,148 @@ def test_bootstrap_no_apply_skips_apply_patches_step(tmp_path):
     result = bootstrap_run(workspace=workspace, ci=False, apply=False)
     labels = [s["label"] for s in result["steps"]]
     assert "apply-patches" not in labels
+
+
+def test_bootstrap_honors_custom_output_directory(tmp_path):
+    """When the manifest sets `output.directory: custom-reports`, scan
+    writes the report there and bootstrap must locate it there too.
+    Earlier `_locate_report` only checked `agents-shipgate-reports/`,
+    so a custom directory produced `verdict: complete_no_report` and
+    silently skipped apply-patches (#64 review P1)."""
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    manifest = workspace / "shipgate.yaml"
+    text = manifest.read_text(encoding="utf-8")
+    manifest.write_text(
+        text.replace(
+            "directory: agents-shipgate-reports", "directory: custom-reports"
+        ),
+        encoding="utf-8",
+    )
+
+    result = bootstrap_run(workspace=workspace, ci=False, apply=True)
+    assert result["report_path"], (
+        "Bootstrap must locate the report when output.directory is custom; "
+        f"got result={result!r}"
+    )
+    assert "custom-reports" in result["report_path"], (
+        f"report_path {result['report_path']!r} should be under custom-reports/"
+    )
+    assert result["verdict"] != "complete_no_report"
+    # apply-patches step must have run (no early `complete_no_report` skip)
+    assert any(s["label"] == "apply-patches" for s in result["steps"])
+
+
+def test_bootstrap_does_not_read_stale_canonical_when_manifest_pins_custom(tmp_path):
+    """A stale `agents-shipgate-reports/report.json` from a previous
+    run must NOT override a fresh custom-output report. _locate_report
+    short-circuits on the manifest-pinned path; falling back to the
+    canonical path could read a stale report and apply-patches against
+    the wrong scan."""
+    workspace = _copy_sample(SIMPLE_OPENAI_API, tmp_path)
+    manifest = workspace / "shipgate.yaml"
+    text = manifest.read_text(encoding="utf-8")
+    manifest.write_text(
+        text.replace(
+            "directory: agents-shipgate-reports", "directory: custom-reports"
+        ),
+        encoding="utf-8",
+    )
+    # Plant a stale report at the canonical path.
+    stale_dir = workspace / "agents-shipgate-reports"
+    stale_dir.mkdir(parents=True, exist_ok=True)
+    (stale_dir / "report.json").write_text(
+        '{"STALE":true,"report_schema_version":"0.10"}', encoding="utf-8"
+    )
+
+    result = bootstrap_run(workspace=workspace, ci=False, apply=False)
+    assert result["report_path"]
+    assert "custom-reports" in result["report_path"]
+    assert "agents-shipgate-reports" not in result["report_path"], (
+        "Stale canonical-path report leaked into bootstrap's report_path"
+    )
+
+
+def test_locate_report_returns_none_when_manifest_dir_has_no_report(tmp_path):
+    """When the manifest pins a custom directory but the scan didn't
+    write there (e.g. scan was killed before flushing), `_locate_report`
+    returns None rather than silently falling back to the canonical
+    path with a possibly-stale report."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    manifest = workspace / "shipgate.yaml"
+    manifest.write_text(
+        "version: \"0.1\"\n"
+        "project: {name: x}\n"
+        "agent: {name: x, declared_purpose: [test]}\n"
+        "environment: {target: local}\n"
+        "tool_sources: []\n"
+        "output:\n  directory: custom-reports\n",
+        encoding="utf-8",
+    )
+    # Plant a stale report at the canonical path; manifest doesn't
+    # pin canonical so the stale file must NOT be returned.
+    (workspace / "agents-shipgate-reports").mkdir()
+    (workspace / "agents-shipgate-reports" / "report.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    result = _locate_report(workspace, manifest)
+    assert result is None, (
+        f"Expected None when manifest pins a dir without a report; got {result!r}"
+    )
+
+
+def test_failed_step_error_forwards_child_error_kind():
+    """Bootstrap must forward the underlying step's structured error
+    kind and routable fields. A scan-time `input_parse_error` should
+    surface as `error: input_parse_error` in bootstrap's agent-mode
+    output, not as a generic `other_error` that drops the
+    kind-specific `next_actions` (#64 review P2)."""
+    fake_step = {
+        "label": "scan",
+        "exit_code": 3,
+        "stderr": (
+            "Input parsing error: Input file not found: missing.yaml\n"
+            '{"error": "input_parse_error", "message": "Input file not found",'
+            ' "next_action": "agents-shipgate detect --workspace . --json",'
+            ' "next_actions": [{"kind": "command", "command": "x", "why": "y"}]}'
+        ),
+    }
+    kind, forwarded = _failed_step_error(fake_step)
+    assert kind == "input_parse_error"
+    assert forwarded["message"] == "Input file not found"
+    assert forwarded["next_action"] == "agents-shipgate detect --workspace . --json"
+    assert forwarded["next_actions"][0]["command"] == "x"
+
+
+def test_failed_step_error_falls_back_when_stderr_has_no_json():
+    """Without `AGENTS_SHIPGATE_AGENT_MODE=1`, child steps emit prose
+    errors only. Bootstrap then falls back to `other_error` rather
+    than crashing or emitting a malformed kind."""
+    fake_step = {
+        "label": "scan",
+        "exit_code": 3,
+        "stderr": "Input parsing error: missing file (prose only)",
+    }
+    kind, forwarded = _failed_step_error(fake_step)
+    assert kind == "other_error"
+    assert forwarded == {}
+
+
+def test_failed_step_error_skips_lines_without_error_field():
+    """Some commands print multi-line JSON debug output but only the
+    structured-error line carries `error`. The helper must pick the
+    one with `error`, not the first JSON it sees."""
+    fake_step = {
+        "label": "scan",
+        "exit_code": 3,
+        "stderr": (
+            '{"warning": "deprecated flag", "note": "use --new"}\n'
+            'Input parsing error: bad spec\n'
+            '{"error": "input_parse_error", "message": "bad spec"}'
+        ),
+    }
+    kind, _forwarded = _failed_step_error(fake_step)
+    assert kind == "input_parse_error"
 
 
 def test_bootstrap_reports_release_decision_verdict_in_summary(tmp_path):


### PR DESCRIPTION
## Summary

- Ships **P2-1** of the agent-adoption strategy backlog. Chains the canonical 4-call adoption flow into a single command.
- `agents-shipgate bootstrap` runs `detect → init --write --ci → scan --suggest-patches → apply-patches --confidence high`. Each step shells out to the same agents-shipgate binary via `python -m agents_shipgate`, so behavior is identical to manual invocation.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior _(new `bootstrap` super-command)_
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest` → 914 passed (was 907 on main; +7 new), 3 skipped
- `python -m ruff check .` → clean
- Manual end-to-end: `agents-shipgate bootstrap --workspace samples/simple_openai_api_agent --no-apply` chains correctly through detect → init (skipped_existing) → scan, surfacing `verdict: complete_review_required` with the report.json path.

## Release-readiness notes

- [x] No user-code import added to default scan paths _(thin orchestrator; subprocess-only)_
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` _(no new check IDs)_
- [x] Report/schema changes are additive or documented in `STABILITY.md` _(no schema changes; new stable command added to STABILITY.md)_

## Behavior

```bash
# First-time adoption in one command
agents-shipgate bootstrap --json
```

Flags:
- `--workspace` — workspace to bootstrap (default `.`)
- `--confidence` — apply-patches threshold (default `high`)
- `--no-ci` — skip writing `.github/workflows/agents-shipgate.yml`
- `--no-apply` — run scan but skip apply-patches (preview mode)
- `--json` — structured per-step summary on stdout

Stop conditions:
- detect says no agent surface AND no manifest AND no suggested sources → `verdict: no_agent_surface`, exit 0
- init exits non-zero with `manifest_status: skipped_existing` → continue with existing manifest
- init exits non-zero AND no manifest exists after → hard stop
- scan/apply-patches exit with config/input/internal errors → surface the failing step's exit code

The `--json` output carries every step's argv, exit code, stdout, stderr, and parsed JSON payload (when applicable), plus a top-level `verdict`, `stop_reason`, and `release_decision`. Coding agents gating on the result read `verdict` (one of `complete_passed`, `complete_review_required`, `complete_blocked`, `no_agent_surface`, or `failed_at_<step>`).

## Why subprocess

The init / scan / apply-patches commands are typer-decorated; calling them in-process means refactoring each into a pure function plus typer wrapper. Subprocess is the pragmatic alternative: the underlying `agents-shipgate` binary stays the source of truth, and bootstrap's contract is "behavior identical to a manual invocation." Future refactors of the underlying commands stay invisible to bootstrap. The cost (~50ms × 4 subprocess spawns) is irrelevant for a one-shot adoption command.

## Tests (7 new)

- end-to-end happy path against `simple_openai_api_agent`
- `no_agent_surface` early-stop when detect finds nothing
- tolerates `manifest_already_exists` (init exits 2 but bootstrap continues)
- stops cleanly on scan failure (broken manifest)
- structured `--json` shape with canonical top-level keys
- `--no-apply` skips apply-patches entirely
- top-level `verdict` mirrors `release_decision.decision`

🤖 Generated with [Claude Code](https://claude.com/claude-code)