### PR TITLE
Add P0.1 public-contract drift guards and align surfaces

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -25,7 +25,7 @@
   "self_check": "agents-shipgate self-check --json",
   "contract": "agents-shipgate contract --json",
   "contract_version": "1",
-  "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_messages_api", "google_adk", "langchain", "crewai", "openai_api", "codex_plugin"],
+  "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_api", "google_adk", "langchain", "crewai", "openai_api", "codex_plugin", "n8n"],
   "outputs": ["markdown", "json", "sarif", "packet_md", "packet_json", "packet_html"],
   "gating_signal": "release_decision.decision",
   "trust_model": "static_by_default",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aid
 
 ## What this project is
 
-Local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, n8n workflow JSON/stubs) and produces deterministic findings.
+Local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, OpenAI API artifacts, Codex plugin packages and marketplaces, n8n workflow JSON/stubs) and produces deterministic findings.
 
-- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · n8n
+- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · OpenAI API · Codex plugin · n8n
 - **Outputs:** Markdown · JSON · SARIF
 - **Trust:** Static-by-default. No agent execution, tool calls, LLM calls, or network access.
 - **Marketing site:** [threemoonslab.com](https://threemoonslab.com/) — canonical brand URL with human-readable companion pages: [/quickstart/](https://threemoonslab.com/quickstart/), [/glossary/](https://threemoonslab.com/glossary/), [/checks/](https://threemoonslab.com/checks/), [/design-partners/](https://threemoonslab.com/design-partners/). The site also serves a [/.well-known/agents-shipgate.json](https://threemoonslab.com/.well-known/agents-shipgate.json) discovery file **pinned to the latest released tag** for external consumers and AI search. **If you are an agent working inside this repo, use the in-tree [`.well-known/agents-shipgate.json`](.well-known/agents-shipgate.json) (current `main` contract, may be ahead of the released file) for schema-version and gating-signal decisions.**

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Report** before your agent gets production-like permissions.
 [check catalog](https://threemoonslab.com/checks/), and
 [design partners](https://threemoonslab.com/design-partners/).
 
-No agent execution. No LLM calls. No MCP server connections. No scanner network
-calls. No scanner telemetry. Apache-2.0.
+Static-by-default — no agent execution, no LLM calls, no MCP server connections,
+no scanner network calls, no scanner telemetry. Audited exceptions are pinned
+in [`tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS`](tests/test_adapter_static_only.py).
+Apache-2.0.
 
 ## One-command quickstart
 
@@ -410,7 +412,7 @@ agents-shipgate scan --config shipgate.yaml --policy-pack policies/org-release.y
 
 Agents Shipgate is a static, manifest-first scanner. It is intentionally narrow:
 
-- It does not run agents, call tools, invoke LLMs, or verify model availability.
+- It does not run agents, call tools, invoke LLMs, or verify model availability by default (static-by-default; see [Trust Model](#trust-model) and [`ALLOWED_EXCEPTIONS`](tests/test_adapter_static_only.py)).
 - It does not verify runtime behavior, latency, prompt quality, or routing decisions.
 - It does not replace dynamic security testing or human security review of the underlying systems.
 - It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, simple OpenAI API artifacts, optional SDK AST metadata, static Google ADK/LangChain/CrewAI inputs, and static Codex plugin package metadata; tools that are not declared or statically discoverable are not scanned.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 Agents Shipgate is an open-source CLI and GitHub Action for local-first,
 static Tool-Use Readiness review. It scans MCP, OpenAPI, OpenAI Agents SDK,
-Anthropic Messages API, Google ADK, LangChain/LangGraph, CrewAI, n8n, and
-OpenAI API artifacts, then writes a deterministic **Tool-Use Readiness
-Report** before your agent gets production-like permissions.
+Anthropic Messages API, Google ADK, LangChain/LangGraph, CrewAI, OpenAI API,
+Codex plugin, and n8n artifacts, then writes a deterministic **Tool-Use
+Readiness Report** before your agent gets production-like permissions.
 
 **Website:** [threemoonslab.com](https://threemoonslab.com/) —
 [quickstart](https://threemoonslab.com/quickstart/),

--- a/action.yml
+++ b/action.yml
@@ -2,10 +2,11 @@ name: Agents Shipgate
 description: >-
   Local-first, static Tool-Use Readiness release gate for AI agent tool
   surfaces. Scans MCP, OpenAPI, OpenAI Agents SDK, Anthropic, Google ADK,
-  LangChain, and CrewAI artifacts.
+  LangChain, CrewAI, OpenAI API, Codex plugin, and n8n artifacts.
   Writes a Tool-Use Readiness Report (Markdown / JSON / SARIF) before your
-  agent gets production-like permissions. No LLM calls. No agent execution.
-  Apache-2.0.
+  agent gets production-like permissions. Static-by-default. Audited
+  exceptions are pinned per call site in
+  tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS. Apache-2.0.
 author: ThreeMoonsLab
 
 branding:
@@ -79,8 +80,10 @@ inputs:
     description: Optional Agents Shipgate PyPI version to install. Empty installs this action source.
 
 outputs:
+  # Legacy v0.7-caller output; baseline-blind. Prefer release_decision.decision
+  # via the `decision` output below for gating.
   status:
-    description: Agents Shipgate summary status.
+    description: Agents Shipgate summary status (legacy v0.7 caller; baseline-blind).
     value: ${{ steps.report_outputs.outputs.status }}
   critical_count:
     description: Number of unsuppressed critical findings.

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -2,8 +2,9 @@
 
 Copy-pasteable workflows for AI coding agents (Claude Code, Codex, Cursor,
 Aider) that need to drive `agents-shipgate` end-to-end without prompting
-the user. Every command is read-only or schema-validated; no agent
-execution, no LLM calls, no network access.
+the user. Every command is read-only or schema-validated;
+static-by-default, with audited exceptions pinned in
+[`tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS`](../tests/test_adapter_static_only.py).
 
 > If you are a human, [`quickstart.md`](quickstart.md) is the friendlier
 > entry point. This page is structured for agents that consume `--json`.

--- a/docs/ai-search-summary.md
+++ b/docs/ai-search-summary.md
@@ -45,6 +45,8 @@ Agents Shipgate supports these static tool-source inputs:
 - CrewAI Python entrypoints, using static AST extraction.
 - OpenAI API artifacts, including prompts, function schemas, response
   formats, tests, and traces.
+- Codex plugin packages and marketplaces, using static parsing.
+- n8n workflow JSON and source-control stubs, using static parsing.
 
 ## What it is not
 

--- a/docs/design-partners.md
+++ b/docs/design-partners.md
@@ -9,8 +9,8 @@ production-like permissions are granted.
 You are likely a good fit if your team:
 
 - Ships agents that call tools through MCP, OpenAPI, OpenAI Agents SDK,
-  Anthropic Messages API, Google ADK, LangChain/LangGraph, CrewAI, or OpenAI
-  Agents API artifacts.
+  Anthropic Messages API, Google ADK, LangChain/LangGraph, CrewAI, OpenAI API
+  artifacts, Codex plugin packages and marketplaces, or n8n workflows.
 - Has tools that refund, email, cancel, deploy, modify records, read sensitive
   data, or change infrastructure.
 - Wants advisory PR evidence before moving to stricter CI behavior.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,8 +28,8 @@ reviewable before production-like permissions are granted.
 An AI agent tool surface is the set of named, schemaed actions an agent can
 invoke at runtime. agents-shipgate reads tool surfaces from MCP exports,
 OpenAPI specs, OpenAI Agents SDK Python entrypoints, Anthropic Messages API
-artifacts, Google ADK, LangChain/LangGraph, CrewAI, and OpenAI API
-artifacts.
+artifacts, Google ADK, LangChain/LangGraph, CrewAI, OpenAI API artifacts,
+Codex plugin packages and marketplaces, and n8n workflow JSON.
 
 ## How does agents-shipgate work?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,6 +84,8 @@ See [`docs/trust-model.md`](trust-model.md) for the full disclosure.
 - LangChain/LangGraph Python entrypoints
 - CrewAI Python entrypoints
 - OpenAI API artifacts (prompts + function schemas + response formats)
+- Codex plugin packages and marketplaces (static parsing)
+- n8n workflow JSON and source-control stubs (static parsing)
 
 See [`docs/manifest-v0.1.md`](manifest-v0.1.md) for the full manifest
 schema.
@@ -92,7 +94,7 @@ schema.
 
 - **Markdown** — `agents-shipgate-reports/report.md`, for human review.
 - **JSON** — `agents-shipgate-reports/report.json`, machine-readable
-  (schema v0.17, current). Always parse this for programmatic use.
+  (schema v0.18, current). Always parse this for programmatic use.
   For release gating, read `release_decision.decision`; the legacy
   `summary.status` field is baseline-blind (kept for v0.7 callers).
 - **SARIF** — `agents-shipgate-reports/report.sarif`, compatible with

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -33,6 +33,8 @@ surface before production-like permissions are granted.
 - LangChain/LangGraph Python entrypoints
 - CrewAI Python entrypoints
 - OpenAI API artifacts
+- Codex plugin packages and marketplaces
+- n8n workflow JSON and source-control stubs
 
 ## Core references
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -33,9 +33,9 @@ Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aid
 
 ## What this project is
 
-Local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, n8n workflow JSON/stubs) and produces deterministic findings.
+Local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, OpenAI API artifacts, Codex plugin packages and marketplaces, n8n workflow JSON/stubs) and produces deterministic findings.
 
-- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · n8n
+- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · OpenAI API · Codex plugin · n8n
 - **Outputs:** Markdown · JSON · SARIF
 - **Trust:** Static-by-default. No agent execution, tool calls, LLM calls, or network access.
 - **Marketing site:** [threemoonslab.com](https://threemoonslab.com/) — canonical brand URL with human-readable companion pages: [/quickstart/](https://threemoonslab.com/quickstart/), [/glossary/](https://threemoonslab.com/glossary/), [/checks/](https://threemoonslab.com/checks/), [/design-partners/](https://threemoonslab.com/design-partners/). The site also serves a [/.well-known/agents-shipgate.json](https://threemoonslab.com/.well-known/agents-shipgate.json) discovery file **pinned to the latest released tag** for external consumers and AI search. **If you are an agent working inside this repo, use the in-tree [`.well-known/agents-shipgate.json`](.well-known/agents-shipgate.json) (current `main` contract, may be ahead of the released file) for schema-version and gating-signal decisions.**
@@ -535,8 +535,9 @@ After you (the agent) complete a task involving Agents Shipgate, verify:
 
 Copy-pasteable workflows for AI coding agents (Claude Code, Codex, Cursor,
 Aider) that need to drive `agents-shipgate` end-to-end without prompting
-the user. Every command is read-only or schema-validated; no agent
-execution, no LLM calls, no network access.
+the user. Every command is read-only or schema-validated;
+static-by-default, with audited exceptions pinned in
+[`tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS`](../tests/test_adapter_static_only.py).
 
 > If you are a human, [`quickstart.md`](quickstart.md) is the friendlier
 > entry point. This page is structured for agents that consume `--json`.

--- a/llms.txt
+++ b/llms.txt
@@ -50,6 +50,8 @@
 - LangChain and LangGraph Python entrypoints, using static AST extraction.
 - CrewAI Python entrypoints, using static AST extraction.
 - OpenAI API artifacts: prompts, function schemas, response formats, tests, and traces.
+- Codex plugin packages and marketplaces, using static parsing.
+- n8n workflow JSON and source-control stubs, using static parsing.
 
 ## Outputs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "agents-shipgate"
 version = "0.10.0"
-description = "Local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. CLI + GitHub Action. Scans MCP, OpenAPI, OpenAI Agents SDK, Anthropic, Google ADK, LangChain, CrewAI, n8n."
+description = "Local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. CLI + GitHub Action. Scans MCP, OpenAPI, OpenAI Agents SDK, Anthropic, Google ADK, LangChain, CrewAI, OpenAI API, Codex plugin, n8n."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"

--- a/skills/agents-shipgate/SKILL.md
+++ b/skills/agents-shipgate/SKILL.md
@@ -5,9 +5,9 @@ description: Use when the user wants to add a local-first, static Tool-Use Readi
 
 # agents-shipgate skill
 
-`agents-shipgate` is a local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. It analyzes `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API artifacts, Google ADK files, LangChain/LangGraph files, CrewAI files, Codex plugin package metadata) and emits deterministic findings as Markdown, JSON, and SARIF.
+`agents-shipgate` is a local-first, static Tool-Use Readiness release gate for AI agent tool surfaces. It analyzes `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API artifacts, Google ADK files, LangChain/LangGraph files, CrewAI files, OpenAI API artifacts, Codex plugin packages and marketplaces, n8n workflow JSON) and emits deterministic findings as Markdown, JSON, and SARIF.
 
-It does **not** run agents, call tools, invoke LLMs, connect to MCP servers, or send telemetry. Static analysis only.
+It does **not** run agents, call tools, invoke LLMs, connect to MCP servers, or send telemetry by default. Static analysis only; audited exceptions are pinned in `tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS`.
 
 > The skill name is intentionally `agents-shipgate` (not `shipgate`) so it does not collide with the `/shipgate` slash command shipped at `.claude/commands/shipgate.md` — Claude Code lets a skill with the same name preempt a command, which would bypass the bootstrap flow the slash command is meant to deliver.
 

--- a/src/agents_shipgate/schemas/contract.py
+++ b/src/agents_shipgate/schemas/contract.py
@@ -13,6 +13,25 @@ from agents_shipgate.schemas.report import ReadinessReport
 CONTRACT_VERSION: Literal["1"] = "1"
 GATING_SIGNAL: Literal["release_decision.decision"] = "release_decision.decision"
 # Adding `gating_signal_values` would be a `contract_version: "2"` change.
+# Wire-stable enum-id -> display-alias tuple. Enum-ids match adapter
+# `source_type` ClassVars on inputs/*.py and the `inputs[]` array in
+# .well-known/agents-shipgate.json. Alias tuples are ordered
+# longest-first so substring resolution prefers more specific names
+# (e.g. "Anthropic Messages API" wins over "Anthropic"). Iteration
+# order is the canonical public order; the wire array in .well-known
+# is pinned to list(SUPPORTED_INPUTS).
+SUPPORTED_INPUTS: dict[str, tuple[str, ...]] = {
+    "mcp": ("Model Context Protocol (MCP)", "Model Context Protocol", "MCP"),
+    "openapi": ("OpenAPI 3.x", "OpenAPI"),
+    "openai_agents_sdk": ("OpenAI Agents SDK",),
+    "anthropic_api": ("Anthropic Messages API", "Anthropic"),
+    "google_adk": ("Google ADK",),
+    "langchain": ("LangChain and LangGraph", "LangChain/LangGraph", "LangChain"),
+    "crewai": ("CrewAI",),
+    "openai_api": ("OpenAI API",),
+    "codex_plugin": ("Codex plugin packages and marketplaces", "Codex plugin"),
+    "n8n": ("n8n",),
+}
 MANUAL_REVIEW_SIGNALS: tuple[str, ...] = (
     "release_decision.review_items",
     # v0.17: per-finding decision audit. Reviewers triaging
@@ -72,6 +91,7 @@ __all__ = [
     "CONTRACT_VERSION",
     "GATING_SIGNAL",
     "MANUAL_REVIEW_SIGNALS",
+    "SUPPORTED_INPUTS",
     "ContractPayload",
     "build_contract_payload",
 ]

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -32,6 +32,7 @@ from agents_shipgate.report.markdown import DISCLAIMER
 from agents_shipgate.schemas.contract import (
     CONTRACT_VERSION,
     GATING_SIGNAL,
+    SUPPORTED_INPUTS,
     build_contract_payload,
 )
 from agents_shipgate.schemas.diagnostics import NextActionKind
@@ -105,10 +106,21 @@ VERSION_LITERAL_TARGETS = (
         re.compile(r"preparing the\s+`v(\d+\.\d+\.\d+)`\s+release"),
     ),
 )
-# Forbidden public/display forms. Word boundaries on both sides keep
-# "Agents Shipgate" (canonical) from matching.
+# Forbidden public/display forms. Case-sensitive on purpose: `Agents
+# Shipgate` (canonical) must never match. The four banned variants
+# below mirror the "Do not use" list in AGENTS.md §Naming (canonical).
 FORBIDDEN_NAME_PATTERN = re.compile(
-    r"(?<![A-Za-z])Agent\s+(?:Shipcheck|Shipgate)(?![A-Za-z])"
+    r"(?<![A-Za-z])("
+    r"Agent\s+(?:Shipcheck|Shipgate)"      # singular display: "Agent Shipgate"
+    r"|Agents-Shipgate"                     # display kebab
+    r"|agents\s+shipgate"                   # display lowercase
+    r")(?![A-Za-z])"
+)
+# `agent_shipgate` (singular underscore) is always wrong; the correct
+# Python module is `agents_shipgate` (plural). Pinned separately
+# because Python contexts otherwise need `agents_shipgate` to pass.
+SINGULAR_UNDERSCORE_PATTERN = re.compile(
+    r"(?<![A-Za-z_])agent_shipgate(?![A-Za-z_])"
 )
 DO_NOT_USE_CONTEXT_PATTERN = re.compile(
     r"do\s*\*{0,2}\s*not\s*\*{0,2}\s*use|avoid these names|forbidden",
@@ -1408,3 +1420,351 @@ def test_pre_commit_docs_do_not_reference_missing_trigger_subcommand():
     text = _read(".pre-commit-hooks.yaml")
     assert "agents-shipgate triggers --diff" not in text
     assert "python -m agents_shipgate.triggers --git-diff HEAD" in text
+
+
+# ---------------------------------------------------------------------------
+# Supported-input alignment (P0.1)
+# ---------------------------------------------------------------------------
+#
+# SUPPORTED_INPUTS in agents_shipgate.schemas.contract is the in-code
+# source of truth. Every public surface that lists supported inputs must
+# (a) mention every enum-id and (b) not mention anything unknown.
+# Adapter ClassVars are pinned bidirectionally against the constant so a
+# new adapter cannot land without updating SUPPORTED_INPUTS, and a
+# docs-only addition cannot land without a backing adapter (the n8n
+# failure mode that motivated this block).
+
+# Build longest-first so "Anthropic Messages API" beats "Anthropic"
+# when both appear in the same token.
+_ALIAS_TO_ENUM: dict[str, str] = {
+    alias: enum_id
+    for enum_id, aliases in SUPPORTED_INPUTS.items()
+    for alias in aliases
+}
+_ALIASES_LONGEST_FIRST: list[str] = sorted(
+    _ALIAS_TO_ENUM, key=len, reverse=True
+)
+
+# Internal-only adapters that intentionally never appear in user-facing
+# input lists. Adding to this set requires a comment justifying why
+# the adapter isn't a SUPPORTED_INPUTS key.
+INTERNAL_ADAPTERS: set[str] = {
+    # `validation` is the catch-all adapter for shipgate.yaml-only
+    # manifest entries; it's never a user-facing input source.
+    "validation",
+}
+
+
+def _resolve_alias(token: str) -> str | None:
+    """Return the enum-id matching the longest alias that appears as
+    a substring of `token`, or None if nothing matches."""
+    clean = token.strip().rstrip(",.;:")
+    for alias in _ALIASES_LONGEST_FIRST:
+        if alias in clean:
+            return _ALIAS_TO_ENUM[alias]
+    return None
+
+
+def _slice_section(text: str, start_marker: str, end_marker: str) -> str:
+    """Slice between `start_marker` (inclusive of length) and the next
+    occurrence of `end_marker`. Returns the tail if `end_marker` is
+    absent."""
+    start = text.index(start_marker) + len(start_marker)
+    end = text.find(end_marker, start)
+    return text[start:] if end == -1 else text[start:end]
+
+
+def _resolve_tokens(tokens: list[str]) -> tuple[set[str], list[str]]:
+    resolved: set[str] = set()
+    unresolved: list[str] = []
+    for token in tokens:
+        enum_id = _resolve_alias(token)
+        if enum_id is None:
+            unresolved.append(token)
+        else:
+            resolved.add(enum_id)
+    return resolved, unresolved
+
+
+def _resolve_freeform(text: str) -> tuple[set[str], list[str]]:
+    """Substring-scan freeform prose for every alias. Unresolved is
+    always empty for prose — the bidirectional adapter test plus the
+    structured extractors below catch unknown-input drift on surfaces
+    that have a parseable list shape."""
+    resolved: set[str] = set()
+    for alias in _ALIASES_LONGEST_FIRST:
+        if alias in text:
+            resolved.add(_ALIAS_TO_ENUM[alias])
+    return resolved, []
+
+
+def _well_known_input_ids(text: str) -> tuple[set[str], list[str]]:
+    ids = json.loads(text)["inputs"]
+    resolved = {i for i in ids if i in SUPPORTED_INPUTS}
+    unresolved = [i for i in ids if i not in SUPPORTED_INPUTS]
+    return resolved, unresolved
+
+
+def _llms_txt_inputs(text: str) -> tuple[set[str], list[str]]:
+    block = _slice_section(text, "## Inputs", "\n## ")
+    tokens = re.findall(r"^- (.+?)\.?\s*$", block, flags=re.M)
+    return _resolve_tokens(tokens)
+
+
+def _agents_md_inputs_bullet(text: str) -> tuple[set[str], list[str]]:
+    m = re.search(r"\*\*Inputs:\*\*\s+(.+)", text)
+    if not m:
+        return set(), ["<no Inputs bullet found>"]
+    return _resolve_tokens([t.strip() for t in m.group(1).split("·")])
+
+
+def _readme_inputs_table(text: str) -> tuple[set[str], list[str]]:
+    rows = re.findall(
+        r"^\|\s*([^|]+?)\s*\|\s*Supported\s*\|", text, flags=re.M
+    )
+    return _resolve_tokens(rows)
+
+
+def _pyproject_description(text: str) -> tuple[set[str], list[str]]:
+    m = re.search(r'^description\s*=\s*"([^"]+)"', text, flags=re.M)
+    if not m:
+        return set(), ["<no description>"]
+    return _resolve_freeform(m.group(1))
+
+
+def _action_yml_description(text: str) -> tuple[set[str], list[str]]:
+    m = re.search(r"^description:\s*>-\n((?:\s{2,}.+\n)+)", text, flags=re.M)
+    if not m:
+        return set(), ["<no description>"]
+    return _resolve_freeform(m.group(1))
+
+
+def _faq_inputs_block(text: str) -> tuple[set[str], list[str]]:
+    block = _slice_section(
+        text, "## What inputs does it support?", "\n## "
+    )
+    tokens = re.findall(r"^- (.+)$", block, flags=re.M)
+    return _resolve_tokens(tokens)
+
+
+INPUT_SURFACES: tuple[tuple[str, object], ...] = (
+    (".well-known/agents-shipgate.json", _well_known_input_ids),
+    ("llms.txt", _llms_txt_inputs),
+    ("AGENTS.md", _agents_md_inputs_bullet),
+    ("README.md", _readme_inputs_table),
+    ("pyproject.toml", _pyproject_description),
+    ("action.yml", _action_yml_description),
+    ("docs/faq.md", _faq_inputs_block),
+)
+
+
+@pytest.mark.parametrize("relpath,extractor", INPUT_SURFACES)
+def test_public_surface_lists_every_supported_input(relpath, extractor):
+    """Every supported-input surface must list each SUPPORTED_INPUTS
+    enum-id (via at least one alias) and must not list any unknown
+    tokens. Catches the n8n failure mode where a runtime adapter ships
+    but discovery and docs surfaces miss it."""
+    observed, unresolved = extractor(_read(relpath))
+    missing = set(SUPPORTED_INPUTS) - observed
+    assert not missing, (
+        f"{relpath} missing input enum-ids: {sorted(missing)}. "
+        f"Bump the surface or update SUPPORTED_INPUTS in "
+        f"src/agents_shipgate/schemas/contract.py."
+    )
+    assert not unresolved, (
+        f"{relpath} mentions tokens not in SUPPORTED_INPUTS: "
+        f"{unresolved}. Either add the input as an adapter + "
+        f"SUPPORTED_INPUTS entry, or remove the stray reference."
+    )
+
+
+def test_well_known_inputs_order_matches_constant():
+    """Beyond set equality: the wire-stable `inputs` array order must
+    match the declared order of SUPPORTED_INPUTS so external consumers
+    that index positionally see a stable contract."""
+    data = json.loads(_read(".well-known/agents-shipgate.json"))
+    assert data["inputs"] == list(SUPPORTED_INPUTS), (
+        f"`.well-known/agents-shipgate.json::inputs` order drift: got "
+        f"{data['inputs']}, expected {list(SUPPORTED_INPUTS)}."
+    )
+
+
+def test_supported_inputs_match_adapter_class_vars_bidirectionally():
+    """Bidirectional: every adapter `source_type` ClassVar (minus
+    INTERNAL_ADAPTERS) must be in SUPPORTED_INPUTS — catches a new
+    adapter added without updating the contract (the exact n8n
+    failure mode that motivated this test). And every SUPPORTED_INPUTS
+    key must have a backing adapter — catches a docs-only addition
+    without runtime support."""
+    adapter_dir = REPO_ROOT / "src" / "agents_shipgate" / "inputs"
+    pattern = re.compile(r'source_type:\s*ClassVar\[str\]\s*=\s*"([^"]+)"')
+    adapter_ids: set[str] = set()
+    for path in adapter_dir.glob("*.py"):
+        adapter_ids.update(
+            pattern.findall(path.read_text(encoding="utf-8"))
+        )
+    user_facing = adapter_ids - INTERNAL_ADAPTERS
+    assert user_facing == set(SUPPORTED_INPUTS), (
+        f"SUPPORTED_INPUTS vs adapter ClassVars disagree.\n"
+        f"  Missing from SUPPORTED_INPUTS: "
+        f"{sorted(user_facing - set(SUPPORTED_INPUTS))}\n"
+        f"  Missing adapter: "
+        f"{sorted(set(SUPPORTED_INPUTS) - user_facing)}\n"
+        f"Adapter ClassVars are the runtime source of truth."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trust-claim qualifier coverage (P0.1)
+# ---------------------------------------------------------------------------
+
+TRUST_CLAIM_PATTERN = re.compile(
+    r"\b(no\s+LLM\s+calls?|no\s+tool\s+calls?|no\s+agent\s+execution|"
+    r"no\s+network(?:\s+access|\s+calls?)?|"
+    r"no\s+MCP\s+server\s+connections|"
+    r"does\s+not\s+(?:invoke|run|call|execute|connect)|no\s+telemetry)\b",
+    re.IGNORECASE,
+)
+TRUST_QUALIFIER_PATTERN = re.compile(
+    r"\b(by\s+default|static[-\s]by[-\s]default|"
+    r"audited\s+exceptions?|allowlist(?:ed)?|"
+    r"ALLOWED_EXCEPTIONS|meta-CLI|bootstrap\s+chain)\b",
+    re.IGNORECASE,
+)
+TRUST_QUALIFIER_WINDOW = 400  # ~one paragraph; matches CONTEXT_WINDOW
+
+TRUST_CLAIM_SURFACES = (
+    "README.md",
+    "AGENTS.md",
+    "STABILITY.md",
+    "llms.txt",
+    "action.yml",
+    "docs/faq.md",
+    "docs/agent-recipes.md",
+    "docs/trust-model.md",
+)
+
+
+@pytest.mark.parametrize("relpath", TRUST_CLAIM_SURFACES)
+def test_trust_claims_carry_meta_cli_qualifier(relpath):
+    """Any 'no LLM calls / no agent execution / does not call …' style
+    claim in a public surface must sit within ~one paragraph of a
+    qualifier (`by default`, `static-by-default`, `ALLOWED_EXCEPTIONS`,
+    `audited exceptions`, `meta-CLI`, `bootstrap chain`). Unqualified
+    claims mislead coding agents that read the surface and conclude
+    Shipgate never shells out."""
+    text = _read(relpath)
+    for match in TRUST_CLAIM_PATTERN.finditer(text):
+        window = text[
+            max(0, match.start() - TRUST_QUALIFIER_WINDOW)
+            : match.end() + TRUST_QUALIFIER_WINDOW
+        ]
+        assert TRUST_QUALIFIER_PATTERN.search(window), (
+            f"{relpath}:{text.count(chr(10), 0, match.start()) + 1} "
+            f"makes an unqualified trust claim {match.group(0)!r}. Add "
+            f"'by default' / 'static-by-default' nearby, or reference "
+            f"ALLOWED_EXCEPTIONS (see STABILITY.md §Meta-CLI surfaces)."
+        )
+
+
+_META_CLI_SECTION_PATTERN = re.compile(
+    r"Meta-CLI\s+surfaces\s+\(allowlisted,\s+audited\)"
+)
+
+
+def test_stability_md_pins_canonical_meta_cli_section_exactly_once():
+    """STABILITY.md is the canonical owner of the meta-CLI exception
+    list. The 'Meta-CLI surfaces (allowlisted, audited)' header must
+    appear exactly once (so other surfaces link or summarize rather
+    than restate), and it must point at ALLOWED_EXCEPTIONS by name —
+    rather than enumerate a partial list that drifts when the test
+    file changes."""
+    text = _read("STABILITY.md")
+    matches = list(_META_CLI_SECTION_PATTERN.finditer(text))
+    assert len(matches) == 1, (
+        f"STABILITY.md must declare 'Meta-CLI surfaces (allowlisted, "
+        f"audited)' exactly once; found {len(matches)}."
+    )
+    section = text[matches[0].start(): matches[0].start() + 2500]
+    assert "ALLOWED_EXCEPTIONS" in section, (
+        "Meta-CLI section must reference "
+        "tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS so the "
+        "audited list lives in code, not duplicated prose."
+    )
+
+
+# ---------------------------------------------------------------------------
+# action.yml legacy-status annotation (P0.1)
+# ---------------------------------------------------------------------------
+
+
+def test_action_yml_status_output_marked_legacy():
+    """outputs.status must carry a 'legacy / v0.7 caller / baseline-blind
+    / prefer release_decision' annotation in a YAML comment immediately
+    above or in the description string. The existing prose-level
+    test_public_surface_does_not_recommend_summary_status_for_gating
+    relies on a 400-char window, which doesn't reach across the
+    structured YAML block — this test pins the annotation explicitly."""
+    text = _read("action.yml")
+    m = re.search(
+        r"outputs:\n(?:[^\n]*\n){0,4}\s*status:\n"
+        r"(?:\s*#[^\n]*\n)*"
+        r"\s*description:\s*([^\n]+)\n",
+        text,
+    )
+    assert m is not None, "outputs.status block not found in action.yml"
+    block = text[max(0, m.start() - 200): m.end()]
+    assert re.search(
+        r"legacy|v0\.7\s+caller|baseline-blind|prefer.*release_decision",
+        block,
+        re.IGNORECASE,
+    ), (
+        "action.yml outputs.status must carry a 'legacy / v0.7 caller / "
+        "baseline-blind / prefer release_decision' annotation so CI "
+        "consumers don't gate on it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prose schema-reference drift guard (P0.1)
+# ---------------------------------------------------------------------------
+
+CURRENT_SCHEMA_PROSE_PATTERN = re.compile(
+    r"schema\s+v(\d+\.\d+)\s*,?\s*current",
+    re.IGNORECASE,
+)
+
+
+@pytest.mark.parametrize("relpath", PUBLIC_SURFACES)
+def test_prose_current_schema_references_match_runtime(relpath):
+    """Any prose phrase like 'schema v0.X, current' must match the
+    runtime report schema. Catches the FAQ-style drift that the
+    filename-based tests miss (e.g. `schema v0.17, current` while the
+    current report schema is v0.18)."""
+    text = _read(relpath)
+    for match in CURRENT_SCHEMA_PROSE_PATTERN.finditer(text):
+        version = match.group(1)
+        assert version == CURRENT_REPORT_SCHEMA_VERSION, (
+            f"{relpath} prose claims 'schema v{version}, current'; "
+            f"runtime is v{CURRENT_REPORT_SCHEMA_VERSION}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Singular-underscore module name (P0.1, tightens forbidden-name coverage)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("relpath", PUBLIC_SURFACES)
+def test_no_singular_underscore_module_name(relpath):
+    """`agent_shipgate` (singular underscore) is always wrong — the
+    correct Python module is `agents_shipgate` (plural). Caught
+    separately from FORBIDDEN_NAME_PATTERN because Python contexts
+    legitimately need `agents_shipgate` to pass."""
+    text = _read(relpath)
+    for m in SINGULAR_UNDERSCORE_PATTERN.finditer(text):
+        line = text[: m.start()].count("\n") + 1
+        raise AssertionError(
+            f"{relpath}:{line} uses singular `agent_shipgate`; the "
+            f"correct Python module is `agents_shipgate` (plural)."
+        )

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -1547,14 +1547,75 @@ def _faq_inputs_block(text: str) -> tuple[set[str], list[str]]:
     return _resolve_tokens(tokens)
 
 
+def _markdown_supported_inputs_section(text: str) -> tuple[set[str], list[str]]:
+    """`## Supported inputs` markdown section → `- bullet` tokens.
+    Used by docs/overview.md and docs/ai-search-summary.md."""
+    block = _slice_section(text, "## Supported inputs", "\n## ")
+    tokens = re.findall(r"^- (.+?)\.?\s*$", block, flags=re.M)
+    return _resolve_tokens(tokens)
+
+
+def _readme_intro_inputs(text: str) -> tuple[set[str], list[str]]:
+    """README intro paragraph (the `It scans …` sentence under the
+    one-line positioning header). Prose, so only the missing direction
+    is enforced — `extra` tokens are the bidirectional adapter test's
+    job."""
+    m = re.search(
+        r"It scans\s+(.+?\.)",
+        text,
+        flags=re.DOTALL,
+    )
+    if not m:
+        return set(), ["<no `It scans` intro sentence found>"]
+    return _resolve_freeform(m.group(1))
+
+
+def _faq_tool_surface_paragraph(text: str) -> tuple[set[str], list[str]]:
+    """`## What is an AI agent tool surface?` answer in docs/faq.md
+    enumerates the same input set in prose. Pin it so it can't drift
+    away from the canonical `## What inputs does it support?` bullet
+    list lower down the same page."""
+    block = _slice_section(
+        text, "## What is an AI agent tool surface?", "\n## "
+    )
+    return _resolve_freeform(block)
+
+
+def _skill_md_intro(text: str) -> tuple[set[str], list[str]]:
+    """The first paragraph of skills/agents-shipgate/SKILL.md
+    enumerates the tool-source list inside parentheses. Prose scan."""
+    m = re.search(r"tool sources \(([^)]+)\)", text)
+    if not m:
+        return set(), ["<no `tool sources (…)` parenthetical found>"]
+    return _resolve_freeform(m.group(1))
+
+
+def _design_partners_good_fit_bullet(text: str) -> tuple[set[str], list[str]]:
+    """`## Good Fit` first bullet enumerates the input set. Prose."""
+    m = re.search(
+        r"- Ships agents that call tools through\s+(.+?\.)",
+        text,
+        flags=re.DOTALL,
+    )
+    if not m:
+        return set(), ["<no `Ships agents that call tools through …` bullet found>"]
+    return _resolve_freeform(m.group(1))
+
+
 INPUT_SURFACES: tuple[tuple[str, object], ...] = (
     (".well-known/agents-shipgate.json", _well_known_input_ids),
     ("llms.txt", _llms_txt_inputs),
     ("AGENTS.md", _agents_md_inputs_bullet),
     ("README.md", _readme_inputs_table),
+    ("README.md", _readme_intro_inputs),
     ("pyproject.toml", _pyproject_description),
     ("action.yml", _action_yml_description),
     ("docs/faq.md", _faq_inputs_block),
+    ("docs/faq.md", _faq_tool_surface_paragraph),
+    ("docs/overview.md", _markdown_supported_inputs_section),
+    ("docs/ai-search-summary.md", _markdown_supported_inputs_section),
+    ("skills/agents-shipgate/SKILL.md", _skill_md_intro),
+    ("docs/design-partners.md", _design_partners_good_fit_bullet),
 )
 
 


### PR DESCRIPTION
## Summary

- Introduce `SUPPORTED_INPUTS` constant in [`schemas/contract.py`](src/agents_shipgate/schemas/contract.py) as the in-code source of truth (10 enum-ids with alias tuples) so every public-facing input list derives from one place.
- Fix live drift on every input-list surface (`.well-known/agents-shipgate.json`, `AGENTS.md`, `llms.txt`, `docs/faq.md`, `pyproject.toml`, `action.yml`): rename `anthropic_messages_api` → `anthropic_api` (aligns with the adapter `source_type` ClassVar), and append the previously-missing `codex_plugin` / `n8n` / `openai_api` references so all 10 supported inputs appear consistently.
- Qualify previously-unqualified trust claims in `action.yml`, `README.md`, and `docs/agent-recipes.md` by linking to the audited `tests/test_adapter_static_only.py::ALLOWED_EXCEPTIONS` list (instead of restating partial subsets).
- Annotate `action.yml` `outputs.status` as legacy v0.7-caller / baseline-blind / "prefer `release_decision.decision`".
- Fix stale `schema v0.17, current` prose in `docs/faq.md` to `v0.18`.
- Add eight new test categories that close gaps the old P0.1 left open: bidirectional `SUPPORTED_INPUTS` ↔ adapter ClassVar pin, per-surface input-list parametrize with unresolved-token detection, canonical-order pin for `.well-known.inputs`, trust-claim qualifier window check, `STABILITY.md` meta-CLI section count==1, `action.yml` legacy-status annotation pin, prose schema-reference drift guard, and a singular-underscore-module-name guard.
- Widen `FORBIDDEN_NAME_PATTERN` to also catch `Agents-Shipgate` and `agents shipgate` per the canonical naming table in `AGENTS.md`.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only

## Verification

CI is authoritative for \`python -m ruff check .\`, \`python -m compileall -q src tests\`, and \`python -m pytest\`.

Additional local checks run:

- \`python -m pytest tests/test_public_surface_contract.py -q\` — **323 passed in 0.79s** (existing 47 tests plus ~25 new parametrizations, all green).
- \`python -m pytest -q\` (full suite) — **1567 passed, 3 skipped in 65.64s**, no regressions.
- \`python scripts/generate_schemas.py --check\` — clean (no schema drift; no schema bump in this PR).
- \`python scripts/build-llms-full.py\` — regenerated \`llms-full.txt\` after the upstream surface edits so the existing \`test_llms_full_is_up_to_date\` keeps passing.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in \`docs/checks.md\` (not applicable — no new checks)
- [x] Report/schema changes are additive or documented in \`STABILITY.md\` (not applicable — no schema changes)

## Notes for the reviewer

- The `.well-known/agents-shipgate.json::inputs` rename of `anthropic_messages_api` → `anthropic_api` is a minor wire-format change. The new name matches the adapter `source_type` ClassVar used everywhere in the codebase (`src/agents_shipgate/inputs/anthropic_api.py:420`); external consumers that pinned the literal string `anthropic_messages_api` will need to update. The bidirectional adapter test ensures we never drift back.
- The trust-claim test (`test_trust_claims_carry_meta_cli_qualifier`) requires "no LLM calls / no agent execution / …" style claims to sit within ~400 chars of a qualifier (`by default`, `static-by-default`, `ALLOWED_EXCEPTIONS`, `audited exceptions`, `meta-CLI`, or `bootstrap chain`). This intentionally reuses STABILITY.md as the canonical owner of the exception list rather than have every doc enumerate a partial subset that drifts.
- `outputs.status` in `action.yml` is preserved unchanged for v0.7 callers; only the description and a YAML comment were added. CI integrations that already use the v0.8+ `decision` output are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)