### PR TITLE
Document 5-minute onboarding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 [![License](https://img.shields.io/pypi/l/agents-shipgate)](LICENSE)
 [![CI](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml/badge.svg)](https://github.com/ThreeMoonsLab/agents-shipgate/actions/workflows/ci.yml)
 
-**Static release-readiness gate for AI agent tool surfaces.**
+**Static release checks for tool-using AI agents.**
+
+<!-- Canonical tagline: Static release-readiness gate for AI agent tool surfaces. -->
 
 Agents Shipgate is an open-source CLI and GitHub Action that scans MCP,
 OpenAPI, OpenAI Agents SDK, Anthropic Messages API, Google ADK,
@@ -29,6 +31,78 @@ production-like permissions.
 
 No agent execution. No LLM calls. No MCP server connections. No scanner network
 calls. No scanner telemetry. Apache-2.0.
+
+## One-command quickstart
+
+For a 5-minute first run, scan a bundled fixture and inspect the generated
+report. If you already have [`uv`](https://docs.astral.sh/uv/) installed, this
+is a one-command check with no persistent install:
+
+```bash
+uvx agents-shipgate fixture run support_refund_agent
+```
+
+Otherwise, install once with `pipx` and run the same fixture:
+
+```bash
+pipx install agents-shipgate
+agents-shipgate fixture run support_refund_agent
+```
+
+The fixture prints:
+
+```text
+Fixture: support_refund_agent
+Decision: blocked
+Blockers: 2  Review items: 16
+Counts:  critical=2 high=14 medium=2
+Reports: <tempdir>/reports
+Fixture copy at <tempdir>; pass --keep to retain after the run.
+```
+
+Both blockers are on `stripe.create_refund`: missing approval policy and missing idempotency evidence. The fixture writes `report.{md,json}` and `packet.{md,json,html}` into the temp `reports/` directory. To scan your own repo and write the standard `agents-shipgate-reports/` directory, see [Scan your repo](#scan-your-repo) below.
+
+![Sample Tool-Use Readiness Report showing 2 critical, 14 high, and 2 medium findings on the support_refund_agent fixture, including a missing approval policy on stripe.create_refund.](assets/sample-report.png)
+
+## GitHub Action Marketplace
+
+The public Action is listed on the
+[GitHub Action Marketplace](https://github.com/marketplace/actions/agents-shipgate).
+Use the snippet in [Use in CI](#use-in-ci) to add it to a workflow.
+
+## Sample reports
+
+Open a report first if you want to see the output shape before installing:
+
+| Sample | Markdown | JSON |
+|---|---|---|
+| `support_refund_agent` | [`report.md`](samples/support_refund_agent/expected/report.md) | [`report.json`](samples/support_refund_agent/expected/report.json) |
+| `simple_openai_api_agent` | [`report.md`](samples/simple_openai_api_agent/expected/report.md) | [`report.json`](samples/simple_openai_api_agent/expected/report.json) |
+| `simple_langchain_agent` | [`report.md`](samples/simple_langchain_agent/expected/report.md) | [`report.json`](samples/simple_langchain_agent/expected/report.json) |
+
+The `support_refund_agent` fixture also includes a reviewer-shaped Release
+Evidence Packet in [`packet.md`](samples/support_refund_agent/expected/packet.md),
+[`packet.json`](samples/support_refund_agent/expected/packet.json), and
+[`packet.html`](samples/support_refund_agent/expected/packet.html).
+
+## Copy this into your coding agent
+
+```text
+Add static release checks for this tool-using AI agent with Agents Shipgate.
+Run:
+agents-shipgate detect --workspace . --json
+If Shipgate is relevant, run:
+agents-shipgate contract --json
+agents-shipgate init --workspace . --write --ci --json
+agents-shipgate scan -c shipgate.yaml --suggest-patches --format json
+agents-shipgate apply-patches --from agents-shipgate-reports/report.json --confidence high --apply
+Read `agents-shipgate-reports/report.json`, not Markdown. Summarize
+`release_decision.decision`, blocker count, review item count, top critical/high
+findings, and any safe patches applied. Auto-apply only high-confidence safe
+patches. Do not auto-assert approval, confirmation, idempotency, broad-scope,
+or prohibited-action policy decisions. Ensure `.gitignore` contains
+`agents-shipgate-reports/` before committing.
+```
 
 ## Who this is for
 
@@ -47,28 +121,6 @@ evidence around them:
 - Prompts, permission scopes, approval policies, confirmation policies,
   prohibited actions, or `shipgate.yaml`.
 - GitHub Actions or CI release gates for a tool-using AI agent.
-
-## Try it in 60 seconds
-
-```bash
-pipx install agents-shipgate
-agents-shipgate fixture run support_refund_agent
-```
-
-This runs a bundled fixture with no manifest required and prints:
-
-```text
-Fixture: support_refund_agent
-Decision: blocked
-Blockers: 2  Review items: 16
-Counts:  critical=2 high=14 medium=2
-Reports: <tempdir>/reports
-Fixture copy at <tempdir>; pass --keep to retain after the run.
-```
-
-Both blockers are on `stripe.create_refund`: missing approval policy and missing idempotency evidence. The fixture writes `report.{md,json}` and `packet.{md,json,html}` into the temp `reports/` directory. To scan your own repo and write the standard `agents-shipgate-reports/` directory, see [Scan your repo](#scan-your-repo) below.
-
-![Sample Tool-Use Readiness Report showing 2 critical, 14 high, and 2 medium findings on the support_refund_agent fixture, including a missing approval policy on stripe.create_refund.](assets/sample-report.png)
 
 ## Scan your repo
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,20 @@
 
 A 60-second introduction to agents-shipgate for developers and AI coding agents.
 
+## One-command quickstart
+
+Run the bundled fixture without writing any YAML. If you already have
+[`uv`](https://docs.astral.sh/uv/) installed, this is a one-command check with
+no persistent install:
+
+```bash
+uvx agents-shipgate fixture run support_refund_agent
+```
+
+Use this when you want a 5-minute path to confirm the CLI works and inspect a
+real Tool-Use Readiness Report before touching your own repo. If `uvx` is not
+available, use the `pipx` install path below.
+
 ## Zero-install: is this even relevant?
 
 Coding agents reading a fresh repo can answer "is this an agent project?" in one fetch, no install needed:
@@ -47,8 +61,15 @@ like.
 
 ## Second 60 seconds (your real repo)
 
-In a repo containing an agent and its tools, the canonical four-call flow
-detects, configures, scans, and auto-applies safe fixes in one turn:
+In a repo containing an agent and its tools, `bootstrap` runs the adoption flow
+in one command:
+
+```bash
+agents-shipgate bootstrap --json
+```
+
+The expanded form detects, configures, scans, and auto-applies safe fixes in
+one turn:
 
 ```bash
 agents-shipgate detect --json                                              # 1. classify

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,6 +13,22 @@ agents-shipgate fixture run support_refund_agent
 This produces a Tool-Use Readiness Report with 18 findings, including critical
 approval and idempotency findings on `stripe.create_refund`.
 
+## Sample reports
+
+These golden reports are committed so you can inspect the output shape without
+running a scan first:
+
+| Sample | Markdown | JSON |
+| --- | --- | --- |
+| [`support_refund_agent`](support_refund_agent/) | [`report.md`](support_refund_agent/expected/report.md) | [`report.json`](support_refund_agent/expected/report.json) |
+| [`simple_openai_api_agent`](simple_openai_api_agent/) | [`report.md`](simple_openai_api_agent/expected/report.md) | [`report.json`](simple_openai_api_agent/expected/report.json) |
+| [`simple_langchain_agent`](simple_langchain_agent/) | [`report.md`](simple_langchain_agent/expected/report.md) | [`report.json`](simple_langchain_agent/expected/report.json) |
+
+The `support_refund_agent` fixture also includes the Release Evidence Packet at
+[`packet.md`](support_refund_agent/expected/packet.md),
+[`packet.json`](support_refund_agent/expected/packet.json), and
+[`packet.html`](support_refund_agent/expected/packet.html).
+
 ## Fixtures
 
 | Sample | Purpose |

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -48,8 +48,10 @@ AGENT_FACING_DOCS = (
 )
 
 ADOPTION_DOCS_WITH_LINKS = (
+    REPO_ROOT / "README.md",
     DOCS_DIR / "target-repo-agent-snippets.md",
     DOCS_DIR / "agent-adoption-harness.md",
+    REPO_ROOT / "samples" / "README.md",
     REPO_ROOT / "examples" / "golden-prs" / "README.md",
     REPO_ROOT / "examples" / "golden-prs" / "openai-agents-sdk-refund-agent" / "README.md",
     REPO_ROOT / "examples" / "golden-prs" / "mcp-only-tool-server" / "README.md",
@@ -200,6 +202,26 @@ def test_target_repo_snippets_pin_advisory_agent_contract():
     assert "broad-scope" in text
     assert "prohibited-action" in text
     assert "pure docs, tests, formatting" in text
+
+
+def test_readme_onboarding_copy_pins_agent_contract():
+    text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "Static release checks for tool-using AI agents" in text
+    assert "5-minute" in text
+    assert "Copy this into your coding agent" in text
+    assert "https://github.com/marketplace/actions/agents-shipgate" in text
+    assert "Sample reports" in text
+    assert "release_decision.decision" in text
+    assert "agents-shipgate-reports/report.json" in text
+    assert "agents-shipgate contract --json" in text
+    assert "apply-patches" in text
+    assert "--confidence high --apply" in text
+    assert "Do not auto-assert approval" in text
+    assert "confirmation" in text
+    assert "idempotency" in text
+    assert "broad-scope" in text
+    assert "prohibited-action" in text
+    assert "agents-shipgate-reports/" in text
 
 
 def test_target_repo_cursor_globs_cover_shipgate_discovery_names():


### PR DESCRIPTION
## Summary
- make the README first screen say `Static release checks for tool-using AI agents` while preserving the canonical tagline
- add one-command onboarding, Marketplace, sample report, and copy-paste coding-agent prompt sections
- mirror the quickstart and sample report entry points in supporting docs

## Validation
- `PYTHONPATH=src python -m agents_shipgate fixture run support_refund_agent`
- `python -m pytest tests/test_docs_links.py tests/test_public_surface_contract.py tests/test_prompt_parity.py`
- `rg "Static release checks for tool-using AI agents|Copy this into your coding agent|Sample reports|github.com/marketplace/actions/agents-shipgate" README.md`

## Notes
- This does not create tags, publish releases, or update the external GitHub Marketplace latest version.