### PR TITLE
Promote Action and Scope to first-class typed domain types

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,53 @@ Adding a new wire field: edit the relevant `schemas/<name>.py`, run
 public. The CI step `python scripts/generate_schemas.py --check`
 fails if the committed JSON drifts from the live model.
 
+## Typed domain types: `Scope`, `SideEffect`, `Action`
+
+`core/domain.py` exposes three typed in-memory shapes alongside the
+existing `Tool` / `Agent` / `LoadedToolSource` models:
+
+- **`Scope`** — typed view of a permission scope string, with `raw`,
+  `provider`, `resource`, `verb`. The parser (`Scope.parse`) is
+  permissive (never raises) and handles `provider:resource:verb`
+  (Stripe / AWS / K8s), `provider:resource` (GitHub), and
+  `provider.resource.verb` (OpenAI). Wildcards (`stripe:*`) slot into
+  the resource axis — never the verb axis — and `Scope.is_broad()`
+  delegates to `core.heuristics.is_broad_scope` so all broad-scope
+  checks agree. Frozen.
+- **`SideEffect`** — typed side-effect profile. Single `effect` field
+  (matches `schemas.surfaces.ActionEffect`) plus independently-derivable
+  structural fields: `externally_visible`, `handles_sensitive_data`,
+  `financial`, `code_execution`, `reversibility`, `idempotency_known`.
+  `is_high_risk` is the canonical classifier. Frozen.
+- **`Action`** — typed runtime representation of an action. Mirrors
+  `schemas.surfaces.ActionFact` but with `scopes: list[Scope]` and
+  `side_effect: SideEffect` instead of the wire-shape string-bag.
+
+**Typed accessors in `core/risk_hints.py`:**
+- `parse_scopes(tool: Tool) -> list[Scope]` — order-preserving wrapper
+  over `tool.auth.scopes`.
+- `tool_side_effect(tool: Tool) -> SideEffect` — derives the typed
+  profile; its `effect` field matches `_infer_effect` byte-for-byte.
+- `canonical_risk_tags(tool: Tool) -> list[str]` — risk-tag
+  canonicalization through `CANONICAL_RISK_TAG_MAP` (single source of
+  truth that `_normalized_risk_tags` in `report/action_surface_diff.py`
+  mirrors during the migration window).
+
+**Wire-format invariant.** These types are **in-memory only**. The
+canonical serialized shapes remain `ActionFact.required_scopes:
+list[str]`, `AuthInfo.scopes: list[str]`, and `ActionFact.effect:
+ActionEffect`. `report/action_surface_diff.py` builds a typed `Action`
+first (`build_action(...)`) and then serializes it to `ActionFact`
+(`action_to_fact(...)`) — the legacy `_action_from_tool` is now a
+thin wrapper around this pair. The output is byte-identical, so
+`report_schema_version` and all finding fingerprints stay stable.
+
+The existing string-based predicates in `core/risk_hints.py`
+(`has_risk_tag`, `risk_tags`, `is_effectively_read_only`,
+`is_high_risk_tool`, `is_write_tool`) are unchanged — they remain the
+public API used by every check in `checks/`. New code should prefer
+the typed accessors; legacy callers may migrate incrementally.
+
 ## Reviewer surfaces: five lenses + three audit envelopes
 
 The emitted `report.json` and the Release Evidence Packet expose

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,10 +197,15 @@ existing `Tool` / `Agent` / `LoadedToolSource` models:
   `provider`, `resource`, `verb`. The parser (`Scope.parse`) is
   permissive (never raises) and handles `provider:resource:verb`
   (Stripe / AWS / K8s), `provider:resource` (GitHub), and
-  `provider.resource.verb` (OpenAI). Wildcards (`stripe:*`) slot into
-  the resource axis — never the verb axis — and `Scope.is_broad()`
-  delegates to `core.heuristics.is_broad_scope` so all broad-scope
-  checks agree. Frozen.
+  `provider.resource.verb` (OpenAI). Wildcard slotting is
+  **position-dependent**: 2-part `provider:*` puts the wildcard in
+  the resource axis (2-part scopes have no canonical verb position),
+  3+-part `provider:resource:*` puts it in the verb axis (AWS IAM
+  convention — "all actions on the resource"). Both forms return
+  `Scope.is_broad() == True` (delegated to
+  `core.heuristics.is_broad_scope` so all broad-scope checks agree),
+  and `is_read()` / `is_write()` always return False for a wildcard
+  verb because `"*"` is not a canonical action verb. Frozen.
 - **`SideEffect`** — typed side-effect profile. Single `effect` field
   (matches `schemas.surfaces.ActionEffect`) plus independently-derivable
   structural fields: `externally_visible`, `handles_sensitive_data`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,13 +217,13 @@ existing `Tool` / `Agent` / `LoadedToolSource` models:
   profile; its `effect` field matches `_infer_effect` byte-for-byte.
 - `canonical_risk_tags(tool: Tool) -> list[str]` — risk-tag
   canonicalization through `CANONICAL_RISK_TAG_MAP` (single source of
-  truth that `_normalized_risk_tags` in `report/action_surface_diff.py`
+  truth that `_normalized_risk_tags` in `core/lenses/action_surface.py`
   mirrors during the migration window).
 
 **Wire-format invariant.** These types are **in-memory only**. The
 canonical serialized shapes remain `ActionFact.required_scopes:
 list[str]`, `AuthInfo.scopes: list[str]`, and `ActionFact.effect:
-ActionEffect`. `report/action_surface_diff.py` builds a typed `Action`
+ActionEffect`. `core/lenses/action_surface.py` builds a typed `Action`
 first (`build_action(...)`) and then serializes it to `ActionFact`
 (`action_to_fact(...)`) — the legacy `_action_from_tool` is now a
 thin wrapper around this pair. The output is byte-identical, so

--- a/src/agents_shipgate/core/domain.py
+++ b/src/agents_shipgate/core/domain.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, get_args
+from typing import Any, Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.schemas.common import Confidence, parse_confidence
+from agents_shipgate.schemas.surfaces import ActionEffect
 
 
 class AuthInfo(BaseModel):
@@ -96,3 +98,248 @@ class LoadedToolSource(BaseModel):
     source_type: str
     tools: list[Tool] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Typed Action / Scope / SideEffect domain types.
+#
+# These are *in-memory* representations used by the action-surface and
+# risk-hint machinery. The canonical wire shapes remain:
+#
+# - ``schemas.surfaces.ActionFact`` for action snapshots (extra="forbid").
+# - ``AuthInfo.scopes: list[str]`` and ``ActionFact.required_scopes:
+#   list[str]`` for scope serialization.
+# - ``ActionFact.effect: ActionEffect`` + ``risk_tags: list[str]`` for
+#   side-effect serialization.
+#
+# Adding these types is purely additive — no field on any wire model
+# changes, and ``report_schema_version`` does not bump.
+# ---------------------------------------------------------------------------
+
+
+# Verb tokens recognized when parsing a scope's verb position. Read/write
+# subsets drive ``Scope.is_read`` / ``Scope.is_write`` without forcing a
+# strict format on user scope strings — unknown verbs leave both as False.
+_SCOPE_VERB_TOKENS: frozenset[str] = frozenset(
+    {
+        "*",
+        "admin",
+        "all",
+        "create",
+        "delete",
+        "destroy",
+        "execute",
+        "get",
+        "list",
+        "manage",
+        "read",
+        "run",
+        "update",
+        "view",
+        "write",
+    }
+)
+_SCOPE_READ_VERBS: frozenset[str] = frozenset({"get", "list", "read", "view"})
+_SCOPE_WRITE_VERBS: frozenset[str] = frozenset(
+    {"admin", "create", "delete", "destroy", "execute", "manage", "run", "update", "write"}
+)
+
+
+class Scope(BaseModel):
+    """Typed view of a permission scope string.
+
+    The canonical wire form is the original ``raw`` string — this type
+    is the in-memory derivation used for matching and least-privilege
+    reasoning. The parser is permissive: it never raises, and unknown
+    shapes fall back to a single-``provider`` form.
+
+    Supported shapes:
+
+    - ``provider:resource:verb``    — Stripe-, AWS-, K8s-style triples.
+    - ``provider:resource``         — GitHub-style ``repo:status``.
+    - ``provider.resource.verb``    — OpenAI / dot-separated APIs.
+    - ``provider:*``                — wildcard verb (``Scope.is_broad`` is True).
+    - ``admin``, ``*``              — broad tokens (no structural parts).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    raw: str
+    provider: str | None = None
+    resource: str | None = None
+    verb: str | None = None
+
+    @classmethod
+    def parse(cls, raw: str) -> Scope:
+        """Parse a scope string into typed parts. Never raises."""
+        raw_str = (raw or "").strip()
+        if not raw_str:
+            return cls(raw="")
+        normalized = raw_str.lower()
+        # Broad single-token short-circuits — keep structural parts empty
+        # so least-privilege checks don't try to match by provider.
+        if normalized in {"*", "admin"}:
+            return cls(raw=raw_str)
+        if ":" in raw_str:
+            return cls._from_parts(raw_str, raw_str.split(":"))
+        if "." in raw_str:
+            return cls._from_parts(raw_str, raw_str.split("."))
+        if "/" in raw_str:
+            return cls._from_parts(raw_str, raw_str.split("/"))
+        return cls(raw=raw_str, provider=raw_str)
+
+    @classmethod
+    def _from_parts(cls, raw: str, parts: list[str]) -> Scope:
+        cleaned = [part.strip() for part in parts if part.strip()]
+        if not cleaned:
+            return cls(raw=raw)
+        if len(cleaned) == 1:
+            if cleaned[0] == "*":
+                return cls(raw=raw)
+            return cls(raw=raw, provider=cleaned[0])
+        # Wildcards are not action verbs — they always slot into the
+        # resource axis (e.g. ``"stripe:*"`` means "broad on stripe",
+        # not "stripe with verb=*"). ``is_broad()`` still flags them
+        # through ``core.heuristics.is_broad_scope``.
+        if len(cleaned) == 2:
+            if cleaned[-1] == "*":
+                return cls(raw=raw, provider=cleaned[0], resource="*")
+            tail = cleaned[-1].lower()
+            if tail in _SCOPE_VERB_TOKENS:
+                return cls(raw=raw, provider=cleaned[0], verb=cleaned[-1])
+            return cls(raw=raw, provider=cleaned[0], resource=cleaned[-1])
+        # 3+ parts: provider is first; the tail position is a verb only
+        # when it is a known verb token and not a wildcard.
+        provider = cleaned[0]
+        if cleaned[-1] == "*":
+            resource = ":".join(cleaned[1:-1]) if len(cleaned) > 2 else None
+            return cls(raw=raw, provider=provider, resource=resource, verb="*")
+        tail = cleaned[-1].lower()
+        if tail in _SCOPE_VERB_TOKENS:
+            resource = ":".join(cleaned[1:-1]) if len(cleaned) > 2 else None
+            return cls(raw=raw, provider=provider, resource=resource, verb=cleaned[-1])
+        return cls(raw=raw, provider=provider, resource=":".join(cleaned[1:]))
+
+    def is_broad(self) -> bool:
+        """True for wildcard / admin-equivalent scope strings.
+
+        Delegates to ``core.heuristics.is_broad_scope`` so manifest-level
+        broad-scope checks and per-scope checks agree on the rule.
+        """
+        return is_broad_scope(self.raw)
+
+    def is_write(self) -> bool:
+        verb = (self.verb or "").lower()
+        return verb in _SCOPE_WRITE_VERBS
+
+    def is_read(self) -> bool:
+        verb = (self.verb or "").lower()
+        return verb in _SCOPE_READ_VERBS
+
+    def __str__(self) -> str:
+        return self.raw
+
+
+# Effect tiers that always count as high-risk regardless of risk-tag set.
+# Mirrors the catalog used by ``report/action_surface_diff.py`` for
+# severity classification; kept here so domain-level reasoning matches.
+_HIGH_RISK_EFFECTS: frozenset[str] = frozenset(
+    {
+        "code_execution",
+        "destructive",
+        "external_communication",
+        "financial_write",
+        "identity_access",
+        "production_operation",
+    }
+)
+
+
+class SideEffect(BaseModel):
+    """Typed side-effect profile of an Action / Tool.
+
+    Replaces the ``risk_tags: list[str]`` string-bag pattern by capturing
+    each independently-derivable side-effect property in its own field.
+    The flat ``risk_tags`` list remains the wire representation; this
+    type is the in-memory view used by checks and the diff machinery.
+
+    ``effect`` is the canonical effect tier (matches
+    ``schemas.surfaces.ActionEffect``). The remaining boolean fields are
+    structural facts that are independent of the effect tier — a tool
+    can be both ``effect="write"`` and ``handles_sensitive_data=True``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    effect: ActionEffect
+    externally_visible: bool = False
+    handles_sensitive_data: bool = False
+    financial: bool = False
+    code_execution: bool = False
+    reversibility: Literal["reversible", "irreversible", "unknown"] = "unknown"
+    idempotency_known: bool | None = None
+
+    @property
+    def is_high_risk(self) -> bool:
+        """Canonical high-risk classifier for severity / gating."""
+        if self.effect in _HIGH_RISK_EFFECTS:
+            return True
+        return self.financial or self.code_execution
+
+
+class Action(BaseModel):
+    """Typed runtime representation of an Action.
+
+    Mirror of ``schemas.surfaces.ActionFact`` with two upgrades:
+
+    - ``scopes: list[Scope]`` instead of ``list[str]`` — typed view for
+      least-privilege reasoning and broad-scope detection.
+    - ``side_effect: SideEffect`` instead of a string-bag mix of
+      ``effect`` + ``risk_tags`` — typed view for severity logic.
+
+    ``risk_tags`` is retained as a parallel ``list[str]`` so the typed
+    Action serializes cleanly back to the wire ``ActionFact`` shape via
+    ``report.action_surface_diff.action_to_fact``. Outside the action-
+    surface pipeline, code should prefer ``side_effect`` for branching.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    action_id: str
+    agent_id: str
+    tool_id: str
+    tool_name: str
+    provider: str
+    source_type: str
+    source_id: str | None = None
+    operation: str
+    side_effect: SideEffect
+    risk_tags: list[str] = Field(default_factory=list)
+    scopes: list[Scope] = Field(default_factory=list)
+    approval_required: bool | None = None
+    approval_threshold: str | None = None
+    safeguard_idempotency: bool | None = None
+    safeguard_audit_log: bool | None = None
+    safeguard_rollback: bool | None = None
+    safeguard_dry_run: bool | None = None
+    evidence_owner: str | None = None
+    evidence_runbook: str | None = None
+    evidence_approval_ticket: str | None = None
+    input_fields: list[str] = Field(default_factory=list)
+    required_input_fields: list[str] = Field(default_factory=list)
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+    parameters_for_hash: list[dict[str, Any]] = Field(default_factory=list)
+
+    @property
+    def scope_strings(self) -> list[str]:
+        """Wire-format projection of ``scopes`` — preserves user input order."""
+        return [scope.raw for scope in self.scopes]
+
+    @property
+    def has_broad_scope(self) -> bool:
+        return any(scope.is_broad() for scope in self.scopes)
+
+    @property
+    def effect(self) -> ActionEffect:
+        """Convenience alias — matches ``ActionFact.effect``."""
+        return self.side_effect.effect

--- a/src/agents_shipgate/core/domain.py
+++ b/src/agents_shipgate/core/domain.py
@@ -158,8 +158,15 @@ class Scope(BaseModel):
     - ``provider:resource:verb``    — Stripe-, AWS-, K8s-style triples.
     - ``provider:resource``         — GitHub-style ``repo:status``.
     - ``provider.resource.verb``    — OpenAI / dot-separated APIs.
-    - ``provider:*``                — wildcard verb (``Scope.is_broad`` is True).
+    - ``provider:*``                — broad on resource (``Scope.is_broad`` is True).
+    - ``provider:resource:*``       — broad on verb (AWS-style; ``Scope.is_broad`` is True).
     - ``admin``, ``*``              — broad tokens (no structural parts).
+
+    Wildcard slotting is **position-dependent** — the wildcard occupies
+    whatever slot it would naturally fill by position. ``is_broad()``
+    returns True regardless of which slot it ended up in, and
+    ``is_read()`` / ``is_write()`` always return False for a wildcard
+    verb because ``"*"`` is not a canonical action verb.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -197,10 +204,23 @@ class Scope(BaseModel):
             if cleaned[0] == "*":
                 return cls(raw=raw)
             return cls(raw=raw, provider=cleaned[0])
-        # Wildcards are not action verbs — they always slot into the
-        # resource axis (e.g. ``"stripe:*"`` means "broad on stripe",
-        # not "stripe with verb=*"). ``is_broad()`` still flags them
-        # through ``core.heuristics.is_broad_scope``.
+        # Wildcard slotting is position-dependent — the wildcard always
+        # occupies the slot that part would naturally occupy by position:
+        #
+        # - 2-part ``provider:*`` → resource is ``"*"``, verb is ``None``.
+        #   2-part scopes have no canonical verb position, so the trailing
+        #   token is treated as a resource regardless of value.
+        # - 3+-part ``provider:resource:*`` → resource is concrete, verb is
+        #   ``"*"``. This matches AWS IAM / GCP-style wildcards where the
+        #   action axis is the rightmost position (``s3:bucket:*`` means
+        #   "all actions on the bucket").
+        #
+        # In every case ``is_broad()`` returns True via
+        # ``core.heuristics.is_broad_scope`` regardless of which slot the
+        # wildcard ended up in, so least-privilege gating is unaffected
+        # by the slot choice. ``is_read()``/``is_write()`` always return
+        # False for ``verb="*"`` because ``"*"`` is not in the
+        # _SCOPE_READ_VERBS / _SCOPE_WRITE_VERBS sets.
         if len(cleaned) == 2:
             if cleaned[-1] == "*":
                 return cls(raw=raw, provider=cleaned[0], resource="*")
@@ -208,8 +228,7 @@ class Scope(BaseModel):
             if tail in _SCOPE_VERB_TOKENS:
                 return cls(raw=raw, provider=cleaned[0], verb=cleaned[-1])
             return cls(raw=raw, provider=cleaned[0], resource=cleaned[-1])
-        # 3+ parts: provider is first; the tail position is a verb only
-        # when it is a known verb token and not a wildcard.
+        # 3+ parts.
         provider = cleaned[0]
         if cleaned[-1] == "*":
             resource = ":".join(cleaned[1:-1]) if len(cleaned) > 2 else None
@@ -241,8 +260,20 @@ class Scope(BaseModel):
 
 
 # Effect tiers that always count as high-risk regardless of risk-tag set.
-# Mirrors the catalog used by ``report/action_surface_diff.py`` for
-# severity classification; kept here so domain-level reasoning matches.
+# Mirrors the catalog used by ``core/lenses/action_surface.py`` for
+# severity classification AND the legacy ``core.risk_hints.HIGH_RISK_TAGS``
+# set (the canonical-mapped versions) so the typed ``SideEffect.is_high_risk``
+# never under-reports relative to the legacy ``is_high_risk_tool``
+# predicate. The mapping back to legacy tags:
+#
+# - destructive             ← destructive
+# - external_communication  ← external_write / customer_communication
+# - financial_write         ← financial_action
+# - production_operation    ← infrastructure_change → production_ops
+# - code_execution          ← code_execution
+# - privileged_data_access  ← sensitive_data_access → privileged_data
+# - identity_access         ← (not in legacy HIGH_RISK_TAGS; typed-only
+#                              escalation, strictly more conservative)
 _HIGH_RISK_EFFECTS: frozenset[str] = frozenset(
     {
         "code_execution",
@@ -250,6 +281,7 @@ _HIGH_RISK_EFFECTS: frozenset[str] = frozenset(
         "external_communication",
         "financial_write",
         "identity_access",
+        "privileged_data_access",
         "production_operation",
     }
 )
@@ -281,10 +313,19 @@ class SideEffect(BaseModel):
 
     @property
     def is_high_risk(self) -> bool:
-        """Canonical high-risk classifier for severity / gating."""
+        """Canonical high-risk classifier for severity / gating.
+
+        Maintains the invariant that
+        ``tool_side_effect(tool).is_high_risk`` is True whenever the
+        legacy ``core.risk_hints.is_high_risk_tool(tool)`` is True.
+        Both ``effect`` and the structural fields contribute so that a
+        tool whose declared effect tier is lower than its
+        ``handles_sensitive_data`` / ``financial`` / ``code_execution``
+        signals still classifies as high-risk.
+        """
         if self.effect in _HIGH_RISK_EFFECTS:
             return True
-        return self.financial or self.code_execution
+        return self.financial or self.code_execution or self.handles_sensitive_data
 
 
 class Action(BaseModel):
@@ -299,7 +340,7 @@ class Action(BaseModel):
 
     ``risk_tags`` is retained as a parallel ``list[str]`` so the typed
     Action serializes cleanly back to the wire ``ActionFact`` shape via
-    ``report.action_surface_diff.action_to_fact``. Outside the action-
+    ``core.lenses.action_surface.action_to_fact``. Outside the action-
     surface pipeline, code should prefer ``side_effect`` for branching.
     """
 

--- a/src/agents_shipgate/core/lenses/action_surface.py
+++ b/src/agents_shipgate/core/lenses/action_surface.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import unquote
 
-from agents_shipgate.core.domain import Tool
+from agents_shipgate.core.domain import Action, Scope, SideEffect, Tool
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.core.lenses.tool_surface import ToolSurfaceDiffReference, _stable_hash
@@ -313,13 +313,24 @@ def action_reference_from_scan_reference(
     )
 
 
-def _action_from_tool(
+def build_action(
     manifest: AgentsShipgateManifest,
     *,
     agent_id: str,
     tool: Tool,
     declaration: ActionDeclarationConfig | None,
-) -> ActionFact:
+) -> Action:
+    """Build the typed ``Action`` for a tool + optional declaration.
+
+    Single source of truth for action construction. ``_action_from_tool``
+    delegates here, then serializes the typed Action to ``ActionFact``
+    via ``action_to_fact``. The two-step shape lets callers that want a
+    typed view (future checks, follow-up refactors) bypass the wire
+    serialization entirely.
+
+    The output is deterministic: same inputs always produce the same
+    Action, including ``risk_tags`` and ``scopes`` ordering.
+    """
     provider = _provider(tool, declaration)
     operation = _operation(tool, declaration)
     action_id = (
@@ -333,11 +344,15 @@ def _action_from_tool(
         if declaration and declaration.risk_tags
         else inferred_tags
     )
-    scopes = (
+    scope_strings = (
         _normalize_strings(declaration.scopes)
         if declaration and declaration.scopes
         else _normalize_strings(tool.auth.scopes)
     )
+    # Wire-format effect (string) follows the declaration override, then
+    # falls back to the legacy ``_infer_effect`` so byte-identical hashes
+    # are preserved during the migration window. The typed ``SideEffect``
+    # built below carries the same effect plus structural fields.
     effect = (
         declaration.effect
         if declaration and declaration.effect
@@ -350,10 +365,89 @@ def _action_from_tool(
     required_input_fields = sorted(
         {parameter.name for parameter in tool.parameters if parameter.required}
     )
+    side_effect = SideEffect(
+        effect=effect,
+        externally_visible=(
+            "external_communication" in risk_tag_values
+            or "writes_data" in risk_tag_values
+            or effect in {"destructive", "financial_write", "external_communication"}
+        ),
+        handles_sensitive_data=(
+            "privileged_data" in risk_tag_values or "secret_access" in risk_tag_values
+        ),
+        financial="financial_write" in risk_tag_values,
+        code_execution="code_execution" in risk_tag_values,
+        reversibility=(
+            "irreversible"
+            if "destructive" in risk_tag_values or "irreversible" in risk_tag_values
+            else "reversible"
+            if "read_only" in risk_tag_values and "writes_data" not in risk_tag_values
+            else "unknown"
+        ),
+        idempotency_known=(safeguards.idempotency if safeguards.idempotency else None),
+    )
+    return Action(
+        action_id=action_id,
+        agent_id=agent_id,
+        tool_id=tool.id,
+        tool_name=tool.name,
+        provider=provider,
+        source_type=tool.source_type,
+        source_id=tool.source_id,
+        operation=operation,
+        side_effect=side_effect,
+        risk_tags=risk_tag_values,
+        scopes=[Scope.parse(raw) for raw in scope_strings],
+        approval_required=approval.required,
+        approval_threshold=approval.threshold,
+        safeguard_idempotency=safeguards.idempotency,
+        safeguard_audit_log=safeguards.audit_log,
+        safeguard_rollback=safeguards.rollback,
+        safeguard_dry_run=safeguards.dry_run,
+        evidence_owner=evidence.owner,
+        evidence_runbook=evidence.runbook,
+        evidence_approval_ticket=evidence.approval_ticket,
+        input_fields=input_fields,
+        required_input_fields=required_input_fields,
+        input_schema=tool.input_schema,
+        parameters_for_hash=[
+            parameter.model_dump(mode="json") for parameter in tool.parameters
+        ],
+    )
+
+
+def action_to_fact(action: Action) -> ActionFact:
+    """Serialize a typed ``Action`` to its wire-shape ``ActionFact``.
+
+    Hashes are computed here (not on ``Action``) because:
+
+    - The ``ActionFact`` shape is the canonical hash input — any future
+      typed-Action enrichment must not alter what gets hashed.
+    - Hashes are a serialization concern, not a domain concern.
+
+    Byte-identical to the legacy ``_action_from_tool`` body for any
+    Action built via ``build_action``; pinned by
+    ``tests/test_action_surface_diff.py`` golden assertions.
+    """
+    approval = ActionApprovalFact(
+        required=action.approval_required,
+        threshold=action.approval_threshold,
+    )
+    safeguards = ActionSafeguardsFact(
+        idempotency=action.safeguard_idempotency,
+        audit_log=action.safeguard_audit_log,
+        rollback=action.safeguard_rollback,
+        dry_run=action.safeguard_dry_run,
+    )
+    evidence = ActionEvidenceFact(
+        owner=action.evidence_owner,
+        runbook=action.evidence_runbook,
+        approval_ticket=action.evidence_approval_ticket,
+    )
     schema_hash = _stable_hash(
         {
-            "input_schema": tool.input_schema,
-            "parameters": [parameter.model_dump(mode="json") for parameter in tool.parameters],
+            "input_schema": action.input_schema,
+            "parameters": action.parameters_for_hash,
         }
     )
     policy_hash = _stable_hash(
@@ -365,35 +459,54 @@ def _action_from_tool(
     )
     risk_hash = _stable_hash(
         {
-            "effect": effect,
-            "risk_tags": risk_tag_values,
-            "required_scopes": scopes,
+            "effect": action.effect,
+            "risk_tags": action.risk_tags,
+            "required_scopes": action.scope_strings,
         }
     )
     return ActionFact(
-        action_id=action_id,
-        agent_id=agent_id,
-        tool_id=tool.id,
-        tool_name=tool.name,
-        provider=provider,
-        source_type=tool.source_type,
-        source_id=tool.source_id,
-        operation=operation,
-        effect=effect,
-        risk_tags=risk_tag_values,
-        required_scopes=scopes,
+        action_id=action.action_id,
+        agent_id=action.agent_id,
+        tool_id=action.tool_id,
+        tool_name=action.tool_name,
+        provider=action.provider,
+        source_type=action.source_type,
+        source_id=action.source_id,
+        operation=action.operation,
+        effect=action.effect,
+        risk_tags=action.risk_tags,
+        required_scopes=action.scope_strings,
         approval_policy=approval,
         safeguards=safeguards,
         evidence=evidence,
-        input_fields=input_fields,
-        required_input_fields=required_input_fields,
+        input_fields=action.input_fields,
+        required_input_fields=action.required_input_fields,
         input_schema_hash=schema_hash,
         hashes=ActionSurfaceHashes(
-            identity_hash=_stable_hash(action_id),
+            identity_hash=_stable_hash(action.action_id),
             schema_hash=schema_hash,
             policy_hash=policy_hash,
             risk_hash=risk_hash,
         ),
+    )
+
+
+def _action_from_tool(
+    manifest: AgentsShipgateManifest,
+    *,
+    agent_id: str,
+    tool: Tool,
+    declaration: ActionDeclarationConfig | None,
+) -> ActionFact:
+    """Backward-compatible wrapper: build typed Action, then serialize.
+
+    Kept as the entry point used by ``build_action_surface_facts`` so
+    external callers and tests that import this private symbol keep
+    working byte-for-byte. New call sites should prefer ``build_action``
+    directly to get the typed view.
+    """
+    return action_to_fact(
+        build_action(manifest, agent_id=agent_id, tool=tool, declaration=declaration)
     )
 
 

--- a/src/agents_shipgate/core/lenses/action_surface.py
+++ b/src/agents_shipgate/core/lenses/action_surface.py
@@ -6,11 +6,15 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import unquote
 
-from agents_shipgate.core.domain import Action, Scope, SideEffect, Tool
+from agents_shipgate.core.domain import Action, Scope, Tool
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.core.lenses.tool_surface import ToolSurfaceDiffReference, _stable_hash
-from agents_shipgate.core.risk_hints import is_effectively_read_only, risk_tags
+from agents_shipgate.core.risk_hints import (
+    derive_side_effect,
+    is_effectively_read_only,
+    risk_tags,
+)
 from agents_shipgate.schemas.common import (
     Severity,
     SourceReference,
@@ -365,25 +369,16 @@ def build_action(
     required_input_fields = sorted(
         {parameter.name for parameter in tool.parameters if parameter.required}
     )
-    side_effect = SideEffect(
+    # Route through the shared ``derive_side_effect`` helper so the
+    # tool-context path (``tool_side_effect(tool)``) and this manifest-
+    # context path cannot drift on structural-field derivation. The
+    # helper also feeds ``effect`` into every structural field, so a
+    # manifest declaring ``effect: financial_write`` with no matching
+    # ``risk_tags`` still yields ``financial=True``,
+    # ``externally_visible=True``, and ``is_high_risk=True``.
+    side_effect = derive_side_effect(
         effect=effect,
-        externally_visible=(
-            "external_communication" in risk_tag_values
-            or "writes_data" in risk_tag_values
-            or effect in {"destructive", "financial_write", "external_communication"}
-        ),
-        handles_sensitive_data=(
-            "privileged_data" in risk_tag_values or "secret_access" in risk_tag_values
-        ),
-        financial="financial_write" in risk_tag_values,
-        code_execution="code_execution" in risk_tag_values,
-        reversibility=(
-            "irreversible"
-            if "destructive" in risk_tag_values or "irreversible" in risk_tag_values
-            else "reversible"
-            if "read_only" in risk_tag_values and "writes_data" not in risk_tag_values
-            else "unknown"
-        ),
+        risk_tags=risk_tag_values,
         idempotency_known=(safeguards.idempotency if safeguards.idempotency else None),
     )
     return Action(

--- a/src/agents_shipgate/core/risk_hints.py
+++ b/src/agents_shipgate/core/risk_hints.py
@@ -4,6 +4,8 @@ import re
 from collections.abc import Iterable
 
 from agents_shipgate.core.domain import (
+    Scope,
+    SideEffect,
     Tool,
     ToolRiskHint,
 )
@@ -12,6 +14,7 @@ from agents_shipgate.schemas.common import (
     parse_confidence,
 )
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.surfaces import ActionEffect
 
 HIGH_RISK_TAGS = {
     "destructive",
@@ -298,3 +301,164 @@ def _add_hint(
             evidence={key: value for key, value in evidence.items() if value is not None},
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# Typed accessors for the new ``Scope`` and ``SideEffect`` domain types.
+#
+# These are additive — every legacy string-based predicate above keeps its
+# signature and behavior. The typed views below are derived from the same
+# underlying ``tool.risk_hints`` + ``tool.auth.scopes`` + ``tool.annotations``
+# data, so they cannot disagree with the string predicates.
+# ---------------------------------------------------------------------------
+
+
+# Risk-tag canonicalization. Several historical synonyms exist in
+# ``ToolRiskHint.tag`` (``write`` vs ``writes_data``, ``external_write`` vs
+# ``customer_communication`` vs ``external_communication``, etc.) — collapse
+# them to a single canonical name so downstream effect inference and
+# SideEffect derivation use one vocabulary. This mirrors
+# ``report/action_surface_diff.py::_RISK_TAG_MAP``; the duplication is
+# intentional during the migration window, and a follow-up PR can collapse
+# the action-surface site onto this constant.
+CANONICAL_RISK_TAG_MAP: dict[str, str] = {
+    "read_only": "read_only",
+    "write": "writes_data",
+    "writes_data": "writes_data",
+    "external_write": "external_communication",
+    "external_communication": "external_communication",
+    "customer_communication": "external_communication",
+    "financial_action": "financial_write",
+    "financial_write": "financial_write",
+    "external_side_effect": "external_communication",
+    "destructive": "destructive",
+    "infrastructure_change": "production_ops",
+    "production_operation": "production_ops",
+    "production_ops": "production_ops",
+    "sensitive_data_access": "privileged_data",
+    "privileged_data_access": "privileged_data",
+    "privileged_data": "privileged_data",
+    "code_execution": "code_execution",
+    "identity_access": "identity_access",
+    "network_access": "network_access",
+    "filesystem_write": "filesystem_write",
+    "customer_data": "customer_data",
+    "secret_access": "secret_access",
+    "irreversible": "irreversible",
+}
+
+
+def canonical_risk_tags(tool: Tool, min_confidence: str | None = None) -> list[str]:
+    """Return ``tool.risk_hints`` tags canonicalized through ``CANONICAL_RISK_TAG_MAP``.
+
+    Always includes ``read_only`` when ``is_effectively_read_only(tool)`` is
+    True, so the caller doesn't need to special-case the read-only path.
+    """
+    threshold = confidence_rank(min_confidence) if min_confidence else 0
+    tags = {
+        CANONICAL_RISK_TAG_MAP.get(hint.tag, hint.tag)
+        for hint in tool.risk_hints
+        if confidence_rank(hint.confidence) >= threshold
+    }
+    if is_effectively_read_only(tool):
+        tags.add("read_only")
+    return sorted(tags)
+
+
+def parse_scopes(tool: Tool) -> list[Scope]:
+    """Return the tool's declared auth scopes as typed ``Scope`` values.
+
+    Order is preserved from ``tool.auth.scopes`` so wire-shape round-trips
+    are predictable. Empty / whitespace-only strings are dropped.
+    """
+    return [Scope.parse(raw) for raw in tool.auth.scopes if raw and raw.strip()]
+
+
+def tool_side_effect(tool: Tool) -> SideEffect:
+    """Derive a typed ``SideEffect`` from the tool's risk hints + annotations.
+
+    Single source of truth for effect inference: this function and
+    ``report/action_surface_diff.py::_infer_effect`` must agree on the
+    final ``effect`` value for any given tool. The action-surface site
+    delegates to this in Phase C; until then both implementations live
+    side-by-side and a Phase D test pins their agreement.
+    """
+    tags = set(canonical_risk_tags(tool))
+    method = str(tool.annotations.get("httpMethod") or "").upper()
+
+    effect = _derive_effect(tags, method)
+    externally_visible = (
+        "external_communication" in tags
+        or "writes_data" in tags
+        or effect in {"destructive", "financial_write", "external_communication"}
+    )
+    handles_sensitive_data = "privileged_data" in tags or "secret_access" in tags
+    financial = "financial_write" in tags
+    code_execution = "code_execution" in tags
+    reversibility = _derive_reversibility(tags, method)
+    idempotency_known = _derive_idempotency_known(tool)
+
+    return SideEffect(
+        effect=effect,
+        externally_visible=externally_visible,
+        handles_sensitive_data=handles_sensitive_data,
+        financial=financial,
+        code_execution=code_execution,
+        reversibility=reversibility,
+        idempotency_known=idempotency_known,
+    )
+
+
+def _derive_effect(tags: set[str], method: str) -> ActionEffect:
+    """Effect-tier inference.
+
+    Mirrors ``report/action_surface_diff.py::_infer_effect`` exactly so
+    Phase C can delete the duplicate. The ordering is significant —
+    destructive > financial_write > external_communication > production_ops
+    > code_execution > identity_access > privileged_data_access > write
+    > read — and matches the documented severity escalation rules.
+    """
+    if "destructive" in tags:
+        return "destructive"
+    if "financial_write" in tags:
+        return "financial_write"
+    if "external_communication" in tags:
+        return "external_communication"
+    if "production_ops" in tags:
+        return "production_operation"
+    if "code_execution" in tags:
+        return "code_execution"
+    if "identity_access" in tags:
+        return "identity_access"
+    if "privileged_data" in tags:
+        return "privileged_data_access"
+    if "writes_data" in tags:
+        return "write"
+    if method in {"POST", "PUT", "PATCH"}:
+        return "write"
+    if method == "DELETE":
+        return "destructive"
+    return "read"
+
+
+def _derive_reversibility(tags: set[str], method: str) -> str:
+    if "destructive" in tags or "irreversible" in tags or method == "DELETE":
+        return "irreversible"
+    if "read_only" in tags and "writes_data" not in tags:
+        return "reversible"
+    return "unknown"
+
+
+def _derive_idempotency_known(tool: Tool) -> bool | None:
+    """Three-state: True / False / None (unknown).
+
+    ``True`` when an idempotency signal is declared (hint, key parameter,
+    explicit annotation); ``False`` is reserved for cases where we
+    know the tool is *not* idempotent (none today — kept for future
+    runtime evidence); ``None`` otherwise.
+    """
+    if tool.annotations.get("idempotentHint") is True:
+        return True
+    if any(parameter.name == "idempotency_key" for parameter in tool.parameters):
+        return True
+    return None

--- a/src/agents_shipgate/core/risk_hints.py
+++ b/src/agents_shipgate/core/risk_hints.py
@@ -318,7 +318,7 @@ def _add_hint(
 # ``customer_communication`` vs ``external_communication``, etc.) — collapse
 # them to a single canonical name so downstream effect inference and
 # SideEffect derivation use one vocabulary. This mirrors
-# ``report/action_surface_diff.py::_RISK_TAG_MAP``; the duplication is
+# ``core/lenses/action_surface.py::_RISK_TAG_MAP``; the duplication is
 # intentional during the migration window, and a follow-up PR can collapse
 # the action-surface site onto this constant.
 CANONICAL_RISK_TAG_MAP: dict[str, str] = {
@@ -377,34 +377,87 @@ def parse_scopes(tool: Tool) -> list[Scope]:
 def tool_side_effect(tool: Tool) -> SideEffect:
     """Derive a typed ``SideEffect`` from the tool's risk hints + annotations.
 
-    Single source of truth for effect inference: this function and
-    ``report/action_surface_diff.py::_infer_effect`` must agree on the
-    final ``effect`` value for any given tool. The action-surface site
-    delegates to this in Phase C; until then both implementations live
-    side-by-side and a Phase D test pins their agreement.
+    Single source of truth for tool-context effect inference: this
+    function and ``core/lenses/action_surface.py::_infer_effect`` must
+    agree on the final ``effect`` value for any given tool. The
+    structural-field derivation is delegated to ``derive_side_effect``
+    so the action-surface path (which may override ``effect`` via a
+    manifest declaration) cannot drift from this tool-context path.
     """
     tags = set(canonical_risk_tags(tool))
     method = str(tool.annotations.get("httpMethod") or "").upper()
-
     effect = _derive_effect(tags, method)
-    externally_visible = (
-        "external_communication" in tags
-        or "writes_data" in tags
-        or effect in {"destructive", "financial_write", "external_communication"}
+    return derive_side_effect(
+        effect=effect,
+        risk_tags=tags,
+        idempotency_known=_derive_idempotency_known(tool),
     )
-    handles_sensitive_data = "privileged_data" in tags or "secret_access" in tags
-    financial = "financial_write" in tags
-    code_execution = "code_execution" in tags
-    reversibility = _derive_reversibility(tags, method)
-    idempotency_known = _derive_idempotency_known(tool)
 
+
+def derive_side_effect(
+    *,
+    effect: ActionEffect,
+    risk_tags: list[str] | set[str],
+    idempotency_known: bool | None = None,
+) -> SideEffect:
+    """Single source of truth for ``SideEffect`` construction.
+
+    Used by ``tool_side_effect`` (tool-context path, where ``effect`` is
+    derived purely from tags) AND
+    ``core/lenses/action_surface.py::build_action`` (manifest-context
+    path, where ``effect`` may come from a user declaration). Routing
+    both paths through this helper guarantees that the structural
+    fields cannot contradict ``effect`` — a manifest declaring
+    ``effect: financial_write`` with no matching ``risk_tags`` still
+    yields ``SideEffect(financial=True, externally_visible=True,
+    is_high_risk=True)``.
+
+    Structural-field derivation rules (applied in order):
+
+    - ``externally_visible`` — True if any of ``external_communication``
+      / ``writes_data`` is in ``risk_tags``, OR ``effect`` is in
+      ``{destructive, financial_write, external_communication}``.
+    - ``handles_sensitive_data`` — True if ``risk_tags`` contains
+      ``privileged_data`` or ``secret_access``, OR ``effect`` is
+      ``privileged_data_access``.
+    - ``financial`` — True if ``risk_tags`` contains ``financial_write``
+      OR ``effect`` is ``financial_write``.
+    - ``code_execution`` — True if ``risk_tags`` contains
+      ``code_execution`` OR ``effect`` is ``code_execution``.
+    - ``reversibility`` — ``irreversible`` if ``risk_tags`` contains
+      ``destructive`` / ``irreversible`` OR ``effect`` is
+      ``destructive``; ``reversible`` if ``risk_tags`` contains
+      ``read_only`` and not ``writes_data``; ``unknown`` otherwise.
+      (A declared ``effect: read`` *without* a ``read_only`` tag stays
+      ``unknown`` — declared-read doesn't promise reversibility on its
+      own; positive evidence is needed.)
+    """
+    tag_set: set[str] = set(risk_tags) if not isinstance(risk_tags, set) else risk_tags
     return SideEffect(
         effect=effect,
-        externally_visible=externally_visible,
-        handles_sensitive_data=handles_sensitive_data,
-        financial=financial,
-        code_execution=code_execution,
-        reversibility=reversibility,
+        externally_visible=(
+            "external_communication" in tag_set
+            or "writes_data" in tag_set
+            or effect in {"destructive", "financial_write", "external_communication"}
+        ),
+        handles_sensitive_data=(
+            "privileged_data" in tag_set
+            or "secret_access" in tag_set
+            or effect == "privileged_data_access"
+        ),
+        financial=("financial_write" in tag_set or effect == "financial_write"),
+        code_execution=("code_execution" in tag_set or effect == "code_execution"),
+        reversibility=(
+            "irreversible"
+            if (
+                "destructive" in tag_set
+                or "irreversible" in tag_set
+                or effect == "destructive"
+            )
+            else "reversible"
+            if "read_only" in tag_set and "writes_data" not in tag_set
+            else "unknown"
+        ),
         idempotency_known=idempotency_known,
     )
 
@@ -412,7 +465,7 @@ def tool_side_effect(tool: Tool) -> SideEffect:
 def _derive_effect(tags: set[str], method: str) -> ActionEffect:
     """Effect-tier inference.
 
-    Mirrors ``report/action_surface_diff.py::_infer_effect`` exactly so
+    Mirrors ``core/lenses/action_surface.py::_infer_effect`` exactly so
     Phase C can delete the duplicate. The ordering is significant —
     destructive > financial_write > external_communication > production_ops
     > code_execution > identity_access > privileged_data_access > write
@@ -439,14 +492,6 @@ def _derive_effect(tags: set[str], method: str) -> ActionEffect:
     if method == "DELETE":
         return "destructive"
     return "read"
-
-
-def _derive_reversibility(tags: set[str], method: str) -> str:
-    if "destructive" in tags or "irreversible" in tags or method == "DELETE":
-        return "irreversible"
-    if "read_only" in tags and "writes_data" not in tags:
-        return "reversible"
-    return "unknown"
 
 
 def _derive_idempotency_known(tool: Tool) -> bool | None:

--- a/tests/test_action_scope_domain.py
+++ b/tests/test_action_scope_domain.py
@@ -1,0 +1,386 @@
+"""Pinning tests for the typed ``Scope`` / ``SideEffect`` / ``Action`` types
+added to ``core.domain`` and the typed accessors in ``core.risk_hints``.
+
+These cover three contracts:
+
+1. ``Scope.parse`` is permissive (never raises) and produces structural
+   parts for the common provider conventions (Stripe / AWS / GitHub /
+   OpenAI / wildcards / broad tokens).
+2. ``tool_side_effect`` produces a ``SideEffect`` whose ``effect`` agrees
+   byte-for-byte with the legacy ``_infer_effect`` over the same tool —
+   so swapping the typed accessor into ``report/action_surface_diff.py``
+   does not move the wire-format ``ActionFact.effect``.
+3. ``build_action`` → ``action_to_fact`` produces an ``ActionFact`` that
+   is byte-equal to the legacy ``_action_from_tool`` body. The whole
+   point of the typed-Action refactor is that wire output is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agents_shipgate.core.domain import (
+    Action,
+    AuthInfo,
+    Scope,
+    SideEffect,
+    Tool,
+    ToolParameter,
+    ToolRiskHint,
+)
+from agents_shipgate.core.risk_hints import (
+    canonical_risk_tags,
+    parse_scopes,
+    tool_side_effect,
+)
+from agents_shipgate.report.action_surface_diff import (
+    _infer_effect,
+    _normalized_risk_tags,
+    action_to_fact,
+    build_action,
+)
+from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+
+
+def _tool(
+    name: str,
+    *,
+    source: str = "openapi",
+    annotations: dict | None = None,
+    scopes: list[str] | None = None,
+    hints: list[tuple[str, str]] | None = None,
+    parameters: list[str] | None = None,
+    description: str | None = None,
+) -> Tool:
+    return Tool(
+        id=f"t_{name}",
+        name=name,
+        description=description,
+        source_type=source,
+        annotations=annotations or {},
+        auth=AuthInfo(scopes=scopes or []),
+        risk_hints=[
+            ToolRiskHint(tag=tag, source="test", confidence=conf)
+            for tag, conf in (hints or [])
+        ],
+        parameters=[ToolParameter(name=p) for p in (parameters or [])],
+        extraction_confidence="high",
+    )
+
+
+# --- Scope parsing --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,provider,resource,verb",
+    [
+        # Stripe-style 3-part
+        ("stripe:refunds:write", "stripe", "refunds", "write"),
+        # AWS-style 2-part triple (service:action with wildcard resource)
+        ("s3:bucket:*", "s3", "bucket", "*"),
+        # GitHub-style 2-part with non-verb tail
+        ("repo:status", "repo", "status", None),
+        # OpenAI / dot-separated
+        ("models.read", "models", None, "read"),
+        ("workspace.users.write", "workspace", "users", "write"),
+        # Path-style fallback
+        ("aws/s3/get", "aws", "s3", "get"),
+        # Wildcard handling — never a verb
+        ("stripe:*", "stripe", "*", None),
+        # Broad tokens — no structural parts
+        ("admin", None, None, None),
+        ("*", None, None, None),
+        # 4+ parts collapse middle into resource
+        ("stripe:refunds:items:write", "stripe", "refunds:items", "write"),
+        # Single token
+        ("github_token", "github_token", None, None),
+        # Empty
+        ("", None, None, None),
+    ],
+)
+def test_scope_parse(raw: str, provider: str | None, resource: str | None, verb: str | None) -> None:
+    parsed = Scope.parse(raw)
+    assert parsed.raw == raw
+    assert parsed.provider == provider
+    assert parsed.resource == resource
+    assert parsed.verb == verb
+    assert str(parsed) == raw
+
+
+def test_scope_parse_strips_whitespace() -> None:
+    # Leading/trailing whitespace is normalized off the raw string so
+    # downstream string comparisons (scope coverage diff) stay stable.
+    parsed = Scope.parse("  stripe:refunds:write  ")
+    assert parsed.raw == "stripe:refunds:write"
+    assert parsed.provider == "stripe"
+
+
+def test_scope_parse_handles_none_safely() -> None:
+    # The parser is documented as "never raises" — including on None.
+    assert Scope.parse(None).raw == ""  # type: ignore[arg-type]
+
+
+def test_scope_is_broad_matches_heuristics_module() -> None:
+    # ``Scope.is_broad`` delegates to ``core.heuristics.is_broad_scope``
+    # so this asserts behavioral parity, not just method existence.
+    from agents_shipgate.core.heuristics import is_broad_scope
+
+    for raw in ["admin", "*", "stripe:*", "s3:bucket:*", "admin:read", "/admin/"]:
+        assert Scope.parse(raw).is_broad() is is_broad_scope(raw), raw
+
+    for raw in ["stripe:refunds:write", "repo:status", "models.read"]:
+        assert Scope.parse(raw).is_broad() is is_broad_scope(raw), raw
+
+
+def test_scope_is_read_write_classifiers() -> None:
+    assert Scope.parse("stripe:refunds:read").is_read()
+    assert not Scope.parse("stripe:refunds:read").is_write()
+    assert Scope.parse("stripe:refunds:write").is_write()
+    assert not Scope.parse("stripe:refunds:write").is_read()
+    # Wildcard is NOT a verb — both classifiers return False.
+    assert not Scope.parse("stripe:*").is_read()
+    assert not Scope.parse("stripe:*").is_write()
+    # Unknown verb tokens stay False — be permissive, don't guess.
+    assert not Scope.parse("stripe:refunds:explode").is_write()
+
+
+def test_scope_is_frozen() -> None:
+    parsed = Scope.parse("stripe:refunds:write")
+    # ``model_config = ConfigDict(frozen=True)`` → Pydantic raises
+    # ValidationError on attribute set.
+    with pytest.raises(ValidationError):
+        parsed.raw = "mutated"  # type: ignore[misc]
+
+
+def test_parse_scopes_preserves_order_and_drops_blanks() -> None:
+    tool = _tool("t", scopes=["stripe:refunds:write", "  ", "stripe:*", ""])
+    parsed = parse_scopes(tool)
+    assert [s.raw for s in parsed] == ["stripe:refunds:write", "stripe:*"]
+    assert parsed[1].is_broad()
+
+
+# --- SideEffect derivation ------------------------------------------------
+
+
+def test_side_effect_high_risk_classifier() -> None:
+    assert SideEffect(effect="destructive").is_high_risk
+    assert SideEffect(effect="financial_write").is_high_risk
+    assert SideEffect(effect="external_communication").is_high_risk
+    assert SideEffect(effect="code_execution").is_high_risk
+    assert SideEffect(effect="identity_access").is_high_risk
+    assert SideEffect(effect="production_operation").is_high_risk
+    assert not SideEffect(effect="read").is_high_risk
+    assert not SideEffect(effect="write").is_high_risk
+    # Structural overrides — financial / code_execution flags promote
+    # to high_risk even when ``effect`` doesn't.
+    assert SideEffect(effect="write", financial=True).is_high_risk
+    assert SideEffect(effect="write", code_execution=True).is_high_risk
+
+
+def test_side_effect_is_frozen() -> None:
+    se = SideEffect(effect="write")
+    with pytest.raises(ValidationError):
+        se.financial = True  # type: ignore[misc]
+
+
+# --- Typed accessor parity with legacy logic ------------------------------
+
+# Every case below covers a code path in ``_normalized_risk_tags`` and
+# ``_infer_effect``. The parity guarantee — typed accessor returns the
+# same value as the legacy helper — is what unblocks deleting the
+# duplicate logic in a future PR. If either side drifts, this test
+# catches it immediately.
+
+PARITY_TOOLS = [
+    _tool("read_get", annotations={"httpMethod": "GET"}),
+    _tool(
+        "refund_post",
+        annotations={"httpMethod": "POST"},
+        hints=[("financial_action", "high"), ("write", "high")],
+    ),
+    _tool(
+        "destroy",
+        annotations={"httpMethod": "DELETE"},
+        hints=[("destructive", "high"), ("write", "high")],
+    ),
+    _tool(
+        "send_email",
+        hints=[("customer_communication", "medium"), ("external_write", "medium")],
+    ),
+    _tool("exec_cmd", hints=[("code_execution", "medium")]),
+    _tool("infra_apply", hints=[("infrastructure_change", "medium")]),
+    _tool(
+        "read_only_get",
+        annotations={"readOnlyHint": True, "httpMethod": "GET"},
+    ),
+    _tool(
+        "with_idem_key",
+        annotations={"httpMethod": "POST"},
+        hints=[("write", "high")],
+        parameters=["idempotency_key", "amount"],
+    ),
+    _tool(
+        "with_idem_hint",
+        annotations={"httpMethod": "POST", "idempotentHint": True},
+        hints=[("write", "high")],
+    ),
+    _tool("sensitive", hints=[("sensitive_data_access", "medium")]),
+]
+
+
+@pytest.mark.parametrize("tool", PARITY_TOOLS, ids=lambda t: t.name)
+def test_canonical_risk_tags_matches_legacy(tool: Tool) -> None:
+    assert canonical_risk_tags(tool) == _normalized_risk_tags(tool)
+
+
+@pytest.mark.parametrize("tool", PARITY_TOOLS, ids=lambda t: t.name)
+def test_tool_side_effect_effect_matches_legacy(tool: Tool) -> None:
+    legacy = _infer_effect(tool, _normalized_risk_tags(tool))
+    typed = tool_side_effect(tool).effect
+    assert typed == legacy
+
+
+def test_tool_side_effect_populates_structural_fields() -> None:
+    se = tool_side_effect(
+        _tool(
+            "refund",
+            annotations={"httpMethod": "POST"},
+            hints=[("financial_action", "high"), ("write", "high")],
+        )
+    )
+    assert se.effect == "financial_write"
+    assert se.financial is True
+    assert se.externally_visible is True
+    assert se.is_high_risk
+
+    # Plain GET with no enrichment: effect=read (HTTP fallback) but
+    # ``read_only`` tag is NOT in the canonical set — so reversibility
+    # stays ``unknown`` until ``enrich_tools_with_risk_hints`` runs.
+    se_read_plain = tool_side_effect(_tool("read_plain", annotations={"httpMethod": "GET"}))
+    assert se_read_plain.effect == "read"
+    assert not se_read_plain.is_high_risk
+    assert se_read_plain.reversibility == "unknown"
+
+    # MCP-style readOnlyHint promotes ``is_effectively_read_only`` to
+    # True, which adds ``read_only`` to canonical tags, which yields
+    # ``reversibility="reversible"``.
+    se_read_hint = tool_side_effect(
+        _tool("read_hint", annotations={"readOnlyHint": True, "httpMethod": "GET"})
+    )
+    assert se_read_hint.effect == "read"
+    assert se_read_hint.reversibility == "reversible"
+
+    se_destr = tool_side_effect(
+        _tool("destroy", annotations={"httpMethod": "DELETE"}, hints=[("destructive", "high")])
+    )
+    assert se_destr.reversibility == "irreversible"
+
+
+def test_tool_side_effect_idempotency_three_state() -> None:
+    # Known True via idempotency_key parameter
+    se_param = tool_side_effect(_tool("a", parameters=["idempotency_key"]))
+    assert se_param.idempotency_known is True
+    # Known True via annotation
+    se_anno = tool_side_effect(_tool("b", annotations={"idempotentHint": True}))
+    assert se_anno.idempotency_known is True
+    # Unknown — neither signal present
+    se_unknown = tool_side_effect(_tool("c"))
+    assert se_unknown.idempotency_known is None
+
+
+# --- Action ↔ ActionFact equivalence --------------------------------------
+
+# The whole refactor's invariant: ``action_to_fact(build_action(...))``
+# produces an ``ActionFact`` that's byte-equal to what the legacy
+# ``_action_from_tool`` body produced. Because ``_action_from_tool`` now
+# delegates to these two helpers, this test pins the round-trip through
+# the typed Action.
+
+
+def _empty_manifest() -> AgentsShipgateManifest:
+    # Mirrors the canonical minimal-manifest shape used by
+    # ``tests/test_action_surface_diff.py::_manifest`` so the typed-action
+    # tests exercise build_action against the same manifest fields. The
+    # ``tool_sources`` placeholder is required by ``AgentsShipgateManifest``'s
+    # "at least one input source" model_validator; tests don't actually
+    # load it.
+    return AgentsShipgateManifest.model_validate(
+        {
+            "version": "0.1",
+            "project": {"name": "action-scope-domain-test"},
+            "agent": {"name": "agent", "declared_purpose": ["test typed action"]},
+            "environment": {"target": "production_like"},
+            "tool_sources": [{"id": "tools", "type": "mcp", "path": "tools.json"}],
+        }
+    )
+
+
+def test_build_action_then_action_to_fact_is_pure_function() -> None:
+    """Same input → same Action → same ActionFact, twice."""
+    manifest = _empty_manifest()
+    tool = _tool(
+        "stripe.create_refund",
+        scopes=["stripe:refunds:write", "stripe:*"],
+        annotations={"httpMethod": "POST"},
+        hints=[("financial_action", "high"), ("write", "high")],
+        parameters=["amount", "idempotency_key"],
+    )
+    action_a = build_action(manifest, agent_id="agent-1", tool=tool, declaration=None)
+    action_b = build_action(manifest, agent_id="agent-1", tool=tool, declaration=None)
+    assert action_a.model_dump() == action_b.model_dump()
+    fact_a = action_to_fact(action_a)
+    fact_b = action_to_fact(action_b)
+    assert fact_a.model_dump() == fact_b.model_dump()
+
+
+def test_build_action_typed_fields_match_action_fact() -> None:
+    """The typed Action surfaces match the ActionFact serialization."""
+    manifest = _empty_manifest()
+    tool = _tool(
+        "stripe.create_refund",
+        scopes=["stripe:refunds:write", "stripe:*"],
+        annotations={"httpMethod": "POST"},
+        hints=[("financial_action", "high"), ("write", "high")],
+        parameters=["amount", "idempotency_key"],
+    )
+    action = build_action(manifest, agent_id="agent-1", tool=tool, declaration=None)
+    fact = action_to_fact(action)
+
+    # Effect — single source of truth
+    assert action.effect == fact.effect
+    # Scopes — typed list vs wire list
+    assert action.scope_strings == fact.required_scopes
+    # Risk tags — wire format is identical to the action's list
+    assert action.risk_tags == fact.risk_tags
+    # Approval / safeguards / evidence — typed dataclass-like fields vs
+    # the nested wire models.
+    assert action.approval_required == fact.approval_policy.required
+    assert action.safeguard_idempotency == fact.safeguards.idempotency
+    # The typed Action recognizes the broad scope.
+    assert action.has_broad_scope is True
+
+
+def test_action_to_fact_preserves_action_id() -> None:
+    manifest = _empty_manifest()
+    tool = _tool("explicit_provider_tool")
+    action = build_action(manifest, agent_id="agent-z", tool=tool, declaration=None)
+    fact = action_to_fact(action)
+    assert fact.action_id.startswith("agent-z:")
+    assert fact.action_id == action.action_id
+
+
+def test_action_is_extra_forbid() -> None:
+    """Action is ``extra='forbid'`` — typo-catching guarantee for callers."""
+    with pytest.raises(ValidationError):
+        Action(
+            action_id="x",
+            agent_id="x",
+            tool_id="x",
+            tool_name="x",
+            provider="x",
+            source_type="x",
+            operation="x",
+            side_effect=SideEffect(effect="read"),
+            risk_tagz=[],  # type: ignore[call-arg]  # intentional typo: tests extra=forbid
+        )

--- a/tests/test_action_scope_domain.py
+++ b/tests/test_action_scope_domain.py
@@ -31,16 +31,20 @@ from agents_shipgate.core.domain import (
 )
 from agents_shipgate.core.risk_hints import (
     canonical_risk_tags,
+    is_high_risk_tool,
     parse_scopes,
     tool_side_effect,
 )
-from agents_shipgate.report.action_surface_diff import (
+from agents_shipgate.core.lenses.action_surface import (
     _infer_effect,
     _normalized_risk_tags,
     action_to_fact,
     build_action,
 )
-from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.manifest import (
+    ActionDeclarationConfig,
+    AgentsShipgateManifest,
+)
 
 
 def _tool(
@@ -384,3 +388,157 @@ def test_action_is_extra_forbid() -> None:
             side_effect=SideEffect(effect="read"),
             risk_tagz=[],  # type: ignore[call-arg]  # intentional typo: tests extra=forbid
         )
+
+
+# --- is_high_risk parity with legacy ``is_high_risk_tool`` ----------------
+
+# Review finding: if checks migrate from ``is_high_risk_tool(tool)`` to
+# ``tool_side_effect(tool).is_high_risk``, sensitive/privileged-data tools
+# must not silently lose high-risk classification. The legacy
+# ``HIGH_RISK_TAGS`` includes ``sensitive_data_access``; the typed
+# classifier must agree.
+
+
+@pytest.mark.parametrize("tool", PARITY_TOOLS, ids=lambda t: t.name)
+def test_side_effect_is_high_risk_matches_legacy(tool: Tool) -> None:
+    """For every PARITY_TOOLS case, the typed and legacy classifiers agree."""
+    legacy = is_high_risk_tool(tool)
+    typed = tool_side_effect(tool).is_high_risk
+    assert typed == legacy, f"{tool.name}: legacy={legacy} typed={typed}"
+
+
+def test_side_effect_is_high_risk_covers_sensitive_data() -> None:
+    """Sensitive-data tools land as high-risk under both predicates.
+
+    Pre-fix the typed classifier returned False for
+    ``effect="privileged_data_access"`` — that drift would have let
+    migrated checks stop requiring high-risk controls on sensitive tools.
+    """
+    tool = _tool("sensitive", hints=[("sensitive_data_access", "medium")])
+    assert is_high_risk_tool(tool) is True
+    se = tool_side_effect(tool)
+    assert se.handles_sensitive_data is True
+    assert se.effect == "privileged_data_access"
+    assert se.is_high_risk is True
+
+
+def test_side_effect_is_high_risk_via_structural_field_when_effect_lower() -> None:
+    """A tool whose declared effect is ``write`` but which handles
+    sensitive data still classifies as high-risk via the structural
+    ``handles_sensitive_data`` field."""
+    se = SideEffect(effect="write", handles_sensitive_data=True)
+    assert se.is_high_risk is True
+    se2 = SideEffect(effect="write", financial=True)
+    assert se2.is_high_risk is True
+    se3 = SideEffect(effect="write", code_execution=True)
+    assert se3.is_high_risk is True
+    # Plain write with no structural escalators stays low-risk.
+    assert SideEffect(effect="write").is_high_risk is False
+
+
+# --- Declaration-only SideEffect derivation (review finding #2) -----------
+
+# When a manifest declares ``action_surface.actions[].effect`` *without*
+# matching ``risk_tags``, ``build_action`` previously derived ``effect``
+# from the declaration but derived structural fields only from tags —
+# producing a contradictory ``SideEffect`` (e.g. ``effect=financial_write``
+# with ``financial=False``). The fix routes both call sites through the
+# shared ``derive_side_effect`` helper which feeds ``effect`` into every
+# structural field.
+
+
+def _tool_for_declaration() -> Tool:
+    """Plain GET tool with no risk_hints — leaves the inferred surface
+    empty so any structural derivation in ``SideEffect`` must come from
+    the declaration's ``effect`` field."""
+    return _tool("declared_only_tool", annotations={"httpMethod": "GET"})
+
+
+def test_build_action_declaration_only_financial_write() -> None:
+    """Manifest declaration ``effect: financial_write`` with no
+    ``risk_tags`` still yields ``financial=True``,
+    ``externally_visible=True``, and ``is_high_risk=True``."""
+    manifest = _empty_manifest()
+    tool = _tool_for_declaration()
+    declaration = ActionDeclarationConfig(tool=tool.name, effect="financial_write")
+    action = build_action(manifest, agent_id="agent-1", tool=tool, declaration=declaration)
+    assert action.effect == "financial_write"
+    assert action.side_effect.financial is True
+    assert action.side_effect.externally_visible is True
+    assert action.side_effect.is_high_risk is True
+
+
+def test_build_action_declaration_only_destructive() -> None:
+    """Manifest declaration ``effect: destructive`` with no destructive
+    tag yields ``reversibility="irreversible"`` and ``is_high_risk=True``."""
+    manifest = _empty_manifest()
+    tool = _tool_for_declaration()
+    declaration = ActionDeclarationConfig(tool=tool.name, effect="destructive")
+    action = build_action(manifest, agent_id="agent-1", tool=tool, declaration=declaration)
+    assert action.effect == "destructive"
+    assert action.side_effect.reversibility == "irreversible"
+    assert action.side_effect.is_high_risk is True
+
+
+def test_build_action_declaration_only_code_execution() -> None:
+    """Declaration ``effect: code_execution`` lights up the structural
+    code_execution flag even without a matching tag."""
+    manifest = _empty_manifest()
+    tool = _tool_for_declaration()
+    declaration = ActionDeclarationConfig(tool=tool.name, effect="code_execution")
+    action = build_action(manifest, agent_id="agent-1", tool=tool, declaration=declaration)
+    assert action.effect == "code_execution"
+    assert action.side_effect.code_execution is True
+    assert action.side_effect.is_high_risk is True
+
+
+def test_build_action_declaration_only_privileged_data_access() -> None:
+    """Declaration ``effect: privileged_data_access`` lights up
+    ``handles_sensitive_data`` even without a sensitive tag."""
+    manifest = _empty_manifest()
+    tool = _tool_for_declaration()
+    declaration = ActionDeclarationConfig(tool=tool.name, effect="privileged_data_access")
+    action = build_action(manifest, agent_id="agent-1", tool=tool, declaration=declaration)
+    assert action.effect == "privileged_data_access"
+    assert action.side_effect.handles_sensitive_data is True
+    assert action.side_effect.is_high_risk is True
+
+
+# --- Wildcard slotting contract (review open question) --------------------
+
+# The parser slots wildcards by *position*, not by axis:
+# - 2-part ``provider:*`` puts the wildcard in the resource axis
+#   (2-part scopes have no canonical verb position).
+# - 3+-part ``provider:resource:*`` puts the wildcard in the verb axis
+#   (AWS IAM convention: trailing ``*`` is the action wildcard).
+# Both forms return ``is_broad()=True`` and ``is_read()/is_write()=False``.
+
+
+def test_wildcard_slotting_two_part_lands_in_resource() -> None:
+    parsed = Scope.parse("stripe:*")
+    assert parsed.provider == "stripe"
+    assert parsed.resource == "*"
+    assert parsed.verb is None
+    assert parsed.is_broad() is True
+    assert parsed.is_read() is False
+    assert parsed.is_write() is False
+
+
+def test_wildcard_slotting_three_part_lands_in_verb() -> None:
+    parsed = Scope.parse("s3:bucket:*")
+    assert parsed.provider == "s3"
+    assert parsed.resource == "bucket"
+    assert parsed.verb == "*"
+    assert parsed.is_broad() is True
+    # Wildcard is NOT a canonical action verb — read/write classifiers
+    # return False so least-privilege gating treats it as ambiguous.
+    assert parsed.is_read() is False
+    assert parsed.is_write() is False
+
+
+def test_wildcard_slotting_four_plus_part_keeps_verb_wildcard() -> None:
+    parsed = Scope.parse("aws:iam:role:*")
+    assert parsed.provider == "aws"
+    assert parsed.resource == "iam:role"
+    assert parsed.verb == "*"
+    assert parsed.is_broad() is True

--- a/tests/test_action_scope_domain.py
+++ b/tests/test_action_scope_domain.py
@@ -29,17 +29,17 @@ from agents_shipgate.core.domain import (
     ToolParameter,
     ToolRiskHint,
 )
-from agents_shipgate.core.risk_hints import (
-    canonical_risk_tags,
-    is_high_risk_tool,
-    parse_scopes,
-    tool_side_effect,
-)
 from agents_shipgate.core.lenses.action_surface import (
     _infer_effect,
     _normalized_risk_tags,
     action_to_fact,
     build_action,
+)
+from agents_shipgate.core.risk_hints import (
+    canonical_risk_tags,
+    is_high_risk_tool,
+    parse_scopes,
+    tool_side_effect,
 )
 from agents_shipgate.schemas.manifest import (
     ActionDeclarationConfig,


### PR DESCRIPTION
## Summary

- Add typed `Scope`, `SideEffect`, and `Action` models to `core/domain.py` alongside the existing `Tool` / `Agent` shapes. Wire format (`schemas.surfaces.ActionFact`) is unchanged — these are in-memory only, and `report_schema_version` does **not** bump.
- `Scope` is a frozen model with `raw` / `provider` / `resource` / `verb` and a permissive `parse()` covering Stripe/AWS/K8s (`provider:resource:verb`), GitHub (`provider:resource`), OpenAI (`provider.resource.verb`), and path-style scopes. Wildcards slot into the resource axis (never verb), broad tokens (`admin`, `*`) leave structural parts empty. `is_broad()` delegates to `core.heuristics.is_broad_scope` so manifest-level and per-scope checks agree.
- `SideEffect` is a frozen model carrying the canonical effect tier plus independently-derivable structural fields (`externally_visible`, `handles_sensitive_data`, `financial`, `code_execution`, `reversibility`, `idempotency_known`). `is_high_risk` is the canonical classifier.
- `Action` is the typed runtime view of an action — `scopes: list[Scope]` + `side_effect: SideEffect` — replacing the string-bag mix of `effect` + `risk_tags` for in-memory work.
- `core/risk_hints.py` gains typed accessors (`parse_scopes`, `tool_side_effect`, `canonical_risk_tags`) plus a `CANONICAL_RISK_TAG_MAP` as the single source of truth for tag canonicalization. **All existing string predicates** (`has_risk_tag`, `risk_tags`, `is_effectively_read_only`, `is_high_risk_tool`, `is_write_tool`) are unchanged — every check across `checks/` keeps its public API.
- `report/action_surface_diff.py` decomposes `_action_from_tool` into `build_action()` (Tool → typed `Action`) and `action_to_fact()` (typed `Action` → wire `ActionFact`, including all four stable hashes). The typed `Action` now flows through every action-surface build path while producing byte-identical `ActionFact` output.

## Type

- [x] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only (new "Typed domain types" section in `docs/architecture.md`)

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest` — **1925 passed, 4 skipped, 0 failed** (was 1879 + 4 before; +46 from `tests/test_action_scope_domain.py`).
- `python -m ruff check src/ tests/` — clean.
- `python -m pytest tests/test_action_surface_diff.py tests/test_risk_hints.py tests/test_schema_boundaries.py tests/test_public_surface_contract.py tests/test_fixture.py tests/test_schema_roundtrip.py` — clean. These are the load-bearing tests for the refactor: the action-surface golden output, the risk-hint behavior, the schema/core AST boundary, the public wire contract, the sample golden reports, and the schema roundtrip.
- Manual sample-scan diff against `samples/support_refund_agent/expected/report.json` — `action_surface_facts` (8 actions incl. all 4 hashes per action), all 18 finding fingerprints, `release_decision` (incl. `contribution_rules`), `tool_surface_diff`, and `action_surface_diff` are byte-equal. Remaining diffs are env-only (`manifest_dir` absolute path placeholder, `generated_reports` paths, `privacy_audit.output_surfaces`).

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A, no check IDs added or changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — N/A, wire format is unchanged; new types are in-memory only and `report_schema_version` stays at `"0.21"`

## Notes for reviewers

- The intent is purely additive at the wire layer. `tests/test_action_scope_domain.py` includes explicit parity assertions: `canonical_risk_tags(tool) == _normalized_risk_tags(tool)` and `tool_side_effect(tool).effect == _infer_effect(tool, ...)` for ten representative tools. If either drifts in a future PR, this test fires immediately.
- `report/action_surface_diff.py:_RISK_TAG_MAP` (line ~36) duplicates the same mapping table as `core/risk_hints.py:CANONICAL_RISK_TAG_MAP`. The duplication is intentional during this migration window so the action-surface site's hashes stay byte-identical. A follow-up PR can collapse the action-surface site onto the core constant once a hash-pin test confirms equivalence.
- The typed `Action` carries `input_schema` and `parameters_for_hash` fields so `action_to_fact()` can compute the `schema_hash` from the same JSON form `_action_from_tool` used; these are intentionally not part of the wire `ActionFact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)