### PR TITLE
Pin architecture doc contract stamp

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,8 @@
 
 A single-page summary of the `agents-shipgate` codebase for new
 contributors and AI coding agents extending the project. Current as of
-report schema **v0.19** / packet schema **v0.6**.
+2026-05-22; auto-checked against `agents-shipgate contract --json`:
+runtime contract `1`, report schema `v0.20`, packet schema `v0.6`.
 
 For the per-field stability contract, see
 [`../STABILITY.md`](../STABILITY.md). For the agent-facing field index,
@@ -118,6 +119,9 @@ core/findings.build_report         assemble ReadinessReport; internally
                                      ↓
 apply_capability_diff              mutate report from public tools
                                      ↓
+build_reviewer_summary             populate v0.20 reviewer_summary from
+                                   final lens/audit data
+                                     ↓
 report/{markdown,json,sarif}       formatters write to agents-shipgate-reports/
 packet/builder.build_packet        Release Evidence Packet (v0.6) including
                                    the evidence_matrix lens
@@ -214,6 +218,10 @@ For a coding agent reading the report, the one-fetch projection is
 `agent_summary` (v0.12) for the action-driven view and
 `release_decision.contribution_rules[]` (v0.17) for the per-finding
 gate-classification audit.
+
+For reviewer triage, `reviewer_summary` (v0.20) mirrors
+`release_decision.decision` and projects lens/audit activity counts plus
+`first_recommended_surface`.
 
 ## Determinism
 
@@ -431,7 +439,7 @@ contract. Headlines:
 
 - **Manifest schema** stable across `0.x` (`version: "0.1"`).
 - **Report JSON shape** is additive across the `0.x` line. Current
-  `report_schema_version: "0.19"`; older schemas frozen as
+  `report_schema_version: "0.20"`; older schemas frozen as
   `docs/report-schema.v0.N.json`.
 - **Packet JSON shape** is additive across the `0.x` line. Current
   `packet_schema_version: "0.6"`; older schemas frozen.

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -186,6 +186,7 @@ PUBLIC_SURFACES = (
     "docs/faq.md",
     "examples/github-actions/README.md",
     "docs/agent-contract-current.md",
+    "docs/architecture.md",
 )
 
 # Strict superset of PUBLIC_SURFACES that adds files which carry
@@ -386,6 +387,49 @@ def test_agent_contract_current_doc_is_canonical():
         "docs/agent-contract-current.md must reference the current packet "
         f"schema (v{CURRENT_PACKET_SCHEMA_VERSION}) so coding agents know "
         "about the Release Evidence Packet."
+    )
+
+
+def test_architecture_doc_contract_stamp_matches_runtime():
+    """docs/architecture.md is easy to stale-date during schema bumps.
+    Pin its stamp to the runtime contract so CI catches future drift."""
+    text = _read("docs/architecture.md")
+    stamp = re.search(
+        r"Current as of\s+(?P<date>\d{4}-\d{2}-\d{2});\s+"
+        r"auto-checked against `agents-shipgate contract --json`:\s*"
+        r"runtime contract `(?P<contract>[^`]+)`, "
+        r"report schema `v(?P<report>\d+\.\d+)`, "
+        r"packet schema `v(?P<packet>\d+\.\d+)`\.",
+        text,
+    )
+    assert stamp, (
+        "docs/architecture.md must carry a contract stamp in the form "
+        "'Current as of YYYY-MM-DD; auto-checked against "
+        "`agents-shipgate contract --json`: runtime contract `N`, "
+        "report schema `vX.Y`, packet schema `vX.Y`.'"
+    )
+    assert stamp.group("date") == "2026-05-22", (
+        "docs/architecture.md contract-check date must stay pinned to "
+        "2026-05-22 until a deliberate architecture-doc refresh moves it."
+    )
+    assert stamp.group("contract") == CONTRACT_VERSION, (
+        f"docs/architecture.md says runtime contract "
+        f"{stamp.group('contract')!r}; runtime is {CONTRACT_VERSION!r}."
+    )
+    assert stamp.group("report") == CURRENT_REPORT_SCHEMA_VERSION, (
+        f"docs/architecture.md says report schema "
+        f"{stamp.group('report')!r}; runtime is "
+        f"{CURRENT_REPORT_SCHEMA_VERSION!r}."
+    )
+    assert stamp.group("packet") == CURRENT_PACKET_SCHEMA_VERSION, (
+        f"docs/architecture.md says packet schema "
+        f"{stamp.group('packet')!r}; runtime is "
+        f"{CURRENT_PACKET_SCHEMA_VERSION!r}."
+    )
+    assert "reviewer_summary" in text, (
+        "docs/architecture.md must mention the v0.20 reviewer_summary "
+        "surface so architecture readers see the current reviewer lens "
+        "projection."
     )
 
 


### PR DESCRIPTION
## Summary
- Pin `docs/architecture.md` to the 2026-05-22 contract-check date and current runtime contract/schema versions.
- Refresh the stale report schema references from v0.19 to v0.20.
- Add architecture-doc coverage to the public-surface contract tests, including a dedicated stamp check for contract, report schema, packet schema, and `reviewer_summary` context.

## Validation
- `python -m pytest tests/test_public_surface_contract.py tests/test_docs_links.py -q`
- `python -m ruff check .`
- `python -m pytest` (`1751 passed, 4 skipped`)
