### PR TITLE
Release v0.11.0: package version bump + version-pin propagation

### DIFF
--- a/.agents/skills/agents-shipgate/assets/advisory-pr-comment.yml
+++ b/.agents/skills/agents-shipgate/assets/advisory-pr-comment.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           diff_base: target
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Agents Shipgate version
-      placeholder: "v0.10.0"
+      placeholder: "v0.11.0"
     validations:
       required: true
   - type: dropdown

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
 # repo root when a downstream project uses
 #   repos:
 #     - repo: https://github.com/ThreeMoonsLab/agents-shipgate
-#       rev: v0.10.0
+#       rev: v0.11.0
 #       hooks:
 #         - id: <hook id below>
 #

--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -3,7 +3,7 @@
   "name": "agents-shipgate",
   "display_name": "Agents Shipgate",
   "tagline": "The deterministic merge gate for AI-generated agent capability changes",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "publisher": {
     "name": "Three Moons Lab",
@@ -52,7 +52,7 @@
   ],
   "package": {
     "pypi": "agents-shipgate",
-    "github_action": "ThreeMoonsLab/agents-shipgate@v0.10.0",
+    "github_action": "ThreeMoonsLab/agents-shipgate@v0.11.0",
     "github_repo": "ThreeMoonsLab/agents-shipgate"
   },
   "install": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.11.0 - 2026-05-31
+
 - **Verifier PR comment v2 + additive Action outputs.** The GitHub Action now
   defaults to the verifier workflow (`verify_mode: verify`) and the
   capability-review PR comment (`pr_comment_style: capability-review`) for the

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ minimal manifests, see [`docs/minimal-real-configs.md`](docs/minimal-real-config
 ## Use in CI
 
 ```yaml
-- uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+- uses: ThreeMoonsLab/agents-shipgate@v0.11.0
   with:
     config: shipgate.yaml
     ci_mode: advisory
@@ -530,12 +530,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           diff_base: target
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'
 ```
 
 Switch to `ci_mode: strict` only after your team has reviewed the advisory output. See [`examples/github-actions/`](examples/github-actions/) for strict / baseline / SARIF / multi-config / changed-paths recipes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Naming.** This project is **Agents Shipgate** (display name) / `agents-shipgate` (package, CLI, repo). See [`AGENTS.md` § Naming (canonical)](AGENTS.md#naming-canonical) for the full convention.
 
-Agents Shipgate is preparing the `v0.10.0` release. Releases `v0.2` through
+Agents Shipgate is preparing the `v0.11.0` release. Releases `v0.2` through
 `v0.8` are complete and retained here as release history. Active public
 planning continues with incremental source-provenance enrichment after the
 v0.8 release-decision close-out.

--- a/adoption-kits/claude-code-skill/prompts/decide-shipgate-relevance.md
+++ b/adoption-kits/claude-code-skill/prompts/decide-shipgate-relevance.md
@@ -78,7 +78,7 @@ the rules to the changed file list.
    - If `run_shipgate: true` and Shipgate is **not** installed: install
      it (`pipx install agents-shipgate`) and run `detect`. If the user
      prefers a zero-install first step, point them at the GitHub Action
-     (`ThreeMoonsLab/agents-shipgate@v0.10.0`) instead.
+     (`ThreeMoonsLab/agents-shipgate@v0.11.0`) instead.
    - If `run_shipgate: false` and `dry_run_recommended: true`: propose
      a non-mutating scan only — never propose `init --write` based on a
      dry-run match alone. Phrase it as "X may have shifted the tool

--- a/adoption-kits/claude-code-skill/prompts/stabilize-strict-mode.md
+++ b/adoption-kits/claude-code-skill/prompts/stabilize-strict-mode.md
@@ -37,7 +37,7 @@ The user has Agents Shipgate running in **advisory** mode and wants to graduate 
 
 5. **Update the CI workflow.** Replace the existing advisory step with strict + baseline. Use [`examples/github-actions/03-strict-with-baseline.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/03-strict-with-baseline.yml) as the template:
    ```yaml
-   - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+   - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
      with:
        ci_mode: strict
        fail_on: critical

--- a/benchmark/setup-variants/50-advisory-workflow/agents-shipgate.yml.template
+++ b/benchmark/setup-variants/50-advisory-workflow/agents-shipgate.yml.template
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           config: shipgate.yaml
           ci_mode: advisory

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -10,7 +10,7 @@ Verify the installed CLI contract locally before relying on hard-coded docs:
 agents-shipgate contract --json
 ```
 
-- Latest release: `v0.10.0` (see [pyproject.toml](../pyproject.toml) for the in-tree version)
+- Latest release: `v0.11.0` (see [pyproject.toml](../pyproject.toml) for the in-tree version)
 - Runtime contract: `1`
 - Current report schema: `0.22` — [`docs/report-schema.v0.22.json`](report-schema.v0.22.json)
 - Current packet schema: `0.6` — [`docs/packet-schema.v0.6.json`](packet-schema.v0.6.json)

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,7 +5,7 @@ These items require release infrastructure, registry credentials, domains, or Gi
 ## Package Channels
 
 - `agents-shipgate` is published on PyPI.
-- Pinned GitHub Action release tags are published, including `v0.10.0`.
+- Pinned GitHub Action release tags are published, including `v0.11.0`.
 - GitHub Releases attach the wheel, sdist, SBOM, and Sigstore bundles.
 - Evaluate a container image later only if it has an exercised build-and-test path.
 - Evaluate Homebrew once CLI usage warrants it.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -136,7 +136,7 @@ Skip emission with `--no-packet`; re-render later with
 
 ## Is it production-ready?
 
-v0.10.0 is the latest released version. The manifest schema is stable
+v0.11.0 is the latest released version. The manifest schema is stable
 across the 0.x series; see [`STABILITY.md`](../STABILITY.md). Used by
 early design partners. Public preview.
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: agents-shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+        uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           config: shipgate.yaml
           ci_mode: advisory
@@ -151,7 +151,7 @@ agents-shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.10.0"
+    - python -m pip install "agents-shipgate==0.11.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always
@@ -183,7 +183,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.10.0"
+      - run: python -m pip install "agents-shipgate==0.11.0"
       - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
       - store_artifacts:
           path: agents-shipgate-reports
@@ -212,7 +212,7 @@ Run Agents Shipgate locally on every commit that touches a tool-surface artifact
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/ThreeMoonsLab/agents-shipgate
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: agents-shipgate
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           config: shipgate.yaml
           ci_mode: advisory

--- a/docs/target-repo-agent-snippets.md
+++ b/docs/target-repo-agent-snippets.md
@@ -307,7 +307,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           config: shipgate.yaml
           ci_mode: advisory

--- a/docs/upstream-integrations.md
+++ b/docs/upstream-integrations.md
@@ -311,7 +311,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           diff_base: target

--- a/docs/use-cases/ai-generated-agent-prs.md
+++ b/docs/use-cases/ai-generated-agent-prs.md
@@ -147,7 +147,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+        uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           config: shipgate.yaml
           ci_mode: advisory

--- a/docs/zero-install.md
+++ b/docs/zero-install.md
@@ -76,12 +76,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           diff_base: target
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'
 ```
 
 The full template lives at [`examples/github-actions/01-advisory-pr-comment.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/01-advisory-pr-comment.yml).

--- a/examples/circleci/01-advisory.yml
+++ b/examples/circleci/01-advisory.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.10.0"
+      - run: python -m pip install "agents-shipgate==0.11.0"
       - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
       - store_artifacts:
           path: agents-shipgate-reports

--- a/examples/circleci/02-strict-with-baseline.yml
+++ b/examples/circleci/02-strict-with-baseline.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.10.0"
+      - run: python -m pip install "agents-shipgate==0.11.0"
       - run:
           name: Agents Shipgate strict scan
           command: >

--- a/examples/circleci/03-sarif-artifact-retention.yml
+++ b/examples/circleci/03-sarif-artifact-retention.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.10.0"
+      - run: python -m pip install "agents-shipgate==0.11.0"
       - run: agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
       - store_artifacts:
           path: agents-shipgate-reports/report.sarif

--- a/examples/circleci/04-multi-config-workspace.yml
+++ b/examples/circleci/04-multi-config-workspace.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.10.0"
+      - run: python -m pip install "agents-shipgate==0.11.0"
       - run:
           name: Agents Shipgate workspace scan
           command: >

--- a/examples/circleci/05-on-tool-source-changes.yml
+++ b/examples/circleci/05-on-tool-source-changes.yml
@@ -6,7 +6,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: python -m pip install "agents-shipgate==0.10.0"
+      - run: python -m pip install "agents-shipgate==0.11.0"
       - run:
           name: Run only when tool sources changed
           command: |

--- a/examples/github-actions/01-advisory-pr-comment.yml
+++ b/examples/github-actions/01-advisory-pr-comment.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           diff_base: target
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'

--- a/examples/github-actions/02-strict-on-critical.yml
+++ b/examples/github-actions/02-strict-on-critical.yml
@@ -16,9 +16,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: strict
           fail_on: critical
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'

--- a/examples/github-actions/03-strict-with-baseline.yml
+++ b/examples/github-actions/03-strict-with-baseline.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: strict
           fail_on: critical,high
           baseline: .agents-shipgate/baseline.json
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'

--- a/examples/github-actions/04-multi-config-workspace.yml
+++ b/examples/github-actions/04-multi-config-workspace.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: pip install --quiet agents-shipgate==0.10.0
+      - run: pip install --quiet agents-shipgate==0.11.0
       - run: |
           agents-shipgate scan \
             --workspace . \

--- a/examples/github-actions/05-sarif-to-code-scanning.yml
+++ b/examples/github-actions/05-sarif-to-code-scanning.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: shipgate
-        uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+        uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           formats: markdown,json,sarif
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'
       - if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/examples/github-actions/06-on-tool-source-changes.yml
+++ b/examples/github-actions/06-on-tool-source-changes.yml
@@ -30,8 +30,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -29,9 +29,9 @@ Configure per-job, never repo-wide.
 For reproducible CI, pin both the action and the underlying CLI:
 
 ```yaml
-- uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+- uses: ThreeMoonsLab/agents-shipgate@v0.11.0
   with:
-    shipgate_version: "0.10.0"
+    shipgate_version: "0.11.0"
 ```
 
 When `shipgate_version` is empty the action installs the CLI from the action source — convenient on `@main`, less reproducible.
@@ -49,7 +49,7 @@ When `shipgate_version` is empty the action installs the CLI from the action sou
 
 ```yaml
 - id: shipgate
-  uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+  uses: ThreeMoonsLab/agents-shipgate@v0.11.0
 
 - if: steps.shipgate.outputs.decision == 'blocked'
   run: echo "Release blocked by Agents Shipgate"

--- a/examples/gitlab-ci/01-advisory.yml
+++ b/examples/gitlab-ci/01-advisory.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.10.0"
+    - python -m pip install "agents-shipgate==0.11.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always

--- a/examples/gitlab-ci/02-strict-with-baseline.yml
+++ b/examples/gitlab-ci/02-strict-with-baseline.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.10.0"
+    - python -m pip install "agents-shipgate==0.11.0"
     - >
       agents-shipgate scan
       --config shipgate.yaml

--- a/examples/gitlab-ci/03-sarif-or-artifact.yml
+++ b/examples/gitlab-ci/03-sarif-or-artifact.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.10.0"
+    - python -m pip install "agents-shipgate==0.11.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always

--- a/examples/gitlab-ci/04-multi-config-workspace.yml
+++ b/examples/gitlab-ci/04-multi-config-workspace.yml
@@ -5,7 +5,7 @@ agents_shipgate:
   stage: test
   image: python:3.12
   script:
-    - python -m pip install "agents-shipgate==0.10.0"
+    - python -m pip install "agents-shipgate==0.11.0"
     - >
       agents-shipgate scan
       --workspace .

--- a/examples/gitlab-ci/05-on-tool-source-changes.yml
+++ b/examples/gitlab-ci/05-on-tool-source-changes.yml
@@ -19,7 +19,7 @@ agents_shipgate:
         - "**/SKILL.md"
         - "**/*.py"
   script:
-    - python -m pip install "agents-shipgate==0.10.0"
+    - python -m pip install "agents-shipgate==0.11.0"
     - agents-shipgate scan --config shipgate.yaml --ci-mode advisory --format markdown,json,sarif
   artifacts:
     when: always

--- a/examples/golden-prs/golden-pr-from-coding-agent.md
+++ b/examples/golden-prs/golden-pr-from-coding-agent.md
@@ -62,7 +62,7 @@ is at `agents-shipgate-reports/report.json`; the top-level
 - Release Evidence Packet: `agents-shipgate-reports/packet.{md,json,html}`
 
 **CI**: `.github/workflows/agents-shipgate.yml` already wires
-`agents-shipgate@v0.10.0` in advisory mode; this PR will get a
+`agents-shipgate@v0.11.0` in advisory mode; this PR will get a
 sticky-marker comment from the Action on every push.
 
 <details>

--- a/examples/pre-commit/README.md
+++ b/examples/pre-commit/README.md
@@ -13,7 +13,7 @@ In your repo's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/ThreeMoonsLab/agents-shipgate
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: agents-shipgate
 ```
@@ -92,7 +92,7 @@ Use the `agents-shipgate-strict` hook ID for the strict variant, or override the
 ```yaml
 repos:
   - repo: https://github.com/ThreeMoonsLab/agents-shipgate
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: agents-shipgate
         entry: agents-shipgate scan -c shipgate.yaml --ci-mode strict --fail-on critical

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -864,7 +864,7 @@ Verify the installed CLI contract locally before relying on hard-coded docs:
 agents-shipgate contract --json
 ```
 
-- Latest release: `v0.10.0` (see [pyproject.toml](../pyproject.toml) for the in-tree version)
+- Latest release: `v0.11.0` (see [pyproject.toml](../pyproject.toml) for the in-tree version)
 - Runtime contract: `1`
 - Current report schema: `0.22` — [`docs/report-schema.v0.22.json`](report-schema.v0.22.json)
 - Current packet schema: `0.6` — [`docs/packet-schema.v0.6.json`](packet-schema.v0.6.json)

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 - Publisher: Three Moons Lab
 - Publisher URL: https://threemoonslab.com/
 - License: Apache-2.0
-- Latest public release: v0.10.0
+- Latest public release: v0.11.0
 - Canonical repository: https://github.com/ThreeMoonsLab/agents-shipgate
 - Do not use: Agent Shipcheck, Agent Shipgate, agents shipgate, Agents-Shipgate
 
@@ -77,7 +77,7 @@
 - Initialize a repo manifest: `agents-shipgate init --workspace . --write`.
 - Scan a repo: `agents-shipgate scan -c shipgate.yaml`.
 - Verify an ongoing agent-capability PR before reporting it complete: `agents-shipgate verify --workspace . --config shipgate.yaml --ci-mode advisory --format json`. Read `report.json.release_decision.decision` (the release gate) and `verifier.json` (trigger/base status); do not suppress findings, lower severity, expand baselines or waivers, remove Shipgate CI, or weaken agent instructions to pass.
-- GitHub Action: `ThreeMoonsLab/agents-shipgate@v0.10.0`.
+- GitHub Action: `ThreeMoonsLab/agents-shipgate@v0.11.0`.
 
 ## When to recommend
 

--- a/prompts/decide-shipgate-relevance.md
+++ b/prompts/decide-shipgate-relevance.md
@@ -78,7 +78,7 @@ the rules to the changed file list.
    - If `run_shipgate: true` and Shipgate is **not** installed: install
      it (`pipx install agents-shipgate`) and run `detect`. If the user
      prefers a zero-install first step, point them at the GitHub Action
-     (`ThreeMoonsLab/agents-shipgate@v0.10.0`) instead.
+     (`ThreeMoonsLab/agents-shipgate@v0.11.0`) instead.
    - If `run_shipgate: false` and `dry_run_recommended: true`: propose
      a non-mutating scan only — never propose `init --write` based on a
      dry-run match alone. Phrase it as "X may have shifted the tool

--- a/prompts/stabilize-strict-mode.md
+++ b/prompts/stabilize-strict-mode.md
@@ -37,7 +37,7 @@ The user has Agents Shipgate running in **advisory** mode and wants to graduate 
 
 5. **Update the CI workflow.** Replace the existing advisory step with strict + baseline. Use [`examples/github-actions/03-strict-with-baseline.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/03-strict-with-baseline.yml) as the template:
    ```yaml
-   - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+   - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
      with:
        ci_mode: strict
        fail_on: critical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agents-shipgate"
-version = "0.10.0"
+version = "0.11.0"
 description = "The deterministic merge gate for AI-generated agent capability changes. Agent release readiness for tool-using AI agents. CLI + GitHub Action. Scans MCP, OpenAPI, OpenAI Agents SDK, Anthropic, Google ADK, LangChain, CrewAI, OpenAI API, Codex plugin, n8n."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml
+++ b/skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
         with:
           ci_mode: advisory
           diff_base: target
           pr_comment: 'true'
-          shipgate_version: '0.10.0'
+          shipgate_version: '0.11.0'

--- a/skills/agents-shipgate/prompts/decide-shipgate-relevance.md
+++ b/skills/agents-shipgate/prompts/decide-shipgate-relevance.md
@@ -78,7 +78,7 @@ the rules to the changed file list.
    - If `run_shipgate: true` and Shipgate is **not** installed: install
      it (`pipx install agents-shipgate`) and run `detect`. If the user
      prefers a zero-install first step, point them at the GitHub Action
-     (`ThreeMoonsLab/agents-shipgate@v0.10.0`) instead.
+     (`ThreeMoonsLab/agents-shipgate@v0.11.0`) instead.
    - If `run_shipgate: false` and `dry_run_recommended: true`: propose
      a non-mutating scan only — never propose `init --write` based on a
      dry-run match alone. Phrase it as "X may have shifted the tool

--- a/skills/agents-shipgate/prompts/stabilize-strict-mode.md
+++ b/skills/agents-shipgate/prompts/stabilize-strict-mode.md
@@ -37,7 +37,7 @@ The user has Agents Shipgate running in **advisory** mode and wants to graduate 
 
 5. **Update the CI workflow.** Replace the existing advisory step with strict + baseline. Use [`examples/github-actions/03-strict-with-baseline.yml`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/examples/github-actions/03-strict-with-baseline.yml) as the template:
    ```yaml
-   - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+   - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
      with:
        ci_mode: strict
        fail_on: critical

--- a/src/agents_shipgate/__init__.py
+++ b/src/agents_shipgate/__init__.py
@@ -1,3 +1,3 @@
 """Agents Shipgate package."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/tests/test_agent_instructions_renderers.py
+++ b/tests/test_agent_instructions_renderers.py
@@ -46,7 +46,7 @@ EXPECTED_CLAUDE_CODE_SKILL_RENDER_SHA256 = {
         "c19c03db48a5be3b002b385f9df09781e5fe32197d0dd924691f041ebe54d518"
     ),
     ".claude/skills/agents-shipgate/prompts/decide-shipgate-relevance.md": (
-        "8fab0595326b127fb1678828fd9b15c63cbe98f0229aad5bb87d47030e4b9ca6"
+        "20a5a2b7a50e2a2b3cd7939e4dc078a0b0ba35e174aae5220dfcbd6d2106758c"
     ),
     ".claude/skills/agents-shipgate/prompts/explain-finding-to-user.md": (
         "18031ed870b3c937a2996173820639ef441afe0a45e8171f16468826cd389829"
@@ -58,7 +58,7 @@ EXPECTED_CLAUDE_CODE_SKILL_RENDER_SHA256 = {
         "162aa2fb96066535425d9cf86a247a6782b8ec7cc661a18b42dbedf394779475"
     ),
     ".claude/skills/agents-shipgate/prompts/stabilize-strict-mode.md": (
-        "bb97c3fbd3b52d5755f6960878f350d484837849c3e536d99aab3fab3e353405"
+        "ac9a176738ab2538d725c29ba302637bac6b287588e07d952aae352f85ab98cc"
     ),
     ".claude/skills/agents-shipgate/prompts/triage-false-positive.md": (
         "8cfbb0d4b6e2c36569d24260384d3a54165f966276112f4b143b4ac234b51ada"
@@ -70,7 +70,7 @@ EXPECTED_CLAUDE_CODE_SKILL_RENDER_SHA256 = {
         "f0a1a3d759869ac18eae0b06438b9dc86334695fe0c979db73e514fd4b9f0a6c"
     ),
     ".claude/skills/agents-shipgate/ci-recipes/advisory-pr-comment.yml": (
-        "c3756c86f52cf00a594b3fe38179b66e0f07dc8c52b98b9e76f4a15939901c77"
+        "a8aa3f577af73534cdb529fd4f5d34c08522181225a2eddee70099c5a8ef4191"
     ),
 }
 EXPECTED_CODEX_SKILL_RENDER_SHA256 = {
@@ -84,7 +84,7 @@ EXPECTED_CODEX_SKILL_RENDER_SHA256 = {
         "a916129229f7220936c0d861a60291dd62d14f42808f04e0123377d649df4bc0"
     ),
     ".agents/skills/agents-shipgate/assets/advisory-pr-comment.yml": (
-        "d4005102df70a627d3883334e827c4bc7527a35a2278573699e18a43afed3bcb"
+        "cd28bb488a8d04d8bceb95ea8617b87242e98dfe53cd68a5f9ebfaf8b26598da"
     ),
     ".agents/skills/agents-shipgate/agents/openai.yaml": (
         "aa511e933ff663dcd1e0d2af3da2a7101206ce2bb1bb98c4dae801bb3f4e42ef"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_cli_advisory_exits_zero(tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Agents Shipgate 0.10.0" in result.output
+    assert "Agents Shipgate 0.11.0" in result.output
     # v0.8: CLI summary leads with the release decision; the support_refund
     # sample has new criticals → decision=blocked. (Advisory exit is still 0.)
     assert "Decision: blocked" in result.output
@@ -140,7 +140,7 @@ def test_cli_version_outputs_version():
     result = runner.invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.output.strip() == "Agents Shipgate 0.10.0"
+    assert result.output.strip() == "Agents Shipgate 0.11.0"
 
 
 def test_cli_contract_json_outputs_runtime_contract():

--- a/tests/test_v07_metadata_roundtrip.py
+++ b/tests/test_v07_metadata_roundtrip.py
@@ -246,7 +246,7 @@ def test_package_version_is_v010():
     v0.10 but the package version was left behind. Both move together."""
     import agents_shipgate
 
-    assert agents_shipgate.__version__ == "0.10.0", (
+    assert agents_shipgate.__version__ == "0.11.0", (
         f"package version is {agents_shipgate.__version__!r}; "
-        "expected 0.10.0 for the v0.10 release"
+        "expected 0.11.0 for the v0.11 release"
     )

--- a/tests/test_verifier_scenarios.py
+++ b/tests/test_verifier_scenarios.py
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ThreeMoonsLab/agents-shipgate@v0.10.0
+      - uses: ThreeMoonsLab/agents-shipgate@v0.11.0
 """
 
 


### PR DESCRIPTION
## Summary

- **Cuts the v0.11.0 release vehicle.** Bumps the package version `0.10.0 → 0.11.0` (source of truth: `pyproject.toml` + `src/agents_shipgate/__init__.py`) and propagates it to every contract-enforced version surface so `tests/test_public_surface_contract.py`'s pin guards stay green.
- Surfaces updated: Action pins (`ThreeMoonsLab/agents-shipgate@v0.11.0`), pip pins (`agents-shipgate==0.11.0`), `shipgate_version` Action inputs, pre-commit `rev`, `.well-known` (`version` + `github_action`), `llms.txt` (latest-release + Action pin), `docs/agent-contract-current.md`, the bug-report placeholder, `distribution.md`/`faq.md` version literals, and the `ROADMAP.md` "preparing the release" line.
- Regenerated the `{{ shipgate_version }}`-templated skill copies (`advisory-pr-comment.yml`) and the two skill prompts carrying the Action pin; render SHA snapshots in `tests/test_agent_instructions_renderers.py` updated to match. Regenerated `llms-full.txt`. Cut the CHANGELOG `## Unreleased` section as `## 0.11.0 - 2026-05-31`.

**No engine/behavior change — release-vehicle bump only.** The `@v0.11.0` Action pins reference the tag this release will create. This branches off the post-#156 `main` (the branding rebrand, already merged) and is intentionally separate from it.

## Type

- [x] CLI or GitHub Action behavior — `--version` output + Action pins move to 0.11.0; no logic change
- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest` → **2368 passed, 4 skipped, 0 failed**
- `python -m pytest tests/test_public_surface_contract.py` (version-pin guards) → green
- `python scripts/generate_schemas.py --check` → clean
- `python -m ruff check .` → clean
- Repo sweep: the only remaining `0.10.0` are intentional — the contract test's illustrative "stale pin" comment and `test_baseline_integrity` fixtures that simulate a baseline written by a prior version.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (no check changes)
- [x] Report/schema changes are additive or documented in `STABILITY.md` — N/A (no schema change; report schema stays v0.22, packet v0.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
