### PR TITLE
Promote trigger to a subcommand + add trust-root-touched verify check (M1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,12 +206,17 @@ Two implicit triggers also fire even when no row above matches:
 - **Repo already opted in (shipgate.yaml present in the workspace)** — run on every PR; the manifest's existence is the opt-in.
 - **(Optional) Refactor or framework upgrade that may shift the extracted tool surface** — dry-run only; bumping `openai-agents`, `langchain`, `crewai`, or `google-adk` can change AST extraction even without app-code edits.
 
-A machine-readable mirror of these triggers lives at [`docs/triggers.json`](docs/triggers.json). Coding agents that have not yet adopted Shipgate can fetch the file (raw URL: `https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/triggers.json`), apply the rules to a PR diff, and decide whether to propose `agents-shipgate detect`. The catalog is stable for `0.x` and pinned by the public-surface contract test against this prose table — if you change a row above, update `triggers.json` in the same commit. To verify a path list locally:
+A machine-readable mirror of these triggers lives at [`docs/triggers.json`](docs/triggers.json). Coding agents that have not yet adopted Shipgate can fetch the file (raw URL: `https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/triggers.json`), apply the rules to a PR diff, and decide whether to propose `agents-shipgate detect`. The catalog is stable for `0.x` and pinned by the public-surface contract test against this prose table — if you change a row above, update `triggers.json` in the same commit. To evaluate a diff locally, use the first-class `trigger` subcommand:
 
 ```bash
-python -m agents_shipgate.triggers shipgate.yaml prompts/refund.md
-python -m agents_shipgate.triggers --list-rules --json
+# From a list of changed paths (and optional diff body for diff_contains rules):
+agents-shipgate trigger --changed-files changed.txt --diff pr.diff --json
+# Or straight from git (the ONLY mode that shells out to git):
+agents-shipgate trigger --base origin/main --head HEAD --json
+agents-shipgate trigger --list-rules --json
 ```
+
+The command emits a stable JSON verdict: `should_run` (alias of `run_shipgate`), `force_run`, `dry_run_recommended`, `skip_reason`, `matched_rules`, `changed_files`, and `diff_tokens`. The developer entry point `python -m agents_shipgate.triggers shipgate.yaml prompts/refund.md` is preserved.
 
 **Stop conditions.** Stop and do not run `init` only when **all** of these hold:
 
@@ -401,7 +406,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 
 | Command | Stable flags |
 |---|---|
-| `agents-shipgate scan` | `-c`, `--out`, `--format`, `--ci-mode`, `--fail-on`, `--baseline`, `--diff-from`, `--no-plugins`, `--no-heuristics`, `--verbose`, `--packet`/`--no-packet`, `--packet-format` |
+| `agents-shipgate scan` | `-c`, `--out`, `--format`, `--ci-mode`, `--fail-on`, `--baseline`, `--diff-from`, `--changed-files`, `--no-plugins`, `--no-heuristics`, `--verbose`, `--packet`/`--no-packet`, `--packet-format` |
 | `agents-shipgate evidence-packet` | `--from`, `--out`, `--format`, `--json` |
 | `agents-shipgate init` | `--workspace`, `--write`, `--json` |
 | `agents-shipgate doctor` | `-c`, `--workspace`, `--json`, `--verbose` |
@@ -409,6 +414,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
 | `agents-shipgate explain-finding` | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
 | `agents-shipgate findings` | `--from`, `--provenance-kind`, `--include-suppressed`, `--json` |
+| `agents-shipgate trigger` | `--workspace`, `--changed-files`, `--diff`, `--base`, `--head`, `--manifest-present`/`--no-manifest-present`, `--user-requested`, `--list-rules`, `--json` |
 | `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--out` |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -14,7 +14,7 @@ These commands and flags are stable across all `0.x.y` releases. They will only 
 
 | Command | Stable flags |
 |---|---|
-| `agents-shipgate scan` | `-c`, `--config`, `--out`, `--format`, `--ci-mode`, `--fail-on`, `--baseline`, `--diff-from`, `--no-plugins`, `--strict-plugins`, `--no-heuristics`, `--verbose`, `--workspace`, `--packet`/`--no-packet`, `--packet-format` |
+| `agents-shipgate scan` | `-c`, `--config`, `--out`, `--format`, `--ci-mode`, `--fail-on`, `--baseline`, `--diff-from`, `--changed-files`, `--no-plugins`, `--strict-plugins`, `--no-heuristics`, `--verbose`, `--workspace`, `--packet`/`--no-packet`, `--packet-format` |
 | `agents-shipgate evidence-packet` | `--from`, `--out`, `--format`, `--json` |
 | `agents-shipgate scenario suggest` | `--from`, `--out` |
 | `agents-shipgate init` | `--workspace`, `--write`, `--json` |
@@ -23,6 +23,7 @@ These commands and flags are stable across all `0.x.y` releases. They will only 
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
 | `agents-shipgate explain-finding` (v0.12+) | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
 | `agents-shipgate findings` (v0.20+) | `--from` (default: `agents-shipgate-reports/report.json`), `--provenance-kind`, `--include-suppressed`, `--json` |
+| `agents-shipgate trigger` (v0.11+) | `--workspace`, `--changed-files`, `--diff`, `--base`, `--head`, `--manifest-present`/`--no-manifest-present`, `--user-requested`, `--list-rules`, `--json` |
 | `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--config`, `--out` |
@@ -371,6 +372,11 @@ tests on every CI run, not by convention:
     first-party adoption-kit files from the installed wheel. Downstream
     customization is explicit repo-local file reading through
     `--agent-instructions-kit`, never dynamic imports or network fetches.
+  - **`cli/trigger.py`** — imports `subprocess` only to catch
+    `subprocess.CalledProcessError` from the shared
+    `triggers._git_diff_context` git probe. The `agents-shipgate trigger`
+    subcommand issues no `subprocess.run` call of its own; git runs in
+    `triggers.py` exclusively, and only when `--base`/`--head` is passed.
   - **`cli/self_check.py`** — one `__import__(module_name)` call
     validates that supplied modules import cleanly. Runs only under
     `agents-shipgate self-check`, never during scan.

--- a/docs/checks.json
+++ b/docs/checks.json
@@ -1608,6 +1608,28 @@
       "requires_human_review": true,
       "requires_human_review_regardless_of_patch": true,
       "suggested_patch_kind": "manual"
+    },
+    {
+      "autofix_safe": false,
+      "category": "verify",
+      "default_severity": "medium",
+      "description": "A PR changed a release trust-root file (manifest, shipgate state, policy, prompts, the Shipgate CI gate, agent instructions, or a tool-surface declaration).",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-verify-trust-root-touched",
+      "dynamic_default": false,
+      "evidence_fields": [
+        "changed_file",
+        "trust_root_class",
+        "matched_glob"
+      ],
+      "fires_when": "A changed file from the verification context matches a trust-root surface glob. Emits nothing on a plain scan (no verification context).",
+      "floor_severity": null,
+      "id": "SHIP-VERIFY-TRUST-ROOT-TOUCHED",
+      "mvp_tier": "lifecycle",
+      "rationale": "Trust-root files define the release gate. A coding agent told to make CI pass can weaken the gate instead of fixing the underlying readiness issue (reward hacking); touching a trust root must therefore require human review.",
+      "recommendation": "Have a human review the trust-root change before merge; do not weaken the gate to pass CI.",
+      "requires_human_review": true,
+      "requires_human_review_regardless_of_patch": false,
+      "suggested_patch_kind": "manual"
     }
   ],
   "description": "Machine-readable catalog of built-in checks. Generated from agents_shipgate.checks.registry.check_catalog(). Do not edit by hand.",

--- a/docs/checks.json
+++ b/docs/checks.json
@@ -1622,7 +1622,7 @@
         "matched_glob"
       ],
       "fires_when": "A changed file from the verification context matches a trust-root surface glob. Emits nothing on a plain scan (no verification context).",
-      "floor_severity": null,
+      "floor_severity": "medium",
       "id": "SHIP-VERIFY-TRUST-ROOT-TOUCHED",
       "mvp_tier": "lifecycle",
       "rationale": "Trust-root files define the release gate. A coding agent told to make CI pass can weaken the gate instead of fixing the underlying readiness issue (reward hacking); touching a trust root must therefore require human review.",

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -102,6 +102,7 @@ baseline summary and do not fail CI.
 | `SHIP-MANIFEST-STALE-RISK-OVERRIDE` | medium | A risk override references a missing tool. |
 | `SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING` | high | A high-risk production or production-like tool lacks owner metadata. |
 | `SHIP-MANIFEST-UNUSED-SCOPE` | medium/high | `permissions.scopes` contains a scope unused by any loaded tool; broad unused scopes are high. |
+| `SHIP-VERIFY-TRUST-ROOT-TOUCHED` | medium | A PR changed a release trust-root file; emitted only when a verification context (changed files) is supplied. |
 
 ## Check Details
 
@@ -569,7 +570,24 @@ Two sub-kinds, both `low` severity:
 - `resolved_not_pruned` — entry matched no active scan finding. Re-run
   `agents-shipgate baseline save` to drop the entry from the baseline.
 
-## Risk Tags
+### SHIP-VERIFY-TRUST-ROOT-TOUCHED
+
+A PR changed a file that defines the release gate's trust spine — the
+manifest (`shipgate.yaml`), `.agents-shipgate/` state (baselines,
+waivers), `policies/`, `prompts/`, the Shipgate CI gate
+(`.github/workflows/agents-shipgate.yml`), agent instructions
+(`AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/rules/`,
+`.agents/skills/`, `.codex/`), Codex plugin packages (`.codex-plugin/`),
+or tool-surface declarations (`.app.json`, `.mcp.json`, `SKILL.md`).
+
+This is Tier A trust-root protection: pure path/glob classification of
+the changed files. It is the cheap half of the reward-hacking guard — a
+coding agent told to make CI pass can weaken the gate instead of fixing
+the readiness issue, so touching a trust root must require human review.
+The finding fires only when a verification context (changed files) is
+supplied (`agents-shipgate scan --changed-files ...` or, later, `verify`);
+a plain `scan` emits nothing. It is one ordinary `Finding` at `medium`
+severity routed through `release_decision` — never a second verdict.
 
 Risk tags are hints, not findings by themselves. Checks consume tags with confidence thresholds.
 

--- a/docs/checks/verify.yaml
+++ b/docs/checks/verify.yaml
@@ -17,6 +17,7 @@
 checks:
 - id: SHIP-VERIFY-TRUST-ROOT-TOUCHED
   default_severity: medium
+  floor_severity: medium
   mvp_tier: lifecycle
   description: A PR changed a release trust-root file (manifest, shipgate state,
     policy, prompts, the Shipgate CI gate, agent instructions, or a tool-surface

--- a/docs/checks/verify.yaml
+++ b/docs/checks/verify.yaml
@@ -1,0 +1,34 @@
+# Check catalog · category: verify
+#
+# This file is the source of truth for the 'verify' category of
+# Agents Shipgate built-in checks (trust-root protection — the
+# reward-hacking guard for AI coding workflows). Loaded at import time
+# by agents_shipgate.checks._metadata_loader.load_check_metadata().
+#
+# Field reference: agents_shipgate.schemas.checks.CheckMetadata.
+# Field order in this file follows the loader's canonical layout
+# (identity → severity → narrative → evidence → remediation).
+# Fields equal to the model default may be omitted.
+#
+# After editing this file, regenerate docs/checks.json with:
+#   python scripts/generate_schemas.py
+# docs/checks.md is human-maintained — update it by hand when the
+# user-facing prose (description/rationale/recommendation) changes.
+checks:
+- id: SHIP-VERIFY-TRUST-ROOT-TOUCHED
+  default_severity: medium
+  mvp_tier: lifecycle
+  description: A PR changed a release trust-root file (manifest, shipgate state,
+    policy, prompts, the Shipgate CI gate, agent instructions, or a tool-surface
+    declaration).
+  rationale: Trust-root files define the release gate. A coding agent told to make
+    CI pass can weaken the gate instead of fixing the underlying readiness issue
+    (reward hacking); touching a trust root must therefore require human review.
+  fires_when: A changed file from the verification context matches a trust-root
+    surface glob. Emits nothing on a plain scan (no verification context).
+  evidence_fields:
+  - changed_file
+  - trust_root_class
+  - matched_glob
+  recommendation: Have a human review the trust-root change before merge; do not
+    weaken the gate to pass CI.

--- a/docs/triggers.json
+++ b/docs/triggers.json
@@ -81,6 +81,21 @@
       "command": "agents-shipgate detect --workspace . --json"
     },
     {
+      "id": "TRIGGER-N8N-WORKFLOW-CHANGED",
+      "agents_md_row": "Adds/changes n8n workflow JSON, credential stubs, or n8n tool inventories",
+      "when": {
+        "any_of": [
+          {"diff_contains": "n8n-nodes-base."},
+          {"diff_contains": "n8n-nodes-langchain."},
+          {"diff_contains": "@n8n/n8n-nodes-"},
+          {"glob": "**/*n8n*.json"},
+          {"glob": "**/.n8n/**"}
+        ]
+      },
+      "action": "run_shipgate",
+      "rationale": "n8n workflow JSON declares an AI tool surface (AI Agent tool sub-nodes, MCP client/server tools, HTTP Request tools); `n8n-nodes-*` node-type tokens are the stable in-diff marker. Changes need a tool-use readiness check."
+    },
+    {
       "id": "TRIGGER-FUNCTION-TOOL-DECORATOR",
       "agents_md_row": "Adds/changes `@function_tool`/`@tool` decorators (LangChain, CrewAI, OpenAI Agents SDK)",
       "when": {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -231,12 +231,17 @@ Two implicit triggers also fire even when no row above matches:
 - **Repo already opted in (shipgate.yaml present in the workspace)** — run on every PR; the manifest's existence is the opt-in.
 - **(Optional) Refactor or framework upgrade that may shift the extracted tool surface** — dry-run only; bumping `openai-agents`, `langchain`, `crewai`, or `google-adk` can change AST extraction even without app-code edits.
 
-A machine-readable mirror of these triggers lives at [`docs/triggers.json`](docs/triggers.json). Coding agents that have not yet adopted Shipgate can fetch the file (raw URL: `https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/triggers.json`), apply the rules to a PR diff, and decide whether to propose `agents-shipgate detect`. The catalog is stable for `0.x` and pinned by the public-surface contract test against this prose table — if you change a row above, update `triggers.json` in the same commit. To verify a path list locally:
+A machine-readable mirror of these triggers lives at [`docs/triggers.json`](docs/triggers.json). Coding agents that have not yet adopted Shipgate can fetch the file (raw URL: `https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/triggers.json`), apply the rules to a PR diff, and decide whether to propose `agents-shipgate detect`. The catalog is stable for `0.x` and pinned by the public-surface contract test against this prose table — if you change a row above, update `triggers.json` in the same commit. To evaluate a diff locally, use the first-class `trigger` subcommand:
 
 ```bash
-python -m agents_shipgate.triggers shipgate.yaml prompts/refund.md
-python -m agents_shipgate.triggers --list-rules --json
+# From a list of changed paths (and optional diff body for diff_contains rules):
+agents-shipgate trigger --changed-files changed.txt --diff pr.diff --json
+# Or straight from git (the ONLY mode that shells out to git):
+agents-shipgate trigger --base origin/main --head HEAD --json
+agents-shipgate trigger --list-rules --json
 ```
+
+The command emits a stable JSON verdict: `should_run` (alias of `run_shipgate`), `force_run`, `dry_run_recommended`, `skip_reason`, `matched_rules`, `changed_files`, and `diff_tokens`. The developer entry point `python -m agents_shipgate.triggers shipgate.yaml prompts/refund.md` is preserved.
 
 **Stop conditions.** Stop and do not run `init` only when **all** of these hold:
 
@@ -426,7 +431,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 
 | Command | Stable flags |
 |---|---|
-| `agents-shipgate scan` | `-c`, `--out`, `--format`, `--ci-mode`, `--fail-on`, `--baseline`, `--diff-from`, `--no-plugins`, `--no-heuristics`, `--verbose`, `--packet`/`--no-packet`, `--packet-format` |
+| `agents-shipgate scan` | `-c`, `--out`, `--format`, `--ci-mode`, `--fail-on`, `--baseline`, `--diff-from`, `--changed-files`, `--no-plugins`, `--no-heuristics`, `--verbose`, `--packet`/`--no-packet`, `--packet-format` |
 | `agents-shipgate evidence-packet` | `--from`, `--out`, `--format`, `--json` |
 | `agents-shipgate init` | `--workspace`, `--write`, `--json` |
 | `agents-shipgate doctor` | `-c`, `--workspace`, `--json`, `--verbose` |
@@ -434,6 +439,7 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate explain` | `<check_id>`, `--no-plugins`, `--json` |
 | `agents-shipgate explain-finding` | `<fingerprint>`, `--from`, `--no-plugins`, `--json` |
 | `agents-shipgate findings` | `--from`, `--provenance-kind`, `--include-suppressed`, `--json` |
+| `agents-shipgate trigger` | `--workspace`, `--changed-files`, `--diff`, `--base`, `--head`, `--manifest-present`/`--no-manifest-present`, `--user-requested`, `--list-rules`, `--json` |
 | `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
 | `agents-shipgate baseline save` | `-c`, `--out` |
@@ -1096,6 +1102,7 @@ baseline summary and do not fail CI.
 | `SHIP-MANIFEST-STALE-RISK-OVERRIDE` | medium | A risk override references a missing tool. |
 | `SHIP-MANIFEST-HIGH-RISK-OWNER-MISSING` | high | A high-risk production or production-like tool lacks owner metadata. |
 | `SHIP-MANIFEST-UNUSED-SCOPE` | medium/high | `permissions.scopes` contains a scope unused by any loaded tool; broad unused scopes are high. |
+| `SHIP-VERIFY-TRUST-ROOT-TOUCHED` | medium | A PR changed a release trust-root file; emitted only when a verification context (changed files) is supplied. |
 
 ## Check Details
 
@@ -1563,7 +1570,24 @@ Two sub-kinds, both `low` severity:
 - `resolved_not_pruned` — entry matched no active scan finding. Re-run
   `agents-shipgate baseline save` to drop the entry from the baseline.
 
-## Risk Tags
+### SHIP-VERIFY-TRUST-ROOT-TOUCHED
+
+A PR changed a file that defines the release gate's trust spine — the
+manifest (`shipgate.yaml`), `.agents-shipgate/` state (baselines,
+waivers), `policies/`, `prompts/`, the Shipgate CI gate
+(`.github/workflows/agents-shipgate.yml`), agent instructions
+(`AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/rules/`,
+`.agents/skills/`, `.codex/`), Codex plugin packages (`.codex-plugin/`),
+or tool-surface declarations (`.app.json`, `.mcp.json`, `SKILL.md`).
+
+This is Tier A trust-root protection: pure path/glob classification of
+the changed files. It is the cheap half of the reward-hacking guard — a
+coding agent told to make CI pass can weaken the gate instead of fixing
+the readiness issue, so touching a trust root must require human review.
+The finding fires only when a verification context (changed files) is
+supplied (`agents-shipgate scan --changed-files ...` or, later, `verify`);
+a plain `scan` emits nothing. It is one ordinary `Finding` at `medium`
+severity routed through `release_decision` — never a second verdict.
 
 Risk tags are hints, not findings by themselves. Checks consume tags with confidence thresholds.
 

--- a/src/agents_shipgate/checks/registry.py
+++ b/src/agents_shipgate/checks/registry.py
@@ -22,6 +22,7 @@ from agents_shipgate.checks import (
     policy,
     schema,
     side_effects,
+    verify,
 )
 from agents_shipgate.checks._metadata_loader import load_check_metadata
 from agents_shipgate.checks.plugin_validation import (
@@ -52,6 +53,7 @@ BUILTIN_CHECKS: list[Callable[[ScanContext], list[Finding]]] = [
     crewai.run,
     codex_plugin.run,
     n8n.run,
+    verify.run,
 ]
 
 

--- a/src/agents_shipgate/checks/verify.py
+++ b/src/agents_shipgate/checks/verify.py
@@ -1,0 +1,111 @@
+"""Verify category — trust-root protection (the cheap reward-hacking guard).
+
+``SHIP-VERIFY-TRUST-ROOT-TOUCHED`` is Tier A of trust-root protection
+(docs/engineering/ai-coding-workflow-verifier.md §5.1): pure path/glob
+classification of the PR's changed files against the release gate's
+trust spine. It is fully deterministic, needs no base scan, and fires
+only when a :class:`VerificationContext` is present — plain ``scan``
+(``context.verification is None``) emits nothing.
+
+Reward hacking is the coding-agent threat model: an optimizer told to
+"make CI green" may edit the gate instead of fixing the readiness issue.
+Touching a trust root requires at least human review, so the finding is
+emitted at ``medium`` severity and routes to ``release_decision``'s
+review tier by default. Strict CI / severity overrides can escalate it
+through the existing decision machinery — it stays one ordinary
+``Finding`` through the one decision engine; it is never a second
+verdict.
+"""
+
+from __future__ import annotations
+
+from agents_shipgate.core.context import ScanContext
+from agents_shipgate.core.globbing import glob_match
+from agents_shipgate.schemas.common import (
+    SourceReference,
+    parse_confidence,
+    parse_severity,
+)
+from agents_shipgate.schemas.report import Finding
+
+CHECK_ID = "SHIP-VERIFY-TRUST-ROOT-TOUCHED"
+
+# Ordered (class, glob) classification of a repo's release trust roots —
+# the surfaces that define the gate in any repo that has adopted
+# Shipgate (target-repo trust roots, §5.2). First match wins; one
+# finding per changed file. ``**/`` prefixes match at any depth
+# (including the repo root) per agents_shipgate.core.globbing.
+TRUST_ROOT_SURFACES: tuple[tuple[str, str], ...] = (
+    ("manifest", "**/shipgate.yaml"),
+    ("shipgate_state", "**/.agents-shipgate/**"),
+    ("policy", "**/policies/**"),
+    ("prompts", "**/prompts/**"),
+    ("ci_gate", "**/.github/workflows/agents-shipgate.yml"),
+    ("ci_gate", "**/.github/workflows/agents-shipgate.yaml"),
+    ("agent_instructions", "**/AGENTS.md"),
+    ("agent_instructions", "**/CLAUDE.md"),
+    ("agent_instructions", "**/.claude/**"),
+    ("agent_instructions", "**/.cursor/rules/**"),
+    ("agent_instructions", "**/.agents/skills/**"),
+    ("agent_instructions", "**/.codex/**"),
+    ("codex_plugin", "**/.codex-plugin/**"),
+    ("tool_surface_decl", "**/.app.json"),
+    ("tool_surface_decl", "**/.mcp.json"),
+    ("tool_surface_decl", "**/SKILL.md"),
+)
+
+
+def run(context: ScanContext) -> list[Finding]:
+    verification = context.verification
+    if verification is None:
+        return []
+    findings: list[Finding] = []
+    seen: set[str] = set()
+    for raw in verification.changed_files:
+        path = raw.replace("\\", "/").strip()
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        classification = _classify(path)
+        if classification is None:
+            continue
+        trust_root_class, matched_glob = classification
+        findings.append(
+            _finding(context, path, trust_root_class, matched_glob)
+        )
+    return findings
+
+
+def _classify(path: str) -> tuple[str, str] | None:
+    for trust_root_class, pattern in TRUST_ROOT_SURFACES:
+        if glob_match(pattern, path):
+            return trust_root_class, pattern
+    return None
+
+
+def _finding(
+    context: ScanContext,
+    path: str,
+    trust_root_class: str,
+    matched_glob: str,
+) -> Finding:
+    return Finding(
+        check_id=CHECK_ID,
+        title=f"Release trust root touched: {path}",
+        severity=parse_severity("medium"),
+        category="verify",
+        agent_id=context.agent.id,
+        evidence={
+            "changed_file": path,
+            "trust_root_class": trust_root_class,
+            "matched_glob": matched_glob,
+        },
+        confidence=parse_confidence("high"),
+        provenance_kind="static_declaration",
+        source=SourceReference(type="changed_file", path=path),
+        recommendation=(
+            "This PR changes a file that defines the release gate's trust "
+            "spine. A human must review the change before merge; do not "
+            "weaken the gate to make CI pass."
+        ),
+    )

--- a/src/agents_shipgate/cli/_helpers.py
+++ b/src/agents_shipgate/cli/_helpers.py
@@ -317,6 +317,7 @@ def _run_multi_scan(
     packet_formats: list[str] | None = None,
     strict_plugins: bool = False,
     no_heuristics: bool = False,
+    verification_context=None,
 ) -> int:
     typer.echo(f"Agents Shipgate {__version__}")
     typer.echo(f"Scanning {len(config_paths)} manifests")
@@ -344,6 +345,7 @@ def _run_multi_scan(
                 packet_enabled=packet_enabled,
                 packet_formats=packet_formats,
                 no_heuristics=no_heuristics,
+                verification_context=verification_context,
             )
         except ConfigError as exc:
             scan_exit_code = 2

--- a/src/agents_shipgate/cli/_helpers.py
+++ b/src/agents_shipgate/cli/_helpers.py
@@ -317,7 +317,6 @@ def _run_multi_scan(
     packet_formats: list[str] | None = None,
     strict_plugins: bool = False,
     no_heuristics: bool = False,
-    verification_context=None,
 ) -> int:
     typer.echo(f"Agents Shipgate {__version__}")
     typer.echo(f"Scanning {len(config_paths)} manifests")
@@ -345,7 +344,6 @@ def _run_multi_scan(
                 packet_enabled=packet_enabled,
                 packet_formats=packet_formats,
                 no_heuristics=no_heuristics,
-                verification_context=verification_context,
             )
         except ConfigError as exc:
             scan_exit_code = 2

--- a/src/agents_shipgate/cli/_register_scan.py
+++ b/src/agents_shipgate/cli/_register_scan.py
@@ -218,6 +218,18 @@ def register(app: typer.Typer) -> None:
 
         try:
             config_paths = _resolve_config_paths(config=config, workspace=workspace)
+            if verification_context is not None and len(config_paths) > 1:
+                # --changed-files describes ONE PR's diff against ONE
+                # manifest's trust roots. Fanning the same changed-files
+                # list across every resolved manifest would mis-attribute
+                # a trust-root touch to unrelated manifests (e.g. flag both
+                # a/ and b/ for an edit under a/). Reject rather than guess.
+                raise ConfigError(
+                    "--changed-files is single-config only, but "
+                    f"{len(config_paths)} manifests resolved. Re-run scan "
+                    "against one manifest (-c <path>) when supplying "
+                    "--changed-files."
+                )
             if len(config_paths) == 1:
                 report, exit_code = run_scan(
                     config_path=config_paths[0],
@@ -261,7 +273,6 @@ def register(app: typer.Typer) -> None:
                 packet_formats=parsed_packet_formats,
                 strict_plugins=strict_plugins,
                 no_heuristics=no_heuristics,
-                verification_context=verification_context,
             )
         except ConfigError as exc:
             typer.echo(f"Config error: {exc}", err=True)

--- a/src/agents_shipgate/cli/_register_scan.py
+++ b/src/agents_shipgate/cli/_register_scan.py
@@ -21,8 +21,30 @@ from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.core.errors import AgentsShipgateError, ConfigError, InputParseError
 from agents_shipgate.core.logging import configure_logging
 from agents_shipgate.schemas.diagnostics import NextAction
+from agents_shipgate.schemas.verification import VerificationContext
 
 logger = logging.getLogger(__name__)
+
+
+def _build_verification_context(
+    changed_files: Path | None,
+) -> VerificationContext | None:
+    """Build the verification context from a --changed-files file.
+
+    Returns None when no file is given (plain scan behavior). Raises
+    ConfigError when the path is supplied but unreadable — a CLI flag
+    value problem, not a manifest problem.
+    """
+    if changed_files is None:
+        return None
+    try:
+        text = changed_files.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigError(
+            f"--changed-files file could not be read: {changed_files} ({exc})"
+        ) from exc
+    paths = [line.strip() for line in text.splitlines() if line.strip()]
+    return VerificationContext(changed_files=paths, diff_text_available=False)
 
 
 def register(app: typer.Typer) -> None:
@@ -146,6 +168,17 @@ def register(app: typer.Typer) -> None:
                 "PDF requires the [pdf] extras."
             ),
         ),
+        changed_files: Path | None = typer.Option(
+            None,
+            "--changed-files",
+            help=(
+                "Path to a file of newline-separated changed paths "
+                "(repo-relative). Supplies the verification context so "
+                "trust-root checks (e.g. SHIP-VERIFY-TRUST-ROOT-TOUCHED) "
+                "fire. Single-config scans only; without it, plain scan "
+                "behavior is unchanged."
+            ),
+        ),
         verbose: bool = typer.Option(False, "--verbose", help="Show debug extraction details."),
     ) -> None:
         """Run the local-first, static Tool-Use Readiness release gate for AI agent tool surfaces."""
@@ -160,6 +193,7 @@ def register(app: typer.Typer) -> None:
             if ci_mode and ci_mode not in {"advisory", "strict"}:
                 raise ConfigError("--ci-mode must be advisory or strict")
             parsed_fail_on = _parse_fail_on(fail_on)
+            verification_context = _build_verification_context(changed_files)
         except ConfigError as exc:
             typer.echo(f"Config error: {exc}", err=True)
             guidance = (
@@ -202,6 +236,7 @@ def register(app: typer.Typer) -> None:
                     packet_enabled=packet,
                     packet_formats=parsed_packet_formats,
                     no_heuristics=no_heuristics,
+                    verification_context=verification_context,
                 )
                 exit_code = _apply_strict_plugins(
                     report, exit_code, strict_plugins=strict_plugins
@@ -226,6 +261,7 @@ def register(app: typer.Typer) -> None:
                 packet_formats=parsed_packet_formats,
                 strict_plugins=strict_plugins,
                 no_heuristics=no_heuristics,
+                verification_context=verification_context,
             )
         except ConfigError as exc:
             typer.echo(f"Config error: {exc}", err=True)

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -23,6 +23,7 @@ from agents_shipgate.cli.findings import findings as _findings_command
 from agents_shipgate.cli.fixture import fixture_app
 from agents_shipgate.cli.scenario import scenario_app
 from agents_shipgate.cli.self_check import self_check
+from agents_shipgate.cli.trigger import trigger as _trigger_command
 
 app = typer.Typer(
     name="agents-shipgate",
@@ -76,6 +77,13 @@ app.command(
         "reviewer triage."
     ),
 )(_findings_command)
+app.command(
+    "trigger",
+    help=(
+        "Evaluate the trigger catalog against a diff and emit a run/skip "
+        "verdict. Reads --changed-files / --diff, or --base/--head (git)."
+    ),
+)(_trigger_command)
 _register_scan.register(app)
 _register_list_checks.register(app)
 _register_contract.register(app)

--- a/src/agents_shipgate/cli/scan/decision.py
+++ b/src/agents_shipgate/cli/scan/decision.py
@@ -23,6 +23,7 @@ from agents_shipgate.core.lenses.action_surface import (
 from agents_shipgate.core.severity_overrides import resolve_severity_overrides
 from agents_shipgate.inputs.policy_packs import run_policy_pack_rules
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.verification import VerificationContext
 
 from .models import _ChecksDecision, _DiffReferences, _LoadedInputs, _ToolsAndAgent
 from .patching import _attach_patches, _check_metadata_lookup
@@ -41,6 +42,7 @@ def _run_checks_and_decide(
     plugins_enabled: bool | None,
     suggest_patches: bool,
     no_heuristics: bool,
+    verification_context: VerificationContext | None = None,
 ) -> _ChecksDecision:
     """Phase 5: build internal action-surface facts, run all checks
     (built-in + plugin + policy-pack + action-surface policies),
@@ -76,6 +78,7 @@ def _run_checks_and_decide(
         framework_artifacts=inputs.artifact_bag,
         action_surface_facts=action_surface_facts,
         manifest_positions=manifest_positions,
+        verification=verification_context,
     )
     loaded_plugins: list[dict[str, str | None]] = []
     findings = run_checks(

--- a/src/agents_shipgate/cli/scan/orchestrator.py
+++ b/src/agents_shipgate/cli/scan/orchestrator.py
@@ -6,6 +6,7 @@ from agents_shipgate import _perf
 from agents_shipgate.ci.github_summary import write_github_step_summary
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.schemas.report import ReadinessReport
+from agents_shipgate.schemas.verification import VerificationContext
 
 from .decision import _run_checks_and_decide
 from .diffs import _load_diff_references
@@ -37,6 +38,7 @@ def run_scan(
     packet_enabled: bool | None = None,
     packet_formats: list[str] | None = None,
     packet_generated_at: str | None = None,
+    verification_context: VerificationContext | None = None,
 ) -> tuple[ReadinessReport, int]:
     """Run a full scan pipeline. Returns ``(report, exit_code)``.
 
@@ -93,6 +95,7 @@ def run_scan(
             plugins_enabled=plugins_enabled,
             suggest_patches=suggest_patches,
             no_heuristics=no_heuristics,
+            verification_context=verification_context,
         )
     with _perf.phase("plan_outputs"):
         plan = _plan_outputs(

--- a/src/agents_shipgate/cli/trigger.py
+++ b/src/agents_shipgate/cli/trigger.py
@@ -126,8 +126,18 @@ def trigger(
             )
             raise typer.Exit(2) from exc
     else:
-        paths = _read_lines(changed_files)
-        diff_text = diff.read_text(encoding="utf-8") if diff is not None else ""
+        try:
+            paths = _read_lines(changed_files)
+            diff_text = (
+                diff.read_text(encoding="utf-8") if diff is not None else ""
+            )
+        except (OSError, UnicodeDecodeError) as exc:
+            typer.echo(
+                f"Could not read trigger input file: {exc}. Check the "
+                "--changed-files / --diff path.",
+                err=True,
+            )
+            raise typer.Exit(2) from exc
 
     if manifest_present is None:
         manifest_present_resolved = (workspace / "shipgate.yaml").is_file()

--- a/src/agents_shipgate/cli/trigger.py
+++ b/src/agents_shipgate/cli/trigger.py
@@ -1,0 +1,172 @@
+"""``agents-shipgate trigger`` — evaluate the published trigger catalog.
+
+Promotes the :mod:`agents_shipgate.triggers` evaluator to a first-class
+subcommand. It decides whether Shipgate should *run* on a diff; it does
+not decide safety (that is ``scan`` / ``verify`` and
+``release_decision.decision``).
+
+Inputs, in precedence order:
+
+1. ``--base``/``--head`` — shell out to ``git diff`` for changed paths
+   and the unified-diff body. This is the ONLY mode that runs git.
+2. ``--changed-files PATH`` / ``--diff PATH`` — read changed paths
+   (newline-separated) and a unified-diff body from local files. No
+   git, no network.
+
+``--list-rules [--json]`` prints the catalog and exits. The developer
+entry point ``python -m agents_shipgate.triggers`` is preserved.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import typer
+
+from agents_shipgate.triggers import (
+    _git_diff_context,
+    evaluate,
+    load_triggers,
+)
+
+
+def trigger(
+    workspace: Path = typer.Option(
+        Path("."),
+        "--workspace",
+        help=(
+            "Workspace root. Used to detect whether shipgate.yaml is "
+            "present (the opt-in that flips force_run) and as the git "
+            "working directory for --base/--head."
+        ),
+    ),
+    changed_files: Path | None = typer.Option(
+        None,
+        "--changed-files",
+        help=(
+            "Path to a file of newline-separated changed paths "
+            "(repo-relative, forward slashes). Ignored when "
+            "--base/--head is passed."
+        ),
+    ),
+    diff: Path | None = typer.Option(
+        None,
+        "--diff",
+        help=(
+            "Path to a file containing the unified-diff body. Used for "
+            "diff_contains predicates (e.g. @function_tool). Ignored "
+            "when --base/--head is passed."
+        ),
+    ),
+    base: str | None = typer.Option(
+        None,
+        "--base",
+        help=(
+            "Git base ref for a PR-style diff (e.g. origin/main). "
+            "Passing --base or --head is the only thing that runs git."
+        ),
+    ),
+    head: str | None = typer.Option(
+        None,
+        "--head",
+        help="Git head ref (defaults to HEAD when --base is given).",
+    ),
+    manifest_present: bool | None = typer.Option(
+        None,
+        "--manifest-present/--no-manifest-present",
+        help=(
+            "Override shipgate.yaml detection. When unset, presence is "
+            "auto-detected under --workspace."
+        ),
+    ),
+    user_requested: bool = typer.Option(
+        False,
+        "--user-requested",
+        help="The user explicitly asked for a Shipgate run (suppresses stop_conditions).",
+    ),
+    list_rules: bool = typer.Option(
+        False,
+        "--list-rules",
+        help="Print the loaded rule catalog and exit.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit JSON output. Default: human-readable summary.",
+    ),
+) -> None:
+    """Decide whether Shipgate should run on a diff (run/skip verdict)."""
+    triggers = load_triggers()
+
+    if list_rules:
+        if json_output:
+            typer.echo(json.dumps(triggers, indent=2))
+        else:
+            for rule in triggers.get("rules", []):
+                typer.echo(
+                    f"{rule['id']}\t{rule['action']}\t{rule.get('rationale', '')}"
+                )
+        return
+
+    use_git = base is not None or head is not None
+    if use_git:
+        head_ref = head or "HEAD"
+        revspec = f"{base}...{head_ref}" if base else head_ref
+        try:
+            paths, diff_text = _git_diff_context(
+                revspec, cwd=workspace.resolve()
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            typer.echo(
+                f"--base/--head git diff failed: {exc}. Run inside a git "
+                "checkout, or pass --changed-files / --diff instead.",
+                err=True,
+            )
+            raise typer.Exit(2) from exc
+    else:
+        paths = _read_lines(changed_files)
+        diff_text = diff.read_text(encoding="utf-8") if diff is not None else ""
+
+    if manifest_present is None:
+        manifest_present_resolved = (workspace / "shipgate.yaml").is_file()
+    else:
+        manifest_present_resolved = manifest_present
+
+    result = evaluate(
+        paths=paths,
+        diff_text=diff_text,
+        manifest_present=manifest_present_resolved,
+        user_requested=user_requested,
+        triggers=triggers,
+    )
+
+    if json_output:
+        typer.echo(json.dumps(result, indent=2))
+        return
+
+    verdict = "RUN" if result["should_run"] else "SKIP"
+    typer.echo(f"Verdict: {verdict}")
+    typer.echo(f"Rationale: {result['rationale']}")
+    if result["dry_run_recommended"]:
+        typer.echo("Dry-run recommended (advisory scan, no manifest write).")
+    if result["matched_rules"]:
+        typer.echo("Matched rules:")
+        for match in result["matched_rules"]:
+            command = f" → {match['command']}" if match.get("command") else ""
+            typer.echo(f"  - {match['id']} [{match['action']}]{command}")
+    if result["diff_tokens"]:
+        typer.echo(f"Diff tokens: {', '.join(result['diff_tokens'])}")
+    if result["stop_conditions_fired"]:
+        typer.echo("Stop conditions fired (overriding any matched rules).")
+
+
+def _read_lines(path: Path | None) -> list[str]:
+    if path is None:
+        return []
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]

--- a/src/agents_shipgate/core/check_ids.py
+++ b/src/agents_shipgate/core/check_ids.py
@@ -2,6 +2,17 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+# Reward-hacking guard. Findings in these categories define the release
+# gate's trust spine (trust-root protection). A manifest ``checks.ignore``
+# suppression must NOT be able to hide them — otherwise a coding agent
+# could edit ``shipgate.yaml`` to add ``ignore: SHIP-VERIFY-TRUST-ROOT-
+# TOUCHED`` and silence the very check that flags that edit. Enforced in
+# ``apply_suppressions``; mirrors how baseline-integrity findings are
+# immune (they are appended after suppression runs). Severity weakening
+# of these checks is blocked separately by ``CheckMetadata.floor_severity``.
+# See docs/engineering/ai-coding-workflow-verifier.md §3 (Principle 3) and §5.
+UNSUPPRESSIBLE_FINDING_CATEGORIES: frozenset[str] = frozenset({"verify"})
+
 LEGACY_CHECK_ID_ALIASES: dict[str, tuple[str, ...]] = {
     "SHIP-API-OPERATIONAL-READINESS": (
         "SHIP-API-RETRY-POLICY-MISSING",

--- a/src/agents_shipgate/core/context.py
+++ b/src/agents_shipgate/core/context.py
@@ -22,6 +22,7 @@ from agents_shipgate.core.domain import (
 from agents_shipgate.inputs.common import PositionIndex
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
 from agents_shipgate.schemas.surfaces import ActionSurfaceFacts
+from agents_shipgate.schemas.verification import VerificationContext
 
 T = TypeVar("T")
 
@@ -55,6 +56,11 @@ class ScanContext:
     # callers that don't thread the index keep working with
     # ``positions.lookup(...) == None``.
     manifest_positions: PositionIndex = field(default_factory=_empty_position_index)
+    # Optional diff-aware metadata supplied by the verifier workflow
+    # (``--changed-files`` today; ``verify`` orchestration in P1). When
+    # None, verify/trust-root checks emit nothing and plain ``scan``
+    # behavior is unchanged. See ``schemas/verification.py``.
+    verification: VerificationContext | None = None
 
     def artifact(self, source_type: str, expected_type: type[T]) -> T | None:
         return self.framework_artifacts.get(source_type, expected_type)

--- a/src/agents_shipgate/core/findings/mutations.py
+++ b/src/agents_shipgate/core/findings/mutations.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from collections import Counter
 
-from agents_shipgate.core.check_ids import expands_to_check_id
+from agents_shipgate.core.check_ids import (
+    UNSUPPRESSIBLE_FINDING_CATEGORIES,
+    expands_to_check_id,
+)
 from agents_shipgate.schemas.common import Severity
 from agents_shipgate.schemas.manifest import SuppressionConfig
 from agents_shipgate.schemas.report import (
@@ -18,6 +21,12 @@ def apply_suppressions(
     findings: list[Finding], suppressions: list[SuppressionConfig]
 ) -> list[Finding]:
     for finding in findings:
+        # Trust-root / verify findings are the reward-hacking guard and
+        # cannot be silenced by a manifest checks.ignore entry — a PR that
+        # edits shipgate.yaml to suppress them must NOT pass. See
+        # UNSUPPRESSIBLE_FINDING_CATEGORIES.
+        if finding.category in UNSUPPRESSIBLE_FINDING_CATEGORIES:
+            continue
         match = _matching_suppression(finding, suppressions)
         if match:
             finding.suppressed = True

--- a/src/agents_shipgate/core/globbing.py
+++ b/src/agents_shipgate/core/globbing.py
@@ -1,0 +1,55 @@
+"""Shared glob matcher with ``**`` (globstar) semantics.
+
+Extracted from :mod:`agents_shipgate.triggers` so the trigger evaluator
+and the verify/trust-root check classify paths against the exact same
+rules. Path separators are forward slashes; backslashes are normalized.
+
+``**/foo`` matches ``foo`` at any depth (including the repo root);
+``dir/**`` matches ``dir`` and anything below it; bare ``**`` matches
+zero or more characters across path segments. ``*`` and ``?`` are
+segment-local (do not cross ``/``).
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def glob_match(pattern: str, path: str) -> bool:
+    """Return whether ``path`` matches the ``**``-extended ``pattern``."""
+    pattern = pattern.replace("\\", "/")
+    path = path.replace("\\", "/")
+    if not any(token in pattern for token in ("*", "?", "[")):
+        return path == pattern
+
+    parts: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        if pattern.startswith("**/", i):
+            parts.append("(?:[^/]+/)*")
+            i += 3
+        elif pattern.startswith("/**", i):
+            parts.append("(?:/.*)?")
+            i += 3
+        elif pattern.startswith("**", i):
+            parts.append(".*")
+            i += 2
+        elif pattern[i] == "*":
+            parts.append("[^/]*")
+            i += 1
+        elif pattern[i] == "?":
+            parts.append("[^/]")
+            i += 1
+        elif pattern[i] == "[":
+            close = pattern.find("]", i + 1)
+            if close == -1:
+                parts.append(re.escape(pattern[i]))
+                i += 1
+            else:
+                parts.append(pattern[i : close + 1])
+                i = close + 1
+        else:
+            parts.append(re.escape(pattern[i]))
+            i += 1
+    return re.fullmatch("".join(parts), path) is not None

--- a/src/agents_shipgate/schemas/verification.py
+++ b/src/agents_shipgate/schemas/verification.py
@@ -1,0 +1,32 @@
+"""Verification context — the optional diff-aware input for verify checks.
+
+``scan`` reads ``shipgate.yaml`` plus declared local sources; it does not
+know which paths a PR changed. Checks that reason about "this PR touched
+a trust root" need that diff context separately. ``VerificationContext``
+carries it.
+
+Rules (see docs/engineering/ai-coding-workflow-verifier.md §2.5, §4.1):
+
+- It is input metadata, NOT a release verdict.
+- It may cause checks to emit ordinary ``Finding``s.
+- It must never bypass ``release_decision``.
+- Absence (``ScanContext.verification is None``) means plain ``scan``
+  behavior — verify checks emit nothing.
+
+M1 populates ``changed_files`` only; ``verify`` (P1) will add base/head
+orchestration fields additively.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VerificationContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    changed_files: list[str] = Field(default_factory=list)
+    diff_text_available: bool = False
+    trigger_result: dict[str, Any] = Field(default_factory=dict)

--- a/src/agents_shipgate/triggers.py
+++ b/src/agents_shipgate/triggers.py
@@ -21,12 +21,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 from importlib.resources import files
 from pathlib import Path
 from typing import Any
+
+from agents_shipgate.core.globbing import glob_match as _glob_match
 
 _TRIGGERS_FILENAME = "triggers.json"
 
@@ -76,51 +77,36 @@ def load_triggers() -> dict[str, Any]:
     )
 
 
-def _glob_match(pattern: str, path: str) -> bool:
-    """Match ``path`` against a glob extended with ``**`` semantics.
+def _collect_diff_contains(pred: Any, out: set[str]) -> None:
+    """Walk a predicate tree and collect every ``diff_contains`` token."""
+    if not isinstance(pred, dict):
+        return
+    for key in ("any_of", "all_of"):
+        if key in pred:
+            for nested in pred[key]:
+                _collect_diff_contains(nested, out)
+    token = pred.get("diff_contains")
+    if isinstance(token, str):
+        out.add(token)
 
-    ``**/foo`` matches ``foo`` at any depth (including the repo root);
-    ``dir/**`` matches ``dir`` and anything below it; bare ``**``
-    matches zero or more characters across path segments. ``*`` and
-    ``?`` are segment-local (do not cross ``/``). Path separators are
-    forward slashes; backslashes are normalized.
+
+def _matched_diff_tokens(triggers: dict[str, Any], diff_text: str) -> list[str]:
+    """Return the catalog ``diff_contains`` tokens present in ``diff_text``.
+
+    Deterministic (sorted, de-duplicated). These are the stable token
+    forms — decorator names, package names, function calls — that the
+    catalog watches for and that actually appear in the supplied diff.
     """
-    pattern = pattern.replace("\\", "/")
-    path = path.replace("\\", "/")
-    if not any(token in pattern for token in ("*", "?", "[")):
-        return path == pattern
-
-    parts: list[str] = []
-    i = 0
-    n = len(pattern)
-    while i < n:
-        if pattern.startswith("**/", i):
-            parts.append("(?:[^/]+/)*")
-            i += 3
-        elif pattern.startswith("/**", i):
-            parts.append("(?:/.*)?")
-            i += 3
-        elif pattern.startswith("**", i):
-            parts.append(".*")
-            i += 2
-        elif pattern[i] == "*":
-            parts.append("[^/]*")
-            i += 1
-        elif pattern[i] == "?":
-            parts.append("[^/]")
-            i += 1
-        elif pattern[i] == "[":
-            close = pattern.find("]", i + 1)
-            if close == -1:
-                parts.append(re.escape(pattern[i]))
-                i += 1
-            else:
-                parts.append(pattern[i : close + 1])
-                i = close + 1
-        else:
-            parts.append(re.escape(pattern[i]))
-            i += 1
-    return re.fullmatch("".join(parts), path) is not None
+    if not diff_text:
+        return []
+    tokens: set[str] = set()
+    for rule in triggers.get("rules", []):
+        _collect_diff_contains(rule.get("when"), tokens)
+    stop_block = triggers.get("stop_conditions") or {}
+    _collect_diff_contains(
+        {k: v for k, v in stop_block.items() if k != "description"}, tokens
+    )
+    return sorted(token for token in tokens if token in diff_text)
 
 
 def _eval_predicate(
@@ -215,16 +201,26 @@ def evaluate(
 
     Returns a dict with:
 
+    - ``schema_version`` (str) — the trigger catalog's schema version.
+    - ``should_run`` (bool) — friendly alias of ``run_shipgate`` (same
+      value); kept so consumers reading either field agree.
     - ``run_shipgate`` (bool) — final verdict.
-    - ``matched_rules`` (list) — every rule whose ``when`` clause fired.
-    - ``stop_conditions_fired`` (bool) — whether the explicit stop
-      block held; this beats every rule action.
+    - ``force_run`` (bool) — a ``force_run`` rule matched and was not
+      overridden by the stop block (opted-in repo → run on every PR).
     - ``dry_run_recommended`` (bool) — true when a ``dry_run`` rule
       fired and no ``run_shipgate``/``force_run``/``skip_shipgate``
       rule did. Callers that want to be helpful can propose a
       non-mutating ``scan`` even though ``run_shipgate`` is false.
+    - ``skip_reason`` (str|None) — ``None`` when running; otherwise a
+      stable token: ``stop_conditions``, ``skip_rule``, ``dry_run_only``
+      or ``no_match``.
+    - ``stop_conditions_fired`` (bool) — whether the explicit stop
+      block held; this beats every rule action.
     - ``rationale`` (str) — single-sentence explanation.
-    - ``schema_version`` (str) — the trigger catalog's schema version.
+    - ``matched_rules`` (list) — every rule whose ``when`` clause fired.
+    - ``changed_files`` (list) — the input paths, echoed back.
+    - ``diff_tokens`` (list) — catalog ``diff_contains`` tokens that
+      are present in ``diff_text`` (sorted, de-duplicated).
 
     Action precedence (highest first): ``stop_conditions`` → skip;
     ``force_run`` → run (overrides skip; used by manifest-present);
@@ -273,8 +269,10 @@ def evaluate(
     has_dry_run = any(a == ACTION_DRY_RUN for a in actions)
 
     dry_run_recommended = False
+    skip_reason: str | None = None
     if stop_fired:
         run = False
+        skip_reason = "stop_conditions"
         rationale = (
             "Stop conditions hold (detect classifies as non-agent, "
             "no manifest, user did not explicitly request a scan)."
@@ -288,6 +286,7 @@ def evaluate(
         )
     elif has_skip:
         run = False
+        skip_reason = "skip_rule"
         skipping = [m["id"] for m in matched if m["action"] == ACTION_SKIP]
         rationale = (
             "skip_shipgate rule(s) matched (beats run_shipgate): "
@@ -300,6 +299,7 @@ def evaluate(
     elif has_dry_run:
         run = False
         dry_run_recommended = True
+        skip_reason = "dry_run_only"
         dry = [m["id"] for m in matched if m["action"] == ACTION_DRY_RUN]
         rationale = (
             "dry_run rule(s) matched (advisory, no manifest write): "
@@ -307,21 +307,31 @@ def evaluate(
         )
     else:
         run = False
+        skip_reason = "no_match"
         rationale = (
             "No rules matched; nothing in this PR signals a tool-surface change."
         )
 
+    # ``should_run`` is a friendlier alias of ``run_shipgate`` (identical
+    # value); both are kept so 0.x consumers reading either field agree.
     return {
+        "schema_version": triggers.get("schema_version"),
+        "should_run": run,
         "run_shipgate": run,
+        "force_run": has_force_run and not stop_fired,
         "dry_run_recommended": dry_run_recommended,
-        "matched_rules": matched,
+        "skip_reason": skip_reason,
         "stop_conditions_fired": stop_fired,
         "rationale": rationale,
-        "schema_version": triggers.get("schema_version"),
+        "matched_rules": matched,
+        "changed_files": list(paths),
+        "diff_tokens": _matched_diff_tokens(triggers, diff_text),
     }
 
 
-def _git_diff_context(revspec: str | None) -> tuple[list[str], str]:
+def _git_diff_context(
+    revspec: str | None, *, cwd: Path | None = None
+) -> tuple[list[str], str]:
     """Read changed paths and the unified-diff body from ``git diff``.
 
     ``revspec`` semantics:
@@ -336,25 +346,33 @@ def _git_diff_context(revspec: str | None) -> tuple[list[str], str]:
       NOT captured in ``diff_text`` because reading arbitrary unstaged
       files into memory is risky.
 
+    ``cwd`` selects the git working directory; ``None`` uses the
+    process cwd.
+
     Returns ``([paths], diff_text)``.
     """
+    run_kwargs: dict[str, Any] = {
+        "capture_output": True,
+        "text": True,
+        "check": True,
+    }
+    if cwd is not None:
+        run_kwargs["cwd"] = str(cwd)
     if revspec:
         names_cmd = ["git", "diff", "--name-only", revspec]
         body_cmd = ["git", "diff", revspec]
     else:
         names_cmd = ["git", "diff", "HEAD", "--name-only"]
         body_cmd = ["git", "diff", "HEAD"]
-    names = subprocess.run(names_cmd, capture_output=True, text=True, check=True)
-    body = subprocess.run(body_cmd, capture_output=True, text=True, check=True)
+    names = subprocess.run(names_cmd, **run_kwargs)
+    body = subprocess.run(body_cmd, **run_kwargs)
     paths = [line for line in names.stdout.splitlines() if line.strip()]
     diff_text = body.stdout
 
     if not revspec:
         untracked = subprocess.run(
             ["git", "ls-files", "--others", "--exclude-standard"],
-            capture_output=True,
-            text=True,
-            check=True,
+            **run_kwargs,
         )
         for line in untracked.stdout.splitlines():
             stripped = line.strip()

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -226,7 +226,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="triggers.py",
         surface="import:subprocess",
-        line=25,
+        line=24,
         snippet="import subprocess",
         rationale=(
             "Trigger evaluation runs ``git diff`` to determine whether a "
@@ -237,43 +237,54 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="triggers.py",
         surface="attr_call:subprocess.run",
-        line=347,
-        snippet=(
-            "subprocess.run(names_cmd, capture_output=True, text=True, "
-            "check=True)"
-        ),
+        line=367,
+        snippet="subprocess.run(names_cmd, **run_kwargs)",
         rationale=(
             "git-diff change-name pass: ``git diff --name-only "
-            "base...HEAD``. argv constructed inside Shipgate from "
-            "validated base ref (names_cmd built at call site)."
+            "base...HEAD``. argv (names_cmd) constructed inside Shipgate "
+            "from validated base ref; run_kwargs is a fixed capture-only "
+            "dict (capture_output/text/check, optional cwd)."
         ),
     ),
     AllowedException(
         relative_path="triggers.py",
         surface="attr_call:subprocess.run",
-        line=348,
-        snippet=(
-            "subprocess.run(body_cmd, capture_output=True, text=True, "
-            "check=True)"
-        ),
+        line=368,
+        snippet="subprocess.run(body_cmd, **run_kwargs)",
         rationale=(
             "git-diff body pass: ``git diff base...HEAD`` for full "
-            "diff body inspection. argv constructed inside Shipgate "
-            "(body_cmd built at call site)."
+            "diff body inspection. argv (body_cmd) constructed inside "
+            "Shipgate; run_kwargs is the same fixed capture-only dict."
         ),
     ),
     AllowedException(
         relative_path="triggers.py",
         surface="attr_call:subprocess.run",
-        line=353,
+        line=373,
         snippet=(
             "subprocess.run(['git', 'ls-files', '--others', "
-            "'--exclude-standard'], capture_output=True, text=True, "
-            "check=True)"
+            "'--exclude-standard'], **run_kwargs)"
         ),
         rationale=(
             "git-untracked enumeration: ``git ls-files --others "
             "--exclude-standard``. Fixed argv, capture-only, no shell."
+        ),
+    ),
+    # cli/trigger.py — the `agents-shipgate trigger` subcommand imports
+    # subprocess ONLY to catch ``subprocess.CalledProcessError`` from the
+    # shared ``triggers._git_diff_context`` git probe (allowlisted above).
+    # It issues no subprocess call of its own — git is invoked exclusively
+    # inside triggers.py, and only when --base/--head is passed.
+    AllowedException(
+        relative_path="cli/trigger.py",
+        surface="import:subprocess",
+        line=23,
+        snippet="import subprocess",
+        rationale=(
+            "trigger subcommand catches subprocess.CalledProcessError from "
+            "the shared triggers._git_diff_context git probe; this file "
+            "issues no subprocess.run call itself (git runs in triggers.py "
+            "only, and only under --base/--head)."
         ),
     ),
     # cli/self_check.py — validates the installed environment via __import__
@@ -298,7 +309,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="triggers.py",
         surface="import:importlib.resources.files",
-        line=27,
+        line=26,
         snippet="from importlib.resources import files",
         rationale=(
             "triggers.py reads the bundled docs/triggers.json catalog from "
@@ -310,7 +321,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="triggers.py",
         surface="attr_call:importlib.resources.files",
-        line=61,
+        line=62,
         snippet="files('agents_shipgate')",
         rationale=(
             "Resolves the bundled trigger catalog (docs/triggers.json) "
@@ -1214,7 +1225,7 @@ def test_allowed_exceptions_pin_subprocess_run_per_call_site() -> None:
 
     Confirms that ``triggers.py`` has THREE distinct
     ``subprocess.run`` AllowedException entries (one per call site at
-    lines 347, 348, 353), not one blanket entry that permits all
+    lines 367, 368, 373), not one blanket entry that permits all
     occurrences. Same for ``cli/discovery/artifacts.py`` (two call
     sites at 361 and 377). Adding a fourth ``subprocess.run`` to
     ``triggers.py`` must require adding a new ALLOWED_EXCEPTIONS entry.
@@ -1234,7 +1245,7 @@ def test_allowed_exceptions_pin_subprocess_run_per_call_site() -> None:
     assert len(triggers_subprocess_run) == 3, (
         f"Expected 3 distinct AllowedException entries for "
         f"triggers.py subprocess.run calls (one per call site at "
-        f"lines 347, 348, 353), got {len(triggers_subprocess_run)}. "
+        f"lines 367, 368, 373), got {len(triggers_subprocess_run)}. "
         f"Per-call-site pinning is the structural fix for the "
         f"P1 review finding — each subprocess.run call must have "
         f"its own entry with line + snippet pinning."

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -853,6 +853,68 @@ def test_triggers_json_rule_rows_appear_verbatim_in_agents_md():
         )
 
 
+def _agents_md_trigger_table_rows() -> list[tuple[str, str]]:
+    """Parse the (trigger, decision) data rows of the AGENTS.md
+    "Should I run Shipgate on this PR?" markdown table."""
+    agents_md = _read("AGENTS.md")
+    start = agents_md.index("| Trigger in this PR")
+    table_lines: list[str] = []
+    for line in agents_md[start:].splitlines():
+        if not line.startswith("|"):
+            break
+        table_lines.append(line)
+    rows: list[tuple[str, str]] = []
+    for line in table_lines[2:]:  # skip header + separator
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) == 2:
+            rows.append((cells[0], cells[1]))
+    return rows
+
+
+def test_agents_md_trigger_table_rows_are_covered_by_catalog():
+    """Reverse of the verbatim-rows test: every row in the AGENTS.md
+    trigger table must be backed by a docs/triggers.json rule. A 'Yes'
+    row needs a run_shipgate/force_run rule with that exact
+    ``agents_md_row``; a plain 'Skip' row needs a skip_shipgate rule;
+    a 'dry-run' row is the advisory refactor case (the dry_run rule uses
+    different prose, so only require that a dry_run rule exists).
+
+    Catches the drift where a new tool surface is added to the prose
+    table (e.g. n8n) but no catalog rule is added, so a coding agent
+    applying triggers.json would silently miss it."""
+    triggers = _load_triggers_json()
+    rows_by_action: dict[str, set[str]] = {}
+    for rule in triggers["rules"]:
+        rows_by_action.setdefault(rule["action"], set()).add(rule["agents_md_row"])
+    run_rows = rows_by_action.get("run_shipgate", set()) | rows_by_action.get(
+        "force_run", set()
+    )
+    skip_rows = rows_by_action.get("skip_shipgate", set())
+    has_dry_run_rule = bool(rows_by_action.get("dry_run"))
+
+    data_rows = _agents_md_trigger_table_rows()
+    assert data_rows, "Could not parse the AGENTS.md trigger table."
+
+    for trigger_text, decision in data_rows:
+        decision_l = decision.lower()
+        if decision_l == "yes":
+            assert trigger_text in run_rows, (
+                f"AGENTS.md trigger row {trigger_text!r} (decision={decision!r}) "
+                "has no run_shipgate/force_run rule in docs/triggers.json. Add a "
+                "rule whose agents_md_row matches this cell, or fix the table."
+            )
+        elif "dry-run" in decision_l:
+            assert has_dry_run_rule, (
+                f"AGENTS.md row {trigger_text!r} (decision={decision!r}) implies "
+                "an advisory dry-run, but docs/triggers.json has no dry_run rule."
+            )
+        else:  # plain Skip
+            assert trigger_text in skip_rows, (
+                f"AGENTS.md skip row {trigger_text!r} (decision={decision!r}) has "
+                "no skip_shipgate rule in docs/triggers.json."
+            )
+
+
 def test_triggers_evaluator_smoke():
     """Sanity-check the evaluator for the canonical positive and
     negative cases. Prevents a regression where rule semantics drift

--- a/tests/test_trigger_command.py
+++ b/tests/test_trigger_command.py
@@ -1,0 +1,151 @@
+"""`agents-shipgate trigger` subcommand + the M1 evaluate() output shape.
+
+The trigger evaluator decides whether Shipgate should run on a diff. M1
+promotes it to a first-class subcommand and extends the output with the
+verifier-workflow fields (should_run, force_run, skip_reason,
+changed_files, diff_tokens) while preserving the back-compat fields.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.triggers import evaluate
+
+runner = CliRunner()
+
+# The full M1 output contract: the spec's documented fields plus the
+# back-compat fields the canonical-evaluator doc requires us to keep.
+M1_KEYS = {
+    "schema_version",
+    "should_run",
+    "run_shipgate",
+    "force_run",
+    "dry_run_recommended",
+    "skip_reason",
+    "stop_conditions_fired",
+    "rationale",
+    "matched_rules",
+    "changed_files",
+    "diff_tokens",
+}
+
+
+def test_evaluate_emits_full_m1_shape():
+    result = evaluate(paths=["agent.py"], diff_text="+@function_tool\n")
+    assert M1_KEYS <= set(result)
+    assert result["should_run"] is True
+    assert result["should_run"] == result["run_shipgate"]
+    assert result["changed_files"] == ["agent.py"]
+    assert result["diff_tokens"] == ["@function_tool"]
+    assert result["skip_reason"] is None
+
+
+def test_evaluate_skip_reason_tokens_track_precedence():
+    forced = evaluate(paths=["README.md"], manifest_present=True)
+    assert forced["should_run"] is True
+    assert forced["force_run"] is True
+    assert forced["skip_reason"] is None
+
+    skipped = evaluate(paths=["README.md"])
+    assert skipped["should_run"] is False
+    assert skipped["skip_reason"] == "skip_rule"
+
+    no_match = evaluate(paths=["src/internal/util.py"])
+    assert no_match["should_run"] is False
+    assert no_match["skip_reason"] == "no_match"
+
+    dry = evaluate(paths=["requirements.txt"], diff_text="+langchain==0.3.0\n")
+    assert dry["should_run"] is False
+    assert dry["dry_run_recommended"] is True
+    assert dry["skip_reason"] == "dry_run_only"
+
+
+def test_evaluate_diff_tokens_only_reports_present_tokens():
+    result = evaluate(paths=["a.py"], diff_text="+ no markers here\n")
+    assert result["diff_tokens"] == []
+    multi = evaluate(
+        paths=["a.py"],
+        diff_text="+@function_tool\n+ type: n8n-nodes-base.httpRequest\n",
+    )
+    assert multi["diff_tokens"] == ["@function_tool", "n8n-nodes-base."]
+
+
+def test_trigger_subcommand_json_shape(tmp_path):
+    (tmp_path / "shipgate.yaml").write_text("schema_version: '0.1'\n", encoding="utf-8")
+    changed = tmp_path / "cf.txt"
+    changed.write_text("shipgate.yaml\nagent.py\n", encoding="utf-8")
+    diff = tmp_path / "df.txt"
+    diff.write_text("+@function_tool\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "trigger",
+            "--workspace",
+            str(tmp_path),
+            "--changed-files",
+            str(changed),
+            "--diff",
+            str(diff),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert M1_KEYS <= set(payload)
+    assert payload["schema_version"] == "0.1"
+    assert payload["should_run"] is True
+    assert payload["force_run"] is True  # shipgate.yaml present in workspace
+    assert payload["skip_reason"] is None
+    assert payload["changed_files"] == ["shipgate.yaml", "agent.py"]
+    assert payload["diff_tokens"] == ["@function_tool"]
+    matched_ids = {m["id"] for m in payload["matched_rules"]}
+    assert "TRIGGER-EXISTING-MANIFEST-PRESENT" in matched_ids
+
+
+def test_trigger_subcommand_runs_without_git_when_no_base_head(tmp_path):
+    """tmp_path is not a git repo. With only --changed-files (no
+    --base/--head) the command must never shell out to git."""
+    changed = tmp_path / "cf.txt"
+    changed.write_text("tools/my_mcp.json\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["trigger", "--workspace", str(tmp_path), "--changed-files", str(changed), "--json"],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["should_run"] is True
+    assert payload["force_run"] is False  # no shipgate.yaml in workspace
+
+
+def test_trigger_subcommand_docs_only_skips(tmp_path):
+    changed = tmp_path / "cf.txt"
+    changed.write_text("README.md\ndocs/guide.md\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["trigger", "--workspace", str(tmp_path), "--changed-files", str(changed), "--json"],
+    )
+    payload = json.loads(result.stdout)
+    assert payload["should_run"] is False
+    assert payload["skip_reason"] == "skip_rule"
+
+
+def test_trigger_subcommand_list_rules_json():
+    result = runner.invoke(app, ["trigger", "--list-rules", "--json"])
+    assert result.exit_code == 0
+    catalog = json.loads(result.stdout)
+    assert catalog["schema_version"] == "0.1"
+    rule_ids = {r["id"] for r in catalog["rules"]}
+    assert "TRIGGER-N8N-WORKFLOW-CHANGED" in rule_ids
+
+
+def test_trigger_subcommand_human_readable_verdict(tmp_path):
+    changed = tmp_path / "cf.txt"
+    changed.write_text("tools/my_mcp.json\n", encoding="utf-8")
+    result = runner.invoke(
+        app, ["trigger", "--workspace", str(tmp_path), "--changed-files", str(changed)]
+    )
+    assert result.exit_code == 0
+    assert "Verdict: RUN" in result.stdout

--- a/tests/test_trigger_command.py
+++ b/tests/test_trigger_command.py
@@ -149,3 +149,28 @@ def test_trigger_subcommand_human_readable_verdict(tmp_path):
     )
     assert result.exit_code == 0
     assert "Verdict: RUN" in result.stdout
+
+
+def test_trigger_missing_changed_files_exits_2(tmp_path):
+    """An unreadable --changed-files path fails deterministically with a
+    clean exit 2 (config/input error), not a Typer traceback."""
+    result = runner.invoke(
+        app, ["trigger", "--changed-files", str(tmp_path / "nope.txt"), "--json"]
+    )
+    assert result.exit_code == 2
+
+
+def test_trigger_missing_diff_exits_2(tmp_path):
+    result = runner.invoke(
+        app, ["trigger", "--diff", str(tmp_path / "nope.diff"), "--json"]
+    )
+    assert result.exit_code == 2
+
+
+def test_trigger_undecodable_changed_files_exits_2(tmp_path):
+    bad = tmp_path / "bad.bin"
+    bad.write_bytes(b"\xff\xfe\x00not utf-8")
+    result = runner.invoke(
+        app, ["trigger", "--changed-files", str(bad), "--json"]
+    )
+    assert result.exit_code == 2

--- a/tests/test_trust_root.py
+++ b/tests/test_trust_root.py
@@ -1,0 +1,164 @@
+"""SHIP-VERIFY-TRUST-ROOT-TOUCHED — Tier A trust-root protection.
+
+Covers the path classifier, the "only fires with a verification context"
+contract, and the end-to-end scan path (findings flow through the
+existing release gate, not a second verdict).
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.checks.verify import CHECK_ID
+from agents_shipgate.checks.verify import run as verify_run
+from agents_shipgate.cli.main import app
+from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.core.context import ScanContext
+from agents_shipgate.core.domain import Agent
+from agents_shipgate.schemas.verification import VerificationContext
+
+runner = CliRunner()
+
+
+def _context(changed_files: list[str] | None = None, *, verification: bool = True) -> ScanContext:
+    manifest = load_manifest(Path("samples/support_refund_agent/shipgate.yaml"))
+    vc = (
+        VerificationContext(changed_files=changed_files or [])
+        if verification
+        else None
+    )
+    return ScanContext(
+        manifest=manifest,
+        agent=Agent(id="agent:test/test", name="test"),
+        tools=[],
+        config_path=Path("shipgate.yaml"),
+        verification=vc,
+    )
+
+
+def test_plain_scan_without_verification_emits_nothing():
+    """Absence of a verification context == plain scan behavior."""
+    assert verify_run(_context(verification=False)) == []
+
+
+def test_empty_changed_files_emits_nothing():
+    assert verify_run(_context(changed_files=[])) == []
+
+
+def test_non_trust_root_files_are_not_flagged():
+    findings = verify_run(
+        _context(
+            changed_files=[
+                "src/agent.py",
+                "README.md",
+                "docs/guide.md",
+                "tests/test_agent.py",
+                "package.json",
+            ]
+        )
+    )
+    assert findings == []
+
+
+@pytest.mark.parametrize(
+    "path,expected_class",
+    [
+        ("shipgate.yaml", "manifest"),
+        ("services/billing/shipgate.yaml", "manifest"),
+        (".agents-shipgate/baseline.json", "shipgate_state"),
+        ("policies/refund.yaml", "policy"),
+        ("prompts/system.md", "prompts"),
+        (".github/workflows/agents-shipgate.yml", "ci_gate"),
+        (".github/workflows/agents-shipgate.yaml", "ci_gate"),
+        ("AGENTS.md", "agent_instructions"),
+        ("CLAUDE.md", "agent_instructions"),
+        (".claude/commands/shipgate.md", "agent_instructions"),
+        (".cursor/rules/agents-shipgate.mdc", "agent_instructions"),
+        (".agents/skills/agents-shipgate/reference.md", "agent_instructions"),
+        (".codex/config.toml", "agent_instructions"),
+        (".codex-plugin/plugin.json", "codex_plugin"),
+        ("plugins/browser/.app.json", "tool_surface_decl"),
+        ("servers/search/.mcp.json", "tool_surface_decl"),
+        ("packages/refund/SKILL.md", "tool_surface_decl"),
+    ],
+)
+def test_trust_root_classification(path, expected_class):
+    findings = verify_run(_context(changed_files=[path]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.check_id == CHECK_ID
+    assert finding.severity == "medium"
+    assert finding.evidence["changed_file"] == path
+    assert finding.evidence["trust_root_class"] == expected_class
+    assert finding.source.type == "changed_file"
+    assert finding.provenance_kind == "static_declaration"
+
+
+def test_ci_gate_only_matches_the_shipgate_workflow():
+    """A generic workflow change is NOT a trust root — only the Shipgate
+    gate workflow is. Keeps target-repo noise low."""
+    findings = verify_run(
+        _context(changed_files=[".github/workflows/test.yml", ".github/workflows/deploy.yaml"])
+    )
+    assert findings == []
+
+
+def test_duplicate_changed_files_are_deduplicated():
+    findings = verify_run(_context(changed_files=["shipgate.yaml", "shipgate.yaml"]))
+    assert len(findings) == 1
+
+
+def test_first_match_wins_classification_order():
+    """A SKILL.md under .agents/skills/ classifies as agent_instructions
+    (ordered earlier) rather than tool_surface_decl — one finding, the
+    earlier class."""
+    findings = verify_run(
+        _context(changed_files=[".agents/skills/agents-shipgate/SKILL.md"])
+    )
+    assert len(findings) == 1
+    assert findings[0].evidence["trust_root_class"] == "agent_instructions"
+
+
+def test_scan_changed_files_emits_finding_through_the_gate(tmp_path):
+    shutil.copytree("samples/clean_read_only_agent", tmp_path / "wk")
+    changed = tmp_path / "changed.txt"
+    changed.write_text("shipgate.yaml\nsrc/agent.py\nREADME.md\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "-c",
+            str(tmp_path / "wk" / "shipgate.yaml"),
+            "--changed-files",
+            str(changed),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    report = json.loads(
+        (tmp_path / "wk" / "agents-shipgate-reports" / "report.json").read_text()
+    )
+    verify_findings = [
+        f for f in report["findings"] if f["check_id"] == CHECK_ID
+    ]
+    assert len(verify_findings) == 1
+    assert verify_findings[0]["evidence"]["changed_file"] == "shipgate.yaml"
+    # Routed through the one decision engine to the review tier.
+    assert report["release_decision"]["decision"] == "review_required"
+    assert verify_findings[0]["requires_human_review"] is True
+
+
+def test_scan_without_changed_files_is_unchanged(tmp_path):
+    shutil.copytree("samples/clean_read_only_agent", tmp_path / "wk")
+    result = runner.invoke(
+        app, ["scan", "-c", str(tmp_path / "wk" / "shipgate.yaml")]
+    )
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(
+        (tmp_path / "wk" / "agents-shipgate-reports" / "report.json").read_text()
+    )
+    assert [f for f in report["findings"] if f["check_id"] == CHECK_ID] == []

--- a/tests/test_trust_root.py
+++ b/tests/test_trust_root.py
@@ -18,6 +18,8 @@ from agents_shipgate.cli.main import app
 from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.core.domain import Agent
+from agents_shipgate.core.findings.mutations import apply_suppressions
+from agents_shipgate.schemas.manifest import SuppressionConfig
 from agents_shipgate.schemas.verification import VerificationContext
 
 runner = CliRunner()
@@ -162,3 +164,85 @@ def test_scan_without_changed_files_is_unchanged(tmp_path):
         (tmp_path / "wk" / "agents-shipgate-reports" / "report.json").read_text()
     )
     assert [f for f in report["findings"] if f["check_id"] == CHECK_ID] == []
+
+
+# --- Reward-hacking guard: the trust-root finding cannot be silenced -------
+
+
+def test_apply_suppressions_cannot_suppress_trust_root_finding():
+    """Unit: a checks.ignore entry targeting the verify check must NOT
+    flip ``suppressed`` — otherwise a PR could edit shipgate.yaml to
+    silence the very check that flags the edit."""
+    findings = verify_run(_context(changed_files=["shipgate.yaml"]))
+    assert len(findings) == 1
+    apply_suppressions(
+        findings,
+        [SuppressionConfig(check_id=CHECK_ID, reason="make CI green")],
+    )
+    assert findings[0].suppressed is False
+
+
+def test_scan_ignore_entry_does_not_silence_trust_root(tmp_path):
+    """End-to-end: shipgate.yaml adding `checks.ignore` for the trust-root
+    check does not suppress it; the finding stays active and the gate
+    still routes to review_required."""
+    shutil.copytree("samples/clean_read_only_agent", tmp_path / "wk")
+    manifest = tmp_path / "wk" / "shipgate.yaml"
+    manifest.write_text(
+        manifest.read_text()
+        + "\nchecks:\n  ignore:\n    - check_id: SHIP-VERIFY-TRUST-ROOT-TOUCHED\n"
+        + "      reason: make CI green\n",
+        encoding="utf-8",
+    )
+    changed = tmp_path / "changed.txt"
+    changed.write_text("shipgate.yaml\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["scan", "-c", str(manifest), "--changed-files", str(changed)]
+    )
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(
+        (tmp_path / "wk" / "agents-shipgate-reports" / "report.json").read_text()
+    )
+    verify_findings = [f for f in report["findings"] if f["check_id"] == CHECK_ID]
+    assert len(verify_findings) == 1
+    assert verify_findings[0]["suppressed"] is False
+    assert report["release_decision"]["decision"] == "review_required"
+
+
+def test_scan_severity_override_below_floor_is_rejected(tmp_path):
+    """Weakening the trust-root check below its medium floor via
+    checks.severity_overrides is a hard ConfigError (exit 2), not a
+    silent downgrade."""
+    shutil.copytree("samples/clean_read_only_agent", tmp_path / "wk")
+    manifest = tmp_path / "wk" / "shipgate.yaml"
+    manifest.write_text(
+        manifest.read_text()
+        + "\nchecks:\n  severity_overrides:\n"
+        + "    SHIP-VERIFY-TRUST-ROOT-TOUCHED: info\n",
+        encoding="utf-8",
+    )
+    changed = tmp_path / "changed.txt"
+    changed.write_text("shipgate.yaml\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["scan", "-c", str(manifest), "--changed-files", str(changed)]
+    )
+    assert result.exit_code == 2, result.stdout
+
+
+def test_scan_changed_files_rejected_for_multi_config(tmp_path):
+    """--changed-files is single-config only: a workspace that resolves
+    more than one manifest must reject it (exit 2) rather than fan the
+    same changed-files list across every manifest."""
+    shutil.copytree("samples/multi_agent_workspace", tmp_path / "wk")
+    manifests = list((tmp_path / "wk").rglob("shipgate.yaml"))
+    assert len(manifests) > 1, "fixture must resolve multiple manifests"
+    changed = tmp_path / "changed.txt"
+    changed.write_text("shipgate.yaml\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["scan", "--workspace", str(tmp_path / "wk"), "--changed-files", str(changed)],
+    )
+    assert result.exit_code == 2, result.stdout


### PR DESCRIPTION
## Summary

- Promote the existing trigger evaluator to a first-class **`agents-shipgate trigger`** subcommand. It takes `--changed-files`/`--diff` file inputs and `--base`/`--head` git mode (the **only** path that shells out to git), keeps `--list-rules --json`, and preserves `python -m agents_shipgate.triggers` for developers. `evaluate()` now emits the M1 output shape (`should_run`, `force_run`, `skip_reason`, `changed_files`, `diff_tokens`) alongside the preserved back-compat fields (`run_shipgate`, `stop_conditions_fired`, `rationale`); action precedence is unchanged.
- Add **`SHIP-VERIFY-TRUST-ROOT-TOUCHED`** — the cheap half of the reward-hacking guard. A changed-files-only path classifier in a new `verify` check category that fires only when a `VerificationContext` is present (`scan --changed-files`) and emits an ordinary `medium`-severity `Finding` routed through `release_decision` to `review_required` — never a second verdict. Plain `scan` behavior is unchanged.
- Add a **reverse `docs/triggers.json` ↔ AGENTS.md parity test**. Closing the gap it surfaced required a new `TRIGGER-N8N-WORKFLOW-CHANGED` rule (keyed on the adapter's own `n8n-nodes-*` markers), so the prose table and catalog are now in true parity.

## Why

This is milestone **M1** of the [AI coding workflow verifier direction](docs/engineering/ai-coding-workflow-verifier.md) (roadmap P0): productize the trigger evaluator and land trust-root protection. Reward hacking is the coding-agent threat model — an optimizer told to "make CI green" may edit the gate instead of fixing the readiness issue — so touching a release trust root (manifest, policies, prompts, the Shipgate CI gate, agent instructions, tool-surface declarations) now requires human review. The `verify` command's base/head orchestration is the separate P1 milestone; `scan --changed-files` is the M1 injection point that makes the check reachable through the existing gate.

## Type

- [x] Check or risk-model change
- [x] CLI or GitHub Action behavior

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m ruff check .` — clean.
- `python -m pytest` — 2104 passed, 5 skipped. The 7 `tests/test_bootstrap.py` failures are pre-existing and environmental (confirmed identical on `main`): this sandbox's editable install points at a sibling worktree without `__main__.py`, so bootstrap's `python -m agents_shipgate` subprocess can't resolve. They are unrelated to this change.
- `python scripts/generate_schemas.py --check` — `docs/checks.json` (and manifest/report/packet schemas) in sync.
- Smoke-tested both `trigger` modes (file inputs and `--base/--head` git) and `scan --changed-files` end-to-end (trust-root finding flows to `review_required`).

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths (git runs only under `trigger --base/--head`; the trust-boundary allowlist in `tests/test_adapter_static_only.py` and `STABILITY.md` § Meta-CLI surfaces are updated to pin the new call sites)
- [x] New or changed check IDs are documented in `docs/checks.md` (`SHIP-VERIFY-TRUST-ROOT-TOUCHED`)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (new `verify` category in `docs/checks.json`; new `trigger` command + `scan --changed-files` flag added to the stable command surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)