### PR TITLE
Harden pilot runbook install step against stale-install footgun

### DIFF
--- a/docs/design-partner-verifier-pilot.md
+++ b/docs/design-partner-verifier-pilot.md
@@ -58,10 +58,18 @@ success path.
 
 ## Pilot Commands
 
-Run these from the target repo root. For committed PR/CI refs, make
-`origin/main` and `HEAD` available before the final verify command.
+Run these from the target repo root. The `verify` and `feedback` commands
+require agents-shipgate >=0.11.0, so the block leads with `pipx install`
+then `pipx upgrade`: a plain `pipx install` is a no-op when an older build
+is already installed, and the follow-up `pipx upgrade` brings a stale copy
+current. If `pipx` is unavailable, use
+`python -m pip install -U "agents-shipgate>=0.11"` and verify with
+`agents-shipgate --version`. For committed PR/CI refs, make `origin/main`
+and `HEAD` available before the final verify command.
 
 ```bash
+pipx install agents-shipgate
+pipx upgrade agents-shipgate
 agents-shipgate verify --preview --json
 agents-shipgate init --workspace . --write --ci --agent-instructions=all
 agents-shipgate verify --workspace . --config shipgate.yaml \
@@ -104,9 +112,13 @@ Add Agents Shipgate as an advisory verifier for this AI-generated
 agent-capability PR.
 
 Use the v0.11.0 verifier-first path:
-1. Install agents-shipgate if it is missing:
+1. Install or upgrade agents-shipgate (the pilot needs >=0.11.0):
    pipx install agents-shipgate
-   If pipx is unavailable, use python -m pip install agents-shipgate.
+   pipx upgrade agents-shipgate
+   A plain pipx install is a no-op when an older build is already installed,
+   so the follow-up pipx upgrade brings a stale copy current. If pipx is
+   unavailable, use python -m pip install -U "agents-shipgate>=0.11" and
+   verify with agents-shipgate --version.
 2. Run:
    agents-shipgate verify --preview --json
    agents-shipgate init --workspace . --write --ci --agent-instructions=all


### PR DESCRIPTION
## Summary

- A plain `pipx install agents-shipgate` (or `pip install`) is a no-op when an older copy is already installed. Anyone who installed 0.8.0 earlier stays stale, and the pilot's `verify`/`feedback` commands only exist in 0.11.0+ — so a stale 0.8.0 silently breaks the whole runbook.
- Hardens both install paths in `docs/design-partner-verifier-pilot.md` to ensure `>=0.11.0`:
  - **Partner Agent Prompt → step 1** (kept as plaintext, since it lives inside a fenced text block rather than markdown prose): adds `pipx upgrade agents-shipgate`, switches the pip fallback to `python -m pip install -U "agents-shipgate>=0.11"`, and adds an `agents-shipgate --version` check.
  - **Pilot Commands**: prepends `pipx install` + `pipx upgrade` to the runnable block and documents the `>=0.11.0` floor and the no-op footgun in the prose.
- Uses a `>=0.11` floor (not `==0.11.0`) — matches the reference wording and avoids the `agents-shipgate==X.Y.Z` form tracked by the version-pin drift tests.

## Type

- [x] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/test_public_surface_contract.py` → **exit 0, all passing**, run with `PYTHONPATH=<worktree>/src` against the project `.venv`. (The ambient `python` here is a miniconda interpreter carrying a stale `agents_shipgate` 0.8.0, which would otherwise falsely fail the version-propagation test.) `docs/design-partner-verifier-pilot.md` is not in the contract test's surface/pin lists, so it isn't directly gated, but the suite is green.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A, no check changes
- [x] Report/schema changes are additive or documented in `STABILITY.md` — N/A, no schema changes

---

**Reviewer note:** this applies the same install-hardening approach intended for `prompts/add-shipgate-to-repo.md`, but that file still carries the older wording on this branch (no `agents-shipgate>=0.11` present). That prompt is a bundled adoption-kit file with 3 byte-identical copies plus a render-hash bump, so updating it is a separate, larger change kept out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
