### PR TITLE
Raise CI coverage gate 75 → 85 (v0.21 E7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,12 @@ jobs:
         # run as part of the main Test step below.
 
       - name: Test
-        run: python -m pytest --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=75
+        # v0.21 (E7): bumped from 75 → 85. Actual aggregate coverage on
+        # current main is ~88%, so the gate is +10pp tighter with ~3pp
+        # headroom for day-to-day movement. The bump catches the next
+        # time a refactor lands materially less-covered code without
+        # a corresponding test pass.
+        run: python -m pytest --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=85
 
       - name: Build package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,12 @@ jobs:
           python -m pip install "uv==0.11.7"
 
       - name: Lint and test
+        # v0.21 (E7): coverage threshold bumped from 75 → 85, matching
+        # CI gate so release cannot bypass the tighter floor.
         run: |
           python -m ruff check .
           python -m compileall -q src tests
-          python -m pytest --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=75
+          python -m pytest --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=85
 
       - name: Build package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **v0.21 — CI coverage gate raised from 75% → 85% (E7 from round-4 review).**
+  Both `.github/workflows/ci.yml` and `.github/workflows/release.yml` now
+  pass `--cov-fail-under=85`. Aggregate coverage on `main` at the time of
+  the bump is ~88%, so the gate is +10pp tighter with ~3pp headroom for
+  day-to-day movement. The bump catches the next time a refactor lands
+  materially less-covered code without corresponding tests. No source
+  change required to land — the gate is simply closer to the actual
+  signal. Per-file coverage is not enforced; the aggregate floor only
+  rises in step with what's already proven on `main`.
+
 - **v0.20 — third-party adapter entry-point discovery (E4 from round-3 review).**
   Opens the same extension surface for adapters (input loaders) that M5
   already opened for check plugins. Discovery is gated by the existing


### PR DESCRIPTION
## Summary

Round-4 architecture-review item E7: bump the CI coverage gate from `--cov-fail-under=75` to `--cov-fail-under=85` in both `.github/workflows/ci.yml` and `.github/workflows/release.yml`. **No source change.** Aggregate coverage on current `main` measures **88.09%** (re-confirmed locally on this branch), so the gate is +10pp tighter with ~3pp headroom for day-to-day movement.

The bump is a "free signal" upgrade — the gate moves closer to actual signal without forcing any test additions to land it. It catches the next time a refactor lands materially less-covered code without corresponding tests.

## Why now

- Round-3 review (v0.19) flagged: "Coverage threshold still 75% — bump is essentially free (actual 87.87%)."
- Round-4 review (v0.20, current `main`) confirmed: actual coverage is now 88.09%; threshold is still 75%.
- Two reviews of headroom proven on `main`; time to lock the floor closer to actual.

## What changed

- `.github/workflows/ci.yml:48` — `--cov-fail-under=75` → `85`
- `.github/workflows/release.yml:37` — same bump so the release path cannot bypass the tighter floor
- `CHANGELOG.md` — Unreleased entry documenting the bump
- No `src/` change

Per-file coverage is **not enforced** — only the aggregate. Adding a lower-covered module is fine as long as the aggregate stays ≥ 85%.

## Verification

- [x] `python -m pytest --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=85 -q` exits 0; coverage **88.09%**
- [x] `python -m ruff check .` clean
- [x] No source under `src/` touched

## Headroom note

With the threshold at 85 and actual at 88.09%, a single refactor could theoretically drop coverage by 3pp before the gate fires. If that becomes a recurring problem in practice, the next move is per-file thresholds (or `--cov-fail-under-per-file`), not lowering the aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)