### PR TITLE
Widen trust-invariant lint to whole scanner package (v0.18 PR #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,47 @@
     `dynamic_default=True` without `floor_severity` lands in
     `dynamic_default_not_supported` rather than being mis-classified
     as `bad_floor` by the new `CheckMetadata` model validator.
+- **v0.18 / PR #2 review follow-up: per-call-site allowlist pinning.**
+  PR #91 review caught two structural holes in the v0.18 trust lint
+  extension:
+  - **P1**: the allowlist matched on `(relative_path, surface)` only,
+    so one entry blanket-permitted every occurrence of a surface in
+    a file. A future unreviewed `subprocess.run(...)` added to an
+    already-allowlisted file would slip past silently.
+  - **P2**: `importlib.resources` was globally exempted, so
+    `files(name)` calls produced no violation. The current uses
+    pass a literal `'agents_shipgate'` anchor, but a future
+    user-controlled anchor would bypass the dynamic-import lint.
+
+  Both are closed by tightening the allowlist contract:
+  - `AllowedException` now carries `line: int` and `snippet: str`
+    (canonical `ast.unparse` of the offending node) in addition to
+    `relative_path` and `surface`. `_violation_allowed` matches on
+    all four fields. Adding a new `subprocess.run` call to an
+    already-allowlisted file now requires a new entry; changing an
+    existing call's argv shape changes the `snippet` and fails the
+    contract test.
+  - `importlib.resources.files` joins `FORBIDDEN_ATTR_CALLS_EXACT`,
+    and `importlib.resources` joins `TRACKED_NON_FORBIDDEN_MODULES`
+    so `from importlib.resources import files; files(...)` is
+    resolved through name-aliases. Both call sites in `triggers.py`
+    and `fixtures.py` are individually pinned with the literal
+    `'agents_shipgate'` anchor in the snippet — a future
+    `files(some_user_anchor)` call would change the snippet and
+    fail the test.
+  - `Violation` gains `snippet: str` captured via `ast.unparse(node)`.
+  - New regression test
+    `test_allowed_exceptions_pin_subprocess_run_per_call_site`
+    asserts that multi-call files (triggers.py, artifacts.py) have
+    distinct entries per call site, so the P1 bypass cannot
+    reappear via consolidation.
+  - New regression test `test_allowed_exceptions_have_no_duplicates`
+    asserts no two entries cover the same call site.
+  - Negative-control: injecting a 4th `subprocess.run` into
+    `triggers.py` now fails the contract test with the precise
+    `(line, surface, snippet)` triple. Injecting
+    `files(user_var)` in place of `files('agents_shipgate')` fails
+    similarly.
 
 - **v0.18 / PR #2 trust-hardening: static AST lint widened to entire scanner.**
   Previously `tests/test_adapter_static_only.py` AST-scanned only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,14 +78,22 @@
     already-allowlisted file now requires a new entry; changing an
     existing call's argv shape changes the `snippet` and fails the
     contract test.
-  - `importlib.resources.files` joins `FORBIDDEN_ATTR_CALLS_EXACT`,
-    and `importlib.resources` joins `TRACKED_NON_FORBIDDEN_MODULES`
-    so `from importlib.resources import files; files(...)` is
-    resolved through name-aliases. Both call sites in `triggers.py`
-    and `fixtures.py` are individually pinned with the literal
-    `'agents_shipgate'` anchor in the snippet — a future
-    `files(some_user_anchor)` call would change the snippet and
-    fail the test.
+  - `importlib.resources.` joins `FORBIDDEN_ATTR_CALL_PREFIXES`, and
+    `importlib.resources` joins `TRACKED_NON_FORBIDDEN_MODULES`. The
+    earlier draft of this PR only forbade `importlib.resources.files`,
+    which left `read_text`, `read_binary`, `path`, `open_text`,
+    `open_binary`, `is_resource`, `contents`, `as_file`, and any
+    future addition under the module as a parallel bypass — each
+    takes the same anchor-package argument and would have been
+    silently allowed. The prefix entry catches the whole family.
+    `from importlib.resources import <attr>; <attr>(...)` and
+    `import importlib.resources as res; res.<attr>(...)` both
+    resolve to canonical `importlib.resources.<attr>` and trip the
+    prefix. Both first-party call sites in `triggers.py` and
+    `fixtures.py` (currently `files`-only) are individually pinned
+    with the literal `'agents_shipgate'` anchor in the snippet — a
+    future `files(some_user_anchor)` or `read_text(some_user_anchor,
+    ...)` call would change the snippet and fail the test.
   - `Violation` gains `snippet: str` captured via `ast.unparse(node)`.
   - New regression test
     `test_allowed_exceptions_pin_subprocess_run_per_call_site`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,46 @@
     `dynamic_default_not_supported` rather than being mis-classified
     as `bad_floor` by the new `CheckMetadata` model validator.
 
+- **v0.18 / PR #2 trust-hardening: static AST lint widened to entire scanner.**
+  Previously `tests/test_adapter_static_only.py` AST-scanned only
+  `src/agents_shipgate/inputs/`; the public claim in STABILITY.md and
+  README is broader ("the scanner does not execute or import user code").
+  The lint now structurally enforces the broader claim.
+  - Scope widened: scanner now walks every `.py` file under
+    `src/agents_shipgate/` via `rglob`. The legacy
+    `test_invariant_lint_covers_every_adapter_module` was paranoid for
+    the 18-file `inputs/` case and no longer scales to ~80 files — the
+    new contract test
+    `test_no_unallowlisted_forbidden_surface_in_scanner` is the
+    replacement, asserting a definitive PASS/FAIL signal over the whole
+    sweep.
+  - Four legitimate first-party meta-CLI surfaces are allowlisted via a
+    new `ALLOWED_EXCEPTIONS` tuple of `AllowedException` entries, each
+    with prose rationale:
+    - `cli/bootstrap.py` `subprocess.run(...)` — chains
+      `detect → init → scan → apply-patches` against Shipgate's own CLI.
+    - `cli/discovery/artifacts.py` `subprocess.run(["git", ...])` —
+      probes the user repo for file inventory.
+    - `triggers.py` `subprocess.run(["git", "diff", ...])` — trigger
+      evaluation reads diff content.
+    - `cli/self_check.py` `__import__(name)` — validates that supplied
+      modules are installed. Runs only under
+      `agents-shipgate self-check`.
+  - Two contract tests prevent allowlist rot:
+    `test_allowlist_entry_matches_real_surface` (every entry must
+    correspond to a real surface) and
+    `test_no_unallowlisted_forbidden_surface_in_scanner` (every forbidden
+    surface must be allowlisted or eliminated).
+  - `importlib.resources` added to `ALLOWED_FORBIDDEN_MODULE_IMPORTS`
+    for bundled-package files (e.g. `fixtures.py`, `triggers.py`).
+    `importlib.metadata` remains allowed for plugin/adapter discovery.
+  - `_scan_source` now returns structured `Violation` objects
+    (`line`, `surface`, `message`) instead of preformatted strings, so
+    callers can route by `surface` against `ALLOWED_EXCEPTIONS`.
+  - STABILITY.md "Trust-model invariants" widened to cite the entire
+    scanner package and adds a "Meta-CLI surfaces (allowlisted,
+    audited)" subsection documenting each of the four entries.
+
 - **v0.17 / M1 trust-hardening: severity-override floor + audit.**
   - `core.models.CheckMetadata` gains an optional `floor_severity` field
     (Severity | None). 16 release-critical built-in checks now declare a

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -278,27 +278,46 @@ tests on every CI run, not by convention:
   dedicated CI step labeled *Trust-model invariant lint* before the
   main test suite so a regression is visible at the top of CI logs.
 
-  **Meta-CLI surfaces (allowlisted, audited).** Four first-party
-  surfaces are allowed with prose rationale captured in
-  [`tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS`](tests/test_adapter_static_only.py).
-  Each entry must correspond to a real surface (enforced by a
-  contract test) and must read no user code:
+  **Meta-CLI surfaces (allowlisted, audited).** First-party meta-CLI
+  surfaces are pinned **per call site** in
+  [`tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS`](tests/test_adapter_static_only.py)
+  by a four-tuple `(relative_path, surface, line, snippet)` where
+  `snippet` is the canonical `ast.unparse` of the offending AST node.
+  Each entry carries a prose rationale and pins a single call:
 
-  - **`cli/bootstrap.py`** — `subprocess.run([sys.executable, "-m", "agents_shipgate", …])`
-    chains `detect → init → scan → apply-patches`. Runs only
-    Shipgate's own CLI.
-  - **`cli/discovery/artifacts.py`** — `subprocess.run(["git", …])`
-    probes the user repo for file inventory. Reads git metadata only.
-  - **`triggers.py`** — `subprocess.run(["git", "diff", …])` for trigger
-    evaluation. Reads diff content only.
-  - **`cli/self_check.py`** — `__import__(name)` validates that a
-    supplied module is installed. Runs only under
+  - **`cli/bootstrap.py`** — one `subprocess.run` call shells the
+    installed agents-shipgate CLI to chain
+    `detect → init → scan → apply-patches`.
+  - **`cli/discovery/artifacts.py`** — two `subprocess.run` calls
+    invoke `git rev-parse` + `git ls-files` to enumerate user-repo
+    files. Reads git metadata only.
+  - **`triggers.py`** — three `subprocess.run` calls (`git diff
+    --name-only`, `git diff`, `git ls-files --others
+    --exclude-standard`) for trigger evaluation. Reads diff content
+    only. **Plus** one `importlib.resources.files('agents_shipgate')`
+    call to resolve the bundled trigger catalog.
+  - **`fixtures.py`** — one `importlib.resources.files('agents_shipgate')`
+    call to resolve the bundled fixture directory.
+  - **`cli/self_check.py`** — one `__import__(module_name)` call
+    validates that supplied modules import cleanly. Runs only under
     `agents-shipgate self-check`, never during scan.
 
-  A contract test pins each allowlist entry to a real surface and
-  fails if the entry goes stale; a second contract test sweeps the
-  whole scanner package and fails on any forbidden surface that lacks
-  an allowlist entry.
+  Per-call-site pinning means **adding a second occurrence of an
+  already-allowlisted surface in the same file STILL requires a new
+  entry**. Changing the call's argv shape (the `snippet` changes)
+  also fails the test, forcing a reviewer to confirm the change is
+  benign. The literal-anchor invariant for
+  `importlib.resources.files('agents_shipgate')` is enforced by
+  snippet pinning: a future `files(user_var)` call would not match.
+
+  Three contract tests pin the audit trail:
+  `test_allowlist_entry_matches_real_surface` (every entry matches a
+  real violation on all four fields),
+  `test_no_unallowlisted_forbidden_surface_in_scanner` (every
+  observed violation has a matching entry), and
+  `test_allowed_exceptions_pin_subprocess_run_per_call_site` (the
+  multi-call files have distinct entries per call site, regression-
+  testing the structural fix from the v0.18 PR #2 review).
 - **[`tests/test_fixture_no_import.py`](tests/test_fixture_no_import.py)** —
   per-adapter live-load tests. Each adapter (LangChain, CrewAI, OpenAI Agents
   SDK, Google ADK, MCP, OpenAPI, Anthropic, OpenAI API, n8n, Codex plugin) is

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -249,7 +249,8 @@ The no-execute / no-import property is enforced by two complementary
 tests on every CI run, not by convention:
 
 - **[`tests/test_adapter_static_only.py`](tests/test_adapter_static_only.py)** —
-  AST scan of every source under `src/agents_shipgate/inputs/`. The scan
+  AST scan of every `.py` file under `src/agents_shipgate/` (v0.18+
+  widened scope from `src/agents_shipgate/inputs/` only). The scan
   rejects:
   - Bare-name calls to `exec` / `eval` / `__import__` / `compile`.
   - Attribute calls to `importlib.import_module`,
@@ -267,14 +268,37 @@ tests on every CI run, not by convention:
   - Wildcard `from os import *`.
 
   `importlib.metadata` is intentionally allowed: the plugin registry
-  under `checks/` (not `inputs/`) uses it for entry-point discovery,
-  and discovery happens against the *installed* environment, not user
-  workspace files. Aliased re-exports (`import os as oo`,
+  uses it for entry-point discovery, and discovery happens against the
+  *installed* environment, not user workspace files. `importlib.resources`
+  is allowed (v0.18+) for bundled-package files inside the
+  agents-shipgate wheel. Aliased re-exports (`import os as oo`,
   `from os import system as sh`, `import os; import pathlib as os`) are
   resolved through union-of-bindings alias maps so a later import
   cannot erase an earlier forbidden binding. The lint runs as a
   dedicated CI step labeled *Trust-model invariant lint* before the
   main test suite so a regression is visible at the top of CI logs.
+
+  **Meta-CLI surfaces (allowlisted, audited).** Four first-party
+  surfaces are allowed with prose rationale captured in
+  [`tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS`](tests/test_adapter_static_only.py).
+  Each entry must correspond to a real surface (enforced by a
+  contract test) and must read no user code:
+
+  - **`cli/bootstrap.py`** — `subprocess.run([sys.executable, "-m", "agents_shipgate", …])`
+    chains `detect → init → scan → apply-patches`. Runs only
+    Shipgate's own CLI.
+  - **`cli/discovery/artifacts.py`** — `subprocess.run(["git", …])`
+    probes the user repo for file inventory. Reads git metadata only.
+  - **`triggers.py`** — `subprocess.run(["git", "diff", …])` for trigger
+    evaluation. Reads diff content only.
+  - **`cli/self_check.py`** — `__import__(name)` validates that a
+    supplied module is installed. Runs only under
+    `agents-shipgate self-check`, never during scan.
+
+  A contract test pins each allowlist entry to a real surface and
+  fails if the entry goes stale; a second contract test sweeps the
+  whole scanner package and fails on any forbidden surface that lacks
+  an allowlist entry.
 - **[`tests/test_fixture_no_import.py`](tests/test_fixture_no_import.py)** —
   per-adapter live-load tests. Each adapter (LangChain, CrewAI, OpenAI Agents
   SDK, Google ADK, MCP, OpenAPI, Anthropic, OpenAI API, n8n, Codex plugin) is

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -270,8 +270,15 @@ tests on every CI run, not by convention:
   `importlib.metadata` is intentionally allowed: the plugin registry
   uses it for entry-point discovery, and discovery happens against the
   *installed* environment, not user workspace files. `importlib.resources`
-  is allowed (v0.18+) for bundled-package files inside the
-  agents-shipgate wheel. Aliased re-exports (`import os as oo`,
+  is allowed (v0.18+) at the import line **only** so name-aliases get
+  built; every `importlib.resources.<attr>(...)` call site is forbidden
+  via the `importlib.resources.` prefix in `FORBIDDEN_ATTR_CALL_PREFIXES`
+  and must carry a per-call-site `ALLOWED_EXCEPTIONS` entry with snippet
+  pinning. This covers `files`, `read_text`, `read_binary`, `path`,
+  `open_text`, `open_binary`, `is_resource`, `contents`, `as_file`, and
+  any future addition under the module — all of which take an
+  anchor-package argument and could bypass the dynamic-import lint if
+  left unrestricted. Aliased re-exports (`import os as oo`,
   `from os import system as sh`, `import os; import pathlib as os`) are
   resolved through union-of-bindings alias maps so a later import
   cannot erase an earlier forbidden binding. The lint runs as a

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -405,27 +405,38 @@ FORBIDDEN_ATTR_CALLS_EXACT: frozenset[str] = frozenset(
         "subprocess.check_output",
         "os.system",
         "os.popen",
-        # v0.18 (PR #2 review follow-up): importlib.resources.files()
-        # resolves an anchor package by name. The first-party call sites
-        # use a literal 'agents_shipgate' anchor; flagging the call
-        # forces every site to be allowlisted with snippet pinning, so a
-        # future non-literal anchor would fail the contract test.
-        "importlib.resources.files",
+        # NOTE: ``importlib.resources.*`` is intentionally NOT enumerated
+        # here — it is caught by the ``importlib.resources.`` entry in
+        # ``FORBIDDEN_ATTR_CALL_PREFIXES`` below. The prefix catches
+        # ``files``, ``read_text``, ``read_binary``, ``path``,
+        # ``open_text``, ``open_binary``, ``is_resource``, ``contents``,
+        # ``as_file``, and any future addition under the module — all of
+        # which take an anchor package argument and could bypass the
+        # dynamic-import lint if left unrestricted.
     }
 )
 
-# Prefix-matched forbidden families. Covers every ``os.exec*`` /
-# ``os.spawn*`` / ``os.posix_spawn*`` variant the os module
-# documents — including current names (``execv``, ``execve``,
-# ``execvp``, ``execvpe``, ``execl``, ``execle``, ``execlp``,
-# ``execlpe``, ``spawnv``, ``spawnve``, ``spawnvp``, ``spawnvpe``,
-# ``spawnl``, ``spawnle``, ``spawnlp``, ``spawnlpe``,
-# ``posix_spawn``, ``posix_spawnp``) and any future addition under
-# these prefixes.
+# Prefix-matched forbidden families. Each prefix captures a family of
+# attribute calls where enumerating every member is fragile (Python adds
+# new variants over time) or where the security boundary is
+# module-wide rather than per-function. The ``importlib.resources.``
+# entry was added in v0.18 PR #2 review follow-up: previously only
+# ``importlib.resources.files`` was forbidden, but ``read_text``,
+# ``read_binary``, etc. take the same anchor argument and produced no
+# violation. Adding the prefix forces every ``importlib.resources.*``
+# call to be allowlisted with snippet pinning, so a non-literal anchor
+# (``read_text(user_var, "x")``) would fail the contract test the same
+# way ``files(user_var)`` does.
 FORBIDDEN_ATTR_CALL_PREFIXES: tuple[str, ...] = (
     "os.exec",
     "os.spawn",
     "os.posix_spawn",
+    # v0.18 (PR #2 review follow-up): catches files, read_text,
+    # read_binary, path, open_text, open_binary, is_resource, contents,
+    # as_file, and any future addition. Trailing dot ensures the prefix
+    # only matches sub-attributes (``importlib.resources.X``), not the
+    # module itself.
+    "importlib.resources.",
 )
 
 # Module imports we forbid outright. ``import X`` / ``import X as Y`` and
@@ -452,12 +463,13 @@ FORBIDDEN_MODULES: frozenset[str] = frozenset(
 #   installed Python environment, not user workspace code.
 # ``importlib.resources`` — bundled-package files (e.g. ``fixtures.py``,
 #   ``triggers.py``) read content packaged inside the agents-shipgate wheel,
-#   not user workspace code. v0.18 (PR #2 review follow-up): the import line
-#   is allowed here so name_aliases get built, but the ``files`` attribute
-#   call is added to ``FORBIDDEN_ATTR_CALLS_EXACT`` above so every call site
-#   needs an ALLOWED_EXCEPTIONS entry with snippet pinning. Combined effect:
-#   the from-import line AND the call line are individually pinned per call
-#   site (catches a future non-literal anchor or unreviewed second use).
+#   not user workspace code. The import line is allowed here so name_aliases
+#   get built, but every ``importlib.resources.<attr>(...)`` call is caught
+#   by the ``importlib.resources.`` prefix in ``FORBIDDEN_ATTR_CALL_PREFIXES``
+#   above (v0.18 PR #2 review follow-up — initially only ``files`` was
+#   forbidden, leaving ``read_text``/``read_binary``/``path``/etc. as a
+#   parallel hole). Each call site needs an ALLOWED_EXCEPTIONS entry with
+#   snippet pinning so a non-literal anchor would fail the contract test.
 ALLOWED_FORBIDDEN_MODULE_IMPORTS: frozenset[str] = frozenset(
     {"importlib.metadata", "importlib.resources"}
 )
@@ -471,9 +483,11 @@ ALLOWED_FORBIDDEN_MODULE_IMPORTS: frozenset[str] = frozenset(
 # ``from os import system as sh; sh(...)`` are resolved before checking.
 #
 # v0.18 (PR #2 review follow-up): ``importlib.resources`` joins this set so
-# ``from importlib.resources import files`` builds a name_alias and the
-# subsequent ``files(...)`` call site can be checked against
-# ``FORBIDDEN_ATTR_CALLS_EXACT``.
+# ``from importlib.resources import files`` (and ``read_text``,
+# ``read_binary``, etc.) builds a name_alias and the subsequent call site
+# can be resolved to a canonical ``importlib.resources.<attr>`` chain that
+# the ``importlib.resources.`` prefix in ``FORBIDDEN_ATTR_CALL_PREFIXES``
+# catches.
 TRACKED_NON_FORBIDDEN_MODULES: frozenset[str] = frozenset(
     {"os", "importlib.resources"}
 )
@@ -939,6 +953,59 @@ def test_scanner_source_contains_no_forbidden_calls_or_imports(
         (
             "from importlib.util.extra import loader",
             "forbidden from-import 'importlib.util.extra'",
+        ),
+        # --- importlib.resources.* prefix family (v0.18 PR #2 review
+        # follow-up: not just files() — every anchor-taking callable
+        # under importlib.resources is forbidden via the
+        # ``importlib.resources.`` prefix entry in
+        # FORBIDDEN_ATTR_CALL_PREFIXES). The reviewer reproduced
+        # ``read_text`` and ``files`` as the canonical bypass shapes;
+        # this parametrize block locks both, plus a few siblings, so a
+        # regression that narrows the prefix back to ``files`` only
+        # fails immediately.
+        (
+            "from importlib.resources import files\nfiles('agents_shipgate')\n",
+            "forbidden call 'importlib.resources.files'",
+        ),
+        (
+            "from importlib.resources import read_text\nread_text(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.read_text'",
+        ),
+        (
+            "from importlib.resources import read_binary\nread_binary(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.read_binary'",
+        ),
+        (
+            "from importlib.resources import open_text\nopen_text(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.open_text'",
+        ),
+        (
+            "from importlib.resources import path\npath(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.path'",
+        ),
+        (
+            "from importlib.resources import is_resource\nis_resource(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.is_resource'",
+        ),
+        (
+            "from importlib.resources import as_file\nas_file(some_traversable)\n",
+            "forbidden call 'importlib.resources.as_file'",
+        ),
+        # Attribute-chain form: ``import importlib.resources;
+        # importlib.resources.read_text(pkg, "x")``.
+        (
+            "import importlib.resources\nimportlib.resources.read_text(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.read_text'",
+        ),
+        # Aliased attribute-chain form.
+        (
+            "import importlib.resources as res\nres.read_text(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.read_text'",
+        ),
+        # From-import alias for the broader surface.
+        (
+            "from importlib.resources import read_text as rt\nrt(pkg, 'x')\n",
+            "forbidden call 'importlib.resources.read_text'",
         ),
     ],
     ids=lambda x: x if isinstance(x, str) and len(x) < 40 else "case",

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -1,10 +1,18 @@
 """Trust-model structural invariant: scanner does not execute or import user code.
 
 This test enforces the core trust property of agents-shipgate at the source
-level: every adapter under ``src/agents_shipgate/inputs/`` must parse user
-files with ``ast.parse``, ``yaml.safe_load``, or ``json.loads`` only — never
-through ``exec`` / ``eval`` / ``__import__`` / ``compile`` builtins, and
-never via dynamic-import or process-execution surfaces.
+level: every Python file under ``src/agents_shipgate/`` (not just
+``inputs/``) must parse user files with ``ast.parse``, ``yaml.safe_load``,
+or ``json.loads`` only — never through ``exec`` / ``eval`` / ``__import__``
+/ ``compile`` builtins, and never via dynamic-import or process-execution
+surfaces.
+
+v0.18 (PR #2): the scope widened from adapter sources only to the whole
+scanner package. A small allowlist (``ALLOWED_EXCEPTIONS`` below) captures
+the four legitimate first-party meta-CLI surfaces with prose rationale —
+bootstrap subprocess chaining, git probing in artifacts/triggers, and
+self-check ``__import__`` validation. Two contract tests prevent
+allowlist rot.
 
 What the scanner catches:
 
@@ -20,9 +28,10 @@ What the scanner catches:
 - Module imports from a forbidden set (``runpy``, ``subprocess``,
   ``importlib``, ``importlib.util``, ``importlib.machinery``, ``builtins``)
   — including ``import X as Y``, ``import X.child``, and
-  ``from X.child import ...`` forms. ``importlib.metadata`` is the one
-  explicit exception because it reads installed-package metadata, not user
-  workspace code.
+  ``from X.child import ...`` forms. Two explicit exceptions:
+  ``importlib.metadata`` (reads installed-package metadata for plugin
+  discovery) and ``importlib.resources`` (reads bundled-package files
+  inside the agents-shipgate wheel) — neither reads user workspace code.
 - **Aliased re-exports.** A two-pass walk first builds alias maps from
   ``import`` and ``from-import`` statements, then resolves attribute chains
   and bare-name calls back to their canonical dotted path before checking
@@ -50,7 +59,8 @@ is the structural floor; code review is the dataflow ceiling.
 Tests live in two layers:
 
 1. **This file** (``test_adapter_static_only.py``) — AST scan of every
-   ``inputs/*.py`` source. Catches a regression *before* it ships and runs
+   ``src/agents_shipgate/**/*.py`` source (v0.18+; previously scoped to
+   ``inputs/*.py`` only). Catches a regression *before* it ships and runs
    in CI in well under a second.
 2. **``test_fixture_no_import.py``** — companion live-load tests that drive
    each adapter end-to-end against a fixture with a module-level
@@ -64,12 +74,112 @@ The two layers together back the public claim in
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-INPUTS_DIR = REPO_ROOT / "src" / "agents_shipgate" / "inputs"
+SCANNER_DIR = REPO_ROOT / "src" / "agents_shipgate"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One forbidden-surface hit from ``_scan_source``.
+
+    ``surface`` is the canonical key used by ``ALLOWED_EXCEPTIONS`` and
+    contract tests. Shape:
+
+      ``"import:<module>"``      — ``import <module>`` / ``from <module> import …``
+      ``"attr_call:<dotted>"``   — call to ``<module>.<func>`` (canonical-resolved)
+      ``"name_call:<name>"``     — bare-name call to ``<name>`` (e.g., ``__import__``)
+    """
+
+    line: int
+    surface: str
+    message: str
+
+
+@dataclass(frozen=True)
+class AllowedException:
+    """v0.18 (PR #2): per-file allowed forbidden-surface entry, with prose rationale.
+
+    Each entry covers exactly one ``(relative_path, surface)`` pair.
+    ``relative_path`` is relative to ``SCANNER_DIR``. Adding an entry is a
+    public commitment; the rationale text lands in the audit trail.
+    """
+
+    relative_path: str
+    surface: str
+    rationale: str
+
+
+# Per-file allowlist of forbidden-surface uses. Each entry MUST correspond to
+# a surface that the scanner would actually flag in the named file — the
+# ``test_allowlist_entry_matches_real_surface`` contract test fails the moment
+# an entry goes stale. Each entry MUST also have a one-sentence prose
+# rationale captured in STABILITY.md § "Meta-CLI surfaces (allowlisted, audited)".
+ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
+    AllowedException(
+        relative_path="cli/bootstrap.py",
+        surface="import:subprocess",
+        rationale=(
+            "Meta-CLI: bootstrap shells to the installed agents-shipgate "
+            "binary to chain detect → init → scan → apply-patches. Reads "
+            "no user code; runs only Shipgate's own CLI."
+        ),
+    ),
+    AllowedException(
+        relative_path="cli/bootstrap.py",
+        surface="attr_call:subprocess.run",
+        rationale="See cli/bootstrap.py import:subprocess rationale.",
+    ),
+    AllowedException(
+        relative_path="cli/discovery/artifacts.py",
+        surface="import:subprocess",
+        rationale=(
+            "Probes the user repo via ``git ls-files`` for file inventory. "
+            "Reads git metadata, does not execute user code."
+        ),
+    ),
+    AllowedException(
+        relative_path="cli/discovery/artifacts.py",
+        surface="attr_call:subprocess.run",
+        rationale="See cli/discovery/artifacts.py import:subprocess rationale.",
+    ),
+    AllowedException(
+        relative_path="triggers.py",
+        surface="import:subprocess",
+        rationale=(
+            "Trigger evaluation runs ``git diff`` against the user repo to "
+            "determine whether to fire a scan. Reads diff content, does "
+            "not execute user code."
+        ),
+    ),
+    AllowedException(
+        relative_path="triggers.py",
+        surface="attr_call:subprocess.run",
+        rationale="See triggers.py import:subprocess rationale.",
+    ),
+    AllowedException(
+        relative_path="cli/self_check.py",
+        surface="name_call:__import__",
+        rationale=(
+            "Self-check validates the installed environment by attempting "
+            "an import of a name supplied via CLI flag. Runs only under "
+            "`agents-shipgate self-check`, never during scan; targets "
+            "installed packages, not user workspace."
+        ),
+    ),
+)
+
+
+def _violation_allowed(relative_path: str, surface: str) -> bool:
+    """v0.18 (PR #2): True iff a (file, surface) pair is allowlisted."""
+    return any(
+        exc.relative_path == relative_path and exc.surface == surface
+        for exc in ALLOWED_EXCEPTIONS
+    )
 
 # Bare-name forbidden builtins. Catches direct calls like ``exec("...")``.
 FORBIDDEN_NAME_CALLS: frozenset[str] = frozenset(
@@ -136,7 +246,15 @@ FORBIDDEN_MODULES: frozenset[str] = frozenset(
 # Exact module import exceptions that would otherwise be caught by a
 # forbidden parent module. Keep this small: each exception needs a trust-model
 # reason in STABILITY.md.
-ALLOWED_FORBIDDEN_MODULE_IMPORTS: frozenset[str] = frozenset({"importlib.metadata"})
+#
+# ``importlib.metadata`` — plugin/adapter discovery via entry_points reads the
+#   installed Python environment, not user workspace code.
+# ``importlib.resources`` — bundled-package files (e.g. ``fixtures.py``,
+#   ``triggers.py``) read content packaged inside the agents-shipgate wheel,
+#   not user workspace code.
+ALLOWED_FORBIDDEN_MODULE_IMPORTS: frozenset[str] = frozenset(
+    {"importlib.metadata", "importlib.resources"}
+)
 
 # Modules we allow at the import line (legitimate adapter use) but whose
 # specific attributes are still subject to the forbidden-chain checks.
@@ -206,8 +324,13 @@ def _resolve_attribute_chain_all(
     ]
 
 
-def _scan_source(source: str, path: Path) -> list[str]:
-    """Return a list of human-readable violation strings.
+def _scan_source(source: str, path: Path) -> list[Violation]:
+    """Return a list of structured ``Violation`` objects.
+
+    v0.18 (PR #2): returns structured violations instead of preformatted
+    strings so callers can route by ``surface`` (e.g., consult
+    ``ALLOWED_EXCEPTIONS``). Use ``_format_violation`` for the
+    human-readable form when rendering errors.
 
     Two passes:
 
@@ -227,9 +350,15 @@ def _scan_source(source: str, path: Path) -> list[str]:
     try:
         tree = ast.parse(source, filename=str(path))
     except SyntaxError as exc:  # pragma: no cover - adapter files compile in CI step
-        return [f"{path}:{exc.lineno}: failed to parse: {exc.msg}"]
+        return [
+            Violation(
+                line=exc.lineno or 0,
+                surface="parse_error",
+                message=f"{path}:{exc.lineno}: failed to parse: {exc.msg}",
+            )
+        ]
     rel = path.relative_to(REPO_ROOT)
-    violations: list[str] = []
+    violations: list[Violation] = []
 
     # --- Pass 1: imports ---------------------------------------------------
     # module_aliases: locally-bound name -> {every canonical module path it
@@ -251,8 +380,14 @@ def _scan_source(source: str, path: Path) -> list[str]:
             for alias in node.names:
                 if _is_forbidden_module_import(alias.name):
                     violations.append(
-                        f"{rel}:{node.lineno}: forbidden import "
-                        f"{alias.name!r} (dynamic Python loading surface)"
+                        Violation(
+                            line=node.lineno,
+                            surface=f"import:{alias.name}",
+                            message=(
+                                f"{rel}:{node.lineno}: forbidden import "
+                                f"{alias.name!r} (dynamic Python loading surface)"
+                            ),
+                        )
                     )
                 if alias.asname:
                     module_aliases.setdefault(alias.asname, set()).add(alias.name)
@@ -264,8 +399,14 @@ def _scan_source(source: str, path: Path) -> list[str]:
             mod = node.module or ""
             if _is_forbidden_module_import(mod):
                 violations.append(
-                    f"{rel}:{node.lineno}: forbidden from-import "
-                    f"{mod!r} (dynamic Python loading surface)"
+                    Violation(
+                        line=node.lineno,
+                        surface=f"import:{mod}",
+                        message=(
+                            f"{rel}:{node.lineno}: forbidden from-import "
+                            f"{mod!r} (dynamic Python loading surface)"
+                        ),
+                    )
                 )
                 # Skip the per-name pass below — the whole module is forbidden.
                 continue
@@ -273,9 +414,15 @@ def _scan_source(source: str, path: Path) -> list[str]:
                 if alias.name == "*":
                     if mod in TRACKED_NON_FORBIDDEN_MODULES:
                         violations.append(
-                            f"{rel}:{node.lineno}: forbidden wildcard "
-                            f"from-import from {mod!r} "
-                            f"(would alias forbidden names into local scope)"
+                            Violation(
+                                line=node.lineno,
+                                surface=f"import:{mod}.*",
+                                message=(
+                                    f"{rel}:{node.lineno}: forbidden wildcard "
+                                    f"from-import from {mod!r} "
+                                    f"(would alias forbidden names into local scope)"
+                                ),
+                            )
                         )
                     continue
                 # Flag the from-import line itself when the imported
@@ -285,8 +432,14 @@ def _scan_source(source: str, path: Path) -> list[str]:
                     canonical = f"{mod}.{alias.name}"
                     if _is_forbidden_chain(canonical):
                         violations.append(
-                            f"{rel}:{node.lineno}: forbidden from-import "
-                            f"of {canonical!r}"
+                            Violation(
+                                line=node.lineno,
+                                surface=f"attr_call:{canonical}",
+                                message=(
+                                    f"{rel}:{node.lineno}: forbidden from-import "
+                                    f"of {canonical!r}"
+                                ),
+                            )
                         )
                     local = alias.asname or alias.name
                     name_aliases.setdefault(local, set()).add((mod, alias.name))
@@ -300,7 +453,14 @@ def _scan_source(source: str, path: Path) -> list[str]:
             # Direct bare-name builtin: e.g. ``exec("...")``.
             if func.id in FORBIDDEN_NAME_CALLS:
                 violations.append(
-                    f"{rel}:{node.lineno}: forbidden builtin call {func.id!r}"
+                    Violation(
+                        line=node.lineno,
+                        surface=f"name_call:{func.id}",
+                        message=(
+                            f"{rel}:{node.lineno}: forbidden builtin call "
+                            f"{func.id!r}"
+                        ),
+                    )
                 )
                 continue
             # Aliased ``from X import Y[ as Z]; Z(...)``. Iterate every
@@ -316,8 +476,14 @@ def _scan_source(source: str, path: Path) -> list[str]:
                             else f" (via from-import of {attr!r})"
                         )
                         violations.append(
-                            f"{rel}:{node.lineno}: forbidden call "
-                            f"{canonical!r}{via}"
+                            Violation(
+                                line=node.lineno,
+                                surface=f"attr_call:{canonical}",
+                                message=(
+                                    f"{rel}:{node.lineno}: forbidden call "
+                                    f"{canonical!r}{via}"
+                                ),
+                            )
                         )
                         break
         elif isinstance(func, ast.Attribute):
@@ -327,44 +493,65 @@ def _scan_source(source: str, path: Path) -> list[str]:
             for chain in _resolve_attribute_chain_all(func, module_aliases):
                 if _is_forbidden_chain(chain):
                     violations.append(
-                        f"{rel}:{node.lineno}: forbidden call {chain!r}"
+                        Violation(
+                            line=node.lineno,
+                            surface=f"attr_call:{chain}",
+                            message=(
+                                f"{rel}:{node.lineno}: forbidden call {chain!r}"
+                            ),
+                        )
                     )
                     break
     return violations
 
 
-def _adapter_sources() -> list[Path]:
-    """Every .py file under inputs/ (including __init__.py and helpers)."""
-    return sorted(INPUTS_DIR.rglob("*.py"))
+def _scanner_sources() -> list[Path]:
+    """v0.18 (PR #2): every .py file under src/agents_shipgate/ (not just
+    ``inputs/``). Skips ``__pycache__`` debris.
+    """
+    return sorted(
+        p for p in SCANNER_DIR.rglob("*.py") if "__pycache__" not in p.parts
+    )
 
 
 @pytest.mark.parametrize(
-    "adapter_source",
-    _adapter_sources(),
-    ids=lambda p: str(p.relative_to(INPUTS_DIR)),
+    "scanner_source",
+    _scanner_sources(),
+    ids=lambda p: str(p.relative_to(SCANNER_DIR)),
 )
-def test_adapter_source_contains_no_forbidden_calls_or_imports(
-    adapter_source: Path,
+def test_scanner_source_contains_no_forbidden_calls_or_imports(
+    scanner_source: Path,
 ) -> None:
-    """Each adapter source under inputs/ is statically free of code-execution
-    surfaces.
+    """Each scanner source is statically free of code-execution surfaces,
+    EXCEPT for the four legitimate first-party meta-CLI surfaces captured
+    in ``ALLOWED_EXCEPTIONS`` (each with prose rationale).
 
     A regression here means a contributor added a way for the scanner to
     execute or import user code. That breaks the public trust claim in
     README and STABILITY.md and must be rejected. If a legitimate need
-    arises (it should not), update STABILITY.md first and consider whether
-    the addition belongs in ``inputs/`` at all.
+    arises (it should not), update STABILITY.md first and add an
+    ``ALLOWED_EXCEPTIONS`` entry with prose rationale.
+
+    v0.18 (PR #2) widens this from ``src/agents_shipgate/inputs/`` to the
+    entire scanner package.
     """
-    source = adapter_source.read_text(encoding="utf-8")
-    violations = _scan_source(source, adapter_source)
-    assert not violations, (
-        "Trust-model invariant violation under src/agents_shipgate/inputs/:\n  "
-        + "\n  ".join(violations)
+    rel = str(scanner_source.relative_to(SCANNER_DIR))
+    source = scanner_source.read_text(encoding="utf-8")
+    violations = _scan_source(source, scanner_source)
+    unallowed = [
+        v for v in violations if not _violation_allowed(rel, v.surface)
+    ]
+    assert not unallowed, (
+        "Trust-model invariant violation under src/agents_shipgate/:\n  "
+        + "\n  ".join(v.message for v in unallowed)
         + "\n\n"
-        + "Adapters MUST NOT execute or import user code. They parse user "
-        + "files with ast.parse / yaml.safe_load / json.loads ONLY. See "
+        + "The scanner MUST NOT execute or import user code. Parse with "
+        + "ast.parse / yaml.safe_load / json.loads ONLY. See "
         + "STABILITY.md § 'Trust-model invariants' and the companion "
-        + "tests/test_fixture_no_import.py live-load tests."
+        + "tests/test_fixture_no_import.py live-load tests. If the surface "
+        + "is a legitimate first-party meta-CLI operation, add an "
+        + "ALLOWED_EXCEPTIONS entry with prose rationale and document it "
+        + "in STABILITY.md § 'Meta-CLI surfaces (allowlisted, audited)'."
     )
 
 
@@ -533,15 +720,15 @@ def test_lint_scanner_catches_known_violation_shapes(
     families, module aliases, from-import aliases, wildcard imports, and
     the ``builtins`` surface).
     """
-    fake_path = INPUTS_DIR / "__synthetic__.py"
+    fake_path = SCANNER_DIR / "__synthetic__.py"
     violations = _scan_source(snippet, fake_path)
     assert violations, (
         f"Scanner failed to flag a forbidden shape:\n  snippet: {snippet!r}\n"
         f"  expected substring: {expected_substring!r}"
     )
-    assert any(expected_substring in v for v in violations), (
+    assert any(expected_substring in v.message for v in violations), (
         f"Scanner caught a violation but not the expected one:\n"
-        f"  snippet: {snippet!r}\n  violations: {violations!r}\n"
+        f"  snippet: {snippet!r}\n  violations: {[v.message for v in violations]!r}\n"
         f"  expected substring: {expected_substring!r}"
     )
 
@@ -571,43 +758,102 @@ def test_lint_scanner_does_not_false_positive_on_safe_shapes() -> None:
         "import importlib.metadata\n"
         "from importlib.metadata import version\npkg_version = version('agents-shipgate')\n"
     )
-    fake_path = INPUTS_DIR / "__synthetic_safe__.py"
+    fake_path = SCANNER_DIR / "__synthetic_safe__.py"
     violations = _scan_source(safe, fake_path)
     assert not violations, (
         "Safe parsing patterns must not be flagged. Unexpected violations:\n  "
-        + "\n  ".join(sorted(violations))
+        + "\n  ".join(sorted(v.message for v in violations))
     )
 
 
-def test_invariant_lint_covers_every_adapter_module() -> None:
-    """Sanity check: the parametrized scan reaches every known adapter file.
+# --- v0.18 (PR #2): allowlist contract tests --------------------------------
 
-    Catches the case where someone reorganizes inputs/ into a subpackage
-    and the rglob silently stops finding the new home.
+
+@pytest.mark.parametrize(
+    "exc",
+    ALLOWED_EXCEPTIONS,
+    ids=lambda e: f"{e.relative_path}:{e.surface}",
+)
+def test_allowlist_entry_matches_real_surface(exc: AllowedException) -> None:
+    """v0.18 (PR #2) stale-allowlist guard.
+
+    Every ``ALLOWED_EXCEPTIONS`` entry MUST correspond to a surface
+    that the scanner would actually flag in the named file. If the
+    file is later refactored to remove the legitimate meta-CLI surface
+    (e.g., self-check stops calling ``__import__``), this test fails
+    and forces the contributor to remove the now-unused allowlist
+    entry — preventing rot.
     """
-    scanned_names = {p.name for p in _adapter_sources()}
-    expected_adapter_files = {
-        "anthropic_api.py",
-        "codex_plugin.py",
-        "common.py",
-        "crewai.py",
-        "google_adk.py",
-        "langchain.py",
-        "mcp.py",
-        "n8n.py",
-        "openai_api.py",
-        "openai_sdk_static.py",
-        "openapi.py",
-        "policy_packs.py",
-        "protocol.py",
-        "python_static.py",
-        "traces.py",
-        "validation.py",
-        "_python_framework.py",
-        "__init__.py",
+    path = SCANNER_DIR / exc.relative_path
+    assert path.exists(), (
+        f"allowlisted file does not exist: {exc.relative_path}"
+    )
+    source = path.read_text(encoding="utf-8")
+    violations = _scan_source(source, path)
+    surfaces = {v.surface for v in violations}
+    assert exc.surface in surfaces, (
+        f"allowlisted surface {exc.surface!r} not present in "
+        f"{exc.relative_path!r}; entry is stale, remove or refactor. "
+        f"Observed surfaces in this file: {sorted(surfaces)!r}"
+    )
+
+
+def test_no_unallowlisted_forbidden_surface_in_scanner() -> None:
+    """v0.18 (PR #2): the whole-scanner sweep with allowlist applied
+    produces zero violations. This is the runtime gate PR #2 hardens.
+
+    The parametrized ``test_scanner_source_contains_no_forbidden_calls_or_imports``
+    above catches per-file regressions. This non-parametrized form gives
+    a single, definitive PASS/FAIL signal at the end of the test session.
+    A failure message lists every ``(relative_path, surface)`` pair the
+    contributor must address — either by refactoring the offending file
+    or by adding an ``ALLOWED_EXCEPTIONS`` entry with prose rationale.
+    """
+    unallowed: list[tuple[str, str]] = []
+    for path in _scanner_sources():
+        rel = str(path.relative_to(SCANNER_DIR))
+        for violation in _scan_source(path.read_text(encoding="utf-8"), path):
+            if not _violation_allowed(rel, violation.surface):
+                unallowed.append((rel, violation.surface))
+    assert unallowed == [], (
+        "Scanner has forbidden surfaces with no allowlist entry. "
+        "Add an ALLOWED_EXCEPTIONS entry with prose rationale, or "
+        "refactor the surface out. Unallowlisted: "
+        + ", ".join(f"{path}::{surface}" for path, surface in unallowed)
+    )
+
+
+def test_scanner_sources_covers_known_files() -> None:
+    """v0.18 (PR #2): non-vacuity guard.
+
+    The pre-v0.18 ``test_invariant_lint_covers_every_adapter_module``
+    pinned a hardcoded 18-file set; that approach didn't scale to the
+    widened whole-scanner scope (~80 files). This replacement asserts a
+    small set of always-present anchor files AND a minimum count,
+    catching both silent ``rglob`` breakage and accidental
+    scope-narrowing (e.g., a typo making ``SCANNER_DIR`` point at an
+    empty directory would make every other test in this file vacuously
+    pass).
+    """
+    sources = _scanner_sources()
+    relative_paths = {str(p.relative_to(SCANNER_DIR)) for p in sources}
+    required = {
+        "cli/scan.py",
+        "inputs/protocol.py",
+        "inputs/mcp.py",
+        "checks/registry.py",
+        "checks/plugin_validation.py",
+        "core/models.py",
+        "core/severity_overrides.py",
+        "core/findings.py",
     }
-    missing = expected_adapter_files - scanned_names
+    missing = required - relative_paths
     assert not missing, (
-        f"Expected adapter files not found under {INPUTS_DIR}: {sorted(missing)}. "
-        f"If inputs/ was reorganized, update the expected set above."
+        f"_scanner_sources() missing known files: {sorted(missing)}. "
+        f"Check SCANNER_DIR ({SCANNER_DIR}) and the rglob predicate."
+    )
+    assert len(sources) >= 50, (
+        f"_scanner_sources() returned only {len(sources)} files; "
+        f"expected >= 50 (whole-scanner coverage). Investigate whether "
+        f"SCANNER_DIR was scoped down."
     )

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -93,93 +93,288 @@ class Violation:
       ``"import:<module>"``      — ``import <module>`` / ``from <module> import …``
       ``"attr_call:<dotted>"``   — call to ``<module>.<func>`` (canonical-resolved)
       ``"name_call:<name>"``     — bare-name call to ``<name>`` (e.g., ``__import__``)
+
+    ``snippet`` is the canonical ``ast.unparse`` of the offending AST node
+    (Import/ImportFrom/Call). Combined with ``line`` it lets the allowlist
+    pin individual call sites rather than blanket-permitting every
+    occurrence in a file.
     """
 
     line: int
     surface: str
     message: str
+    snippet: str
 
 
 @dataclass(frozen=True)
 class AllowedException:
-    """v0.18 (PR #2): per-file allowed forbidden-surface entry, with prose rationale.
+    """v0.18 (PR #2): per-call-site allowed forbidden-surface entry,
+    with prose rationale.
 
-    Each entry covers exactly one ``(relative_path, surface)`` pair.
-    ``relative_path`` is relative to ``SCANNER_DIR``. Adding an entry is a
-    public commitment; the rationale text lands in the audit trail.
+    PR #2 review follow-up: the entry now pins ``line`` and ``snippet``
+    in addition to ``(relative_path, surface)``. The original
+    ``(relative_path, surface)``-only design blanket-permitted every
+    occurrence of a surface in a file, so a future unreviewed
+    ``subprocess.run(...)`` added to ``triggers.py`` would pass silently.
+    Pinning call-site granularity forces every new occurrence to be
+    individually allowlisted with rationale.
+
+    ``line`` is the 1-indexed line number of the offending AST node.
+    ``snippet`` is the canonical ``ast.unparse`` of the node. The two
+    contract tests assert that every entry matches a real violation
+    with the same ``(line, snippet)`` AND that every observed violation
+    has a matching entry.
+
+    Line drift (inserting a comment that pushes a call down) WILL fail
+    the test — that is the intended failure mode, forcing a reviewer to
+    confirm the change is benign and bump the entry.
     """
 
     relative_path: str
     surface: str
+    line: int
+    snippet: str
     rationale: str
 
 
-# Per-file allowlist of forbidden-surface uses. Each entry MUST correspond to
-# a surface that the scanner would actually flag in the named file — the
-# ``test_allowlist_entry_matches_real_surface`` contract test fails the moment
-# an entry goes stale. Each entry MUST also have a one-sentence prose
-# rationale captured in STABILITY.md § "Meta-CLI surfaces (allowlisted, audited)".
+# Per-call-site allowlist of forbidden-surface uses. Each entry MUST
+# correspond to a real call site (verified by
+# ``test_allowlist_entry_matches_real_surface``). Every observed forbidden
+# surface in the scanner MUST have a matching entry (verified by
+# ``test_no_unallowlisted_forbidden_surface_in_scanner``). Rationale text
+# is mirrored in STABILITY.md § "Meta-CLI surfaces (allowlisted, audited)".
+#
+# Adding a new call site requires adding an entry here AND updating the
+# rationale; the entries are intentionally verbose so review-by-grep
+# captures the full audit trail.
 ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
+    # cli/bootstrap.py — chains detect/init/scan/apply-patches against
+    # Shipgate's own CLI. The argv is sys.executable + ``-m agents_shipgate``,
+    # never user input.
     AllowedException(
         relative_path="cli/bootstrap.py",
         surface="import:subprocess",
+        line=31,
+        snippet="import subprocess",
         rationale=(
-            "Meta-CLI: bootstrap shells to the installed agents-shipgate "
-            "binary to chain detect → init → scan → apply-patches. Reads "
-            "no user code; runs only Shipgate's own CLI."
+            "Bootstrap chains detect → init → scan → apply-patches against "
+            "the installed agents-shipgate CLI via subprocess. Reads no "
+            "user code; argv is always sys.executable + Shipgate's own "
+            "module/flags."
         ),
     ),
     AllowedException(
         relative_path="cli/bootstrap.py",
         surface="attr_call:subprocess.run",
-        rationale="See cli/bootstrap.py import:subprocess rationale.",
+        line=72,
+        snippet=(
+            "subprocess.run(argv, cwd=str(cwd), env=env, "
+            "capture_output=True, text=True, check=False)"
+        ),
+        rationale=(
+            "_run_step: invokes the installed agents-shipgate CLI as a "
+            "subprocess with argv constructed inside Shipgate (no user "
+            "input executed as a command)."
+        ),
     ),
+    # cli/discovery/artifacts.py — probes the user repo via git ls-files
+    # for file inventory. Reads git metadata; no shell, no user-code exec.
     AllowedException(
         relative_path="cli/discovery/artifacts.py",
         surface="import:subprocess",
+        line=6,
+        snippet="import subprocess",
         rationale=(
-            "Probes the user repo via ``git ls-files`` for file inventory. "
-            "Reads git metadata, does not execute user code."
+            "Discovery uses ``git ls-files`` to enumerate user-repo files "
+            "without walking ignored paths. argv is a fixed git invocation; "
+            "no shell, no user-code exec."
         ),
     ),
     AllowedException(
         relative_path="cli/discovery/artifacts.py",
         surface="attr_call:subprocess.run",
-        rationale="See cli/discovery/artifacts.py import:subprocess rationale.",
+        line=361,
+        snippet=(
+            "subprocess.run(['git', '-C', str(workspace), 'rev-parse', "
+            "'--show-toplevel'], check=False, capture_output=True, "
+            "text=True, timeout=2)"
+        ),
+        rationale=(
+            "_git_candidate_files step 1: ``git -C <workspace> "
+            "rev-parse --show-toplevel`` to locate the repo root. "
+            "Fixed argv, capture-only, no shell, hard timeout."
+        ),
     ),
+    AllowedException(
+        relative_path="cli/discovery/artifacts.py",
+        surface="attr_call:subprocess.run",
+        line=377,
+        snippet=(
+            "subprocess.run(['git', '-C', str(workspace), 'ls-files', "
+            "'-co', '--exclude-standard', '--full-name', '-z', '--', "
+            "'.'], check=False, capture_output=True, timeout=5)"
+        ),
+        rationale=(
+            "_git_candidate_files step 2: ``git -C <workspace> "
+            "ls-files -co --exclude-standard --full-name -z -- .`` to "
+            "enumerate tracked + untracked-not-ignored files in NUL-"
+            "delimited form. Fixed argv, capture-only, no shell."
+        ),
+    ),
+    # triggers.py — trigger evaluation reads ``git diff`` output. Same
+    # trust profile as discovery/artifacts.py.
     AllowedException(
         relative_path="triggers.py",
         surface="import:subprocess",
+        line=25,
+        snippet="import subprocess",
         rationale=(
-            "Trigger evaluation runs ``git diff`` against the user repo to "
-            "determine whether to fire a scan. Reads diff content, does "
-            "not execute user code."
+            "Trigger evaluation runs ``git diff`` to determine whether a "
+            "PR's changes match Shipgate's triggers.json rules. Fixed git "
+            "argv, capture-only, no shell."
         ),
     ),
     AllowedException(
         relative_path="triggers.py",
         surface="attr_call:subprocess.run",
-        rationale="See triggers.py import:subprocess rationale.",
+        line=347,
+        snippet=(
+            "subprocess.run(names_cmd, capture_output=True, text=True, "
+            "check=True)"
+        ),
+        rationale=(
+            "git-diff change-name pass: ``git diff --name-only "
+            "base...HEAD``. argv constructed inside Shipgate from "
+            "validated base ref (names_cmd built at call site)."
+        ),
     ),
+    AllowedException(
+        relative_path="triggers.py",
+        surface="attr_call:subprocess.run",
+        line=348,
+        snippet=(
+            "subprocess.run(body_cmd, capture_output=True, text=True, "
+            "check=True)"
+        ),
+        rationale=(
+            "git-diff body pass: ``git diff base...HEAD`` for full "
+            "diff body inspection. argv constructed inside Shipgate "
+            "(body_cmd built at call site)."
+        ),
+    ),
+    AllowedException(
+        relative_path="triggers.py",
+        surface="attr_call:subprocess.run",
+        line=353,
+        snippet=(
+            "subprocess.run(['git', 'ls-files', '--others', "
+            "'--exclude-standard'], capture_output=True, text=True, "
+            "check=True)"
+        ),
+        rationale=(
+            "git-untracked enumeration: ``git ls-files --others "
+            "--exclude-standard``. Fixed argv, capture-only, no shell."
+        ),
+    ),
+    # cli/self_check.py — validates the installed environment via __import__
+    # with the module name supplied as a CLI flag. Targets installed
+    # packages, never user workspace.
     AllowedException(
         relative_path="cli/self_check.py",
         surface="name_call:__import__",
+        line=141,
+        snippet="__import__(module_name)",
         rationale=(
-            "Self-check validates the installed environment by attempting "
-            "an import of a name supplied via CLI flag. Runs only under "
-            "`agents-shipgate self-check`, never during scan; targets "
-            "installed packages, not user workspace."
+            "self-check probes whether named modules import cleanly in the "
+            "installed environment. Runs only under ``agents-shipgate "
+            "self-check``, never during scan; module_name is a curated "
+            "list of Shipgate's own modules."
+        ),
+    ),
+    # importlib.resources.files — bundled-package access. Anchor is the
+    # literal 'agents_shipgate' string at both call sites (verified by
+    # snippet pinning); any future call with a non-literal anchor would
+    # change the snippet and fail the test, forcing re-review.
+    AllowedException(
+        relative_path="triggers.py",
+        surface="import:importlib.resources.files",
+        line=27,
+        snippet="from importlib.resources import files",
+        rationale=(
+            "triggers.py reads the bundled docs/triggers.json catalog from "
+            "the installed wheel via importlib.resources.files. The from-"
+            "import line is pinned alongside the call site to catch a "
+            "future refactor that imports files() for a different anchor."
+        ),
+    ),
+    AllowedException(
+        relative_path="triggers.py",
+        surface="attr_call:importlib.resources.files",
+        line=61,
+        snippet="files('agents_shipgate')",
+        rationale=(
+            "Resolves the bundled trigger catalog (docs/triggers.json) "
+            "inside the agents-shipgate wheel. Anchor is the literal "
+            "'agents_shipgate' string (snippet pinning enforces this; a "
+            "future non-literal anchor would change the snippet and fail "
+            "the contract test)."
+        ),
+    ),
+    AllowedException(
+        relative_path="fixtures.py",
+        surface="import:importlib.resources.files",
+        line=11,
+        snippet="from importlib.resources import files",
+        rationale=(
+            "fixtures.py reads the bundled samples/ directory from the "
+            "installed wheel. From-import line pinned alongside the call "
+            "site for the same reason as triggers.py."
+        ),
+    ),
+    AllowedException(
+        relative_path="fixtures.py",
+        surface="attr_call:importlib.resources.files",
+        line=40,
+        snippet="files('agents_shipgate')",
+        rationale=(
+            "Resolves the bundled fixture directory (samples/*) inside the "
+            "agents-shipgate wheel. Anchor is the literal "
+            "'agents_shipgate' string (snippet pinning enforces this)."
         ),
     ),
 )
 
 
-def _violation_allowed(relative_path: str, surface: str) -> bool:
-    """v0.18 (PR #2): True iff a (file, surface) pair is allowlisted."""
-    return any(
-        exc.relative_path == relative_path and exc.surface == surface
-        for exc in ALLOWED_EXCEPTIONS
-    )
+def _lookup_allowed(
+    relative_path: str,
+    surface: str,
+    line: int,
+    snippet: str,
+) -> AllowedException | None:
+    """v0.18 (PR #2): match a violation to an ``AllowedException`` on all
+    four fields. Returns the matching entry, or ``None`` if the violation
+    is not allowlisted.
+
+    Per-call-site pinning closes the P1 review hole: a future unreviewed
+    ``subprocess.run(...)`` added to an already-allowlisted file no
+    longer slips past, because its ``line`` and ``snippet`` will not
+    match any existing entry.
+    """
+    for exc in ALLOWED_EXCEPTIONS:
+        if (
+            exc.relative_path == relative_path
+            and exc.surface == surface
+            and exc.line == line
+            and exc.snippet == snippet
+        ):
+            return exc
+    return None
+
+
+def _violation_allowed(
+    relative_path: str, surface: str, line: int, snippet: str
+) -> bool:
+    return _lookup_allowed(relative_path, surface, line, snippet) is not None
 
 # Bare-name forbidden builtins. Catches direct calls like ``exec("...")``.
 FORBIDDEN_NAME_CALLS: frozenset[str] = frozenset(
@@ -210,6 +405,12 @@ FORBIDDEN_ATTR_CALLS_EXACT: frozenset[str] = frozenset(
         "subprocess.check_output",
         "os.system",
         "os.popen",
+        # v0.18 (PR #2 review follow-up): importlib.resources.files()
+        # resolves an anchor package by name. The first-party call sites
+        # use a literal 'agents_shipgate' anchor; flagging the call
+        # forces every site to be allowlisted with snippet pinning, so a
+        # future non-literal anchor would fail the contract test.
+        "importlib.resources.files",
     }
 )
 
@@ -251,7 +452,12 @@ FORBIDDEN_MODULES: frozenset[str] = frozenset(
 #   installed Python environment, not user workspace code.
 # ``importlib.resources`` — bundled-package files (e.g. ``fixtures.py``,
 #   ``triggers.py``) read content packaged inside the agents-shipgate wheel,
-#   not user workspace code.
+#   not user workspace code. v0.18 (PR #2 review follow-up): the import line
+#   is allowed here so name_aliases get built, but the ``files`` attribute
+#   call is added to ``FORBIDDEN_ATTR_CALLS_EXACT`` above so every call site
+#   needs an ALLOWED_EXCEPTIONS entry with snippet pinning. Combined effect:
+#   the from-import line AND the call line are individually pinned per call
+#   site (catches a future non-literal anchor or unreviewed second use).
 ALLOWED_FORBIDDEN_MODULE_IMPORTS: frozenset[str] = frozenset(
     {"importlib.metadata", "importlib.resources"}
 )
@@ -263,7 +469,14 @@ ALLOWED_FORBIDDEN_MODULE_IMPORTS: frozenset[str] = frozenset(
 # / ``os.popen`` are out of bounds. We track aliases on these modules so
 # ``import os as oo; oo.system(...)`` and
 # ``from os import system as sh; sh(...)`` are resolved before checking.
-TRACKED_NON_FORBIDDEN_MODULES: frozenset[str] = frozenset({"os"})
+#
+# v0.18 (PR #2 review follow-up): ``importlib.resources`` joins this set so
+# ``from importlib.resources import files`` builds a name_alias and the
+# subsequent ``files(...)`` call site can be checked against
+# ``FORBIDDEN_ATTR_CALLS_EXACT``.
+TRACKED_NON_FORBIDDEN_MODULES: frozenset[str] = frozenset(
+    {"os", "importlib.resources"}
+)
 
 
 def _is_forbidden_chain(chain: str) -> bool:
@@ -355,6 +568,7 @@ def _scan_source(source: str, path: Path) -> list[Violation]:
                 line=exc.lineno or 0,
                 surface="parse_error",
                 message=f"{path}:{exc.lineno}: failed to parse: {exc.msg}",
+                snippet="",
             )
         ]
     rel = path.relative_to(REPO_ROOT)
@@ -387,6 +601,7 @@ def _scan_source(source: str, path: Path) -> list[Violation]:
                                 f"{rel}:{node.lineno}: forbidden import "
                                 f"{alias.name!r} (dynamic Python loading surface)"
                             ),
+                            snippet=ast.unparse(node),
                         )
                     )
                 if alias.asname:
@@ -406,6 +621,7 @@ def _scan_source(source: str, path: Path) -> list[Violation]:
                             f"{rel}:{node.lineno}: forbidden from-import "
                             f"{mod!r} (dynamic Python loading surface)"
                         ),
+                        snippet=ast.unparse(node),
                     )
                 )
                 # Skip the per-name pass below — the whole module is forbidden.
@@ -422,23 +638,29 @@ def _scan_source(source: str, path: Path) -> list[Violation]:
                                     f"from-import from {mod!r} "
                                     f"(would alias forbidden names into local scope)"
                                 ),
+                                snippet=ast.unparse(node),
                             )
                         )
                     continue
                 # Flag the from-import line itself when the imported
                 # attribute resolves to a forbidden surface — gives a
-                # clearer error than waiting for the call site.
+                # clearer error than waiting for the call site. v0.18
+                # PR #2 follow-up: emit surface=``import:<canonical>`` so
+                # the from-import line is distinguishable from the call
+                # site (which emits ``attr_call:<canonical>``) when both
+                # exist in the same file.
                 if mod in TRACKED_NON_FORBIDDEN_MODULES:
                     canonical = f"{mod}.{alias.name}"
                     if _is_forbidden_chain(canonical):
                         violations.append(
                             Violation(
                                 line=node.lineno,
-                                surface=f"attr_call:{canonical}",
+                                surface=f"import:{canonical}",
                                 message=(
                                     f"{rel}:{node.lineno}: forbidden from-import "
                                     f"of {canonical!r}"
                                 ),
+                                snippet=ast.unparse(node),
                             )
                         )
                     local = alias.asname or alias.name
@@ -460,6 +682,7 @@ def _scan_source(source: str, path: Path) -> list[Violation]:
                             f"{rel}:{node.lineno}: forbidden builtin call "
                             f"{func.id!r}"
                         ),
+                        snippet=ast.unparse(node),
                     )
                 )
                 continue
@@ -483,6 +706,7 @@ def _scan_source(source: str, path: Path) -> list[Violation]:
                                     f"{rel}:{node.lineno}: forbidden call "
                                     f"{canonical!r}{via}"
                                 ),
+                                snippet=ast.unparse(node),
                             )
                         )
                         break
@@ -499,6 +723,7 @@ def _scan_source(source: str, path: Path) -> list[Violation]:
                             message=(
                                 f"{rel}:{node.lineno}: forbidden call {chain!r}"
                             ),
+                            snippet=ast.unparse(node),
                         )
                     )
                     break
@@ -539,19 +764,29 @@ def test_scanner_source_contains_no_forbidden_calls_or_imports(
     source = scanner_source.read_text(encoding="utf-8")
     violations = _scan_source(source, scanner_source)
     unallowed = [
-        v for v in violations if not _violation_allowed(rel, v.surface)
+        v
+        for v in violations
+        if not _violation_allowed(rel, v.surface, v.line, v.snippet)
     ]
     assert not unallowed, (
         "Trust-model invariant violation under src/agents_shipgate/:\n  "
-        + "\n  ".join(v.message for v in unallowed)
+        + "\n  ".join(
+            f"{v.message}  (surface={v.surface!r}, "
+            f"snippet={v.snippet!r})"
+            for v in unallowed
+        )
         + "\n\n"
         + "The scanner MUST NOT execute or import user code. Parse with "
         + "ast.parse / yaml.safe_load / json.loads ONLY. See "
         + "STABILITY.md § 'Trust-model invariants' and the companion "
         + "tests/test_fixture_no_import.py live-load tests. If the surface "
         + "is a legitimate first-party meta-CLI operation, add an "
-        + "ALLOWED_EXCEPTIONS entry with prose rationale and document it "
-        + "in STABILITY.md § 'Meta-CLI surfaces (allowlisted, audited)'."
+        + "ALLOWED_EXCEPTIONS entry with the exact line, snippet, and "
+        + "prose rationale, and document it in STABILITY.md § 'Meta-CLI "
+        + "surfaces (allowlisted, audited)'. Existing entries cover "
+        + "specific call sites only — adding a new occurrence of an "
+        + "already-allowlisted surface in the same file STILL requires a "
+        + "new entry."
     )
 
 
@@ -772,17 +1007,29 @@ def test_lint_scanner_does_not_false_positive_on_safe_shapes() -> None:
 @pytest.mark.parametrize(
     "exc",
     ALLOWED_EXCEPTIONS,
-    ids=lambda e: f"{e.relative_path}:{e.surface}",
+    ids=lambda e: f"{e.relative_path}:{e.line}:{e.surface}",
 )
 def test_allowlist_entry_matches_real_surface(exc: AllowedException) -> None:
     """v0.18 (PR #2) stale-allowlist guard.
 
-    Every ``ALLOWED_EXCEPTIONS`` entry MUST correspond to a surface
-    that the scanner would actually flag in the named file. If the
-    file is later refactored to remove the legitimate meta-CLI surface
-    (e.g., self-check stops calling ``__import__``), this test fails
-    and forces the contributor to remove the now-unused allowlist
-    entry — preventing rot.
+    Every ``ALLOWED_EXCEPTIONS`` entry MUST correspond to a real
+    violation in the named file with the SAME ``(surface, line,
+    snippet)`` quadruple. Three failure modes are detected:
+
+    - **Removed surface:** file refactored to remove the call site;
+      entry has no matching violation → fail (entry is stale).
+    - **Line drift:** call site moved to a different line (e.g.,
+      a comment was added above); entry's ``line`` no longer
+      matches → fail (forces re-review of the move).
+    - **Snippet drift:** call site's argv or shape changed (e.g.,
+      ``subprocess.run(['git', 'log'])`` was edited to
+      ``subprocess.run(user_input)``); entry's ``snippet`` no
+      longer matches → fail (forces re-review of the semantic
+      change).
+
+    PR #2 review follow-up: the original ``(file, surface)``-only
+    match blanket-permitted every occurrence in a file. The
+    quadruple match restricts each entry to a single call site.
     """
     path = SCANNER_DIR / exc.relative_path
     assert path.exists(), (
@@ -790,36 +1037,126 @@ def test_allowlist_entry_matches_real_surface(exc: AllowedException) -> None:
     )
     source = path.read_text(encoding="utf-8")
     violations = _scan_source(source, path)
-    surfaces = {v.surface for v in violations}
-    assert exc.surface in surfaces, (
+    same_surface = [v for v in violations if v.surface == exc.surface]
+    assert same_surface, (
         f"allowlisted surface {exc.surface!r} not present in "
-        f"{exc.relative_path!r}; entry is stale, remove or refactor. "
-        f"Observed surfaces in this file: {sorted(surfaces)!r}"
+        f"{exc.relative_path!r} at all; entry is stale, remove or "
+        f"refactor. Observed surfaces in this file: "
+        f"{sorted({v.surface for v in violations})!r}"
+    )
+    same_line = [v for v in same_surface if v.line == exc.line]
+    assert same_line, (
+        f"allowlisted entry for {exc.relative_path}:{exc.surface} pins "
+        f"line {exc.line}, but no violation of that surface was found "
+        f"at that line. Lines actually flagged: "
+        f"{sorted({v.line for v in same_surface})!r}. Either the call "
+        f"moved (update the entry) or the entry is stale."
+    )
+    matching = [v for v in same_line if v.snippet == exc.snippet]
+    assert matching, (
+        f"allowlisted entry for {exc.relative_path}:{exc.line}:"
+        f"{exc.surface} has snippet {exc.snippet!r}, but the actual "
+        f"violation at that line has snippet "
+        f"{same_line[0].snippet!r}. The call's argv or shape changed "
+        f"— re-review the rationale and update the snippet."
+    )
+
+
+def test_allowed_exceptions_have_no_duplicates() -> None:
+    """v0.18 (PR #2 review follow-up): every ``ALLOWED_EXCEPTIONS``
+    entry must be a distinct ``(relative_path, surface, line)`` triple.
+    Two entries pointing at the same call site would both match the
+    same violation, hiding a real audit-trail bug.
+    """
+    keys = [(e.relative_path, e.surface, e.line) for e in ALLOWED_EXCEPTIONS]
+    duplicates = sorted({k for k in keys if keys.count(k) > 1})
+    assert not duplicates, (
+        f"ALLOWED_EXCEPTIONS contains duplicate (relative_path, "
+        f"surface, line) entries: {duplicates}. Each call site must "
+        f"have exactly one entry."
     )
 
 
 def test_no_unallowlisted_forbidden_surface_in_scanner() -> None:
     """v0.18 (PR #2): the whole-scanner sweep with allowlist applied
-    produces zero violations. This is the runtime gate PR #2 hardens.
+    produces zero unallowlisted violations. This is the runtime gate
+    PR #2 hardens.
 
-    The parametrized ``test_scanner_source_contains_no_forbidden_calls_or_imports``
-    above catches per-file regressions. This non-parametrized form gives
-    a single, definitive PASS/FAIL signal at the end of the test session.
-    A failure message lists every ``(relative_path, surface)`` pair the
-    contributor must address — either by refactoring the offending file
-    or by adding an ``ALLOWED_EXCEPTIONS`` entry with prose rationale.
+    The parametrized
+    ``test_scanner_source_contains_no_forbidden_calls_or_imports``
+    above catches per-file regressions. This non-parametrized form
+    gives a single, definitive PASS/FAIL signal at the end of the
+    test session. A failure message lists every unallowlisted
+    ``(relative_path, line, surface, snippet)`` quadruple the
+    contributor must address — either by refactoring the offending
+    file or by adding an ``ALLOWED_EXCEPTIONS`` entry with prose
+    rationale.
+
+    PR #2 review follow-up: the previous version matched on
+    ``(file, surface)`` only, so a future second occurrence of an
+    already-allowlisted surface in the same file would silently pass.
+    The quadruple match closes that hole.
     """
-    unallowed: list[tuple[str, str]] = []
+    unallowed: list[tuple[str, int, str, str]] = []
     for path in _scanner_sources():
         rel = str(path.relative_to(SCANNER_DIR))
         for violation in _scan_source(path.read_text(encoding="utf-8"), path):
-            if not _violation_allowed(rel, violation.surface):
-                unallowed.append((rel, violation.surface))
+            if not _violation_allowed(
+                rel, violation.surface, violation.line, violation.snippet
+            ):
+                unallowed.append(
+                    (rel, violation.line, violation.surface, violation.snippet)
+                )
     assert unallowed == [], (
         "Scanner has forbidden surfaces with no allowlist entry. "
         "Add an ALLOWED_EXCEPTIONS entry with prose rationale, or "
-        "refactor the surface out. Unallowlisted: "
-        + ", ".join(f"{path}::{surface}" for path, surface in unallowed)
+        "refactor the surface out. Unallowlisted:\n  "
+        + "\n  ".join(
+            f"{rel}:{line} {surface}  snippet={snippet!r}"
+            for rel, line, surface, snippet in unallowed
+        )
+    )
+
+
+def test_allowed_exceptions_pin_subprocess_run_per_call_site() -> None:
+    """v0.18 (PR #2 review follow-up): regression test for the P1
+    bypass the reviewer caught.
+
+    Confirms that ``triggers.py`` has THREE distinct
+    ``subprocess.run`` AllowedException entries (one per call site at
+    lines 347, 348, 353), not one blanket entry that permits all
+    occurrences. Same for ``cli/discovery/artifacts.py`` (two call
+    sites at 361 and 377). Adding a fourth ``subprocess.run`` to
+    ``triggers.py`` must require adding a new ALLOWED_EXCEPTIONS entry.
+
+    If the test fails because lines drifted, that is the intended
+    failure mode — the contributor must re-review the move and bump
+    the entries. If it fails because the count dropped, an existing
+    entry has gone stale (the call was removed but the entry remains).
+    """
+    by_file_surface: dict[tuple[str, str], list[AllowedException]] = {}
+    for exc in ALLOWED_EXCEPTIONS:
+        by_file_surface.setdefault((exc.relative_path, exc.surface), []).append(exc)
+
+    triggers_subprocess_run = by_file_surface.get(
+        ("triggers.py", "attr_call:subprocess.run"), []
+    )
+    assert len(triggers_subprocess_run) == 3, (
+        f"Expected 3 distinct AllowedException entries for "
+        f"triggers.py subprocess.run calls (one per call site at "
+        f"lines 347, 348, 353), got {len(triggers_subprocess_run)}. "
+        f"Per-call-site pinning is the structural fix for the "
+        f"P1 review finding — each subprocess.run call must have "
+        f"its own entry with line + snippet pinning."
+    )
+    artifacts_subprocess_run = by_file_surface.get(
+        ("cli/discovery/artifacts.py", "attr_call:subprocess.run"), []
+    )
+    assert len(artifacts_subprocess_run) == 2, (
+        f"Expected 2 distinct AllowedException entries for "
+        f"cli/discovery/artifacts.py subprocess.run calls (one per "
+        f"call site at lines 361 and 377), got "
+        f"{len(artifacts_subprocess_run)}."
     )
 
 


### PR DESCRIPTION
## Summary

Brings the trust-invariant AST lint up to the public claim in STABILITY.md and README: "the scanner does not execute or import user code." Pre-v0.18 the lint covered only `src/agents_shipgate/inputs/`; this PR widens it to every `.py` under `src/agents_shipgate/` with a small allowlist of four legitimate first-party meta-CLI surfaces.

**No production code changes.** All changes live in `tests/test_adapter_static_only.py` plus STABILITY.md / CHANGELOG.md.

## Allowlisted surfaces (7 entries across 4 files)

Each `ALLOWED_EXCEPTIONS` entry carries prose rationale and is pinned by a contract test:

- **`cli/bootstrap.py`** — `subprocess.run([sys.executable, "-m", "agents_shipgate", ...])` chains `detect → init → scan → apply-patches` against Shipgate's own CLI.
- **`cli/discovery/artifacts.py`** — `subprocess.run(["git", ...])` probes the user repo for file inventory. Reads git metadata only.
- **`triggers.py`** — `subprocess.run(["git", "diff", ...])` for trigger evaluation. Reads diff content only.
- **`cli/self_check.py`** — `__import__(name)` validates that supplied modules are installed. Runs only under `agents-shipgate self-check`, never during scan.

## Contract tests prevent allowlist rot

- `test_allowlist_entry_matches_real_surface` (parametrized) — every entry MUST correspond to a real surface; entries become stale if the file is later refactored.
- `test_no_unallowlisted_forbidden_surface_in_scanner` — definitive PASS/FAIL signal over the whole sweep, with a failure message listing every `(relative_path, surface)` pair to address.

## Other changes

- `_scan_source` refactored to return structured `Violation` objects (`line`, `surface`, `message`) instead of preformatted strings, so callers can route by `surface` against `ALLOWED_EXCEPTIONS`.
- `importlib.resources` added to `ALLOWED_FORBIDDEN_MODULE_IMPORTS` for bundled-package files inside the wheel.
- Legacy `test_invariant_lint_covers_every_adapter_module` deleted (paranoid for the 18-file `inputs/` case; doesn't scale to ~80 files). Replaced by the new contract tests.

## Test plan

- [x] 170 trust-lint tests pass (62 → 170; 41 negative-control snippet shapes + 41 safe-control + 7 allowlist contract + 79 whole-scanner per-file + 2 contract aggregate).
- [x] Full suite 1192 passes; ruff clean; coverage 87.23%.
- [x] **Negative control:** appending `import subprocess; subprocess.run(['echo', 'hi'])` to `core/findings.py` causes `test_no_unallowlisted_forbidden_surface_in_scanner` to fail with `core/findings.py::import:subprocess, core/findings.py::attr_call:subprocess.run` — clear, actionable message. Revert returns to green.
- [x] STABILITY.md "Trust-model invariants" widened to cite the entire scanner package; new "Meta-CLI surfaces (allowlisted, audited)" subsection documents each entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)