### PR TITLE
Harden adoption-kit install step to ensure agents-shipgate >=0.11.0

### DIFF
--- a/adoption-kits/claude-code-skill/.agents-shipgate-kit-metadata.json
+++ b/adoption-kits/claude-code-skill/.agents-shipgate-kit-metadata.json
@@ -9,6 +9,9 @@
       "e1713eecbbb1538987b7bf2cbe90bcdac9c4491f250105b6c68e788c81d49de3",
       "bd4755e06715c839608c09da302ed844c764fd3e4047d7bdf495d68dc559c2a5"
     ],
+    "prompts/add-shipgate-to-repo.md": [
+      "c67aa56813d76ddafd4091b2120d914fab6e0590b46e3598d856b7c4e6443fb1"
+    ],
     "prompts/stabilize-strict-mode.md": [
       "ac9a176738ab2538d725c29ba302637bac6b287588e07d952aae352f85ab98cc"
     ]

--- a/adoption-kits/claude-code-skill/prompts/add-shipgate-to-repo.md
+++ b/adoption-kits/claude-code-skill/prompts/add-shipgate-to-repo.md
@@ -9,11 +9,12 @@ agent-related PRs should use `agents-shipgate verify` after this adoption step.
 
 ## Your task
 
-1. **Install the tool:**
+1. **Install the tool** — you need `>=0.11.0`, since the `agents-shipgate verify` step this prompt relies on only ships in 0.11.0+:
    ```bash
    pipx install agents-shipgate
+   pipx upgrade agents-shipgate
    ```
-   If `pipx` is unavailable, use `python -m pip install agents-shipgate` and verify with `agents-shipgate --version`.
+   A plain `pipx install` is a no-op when an older build is already installed, so the follow-up `pipx upgrade` brings a stale copy current. If `pipx` is unavailable, use `python -m pip install -U "agents-shipgate>=0.11"` and verify with `agents-shipgate --version`.
 
 2. **Sanity-check the install** before touching the user's code:
    ```bash

--- a/prompts/add-shipgate-to-repo.md
+++ b/prompts/add-shipgate-to-repo.md
@@ -9,11 +9,12 @@ agent-related PRs should use `agents-shipgate verify` after this adoption step.
 
 ## Your task
 
-1. **Install the tool:**
+1. **Install the tool** — you need `>=0.11.0`, since the `agents-shipgate verify` step this prompt relies on only ships in 0.11.0+:
    ```bash
    pipx install agents-shipgate
+   pipx upgrade agents-shipgate
    ```
-   If `pipx` is unavailable, use `python -m pip install agents-shipgate` and verify with `agents-shipgate --version`.
+   A plain `pipx install` is a no-op when an older build is already installed, so the follow-up `pipx upgrade` brings a stale copy current. If `pipx` is unavailable, use `python -m pip install -U "agents-shipgate>=0.11"` and verify with `agents-shipgate --version`.
 
 2. **Sanity-check the install** before touching the user's code:
    ```bash

--- a/skills/agents-shipgate/prompts/add-shipgate-to-repo.md
+++ b/skills/agents-shipgate/prompts/add-shipgate-to-repo.md
@@ -9,11 +9,12 @@ agent-related PRs should use `agents-shipgate verify` after this adoption step.
 
 ## Your task
 
-1. **Install the tool:**
+1. **Install the tool** — you need `>=0.11.0`, since the `agents-shipgate verify` step this prompt relies on only ships in 0.11.0+:
    ```bash
    pipx install agents-shipgate
+   pipx upgrade agents-shipgate
    ```
-   If `pipx` is unavailable, use `python -m pip install agents-shipgate` and verify with `agents-shipgate --version`.
+   A plain `pipx install` is a no-op when an older build is already installed, so the follow-up `pipx upgrade` brings a stale copy current. If `pipx` is unavailable, use `python -m pip install -U "agents-shipgate>=0.11"` and verify with `agents-shipgate --version`.
 
 2. **Sanity-check the install** before touching the user's code:
    ```bash

--- a/tests/test_agent_instructions_renderers.py
+++ b/tests/test_agent_instructions_renderers.py
@@ -43,7 +43,7 @@ EXPECTED_CLAUDE_CODE_SKILL_RENDER_SHA256 = {
         "b442316b7bbdb4b2a84b8543f3589e1bb1d8d2bfd968637db99bd07835c406fd"
     ),
     ".claude/skills/agents-shipgate/prompts/add-shipgate-to-repo.md": (
-        "c67aa56813d76ddafd4091b2120d914fab6e0590b46e3598d856b7c4e6443fb1"
+        "ea3c37cfbbd42c40d164abfe21d468a3a5550d5384125f94a53c947dea6b4b2a"
     ),
     ".claude/skills/agents-shipgate/prompts/decide-shipgate-relevance.md": (
         "9cf6fdf60f45032635482ff96c64684af5f84ef9c10977e6d36e7d1c856d07e9"


### PR DESCRIPTION
## Summary

- A plain `pipx install agents-shipgate` is a **no-op** when an older build is already installed, so anyone who installed 0.8.0 earlier stays stale — and the `agents-shipgate verify` step this onboarding prompt relies on only ships in **0.11.0+**.
- Reworked step 1 of `add-shipgate-to-repo.md` to add `pipx upgrade agents-shipgate` and a pip fallback floored at `python -m pip install -U "agents-shipgate>=0.11"`, keeping the `agents-shipgate --version` confirmation. Wording mirrors the `upgrade-shipgate-version` prompt's idiom and the design-partner runbook's step style.
- Edited **all three byte-identical copies** (`prompts/`, `skills/agents-shipgate/prompts/`, `adoption-kits/claude-code-skill/prompts/`); the protected detect-first strings (`agents-shipgate detect`, `--suggest-patches`, `apply-patches`, `suggested_sources`) are untouched.

## Render-hash bookkeeping

- **Required:** bumped the file's hash in `EXPECTED_CLAUDE_CODE_SKILL_RENDER_SHA256` in `tests/test_agent_instructions_renderers.py` (`c67aa568… → ea3c37cf…`).
- **Convention:** appended the *outgoing* hash to `prior_render_sha256` in the claude-code-skill kit metadata, per the `stabilize-strict-mode` precedent (0726ade).
- **Intentionally not touched:** `bootstrap_legacy_sha256` — it's a frozen *pre-sidecar* set (commit 324e53b). The sidecar mechanism shipped in that same commit, so every repo carrying the current content also has a `.agents-shipgate-kit.json` sidecar, which is what `apply.py` uses to recognize previously-rendered copies. No metadata change is needed for `init --write` idempotency.

## Type

- [x] Documentation only (agent-facing onboarding prompt; the test edit is a required render-hash snapshot bump)

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run (with `PYTHONPATH=<worktree>/src` so the renderer resolves this worktree's `adoption-kits/`):

- `test_prompt_parity` + `test_agent_instructions_renderers` + `test_agent_instructions_apply` + `test_init_agent_instructions` + `test_managed_block` + `test_init_ci` → **121 passed, 3 skipped** (skips = PR-template casing, need a case-sensitive FS — unrelated)
- `test_packaging` (builds the wheel, confirms the kit ships) → **3 passed**
- `test_public_surface_contract` (incl. llms-full freshness + version-pin checks; `>=0.11` is consistent with the current 0.11.0 version) → **passed**
- All three copies confirmed byte-identical (single distinct sha256/md5)

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` (n/a — no check changes)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (n/a — no report/schema changes)

## Reviewer note

The task that prompted this said the design-partner runbook (`docs/design-partner-verifier-pilot.md`) was already hardened against this footgun, but it is **not** — its install step (line 108) still uses a plain `pipx install agents-shipgate` with no version floor. That's out of scope here; a follow-up has been flagged to apply the same fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)