### PR TITLE
Add n8n detection to zero-install detector

### DIFF
--- a/samples/n8n_workflow_agent/workflows/support-refund.json
+++ b/samples/n8n_workflow_agent/workflows/support-refund.json
@@ -1,0 +1,40 @@
+{
+  "id": "support-refund",
+  "name": "Support Refund Workflow",
+  "nodes": [
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "parameters": {
+        "path": "support-refund",
+        "httpMethod": "POST"
+      }
+    },
+    {
+      "id": "lookup-order",
+      "name": "Lookup Order",
+      "type": "n8n-nodes-base.httpRequest",
+      "parameters": {
+        "url": "https://api.example.com/orders/{{ $json.order_id }}",
+        "method": "GET"
+      }
+    },
+    {
+      "id": "human-approval",
+      "name": "Refund Approval",
+      "type": "n8n-nodes-base.sendAndWait",
+      "parameters": {
+        "operation": "sendAndWait"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{"node": "Lookup Order", "type": "main", "index": 0}]]
+    },
+    "Lookup Order": {
+      "main": [[{"node": "Refund Approval", "type": "main", "index": 0}]]
+    }
+  }
+}

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -71,11 +71,12 @@ PACKAGE_HINTS: dict[str, tuple[str, ...]] = {
     "google_adk": ("google-adk", "google_adk", "google-genai"),
     "anthropic": ("anthropic",),
     "openai_agents_sdk": ("openai-agents", "openai_agents", "agents"),
+    "n8n": ("n8n", "@n8n/n8n-nodes-langchain"),
     "openai_api": (),
 }
 FRAMEWORKS = (
     "langchain", "crewai", "google_adk", "anthropic",
-    "openai_agents_sdk", "openai_api",
+    "openai_agents_sdk", "n8n", "openai_api",
 )
 OPENAPI_PATTERNS = (
     "*openapi*.yaml", "*openapi*.yml", "*openapi*.json",
@@ -84,6 +85,11 @@ OPENAPI_PATTERNS = (
 MCP_PATTERNS = ("*mcp*.json", ".agents-shipgate/*.json")
 ANTHROPIC_TOOL_PATTERNS = ("tools/*anthropic*tools*.json", "tools/anthropic-tools.json")
 ANTHROPIC_POLICY_PATTERNS = ("policies/*anthropic*.yaml", "policies/anthropic-policy.yaml")
+N8N_WORKFLOW_PATTERNS = (
+    "workflows/*.json", "workflows/**/*.json",
+    "n8n/*.json", "n8n/**/*.json",
+    "*workflow*.json",
+)
 OPENAI_API_PATTERNS = (
     ("openai-config.json", "openai-config marker"),
     ("tools/*openai*tools*.json", "openai tool file"),
@@ -144,6 +150,37 @@ def _glob(workspace: Path, files: list[Path], patterns: tuple[str, ...]) -> list
             seen.add(rel)
             found.append(rel)
     return sorted(found)
+
+
+def _looks_like_n8n_workflow(path: Path) -> bool:
+    """Match the CLI heuristic in cli/discovery/artifacts.py: a JSON file
+    is an n8n workflow when it (or any element in a list) is a dict with
+    a ``nodes`` list and ``connections`` dict, and at least one node has
+    a ``type`` starting with ``n8n-nodes-`` or ``@n8n/n8n-nodes-``."""
+    if path.suffix.lower() != ".json":
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    candidates = data if isinstance(data, list) else [data]
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        nodes = item.get("nodes")
+        connections = item.get("connections")
+        if not isinstance(nodes, list) or not isinstance(connections, dict):
+            continue
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            node_type = node.get("type")
+            if isinstance(node_type, str) and (
+                node_type.startswith("n8n-nodes-")
+                or node_type.startswith("@n8n/n8n-nodes-")
+            ):
+                return True
+    return False
 
 
 def _name(node: ast.AST) -> str | None:
@@ -278,6 +315,9 @@ def detect(workspace: Path) -> dict[str, Any]:
     for pattern, label in OPENAI_API_PATTERNS:
         for p in _glob(workspace, files, (pattern,)):
             _add(scores, "openai_api", 2.0, "strong", f"{label}: {p}")
+    for p in _glob(workspace, files, N8N_WORKFLOW_PATTERNS):
+        if _looks_like_n8n_workflow(workspace / p):
+            _add(scores, "n8n", 2.0, "strong", f"n8n workflow: {p}")
 
     present_dirs = [d for d in CONVENTIONAL_DIRS if (workspace / d).is_dir()]
     for fw in FRAMEWORKS:


### PR DESCRIPTION
## Summary

- Adds n8n detection to `tools/shipgate-detect.py` so the zero-install script's structural verdict matches `agents-shipgate detect --json` on n8n workflow projects.
- Mirrors the CLI's `_looks_like_n8n_workflow` heuristic and `N8N_WORKFLOW_PATTERNS` glob set; threads `"n8n"` through `FRAMEWORKS` and `PACKAGE_HINTS`.
- Adds a `samples/n8n_workflow_agent/` fixture (a minimal `workflows/support-refund.json` shaped with `n8n-nodes-base.*` node types plus a `connections` dict) so the parametrized parity test in `tests/test_zero_install_detector.py` exercises the new path.

### Why

The CLI's `detect_workspace` scores n8n workflow JSON as a strong-signal framework hit, but the stdlib-only zero-install script did not. Coding agents that fetch the raw script from GitHub would miss n8n projects and disagree with the canonical CLI on `is_agent_project` / `frameworks` for n8n workspaces — drifting the public contract pinned by the parametrized parity test.

## Type

- [ ] Check or risk-model change
- [x] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/test_zero_install_detector.py -v` → **27 passed, no skips** (including the new `test_script_verdict_matches_cli[n8n_workflow_agent]` and `test_script_finds_at_least_one_python_file_when_cli_does[n8n_workflow_agent]` parametrizations).
- `python -m pytest tests/test_fixture_no_import.py tests/test_zero_install_detector.py tests/test_scan.py tests/test_n8n.py` → 89 passed.
- Spot-checked structural parity: the script's `detect()` output on `samples/n8n_workflow_agent/` is identical to `detect_workspace(...).model_dump(mode='json')` modulo the script-only `script_version` field.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (no check changes)
- [x] Report/schema changes are additive or documented in `STABILITY.md` — N/A (zero-install script output gains `frameworks[].type == "n8n"`, which the parity test already pins as a structural superset of `DetectResult`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)