### PR TITLE
Add Who this is for section to README above-the-fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ production-like permissions.
 No agent execution. No LLM calls. No MCP server connections. No scanner network
 calls. No scanner telemetry. Apache-2.0.
 
+## Who this is for
+
+- **Agent builders** — review MCP, OpenAPI, and SDK tool definitions before merging changes that expand the tool surface.
+- **Platform teams** — add release gates for approval, scope, idempotency, and baseline drift to PR review.
+- **Security and GRC reviewers** — get static release evidence without running agents or importing user code.
+
 ## Use this when
 
 Run Agents Shipgate when a PR adds or changes agent tool surfaces or the policy


### PR DESCRIPTION
## Summary

- Adds a three-bullet "Who this is for" section in the README between the trust statement and "Use this when".
- Covers the three audiences agents-shipgate is built for: agent builders, platform teams, security/GRC reviewers.
- Fills the scan-readability gap above the existing detailed persona table later in the README so a first-time reader can confirm "is this for me?" without scrolling.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/test_public_surface_contract.py -x -q` — passes (223 tests), so the new bullets do not introduce `Agent Shipgate` (singular) or `Agent Shipcheck` and do not break the README contract.
- `grep -nP "(?<![A-Za-z])Agent\s+(?:Shipcheck|Shipgate)(?![A-Za-z])" README.md` — no matches.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` (n/a — docs-only)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (n/a — docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)