### PR TITLE
Introduce ToolSourceAdapter Protocol and AdapterRegistry (v0.11 R1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Replaced the hardcoded `if/elif` source-dispatch in `cli/scan.py` with a
+  real `ToolSourceAdapter` Protocol and `AdapterRegistry`. Every loader
+  (MCP, OpenAPI, OpenAI Agents SDK, Google ADK, LangChain, CrewAI, n8n,
+  Codex plugin, OpenAI API, Anthropic API) is now an adapter class that
+  registers with `agents_shipgate.inputs.protocol.REGISTRY`. The scan
+  pipeline returns a typed `ArtifactBag` so framework artifacts retain
+  their concrete types into `ScanContext`. Framework adapters now fire
+  correctly when configured via top-level manifest sections without a
+  matching `tool_sources` entry. Internal refactor — no behavior change
+  for users.
 - Added minimal source provenance to findings. `agents-shipgate scan` now
   emits `report_schema_version: "0.11"` with optional structured location
   keys on `findings[].source`: `path`, `start_line`, `end_line`,

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -546,51 +546,44 @@ def _load_sources(
     Ordering is deterministic and matches the legacy run_scan order:
 
       1. per-source loaders in tool_sources declared order
-      2. framework adapters (triggered by either tool_sources OR a
-         populated manifest section), in REGISTRY iteration order:
-         google_adk → langchain → crewai → n8n
-      3. manifest-only adapters: openai_api → anthropic_api
-      4. codex_plugin (last, per legacy ordering)
+      2. per-scan adapters in REGISTRY iteration order:
+         google_adk → langchain → crewai → n8n → openai_api
+         → anthropic_api → codex_plugin
 
-    Manifest-only adapters always fire via pass 2 regardless of
-    tool_sources contents. Framework adapters fire once per scan via
-    either pass, deduplicated by source_type.
+    Per-scan adapters are invoked unconditionally in pass 2, in
+    canonical order — NOT in tool_sources declared order. This matches
+    today's run_scan exactly: framework loaders fire once per scan via
+    load_framework_artifacts in a fixed order, and the manifest-only
+    loaders (openai_api, anthropic_api) and codex_plugin trail them.
+    Per-scan source types appearing in tool_sources are ignored by
+    pass 1 — they would be redundant; framework loaders already iterate
+    every matching entry internally via the manifest.
     """
     per_source_loaded: list[LoadedToolSource] = []
     per_scan_loaded: list[LoadedToolSource] = []
     bag = ArtifactBag()
-    invoked: set[str] = set()
 
-    # Pass 1 — walk tool_sources in declared order. Per-source adapters
-    # contribute to per_source_loaded immediately. Per-scan adapters
-    # (frameworks) are invoked on first encounter and their output is
-    # buffered into per_scan_loaded so it lands AFTER all per-source
-    # results regardless of where the framework's tool_sources row
-    # appears.
+    # Pass 1 — per-source adapters only, in tool_sources declared
+    # order. Per-scan source types (langchain, crewai, etc.) are
+    # skipped here; pass 2 invokes them in canonical REGISTRY order
+    # regardless of where they appear in tool_sources. This protects
+    # the dedup tie-break in _flatten_and_deduplicate_tools from
+    # changing based on user-facing tool_sources ordering.
     for source in manifest.tool_sources:
         adapter = REGISTRY.require(source.type)
-        if adapter.scope == "per_source":
-            result = _invoke_per_source_adapter(
-                adapter, source, base_dir, manifest, verbose=verbose
-            )
-            _absorb(result, source.type, per_source_loaded, bag, adapter)
-        else:  # per_scan framework triggered by tool_sources
-            if source.type in invoked:
-                continue
-            invoked.add(source.type)
-            result = adapter.load(None, base_dir, manifest)
-            _absorb(result, source.type, per_scan_loaded, bag, adapter)
-
-    # Pass 2 — invoke per-scan adapters not yet run. Covers:
-    #   (a) framework adapters configured only via top-level manifest
-    #       sections (no tool_sources row) — google_adk, langchain,
-    #       crewai, codex_plugin.
-    #   (b) manifest-only adapters (openai_api, anthropic_api, n8n)
-    #       with no tool_sources representation.
-    for adapter in REGISTRY.per_scan_adapters():
-        if adapter.source_type in invoked:
+        if adapter.scope != "per_source":
             continue
-        invoked.add(adapter.source_type)
+        result = _invoke_per_source_adapter(
+            adapter, source, base_dir, manifest, verbose=verbose
+        )
+        _absorb(result, source.type, per_source_loaded, bag, adapter)
+
+    # Pass 2 — every per-scan adapter fires once, in REGISTRY order.
+    # Covers framework adapters (always check their manifest section
+    # internally and may emit zero LoadedToolSource entries when not
+    # configured) and manifest-only adapters (openai_api,
+    # anthropic_api, n8n).
+    for adapter in REGISTRY.per_scan_adapters():
         result = adapter.load(None, base_dir, manifest)
         _absorb(result, adapter.source_type, per_scan_loaded, bag, adapter)
 

--- a/src/agents_shipgate/cli/scan.py
+++ b/src/agents_shipgate/cli/scan.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from agents_shipgate.checks.registry import run_checks
 from agents_shipgate.ci.github_summary import write_github_step_summary
 from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
 from agents_shipgate.core.baseline import apply_baseline, load_baseline
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.errors import ConfigError, InputParseError
@@ -23,6 +24,7 @@ from agents_shipgate.core.findings import (
 from agents_shipgate.core.models import (
     Agent,
     AnthropicArtifacts,
+    CodexPluginArtifacts,
     CodexPluginSurface,
     CrewAiArtifacts,
     GoogleAdkArtifacts,
@@ -35,14 +37,14 @@ from agents_shipgate.core.models import (
     parse_severity,
 )
 from agents_shipgate.core.risk_hints import enrich_tools_with_risk_hints
-from agents_shipgate.inputs.anthropic_api import load_anthropic_artifacts
-from agents_shipgate.inputs.codex_plugin import load_codex_plugin_artifacts
 from agents_shipgate.inputs.frameworks import load_framework_artifacts
-from agents_shipgate.inputs.mcp import load_mcp_tools
-from agents_shipgate.inputs.openai_api import load_openai_api_artifacts
-from agents_shipgate.inputs.openai_sdk_static import load_openai_sdk_static_tools
-from agents_shipgate.inputs.openapi import load_openapi_tools
 from agents_shipgate.inputs.policy_packs import load_policy_packs, run_policy_pack_rules
+from agents_shipgate.inputs.protocol import (
+    REGISTRY,
+    ArtifactBag,
+    LoadedAdapterResult,
+    ToolSourceAdapter,
+)
 from agents_shipgate.inputs.validation import load_validation_artifacts
 from agents_shipgate.packet.builder import build_packet
 from agents_shipgate.packet.html import write_packet_html
@@ -116,25 +118,15 @@ def run_scan(
         raise ConfigError("--baseline-mode supports only new-findings")
 
     base_dir = config_path.resolve().parent
-    loaded_sources = _load_sources(manifest, base_dir, verbose=verbose)
-    framework_result = load_framework_artifacts(manifest, base_dir)
+    loaded_sources, artifact_bag = _load_sources(manifest, base_dir, verbose=verbose)
+    framework_result = load_framework_artifacts(manifest, base_dir, artifact_bag)
     adk_artifacts = framework_result.adk_artifacts
     langchain_artifacts = framework_result.langchain_artifacts
     crewai_artifacts = framework_result.crewai_artifacts
     n8n_artifacts = framework_result.n8n_artifacts
-    loaded_sources.extend(framework_result.loaded_sources)
-    api_source, api_artifacts = load_openai_api_artifacts(manifest.openai_api, base_dir)
-    if api_source:
-        loaded_sources.append(api_source)
-    anthropic_source, anthropic_artifacts = load_anthropic_artifacts(
-        manifest.anthropic, base_dir
-    )
-    if anthropic_source:
-        loaded_sources.append(anthropic_source)
-    codex_plugin_sources, codex_plugin_artifacts = load_codex_plugin_artifacts(
-        manifest, base_dir
-    )
-    loaded_sources.extend(codex_plugin_sources)
+    api_artifacts = artifact_bag.get("openai_api", OpenAIApiArtifacts)
+    anthropic_artifacts = artifact_bag.get("anthropic_api", AnthropicArtifacts)
+    codex_plugin_artifacts = artifact_bag.get("codex_plugin", CodexPluginArtifacts)
     validation_artifacts = load_validation_artifacts(manifest.validation, base_dir)
     logger.debug(
         "loaded sources",
@@ -399,25 +391,15 @@ def inspect_sources(*, config_path: Path, verbose: bool = False) -> dict[str, ob
                 ]
             }
         )
-    loaded_sources = _load_sources(manifest, base_dir, verbose=verbose)
-    framework_result = load_framework_artifacts(manifest, base_dir)
+    loaded_sources, artifact_bag = _load_sources(manifest, base_dir, verbose=verbose)
+    framework_result = load_framework_artifacts(manifest, base_dir, artifact_bag)
     adk_artifacts = framework_result.adk_artifacts
     langchain_artifacts = framework_result.langchain_artifacts
     crewai_artifacts = framework_result.crewai_artifacts
     n8n_artifacts = framework_result.n8n_artifacts
-    loaded_sources.extend(framework_result.loaded_sources)
-    api_source, api_artifacts = load_openai_api_artifacts(manifest.openai_api, base_dir)
-    if api_source:
-        loaded_sources.append(api_source)
-    anthropic_source, anthropic_artifacts = load_anthropic_artifacts(
-        manifest.anthropic, base_dir
-    )
-    if anthropic_source:
-        loaded_sources.append(anthropic_source)
-    codex_plugin_sources, codex_plugin_artifacts = load_codex_plugin_artifacts(
-        manifest, base_dir
-    )
-    loaded_sources.extend(codex_plugin_sources)
+    api_artifacts = artifact_bag.get("openai_api", OpenAIApiArtifacts)
+    anthropic_artifacts = artifact_bag.get("anthropic_api", AnthropicArtifacts)
+    codex_plugin_artifacts = artifact_bag.get("codex_plugin", CodexPluginArtifacts)
     validation_artifacts = load_validation_artifacts(manifest.validation, base_dir)
     tools, duplicate_warnings = _flatten_and_deduplicate_tools(loaded_sources)
     warnings = [warning for loaded in loaded_sources for warning in loaded.warnings]
@@ -548,42 +530,128 @@ def _resolve_source_paths(
     return unresolved
 
 
-def _load_sources(manifest, base_dir: Path, *, verbose: bool) -> list[LoadedToolSource]:
-    loaded: list[LoadedToolSource] = []
+def _load_sources(
+    manifest: AgentsShipgateManifest,
+    base_dir: Path,
+    *,
+    verbose: bool,
+) -> tuple[list[LoadedToolSource], ArtifactBag]:
+    """Dispatch every adapter through ``REGISTRY``.
+
+    Returns ``(loaded_sources, artifact_bag)``. ``artifact_bag`` is a
+    typed ``ArtifactBag`` with per-scan adapter artifacts keyed by
+    ``source_type``. Per-source adapters (mcp, openapi,
+    openai_agents_sdk) never populate artifacts.
+
+    Ordering is deterministic and matches the legacy run_scan order:
+
+      1. per-source loaders in tool_sources declared order
+      2. framework adapters (triggered by either tool_sources OR a
+         populated manifest section), in REGISTRY iteration order:
+         google_adk → langchain → crewai → n8n
+      3. manifest-only adapters: openai_api → anthropic_api
+      4. codex_plugin (last, per legacy ordering)
+
+    Manifest-only adapters always fire via pass 2 regardless of
+    tool_sources contents. Framework adapters fire once per scan via
+    either pass, deduplicated by source_type.
+    """
+    per_source_loaded: list[LoadedToolSource] = []
+    per_scan_loaded: list[LoadedToolSource] = []
+    bag = ArtifactBag()
+    invoked: set[str] = set()
+
+    # Pass 1 — walk tool_sources in declared order. Per-source adapters
+    # contribute to per_source_loaded immediately. Per-scan adapters
+    # (frameworks) are invoked on first encounter and their output is
+    # buffered into per_scan_loaded so it lands AFTER all per-source
+    # results regardless of where the framework's tool_sources row
+    # appears.
     for source in manifest.tool_sources:
-        try:
-            if source.type == "mcp":
-                loaded.append(load_mcp_tools(source, base_dir))
-            elif source.type == "openapi":
-                loaded.append(load_openapi_tools(source, base_dir))
-            elif source.type == "openai_agents_sdk":
-                loaded.append(load_openai_sdk_static_tools(source, manifest, base_dir))
-            elif source.type == "google_adk":
-                # Google ADK sources are loaded with framework artifacts below.
+        adapter = REGISTRY.require(source.type)
+        if adapter.scope == "per_source":
+            result = _invoke_per_source_adapter(
+                adapter, source, base_dir, manifest, verbose=verbose
+            )
+            _absorb(result, source.type, per_source_loaded, bag, adapter)
+        else:  # per_scan framework triggered by tool_sources
+            if source.type in invoked:
                 continue
-            elif source.type in {"langchain", "crewai"}:
-                # Framework sources are loaded with framework artifacts below.
-                continue
-            elif source.type == "codex_plugin":
-                # Codex plugin packages are loaded with plugin artifacts above.
-                continue
-        except InputParseError:
-            if source.optional:
-                warning = f"Optional source {source.id} failed to load"
-                if verbose:
-                    warning = (
-                        f"{warning}; continuing because the source is marked optional"
-                    )
-                loaded.append(
+            invoked.add(source.type)
+            result = adapter.load(None, base_dir, manifest)
+            _absorb(result, source.type, per_scan_loaded, bag, adapter)
+
+    # Pass 2 — invoke per-scan adapters not yet run. Covers:
+    #   (a) framework adapters configured only via top-level manifest
+    #       sections (no tool_sources row) — google_adk, langchain,
+    #       crewai, codex_plugin.
+    #   (b) manifest-only adapters (openai_api, anthropic_api, n8n)
+    #       with no tool_sources representation.
+    for adapter in REGISTRY.per_scan_adapters():
+        if adapter.source_type in invoked:
+            continue
+        invoked.add(adapter.source_type)
+        result = adapter.load(None, base_dir, manifest)
+        _absorb(result, adapter.source_type, per_scan_loaded, bag, adapter)
+
+    return per_source_loaded + per_scan_loaded, bag
+
+
+def _absorb(
+    result: LoadedAdapterResult,
+    source_type: str,
+    sink: list[LoadedToolSource],
+    bag: ArtifactBag,
+    adapter: ToolSourceAdapter,
+) -> None:
+    sink.extend(result.tool_sources)
+    if result.artifact is not None:
+        if adapter.artifact_class is not None and not isinstance(
+            result.artifact, adapter.artifact_class
+        ):
+            raise TypeError(
+                f"Adapter {adapter.source_type!r} declared "
+                f"artifact_class={adapter.artifact_class.__name__} but "
+                f"returned {type(result.artifact).__name__}"
+            )
+        bag.set(source_type, result.artifact)
+    if result.warnings:
+        sink.append(
+            LoadedToolSource(
+                source_id=f"adapter:{source_type}",
+                source_type=source_type,
+                warnings=list(result.warnings),
+            )
+        )
+
+
+def _invoke_per_source_adapter(
+    adapter: ToolSourceAdapter,
+    source: ToolSourceConfig,
+    base_dir: Path,
+    manifest: AgentsShipgateManifest,
+    *,
+    verbose: bool,
+) -> LoadedAdapterResult:
+    try:
+        return adapter.load(source, base_dir, manifest)
+    except InputParseError:
+        if source.optional:
+            warning = f"Optional source {source.id} failed to load"
+            if verbose:
+                warning = (
+                    f"{warning}; continuing because the source is marked optional"
+                )
+            return LoadedAdapterResult(
+                tool_sources=[
                     LoadedToolSource(
                         source_id=source.id,
                         source_type=source.type,
                         warnings=[warning],
                     )
-                )
-                continue
-            raise
-    return loaded
+                ],
+            )
+        raise
 
 
 def _flatten_and_deduplicate_tools(

--- a/src/agents_shipgate/inputs/anthropic_api.py
+++ b/src/agents_shipgate/inputs/anthropic_api.py
@@ -42,9 +42,14 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
-from agents_shipgate.config.schema import AnthropicConfig, ArtifactPathConfig
+from agents_shipgate.config.schema import (
+    AgentsShipgateManifest,
+    AnthropicConfig,
+    ArtifactPathConfig,
+    ToolSourceConfig,
+)
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import (
     AnthropicArtifacts,
@@ -62,6 +67,7 @@ from agents_shipgate.inputs.common import (
     schema_to_parameters,
     stable_tool_id,
 )
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 
 PROMPT_SUFFIXES = {".md", ".markdown", ".txt"}
 
@@ -401,3 +407,28 @@ def _display_path(path: Path, base_dir: Path) -> str:
         return path.resolve().relative_to(base_dir.resolve()).as_posix()
     except ValueError:
         return path.as_posix()
+
+
+class AnthropicAPIAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_anthropic_artifacts`.
+
+    Manifest-only: ``source_type = "anthropic_api"`` is NOT in
+    ``ToolSourceConfig.type``'s Literal. Always invoked once per scan
+    via the dispatcher's pass 2; reads from ``manifest.anthropic``.
+    """
+
+    source_type: ClassVar[str] = "anthropic_api"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+    artifact_class: ClassVar[type | None] = AnthropicArtifacts
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        anthropic_source, artifacts = load_anthropic_artifacts(
+            manifest.anthropic, base_dir
+        )
+        tool_sources = [anthropic_source] if anthropic_source is not None else []
+        return LoadedAdapterResult(tool_sources=tool_sources, artifact=artifacts)

--- a/src/agents_shipgate/inputs/codex_plugin.py
+++ b/src/agents_shipgate/inputs/codex_plugin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from agents_shipgate.config.schema import (
     AgentsShipgateManifest,
@@ -31,6 +31,7 @@ from agents_shipgate.inputs.common import (
     resolve_input_path,
 )
 from agents_shipgate.inputs.mcp import load_mcp_tools
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 
 COMMAND_KEYS = {"command", "cmd", "run", "shell", "script"}
 PLUGIN_MANIFEST = ".codex-plugin/plugin.json"
@@ -751,3 +752,25 @@ def _location(
         source_start_line=start_line,
         source_start_column=start_column,
     )
+
+
+class CodexPluginAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_codex_plugin_artifacts`.
+
+    Framework-scoped. The dispatcher invokes ``load()`` once per scan
+    when either a ``tool_sources`` entry of type ``codex_plugin`` or
+    the top-level ``manifest.codex_plugins`` section is configured.
+    """
+
+    source_type: ClassVar[str] = "codex_plugin"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+    artifact_class: ClassVar[type | None] = CodexPluginArtifacts
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        loaded_sources, artifacts = load_codex_plugin_artifacts(manifest, base_dir)
+        return LoadedAdapterResult(tool_sources=loaded_sources, artifact=artifacts)

--- a/src/agents_shipgate/inputs/crewai.py
+++ b/src/agents_shipgate/inputs/crewai.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
-from agents_shipgate.config.schema import AgentsShipgateManifest
+from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
 from agents_shipgate.core.models import AuthInfo, CrewAiArtifacts, LoadedToolSource, Tool
 from agents_shipgate.inputs._python_framework import (
     assignment_call,
@@ -18,6 +18,7 @@ from agents_shipgate.inputs._python_framework import (
     unique_tools,
 )
 from agents_shipgate.inputs.common import stable_tool_id, tool_name_warning
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 from agents_shipgate.inputs.python_static import (
     dotted_name,
     field_default_string,
@@ -434,3 +435,25 @@ def _resolve_names(node: ast.AST | None) -> list[str] | None:
     if isinstance(node, ast.Name):
         return [node.id]
     return None
+
+
+class CrewAIAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_crewai_artifacts`.
+
+    Framework-scoped. The dispatcher invokes ``load()`` once per scan
+    when either a ``tool_sources`` entry of type ``crewai`` or the
+    top-level ``manifest.crewai`` section is configured.
+    """
+
+    source_type: ClassVar[str] = "crewai"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+    artifact_class: ClassVar[type | None] = CrewAiArtifacts
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        loaded_sources, artifacts = load_crewai_artifacts(manifest, base_dir)
+        return LoadedAdapterResult(tool_sources=loaded_sources, artifact=artifacts)

--- a/src/agents_shipgate/inputs/frameworks.py
+++ b/src/agents_shipgate/inputs/frameworks.py
@@ -1,3 +1,17 @@
+"""Framework-artifact aggregation shim for v0.11.
+
+v0.12 TODO: collapse this into the registry result directly. For now,
+this module exists to keep ``scan.py``'s variable names
+(``adk_artifacts``, ``langchain_artifacts``, etc.) stable across the
+adapter-registry refactor — it reshapes the registry's typed
+``ArtifactBag`` into the existing ``FrameworkLoadResult`` dataclass
+that the rest of ``scan.py`` and ``inspect_sources`` consumes.
+
+When called without an ``artifact_bag`` (the legacy code path for
+tests that bypass the registry), it falls back to direct loader calls.
+That fallback is removed in v0.12.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -15,6 +29,7 @@ from agents_shipgate.inputs.crewai import load_crewai_artifacts
 from agents_shipgate.inputs.google_adk import load_google_adk_artifacts
 from agents_shipgate.inputs.langchain import load_langchain_artifacts
 from agents_shipgate.inputs.n8n import load_n8n_artifacts
+from agents_shipgate.inputs.protocol import ArtifactBag
 
 
 @dataclass(frozen=True)
@@ -27,6 +42,33 @@ class FrameworkLoadResult:
 
 
 def load_framework_artifacts(
+    manifest: AgentsShipgateManifest,
+    base_dir: Path,
+    artifact_bag: ArtifactBag | None = None,
+) -> FrameworkLoadResult:
+    """Reshape registry output into the typed ``FrameworkLoadResult``.
+
+    When ``artifact_bag`` is provided, framework adapters have already
+    run via the registry; this function just unpacks artifacts by key.
+    ``loaded_sources`` is empty in this path because the registry
+    already collected every framework's ``LoadedToolSource``.
+
+    When ``artifact_bag`` is ``None``, falls back to direct loader
+    calls — kept for unit tests that bypass the registry. v0.12 will
+    remove this fallback.
+    """
+    if artifact_bag is None:
+        return _legacy_load_framework_artifacts(manifest, base_dir)
+    return FrameworkLoadResult(
+        loaded_sources=[],
+        adk_artifacts=artifact_bag.get("google_adk", GoogleAdkArtifacts),
+        langchain_artifacts=artifact_bag.get("langchain", LangChainArtifacts),
+        crewai_artifacts=artifact_bag.get("crewai", CrewAiArtifacts),
+        n8n_artifacts=artifact_bag.get("n8n", N8nArtifacts),
+    )
+
+
+def _legacy_load_framework_artifacts(
     manifest: AgentsShipgateManifest,
     base_dir: Path,
 ) -> FrameworkLoadResult:

--- a/src/agents_shipgate/inputs/google_adk.py
+++ b/src/agents_shipgate/inputs/google_adk.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from agents_shipgate.config.schema import (
     AgentsShipgateManifest,
@@ -26,6 +26,7 @@ from agents_shipgate.inputs.common import (
 )
 from agents_shipgate.inputs.mcp import load_mcp_tools
 from agents_shipgate.inputs.openapi import load_openapi_tools
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 from agents_shipgate.inputs.traces import load_trace_artifacts
 
 AGENT_CLASS_NAMES = {
@@ -1111,3 +1112,25 @@ def _display_path(path: Path, base_dir: Path) -> str:
 def _append_unique(values: list[str], value: str) -> None:
     if value not in values:
         values.append(value)
+
+
+class GoogleADKAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_google_adk_artifacts`.
+
+    Framework-scoped. The dispatcher invokes ``load()`` once per scan
+    when either a ``tool_sources`` entry of type ``google_adk`` or the
+    top-level ``manifest.google_adk`` section is configured.
+    """
+
+    source_type: ClassVar[str] = "google_adk"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+    artifact_class: ClassVar[type | None] = GoogleAdkArtifacts
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        loaded_sources, artifacts = load_google_adk_artifacts(manifest, base_dir)
+        return LoadedAdapterResult(tool_sources=loaded_sources, artifact=artifacts)

--- a/src/agents_shipgate/inputs/langchain.py
+++ b/src/agents_shipgate/inputs/langchain.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
-from agents_shipgate.config.schema import AgentsShipgateManifest
+from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
 from agents_shipgate.core.models import LangChainArtifacts, LoadedToolSource, Tool
 from agents_shipgate.inputs._python_framework import (
     assignment_call,
@@ -18,6 +18,7 @@ from agents_shipgate.inputs._python_framework import (
     unique_tools,
 )
 from agents_shipgate.inputs.common import tool_name_warning
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 from agents_shipgate.inputs.python_static import (
     dotted_name,
     first_string_arg,
@@ -303,3 +304,25 @@ def _decorator_tool_name(decorator: ast.Call | ast.Name) -> str | None:
 
 def _decorator_description(decorator: ast.Call | ast.Name) -> str | None:
     return keyword_string(decorator, "description") if isinstance(decorator, ast.Call) else None
+
+
+class LangChainAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_langchain_artifacts`.
+
+    Framework-scoped. The dispatcher invokes ``load()`` once per scan
+    when either a ``tool_sources`` entry of type ``langchain`` or the
+    top-level ``manifest.langchain`` section is configured.
+    """
+
+    source_type: ClassVar[str] = "langchain"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+    artifact_class: ClassVar[type | None] = LangChainArtifacts
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        loaded_sources, artifacts = load_langchain_artifacts(manifest, base_dir)
+        return LoadedAdapterResult(tool_sources=loaded_sources, artifact=artifacts)

--- a/src/agents_shipgate/inputs/mcp.py
+++ b/src/agents_shipgate/inputs/mcp.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
-from agents_shipgate.config.schema import ToolSourceConfig
+from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool
 from agents_shipgate.inputs.common import (
@@ -14,6 +14,7 @@ from agents_shipgate.inputs.common import (
     stable_tool_id,
     tool_name_warning,
 )
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 
 
 def load_mcp_tools(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSource:
@@ -146,3 +147,20 @@ def _first_present(raw: dict[str, Any], names: list[str]) -> Any:
         if name in raw:
             return raw[name]
     return None
+
+
+class MCPAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_mcp_tools`."""
+
+    source_type: ClassVar[str] = "mcp"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_source"
+    artifact_class: ClassVar[type | None] = None
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        assert source is not None, "per_source adapter requires a source"
+        return LoadedAdapterResult(tool_sources=[load_mcp_tools(source, base_dir)])

--- a/src/agents_shipgate/inputs/n8n.py
+++ b/src/agents_shipgate/inputs/n8n.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from agents_shipgate.cli.discovery.artifacts import SKIP_DIR_PREFIXES, SKIP_DIRS
 from agents_shipgate.config.schema import (
@@ -29,6 +29,7 @@ from agents_shipgate.inputs.common import (
     tool_name_warning,
 )
 from agents_shipgate.inputs.mcp import load_mcp_tools
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 
 N8N_NODE_TYPE_RE = re.compile(r"^(@n8n/)?n8n-nodes-")
 SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -1507,3 +1508,25 @@ def _stable_identifier_hash(value: str | None) -> str:
 
 def _display_path(path: Path, base_dir: Path) -> str:
     return manifest_relative_path(str(path), base_dir)
+
+
+class N8nAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_n8n_artifacts`.
+
+    Manifest-only: ``source_type = "n8n"`` is NOT in
+    ``ToolSourceConfig.type``'s Literal. Always invoked once per scan
+    via the dispatcher's pass 2.
+    """
+
+    source_type: ClassVar[str] = "n8n"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+    artifact_class: ClassVar[type | None] = N8nArtifacts
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        loaded_sources, artifacts = load_n8n_artifacts(manifest, base_dir)
+        return LoadedAdapterResult(tool_sources=loaded_sources, artifact=artifacts)

--- a/src/agents_shipgate/inputs/openai_api.py
+++ b/src/agents_shipgate/inputs/openai_api.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from agents_shipgate.config.schema import (
+    AgentsShipgateManifest,
     ArtifactPathConfig,
     NamedArtifactPathConfig,
     OpenAIApiConfig,
+    ToolSourceConfig,
 )
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import (
@@ -27,6 +29,7 @@ from agents_shipgate.inputs.common import (
     stable_tool_id,
     tool_name_warning,
 )
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 
 PROMPT_SUFFIXES = {".md", ".markdown", ".txt"}
 
@@ -438,3 +441,28 @@ def _display_path(path: Path, base_dir: Path) -> str:
         return path.resolve().relative_to(base_dir.resolve()).as_posix()
     except ValueError:
         return path.as_posix()
+
+
+class OpenAIAPIAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_openai_api_artifacts`.
+
+    Manifest-only: ``source_type = "openai_api"`` is NOT in
+    ``ToolSourceConfig.type``'s Literal. Always invoked once per scan
+    via the dispatcher's pass 2; reads from ``manifest.openai_api``.
+    """
+
+    source_type: ClassVar[str] = "openai_api"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+    artifact_class: ClassVar[type | None] = OpenAIApiArtifacts
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        api_source, artifacts = load_openai_api_artifacts(
+            manifest.openai_api, base_dir
+        )
+        tool_sources = [api_source] if api_source is not None else []
+        return LoadedAdapterResult(tool_sources=tool_sources, artifact=artifacts)

--- a/src/agents_shipgate/inputs/openai_sdk_static.py
+++ b/src/agents_shipgate/inputs/openai_sdk_static.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool, ToolParameter
 from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 
 DEFAULT_FUNCTION_TOOL_DECORATORS = frozenset(
     {"function_tool", "agents.function_tool", "openai_agents.function_tool"}
@@ -197,3 +198,22 @@ def _json_schema_type(annotation: str | None) -> str:
     if annotation in {"dict", "Dict"} or (annotation or "").startswith("dict["):
         return "object"
     return "string"
+
+
+class OpenAISDKAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_openai_sdk_static_tools`."""
+
+    source_type: ClassVar[str] = "openai_agents_sdk"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_source"
+    artifact_class: ClassVar[type | None] = None
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        assert source is not None, "per_source adapter requires a source"
+        return LoadedAdapterResult(
+            tool_sources=[load_openai_sdk_static_tools(source, manifest, base_dir)]
+        )

--- a/src/agents_shipgate/inputs/openapi.py
+++ b/src/agents_shipgate/inputs/openapi.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
-from agents_shipgate.config.schema import ToolSourceConfig
+from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.models import AuthInfo, LoadedToolSource, Tool
 from agents_shipgate.inputs.common import (
@@ -18,6 +18,7 @@ from agents_shipgate.inputs.common import (
     stable_tool_id,
     tool_name_warning,
 )
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
 
 MAX_SCHEMA_RESOLVE_DEPTH = 32
 MAX_SCHEMA_RESOLVE_NODES = 5000
@@ -341,3 +342,20 @@ def _operation_name(method: str, path: str) -> str:
     safe_path = path.strip("/").replace("/", "_").replace("{", "").replace("}", "")
     safe_path = safe_path.replace("-", "_") or "root"
     return f"{method}_{safe_path}"
+
+
+class OpenAPIAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_openapi_tools`."""
+
+    source_type: ClassVar[str] = "openapi"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_source"
+    artifact_class: ClassVar[type | None] = None
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        assert source is not None, "per_source adapter requires a source"
+        return LoadedAdapterResult(tool_sources=[load_openapi_tools(source, base_dir)])

--- a/src/agents_shipgate/inputs/protocol.py
+++ b/src/agents_shipgate/inputs/protocol.py
@@ -1,0 +1,256 @@
+"""Adapter Protocol + AdapterRegistry for tool-source loading.
+
+Every tool-source loader (mcp, openapi, openai_agents_sdk, google_adk,
+langchain, crewai, codex_plugin, openai_api, anthropic_api, n8n) is
+exposed as a ``ToolSourceAdapter``. The CLI's ``_load_sources`` walks
+``REGISTRY`` to dispatch.
+
+Adding a new builtin adapter in v0.12+ is a two-file change:
+
+  1. Drop a class in ``inputs/<name>.py`` matching the Protocol.
+  2. Add it to the tuple in ``_register_builtin_adapters()`` below
+     in canonical order (see the docstring there).
+
+Entry-point discovery for third-party plugins is a v0.12 follow-up.
+
+Manifest-only adapters (``openai_api``, ``anthropic_api``, ``n8n``) are
+registered under string keys that are NOT in ``ToolSourceConfig.type``'s
+Literal — they never appear in a user's ``tool_sources`` list and always
+run once per scan via the dispatcher's pass-2 loop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Literal, Protocol, TypeVar, runtime_checkable
+
+from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
+from agents_shipgate.core.models import LoadedToolSource
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class LoadedAdapterResult:
+    """Result returned by ``ToolSourceAdapter.load()``.
+
+    - ``tool_sources``: zero or more ``LoadedToolSource`` entries.
+      Per-source adapters typically return exactly one; per-scan
+      adapters may return many (one per discovered framework
+      entrypoint) or zero (if no inputs).
+    - ``artifact``: optional framework-scoped artifact
+      (``GoogleAdkArtifacts``, ``LangChainArtifacts``,
+      ``OpenAIApiArtifacts``, etc.). ``None`` for pure adapters that
+      don't produce a manifest-level artifact bag. The type MUST match
+      the adapter's ``artifact_class`` (validated at dispatch time).
+    - ``warnings``: adapter-level warnings that don't belong to any
+      single ``LoadedToolSource`` (e.g., "manifest.langchain section is
+      empty but tool_sources declares a langchain entry"). Per-tool-
+      source warnings continue to live on ``LoadedToolSource.warnings``.
+    """
+
+    tool_sources: list[LoadedToolSource] = field(default_factory=list)
+    artifact: object | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+@runtime_checkable
+class ToolSourceAdapter(Protocol):
+    """Adapter contract for a single tool-source loader.
+
+    ``source_type`` is a string identifying the adapter:
+      - For per-source adapters, this matches ``ToolSourceConfig.type``
+        (e.g., "mcp").
+      - For per-scan framework adapters, this also matches a
+        ``ToolSourceConfig.type`` Literal (e.g., "langchain"). The
+        adapter runs once per scan when EITHER a matching
+        ``tool_sources`` entry is present OR the corresponding
+        top-level manifest section is populated.
+      - For per-scan manifest-only adapters ("openai_api",
+        "anthropic_api", "n8n"), the string is the artifact key — never
+        appears in user ``tool_sources`` entries; the adapter always
+        runs once per scan.
+
+    ``scope`` controls dispatch:
+      - "per_source": called once per matching ``tool_sources`` entry.
+      - "per_scan":   called once per scan (registry dedupes by
+                      source_type).
+
+    ``artifact_class`` is the type returned in
+    ``LoadedAdapterResult.artifact`` (or ``None`` for pure adapters).
+    The dispatcher validates returned artifacts via ``isinstance`` and
+    ``ArtifactBag`` uses it for typed retrieval.
+    """
+
+    source_type: ClassVar[str]
+    scope: ClassVar[Literal["per_source", "per_scan"]]
+    artifact_class: ClassVar[type | None]
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult: ...
+
+
+class ArtifactBag:
+    """Typed accessor over per-scan adapter artifacts.
+
+    Wraps a ``dict[str, object]`` keyed by ``source_type``. ``get()``
+    takes the expected concrete type and returns ``T | None``, giving
+    call sites in ``ScanContext`` / packet builder a typed value
+    without per-callsite ``cast`` boilerplate. Mismatches raise
+    ``TypeError`` — protects against an adapter accidentally returning
+    a wrong-typed artifact.
+    """
+
+    __slots__ = ("_by_type",)
+
+    def __init__(self, by_type: dict[str, object] | None = None) -> None:
+        self._by_type: dict[str, object] = dict(by_type or {})
+
+    def set(self, source_type: str, artifact: object) -> None:
+        self._by_type[source_type] = artifact
+
+    def has(self, source_type: str) -> bool:
+        return source_type in self._by_type
+
+    def get(self, source_type: str, expected_type: type[T]) -> T | None:
+        artifact = self._by_type.get(source_type)
+        if artifact is None:
+            return None
+        if not isinstance(artifact, expected_type):
+            raise TypeError(
+                f"Adapter for {source_type!r} returned "
+                f"{type(artifact).__name__}, "
+                f"expected {expected_type.__name__}"
+            )
+        return artifact
+
+    def raw(self) -> dict[str, object]:
+        """Escape hatch for the frameworks.py shim. Not for general use."""
+        return dict(self._by_type)
+
+
+class AdapterRegistry:
+    """Ordered registry of ``ToolSourceAdapter`` instances.
+
+    Iteration is in registration order — used by the scan dispatcher
+    to preserve the canonical cohort ordering today's ``run_scan``
+    produces (per-source loaders → framework adapters → manifest-only
+    adapters). Duplicate registration raises ``RuntimeError``.
+
+    Builtin adapters are populated lazily on first access (see
+    ``_ensure_populated``). This avoids a circular-import hazard: each
+    adapter module imports ``LoadedAdapterResult`` from this module
+    while ``_register_builtin_adapters`` imports the adapter modules.
+    Delaying the registration call to first read guarantees every
+    adapter module has finished its top-level import before its
+    sibling modules are imported during registration.
+    """
+
+    def __init__(self, *, autopopulate: bool = True) -> None:
+        self._adapters: dict[str, ToolSourceAdapter] = {}
+        self._autopopulate = autopopulate
+        self._populated = not autopopulate
+
+    def _ensure_populated(self) -> None:
+        if self._populated:
+            return
+        # Set first to prevent re-entry from inside _register_builtin_adapters.
+        self._populated = True
+        _register_builtin_adapters(self)
+
+    def register(self, adapter: ToolSourceAdapter) -> None:
+        if adapter.source_type in self._adapters:
+            raise RuntimeError(
+                f"ToolSourceAdapter for {adapter.source_type!r} is already registered"
+            )
+        self._adapters[adapter.source_type] = adapter
+
+    def get(self, source_type: str) -> ToolSourceAdapter | None:
+        self._ensure_populated()
+        return self._adapters.get(source_type)
+
+    def require(self, source_type: str) -> ToolSourceAdapter:
+        self._ensure_populated()
+        adapter = self._adapters.get(source_type)
+        if adapter is None:
+            from agents_shipgate.core.errors import ConfigError
+
+            raise ConfigError(
+                f"No adapter registered for source type {source_type!r}. "
+                "Add the adapter to "
+                "agents_shipgate.inputs.protocol._register_builtin_adapters()."
+            )
+        return adapter
+
+    def __iter__(self) -> Iterator[ToolSourceAdapter]:
+        self._ensure_populated()
+        return iter(self._adapters.values())
+
+    def __contains__(self, source_type: object) -> bool:
+        self._ensure_populated()
+        return source_type in self._adapters
+
+    def __len__(self) -> int:
+        self._ensure_populated()
+        return len(self._adapters)
+
+    def per_scan_adapters(self) -> Iterator[ToolSourceAdapter]:
+        self._ensure_populated()
+        for adapter in self._adapters.values():
+            if adapter.scope == "per_scan":
+                yield adapter
+
+
+REGISTRY = AdapterRegistry()
+
+
+def _register_builtin_adapters(registry: AdapterRegistry) -> None:
+    """Populate ``registry`` in canonical cohort order.
+
+    The order matters. Pass-1 of the dispatcher walks
+    ``manifest.tool_sources`` and routes through whichever adapter
+    matches; pass-2 walks ``REGISTRY.per_scan_adapters()`` (in this
+    order) for any per-scan adapter not yet invoked. The resulting
+    output ordering mirrors the legacy ``run_scan``:
+
+        per-source loaders (declared order)
+        → google_adk → langchain → crewai → n8n
+        → openai_api → anthropic_api → codex_plugin
+
+    Adapter modules are imported lazily here to avoid a top-level
+    cycle: each adapter module imports ``LoadedAdapterResult`` from
+    this module at module load time. Doing the imports inside this
+    function (called from ``AdapterRegistry._ensure_populated``) means
+    every adapter module has finished its top-level imports before its
+    siblings are imported here.
+    """
+    from agents_shipgate.inputs.anthropic_api import AnthropicAPIAdapter
+    from agents_shipgate.inputs.codex_plugin import CodexPluginAdapter
+    from agents_shipgate.inputs.crewai import CrewAIAdapter
+    from agents_shipgate.inputs.google_adk import GoogleADKAdapter
+    from agents_shipgate.inputs.langchain import LangChainAdapter
+    from agents_shipgate.inputs.mcp import MCPAdapter
+    from agents_shipgate.inputs.n8n import N8nAdapter
+    from agents_shipgate.inputs.openai_api import OpenAIAPIAdapter
+    from agents_shipgate.inputs.openai_sdk_static import OpenAISDKAdapter
+    from agents_shipgate.inputs.openapi import OpenAPIAdapter
+
+    for adapter in (
+        MCPAdapter(),
+        OpenAPIAdapter(),
+        OpenAISDKAdapter(),
+        GoogleADKAdapter(),
+        LangChainAdapter(),
+        CrewAIAdapter(),
+        N8nAdapter(),
+        OpenAIAPIAdapter(),
+        AnthropicAPIAdapter(),
+        CodexPluginAdapter(),
+    ):
+        registry.register(adapter)

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -1,0 +1,321 @@
+"""Unit tests for the ``inputs/protocol.py`` adapter Protocol + registry.
+
+Coverage builds out across the v0.11 migration steps; see
+``docs/plans/please-carefully-plan-for-hidden-quasar.md`` for the full
+case plan. Steps 1 and 3 add registration / Protocol / ArtifactBag
+coverage; Step 6 adds dispatch-loop coverage (config-only frameworks,
+ordering, type-validation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar, Literal, get_args
+
+import pytest
+
+from agents_shipgate.cli.scan import _load_sources
+from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.config.schema import AgentsShipgateManifest, ToolSourceConfig
+from agents_shipgate.core.errors import ConfigError, InputParseError
+from agents_shipgate.core.models import (
+    AnthropicArtifacts,
+    CodexPluginArtifacts,
+    CrewAiArtifacts,
+    GoogleAdkArtifacts,
+    LangChainArtifacts,
+    OpenAIApiArtifacts,
+)
+from agents_shipgate.inputs.protocol import (
+    REGISTRY,
+    AdapterRegistry,
+    ArtifactBag,
+    LoadedAdapterResult,
+    ToolSourceAdapter,
+)
+
+
+@dataclass
+class _StubArtifact:
+    name: str
+
+
+class _StubAdapter:
+    source_type: ClassVar[str] = "stub"
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_source"
+    artifact_class: ClassVar[type | None] = None
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        return LoadedAdapterResult()
+
+
+def test_register_rejects_duplicate():
+    registry = AdapterRegistry(autopopulate=False)
+    registry.register(_StubAdapter())
+    with pytest.raises(RuntimeError, match="already registered"):
+        registry.register(_StubAdapter())
+
+
+def test_artifact_bag_get_returns_none_when_missing():
+    bag = ArtifactBag()
+    assert bag.get("missing", _StubArtifact) is None
+
+
+def test_artifact_bag_get_returns_typed_value():
+    bag = ArtifactBag()
+    artifact = _StubArtifact(name="hello")
+    bag.set("stub", artifact)
+    retrieved = bag.get("stub", _StubArtifact)
+    assert retrieved is artifact
+    assert retrieved.name == "hello"
+
+
+def test_artifact_bag_get_raises_on_type_mismatch():
+    bag = ArtifactBag()
+    bag.set("stub", "not an artifact")
+    with pytest.raises(TypeError, match="expected _StubArtifact"):
+        bag.get("stub", _StubArtifact)
+
+
+def test_stub_adapter_satisfies_protocol():
+    assert isinstance(_StubAdapter(), ToolSourceAdapter)
+
+
+def test_adapters_registered_for_every_tool_source_type():
+    """Every value in ``ToolSourceConfig.type``'s Literal must have a
+    matching adapter in ``REGISTRY``. Catches drift if a new source
+    type lands without registration."""
+
+    source_types = get_args(ToolSourceConfig.model_fields["type"].annotation)
+    assert source_types, "expected ToolSourceConfig.type to be a Literal"
+    for source_type in source_types:
+        assert source_type in REGISTRY, (
+            f"no adapter registered for tool source type {source_type!r}"
+        )
+
+
+def test_manifest_only_adapters_registered():
+    """The three manifest-only adapters live outside the
+    ``ToolSourceConfig.type`` Literal but must still be in the
+    registry under per_scan scope."""
+
+    for source_type in ("openai_api", "anthropic_api", "n8n"):
+        adapter = REGISTRY.get(source_type)
+        assert adapter is not None, f"{source_type!r} adapter not registered"
+        assert adapter.scope == "per_scan"
+
+
+def test_require_unknown_source_type_raises_config_error():
+    """``REGISTRY.require`` fails loud on unknown types — protects
+    against silent drops if a future schema literal forgets to
+    register an adapter."""
+
+    with pytest.raises(ConfigError, match="No adapter registered"):
+        REGISTRY.require("does_not_exist")
+
+
+def test_every_registered_adapter_satisfies_protocol():
+    """Every adapter in the populated ``REGISTRY`` satisfies the
+    ``ToolSourceAdapter`` Protocol — guards against an adapter class
+    missing a required ``ClassVar``."""
+
+    for adapter in REGISTRY:
+        assert isinstance(adapter, ToolSourceAdapter), (
+            f"{type(adapter).__name__} does not satisfy ToolSourceAdapter Protocol"
+        )
+
+
+def test_canonical_registration_order():
+    """Pin the canonical cohort order. The dispatcher's pass-2 loop
+    iterates ``REGISTRY`` in this order; any reshuffle will change
+    the output ordering of ``_load_sources`` and therefore the
+    dedup-tie-break outcome in ``_flatten_and_deduplicate_tools``."""
+
+    expected = [
+        "mcp",
+        "openapi",
+        "openai_agents_sdk",
+        "google_adk",
+        "langchain",
+        "crewai",
+        "n8n",
+        "openai_api",
+        "anthropic_api",
+        "codex_plugin",
+    ]
+    actual = [adapter.source_type for adapter in REGISTRY]
+    assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-loop coverage. The dispatcher under test is
+# ``cli/scan.py:_load_sources``.
+# ---------------------------------------------------------------------------
+
+
+REFUND_SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
+GOOGLE_ADK_SAMPLE = Path("samples/google_adk_agent/shipgate.yaml")
+
+
+def test_dispatch_optional_source_warning(tmp_path):
+    """An ``optional`` source that fails to load surfaces a warning-
+    only ``LoadedToolSource`` and does NOT escape the dispatcher."""
+
+    manifest = load_manifest(REFUND_SAMPLE)
+    # All refund sources are required today; rewrite one to point at a
+    # missing file with optional=True.
+    rewritten = [
+        ToolSourceConfig(
+            id="missing_mcp",
+            type="mcp",
+            path="does/not/exist.json",
+            optional=True,
+        )
+    ]
+    manifest_with_optional = manifest.model_copy(
+        update={"tool_sources": rewritten}
+    )
+    base_dir = REFUND_SAMPLE.resolve().parent
+    loaded, _bag = _load_sources(manifest_with_optional, base_dir, verbose=False)
+    warning_sources = [
+        src for src in loaded if src.source_id == "missing_mcp"
+    ]
+    assert warning_sources, "expected a warning-only LoadedToolSource for the optional source"
+    assert warning_sources[0].warnings
+    assert "failed to load" in warning_sources[0].warnings[0]
+
+
+def test_dispatch_required_source_raises(tmp_path):
+    """A non-optional source pointing at a missing file propagates
+    ``InputParseError`` from the dispatcher."""
+
+    manifest = load_manifest(REFUND_SAMPLE)
+    rewritten = [
+        ToolSourceConfig(
+            id="missing_mcp",
+            type="mcp",
+            path="does/not/exist.json",
+            optional=False,
+        )
+    ]
+    manifest_with_missing = manifest.model_copy(
+        update={"tool_sources": rewritten}
+    )
+    base_dir = REFUND_SAMPLE.resolve().parent
+    with pytest.raises(InputParseError):
+        _load_sources(manifest_with_missing, base_dir, verbose=False)
+
+
+def test_framework_adapter_invoked_for_config_only():
+    """**P1 regression guard.** Schema permits
+    ``manifest.google_adk`` to be configured without a matching
+    ``tool_sources`` entry. The dispatcher's pass 2 must invoke
+    ``GoogleADKAdapter`` even when the user removes the redundant
+    ``tool_sources`` row."""
+
+    manifest = load_manifest(GOOGLE_ADK_SAMPLE)
+    config_only = manifest.model_copy(update={"tool_sources": []})
+    # The sample still has the top-level `google_adk:` section, so pass 2
+    # should pick it up.
+    base_dir = GOOGLE_ADK_SAMPLE.resolve().parent
+    _loaded, bag = _load_sources(config_only, base_dir, verbose=False)
+    artifacts = bag.get("google_adk", GoogleAdkArtifacts)
+    assert artifacts is not None, (
+        "GoogleADKAdapter must run when manifest.google_adk is configured "
+        "even if no tool_sources entry matches"
+    )
+
+
+def test_manifest_only_adapters_run_with_empty_tool_sources():
+    """openai_api, anthropic_api, and n8n adapters fire via pass 2
+    regardless of ``tool_sources`` contents. With an empty
+    ``tool_sources`` and no manifest sections configured for these
+    adapters, the dispatcher must still call them (they return
+    artifact=None, but the invocation itself shouldn't be skipped)."""
+
+    manifest = load_manifest(REFUND_SAMPLE)
+    base = manifest.model_copy(update={"tool_sources": [], "openai_api": None})
+    base_dir = REFUND_SAMPLE.resolve().parent
+    _loaded, bag = _load_sources(base, base_dir, verbose=False)
+    # No artifacts because configs are absent. The test passes if the
+    # dispatcher didn't raise.
+    assert bag.get("openai_api", OpenAIApiArtifacts) is None
+    assert bag.get("anthropic_api", AnthropicArtifacts) is None
+
+
+def test_per_scan_framework_adapter_invoked_once_with_multiple_tool_sources(monkeypatch):
+    """Duplicate ``tool_sources`` entries of the same framework type
+    invoke the adapter exactly once."""
+
+    call_count = {"value": 0}
+
+    class _RecordingLangChain:
+        source_type: ClassVar[str] = "langchain"
+        scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+        artifact_class: ClassVar[type | None] = LangChainArtifacts
+
+        def load(self, source, base_dir, manifest):
+            call_count["value"] += 1
+            return LoadedAdapterResult(artifact=LangChainArtifacts())
+
+    monkeypatch.setitem(REGISTRY._adapters, "langchain", _RecordingLangChain())
+    manifest = load_manifest(REFUND_SAMPLE)
+    duplicated = manifest.model_copy(
+        update={
+            "tool_sources": [
+                ToolSourceConfig(id="lc1", type="langchain", path="a.py"),
+                ToolSourceConfig(id="lc2", type="langchain", path="b.py"),
+            ]
+        }
+    )
+    base_dir = REFUND_SAMPLE.resolve().parent
+    _load_sources(duplicated, base_dir, verbose=False)
+    assert call_count["value"] == 1
+
+
+def test_dispatcher_validates_adapter_artifact_class(monkeypatch):
+    """**P1 regression guard.** If an adapter declares one
+    ``artifact_class`` but returns a different type, the dispatcher
+    raises ``TypeError`` rather than letting the wrong-typed artifact
+    leak into ``ScanContext``/packet rendering."""
+
+    class _LyingAdapter:
+        source_type: ClassVar[str] = "langchain"
+        scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+        artifact_class: ClassVar[type | None] = LangChainArtifacts
+
+        def load(self, source, base_dir, manifest):
+            # Declares LangChainArtifacts but returns CrewAiArtifacts.
+            return LoadedAdapterResult(artifact=CrewAiArtifacts())
+
+    monkeypatch.setitem(REGISTRY._adapters, "langchain", _LyingAdapter())
+    manifest = load_manifest(REFUND_SAMPLE)
+    triggered = manifest.model_copy(
+        update={
+            "tool_sources": [
+                ToolSourceConfig(id="lc", type="langchain", path="a.py"),
+            ]
+        }
+    )
+    base_dir = REFUND_SAMPLE.resolve().parent
+    with pytest.raises(TypeError, match="declared artifact_class=LangChainArtifacts"):
+        _load_sources(triggered, base_dir, verbose=False)
+
+
+def test_codex_plugin_artifact_in_bag():
+    """Smoke test for the manifest-only ``codex_plugin`` extraction:
+    artifact_bag exposes the typed value to scan.py."""
+
+    manifest = load_manifest(REFUND_SAMPLE)
+    base_dir = REFUND_SAMPLE.resolve().parent
+    _loaded, bag = _load_sources(manifest, base_dir, verbose=False)
+    artifact = bag.get("codex_plugin", CodexPluginArtifacts)
+    # Sample doesn't configure codex_plugins, so artifact is None — but
+    # the typed get() succeeded without TypeError.
+    assert artifact is None or isinstance(artifact, CodexPluginArtifacts)

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -163,6 +163,20 @@ REFUND_SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 GOOGLE_ADK_SAMPLE = Path("samples/google_adk_agent/shipgate.yaml")
 
 
+def _force_registry_populated() -> None:
+    """Trigger ``AdapterRegistry`` lazy population.
+
+    Tests that monkeypatch ``REGISTRY._adapters`` must run this first.
+    Without it, the first read inside the dispatcher triggers
+    ``_register_builtin_adapters`` against an ``_adapters`` dict that
+    already contains the stub, which raises ``RuntimeError`` for
+    duplicate registration. Reading via ``list(REGISTRY)`` runs
+    ``_ensure_populated`` exactly once and is a no-op on subsequent
+    calls.
+    """
+    list(REGISTRY)
+
+
 def test_dispatch_optional_source_warning(tmp_path):
     """An ``optional`` source that fails to load surfaces a warning-
     only ``LoadedToolSource`` and does NOT escape the dispatcher."""
@@ -253,6 +267,7 @@ def test_per_scan_framework_adapter_invoked_once_with_multiple_tool_sources(monk
     """Duplicate ``tool_sources`` entries of the same framework type
     invoke the adapter exactly once."""
 
+    _force_registry_populated()
     call_count = {"value": 0}
 
     class _RecordingLangChain:
@@ -284,6 +299,8 @@ def test_dispatcher_validates_adapter_artifact_class(monkeypatch):
     ``artifact_class`` but returns a different type, the dispatcher
     raises ``TypeError`` rather than letting the wrong-typed artifact
     leak into ``ScanContext``/packet rendering."""
+
+    _force_registry_populated()
 
     class _LyingAdapter:
         source_type: ClassVar[str] = "langchain"
@@ -319,3 +336,52 @@ def test_codex_plugin_artifact_in_bag():
     # Sample doesn't configure codex_plugins, so artifact is None — but
     # the typed get() succeeded without TypeError.
     assert artifact is None or isinstance(artifact, CodexPluginArtifacts)
+
+
+def test_per_scan_order_is_canonical_not_tool_sources(monkeypatch):
+    """**P2 regression guard.** Per-scan adapter output order is fixed
+    by ``REGISTRY`` registration order, NOT by ``manifest.tool_sources``
+    declaration order. Otherwise duplicate tie-break in
+    ``_flatten_and_deduplicate_tools`` (which keeps the first source
+    when priorities tie) would change based on user-facing yaml
+    ordering."""
+
+    _force_registry_populated()
+    invocation_order: list[str] = []
+
+    def _make_recorder(name: str, artifact_cls: type) -> object:
+        class _Recorder:
+            source_type: ClassVar[str] = name
+            scope: ClassVar[Literal["per_source", "per_scan"]] = "per_scan"
+            artifact_class: ClassVar[type | None] = artifact_cls
+
+            def load(self, source, base_dir, manifest):
+                invocation_order.append(name)
+                return LoadedAdapterResult(artifact=artifact_cls())
+
+        return _Recorder()
+
+    monkeypatch.setitem(
+        REGISTRY._adapters, "langchain", _make_recorder("langchain", LangChainArtifacts)
+    )
+    monkeypatch.setitem(
+        REGISTRY._adapters, "google_adk", _make_recorder("google_adk", GoogleAdkArtifacts)
+    )
+
+    manifest = load_manifest(REFUND_SAMPLE)
+    # Declare langchain BEFORE google_adk in tool_sources. If the
+    # dispatcher honored tool_sources order for per-scan adapters,
+    # langchain would invoke first. Canonical REGISTRY order is
+    # google_adk → langchain.
+    swapped = manifest.model_copy(
+        update={
+            "tool_sources": [
+                ToolSourceConfig(id="lc", type="langchain", path="a.py"),
+                ToolSourceConfig(id="adk", type="google_adk", path="b.py"),
+            ]
+        }
+    )
+    base_dir = REFUND_SAMPLE.resolve().parent
+    _load_sources(swapped, base_dir, verbose=False)
+    # google_adk is registered before langchain in _register_builtin_adapters.
+    assert invocation_order.index("google_adk") < invocation_order.index("langchain")


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `if/elif` dispatch in `cli/scan.py:_load_sources` with a real `ToolSourceAdapter` Protocol and `AdapterRegistry`. Every tool-source loader (MCP, OpenAPI, OpenAI Agents SDK, Google ADK, LangChain, CrewAI, n8n, Codex plugin, OpenAI API, Anthropic API) is now a registered adapter class.
- Adds a typed `ArtifactBag` so framework artifacts retain their concrete types into `ScanContext` (no `dict[str, object]` leak).
- Two-pass dispatcher fires framework adapters when configured via top-level manifest sections **or** `tool_sources` entries — fixes a P1 regression risk where config-only `langchain`/`crewai`/`google_adk`/`codex_plugin` would silently drop.

## Type

- [x] Input adapter change
- [ ] Check or risk-model change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## What's in this PR

**New files**
- `src/agents_shipgate/inputs/protocol.py` — `ToolSourceAdapter` Protocol, `LoadedAdapterResult`, `ArtifactBag`, `AdapterRegistry` class with lazy population.
- `tests/test_adapter_registry.py` — 17 tests covering registration, dispatch ordering, config-only framework activation, artifact type validation, and fail-loud on unknown source types.

**Modified**
- 10 adapter modules (`mcp.py`, `openapi.py`, `openai_sdk_static.py`, `google_adk.py`, `langchain.py`, `crewai.py`, `n8n.py`, `openai_api.py`, `anthropic_api.py`, `codex_plugin.py`) get a thin `*Adapter` class that delegates to the existing `load_*` free function. No loader logic moves.
- `cli/scan.py` — `_load_sources` rewritten as a two-pass registry walk; `run_scan` and `inspect_sources` updated to consume `(loaded_sources, artifact_bag)`; six direct loader call sites collapse.
- `inputs/frameworks.py` — `load_framework_artifacts` becomes a typed shim that reshapes `ArtifactBag` into `FrameworkLoadResult` (zero churn for `scan.py`'s `adk_artifacts`/`langchain_artifacts`/etc. variable names). Legacy fallback preserved for tests that bypass the registry. Marked with `v0.12 TODO`.
- `CHANGELOG.md` — Unreleased entry.

## Design highlights

- **Single Protocol** with `scope: \"per_source\" | \"per_scan\"`. Per-source adapters (`mcp`, `openapi`, `openai_agents_sdk`) fire per `tool_sources` row; per-scan adapters fire once per scan.
- **Real `AdapterRegistry` class** with lazy population — fixes a circular import that surfaced during integration (each adapter module imports `LoadedAdapterResult`; registration imports adapters).
- **Canonical cohort ordering** encoded in `_register_builtin_adapters`: per-source loaders → `google_adk` → `langchain` → `crewai` → `n8n` → `openai_api` → `anthropic_api` → `codex_plugin`. Matches today's `run_scan` output ordering exactly. Pinned by `test_canonical_registration_order`.
- **Fail-loud** on unknown source types via `REGISTRY.require(...)` → `ConfigError`.
- **Artifact type validation**: dispatcher asserts `isinstance(result.artifact, adapter.artifact_class)` and raises `TypeError` on mismatch. Pinned by `test_dispatcher_validates_adapter_artifact_class`.

## Notable tests

- `test_framework_adapter_invoked_for_config_only` — P1 regression guard for `manifest.google_adk` without a matching `tool_sources` row.
- `test_per_scan_framework_adapter_invoked_once_with_multiple_tool_sources` — duplicate `langchain` entries fire `.load` exactly once.
- `test_adapters_registered_for_every_tool_source_type` — uses `get_args(ToolSourceConfig.model_fields[\"type\"].annotation)` (Pydantic v2-correct) to catch drift on new Literals.

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest` → 990 passed, 3 skipped (+12 net new tests over the 978 baseline)
- `python -m ruff check .` → clean
- End-to-end scan via `run_scan` on `samples/support_refund_agent/shipgate.yaml` → completes without error

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` (N/A — no check changes)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (N/A — internal refactor only)

## Reviewer notes

- The `frameworks.py` typed shim is intentional for v0.11 to minimize `scan.py` churn. v0.12 will collapse it.
- Adapter classes are thin wrappers around the existing `load_*` free functions — no loader logic moves. The eight internal cross-adapter call sites (`load_mcp_tools` from inside `google_adk.py`, etc.) are unchanged.
- Adding a new builtin adapter in v0.12+ is honestly a two-file change: the adapter class plus the registration tuple in `_register_builtin_adapters`. Entry-point discovery for third-party plugins is a v0.12 follow-up.
- The `AdapterRegistry` populates lazily on first read (`get`/`require`/`__iter__`/etc.) to avoid a circular import. Tests that want a fresh empty registry pass `autopopulate=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)