### PR TITLE
Lead agent surfaces with the merge verdict; add verifier.json applicability

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -93,6 +93,7 @@
   },
   "gating_signal": "release_decision.decision",
   "merge_verdicts": ["mergeable", "human_review_required", "insufficient_evidence", "blocked", "unknown"],
+  "applicability_values": ["verified", "not_applicable", "unknown"],
   "release_decisions": ["passed", "review_required", "insufficient_evidence", "blocked"],
   "merge_verdict_labels": {
     "passed": "mergeable",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,19 @@ python -m pip install -e ".[dev]"
 pytest
 ```
 
+After the editable install, the `agents-shipgate` / `shipgate` console scripts
+run from your working tree. **Beware a stale shadow install.** If you run a bare
+`agents-shipgate` or `python -m agents_shipgate` from a shell where another copy
+is on `PATH` — pipx, a base conda env, a globally pinned older release — you can
+silently execute an old build (we have seen `0.8.0` shadow a worktree, which
+makes new subcommands look "missing"). To stay honest:
+
+- Work inside the project venv and confirm with `agents-shipgate --version`.
+- For a one-off, pin the exact version: `uvx agents-shipgate@<version> ...` or
+  `pipx run agents-shipgate==<version> ...`.
+- When in doubt, `agents-shipgate contract --json` prints the running build's
+  version and contract, so you never reason against a version you don't have.
+
 ## Useful Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -330,8 +330,14 @@ action, and artifact links:
 
 ## What it produces
 
-- **Tool-Use Readiness Report** — `agents-shipgate-reports/report.{md,json,sarif}`. Markdown for human release review, JSON for tools and coding agents, SARIF for GitHub code-scanning workflows. The gating signal is `release_decision.decision`; see [`docs/agent-contract-current.md`](docs/agent-contract-current.md) for the current JSON contract.
-- **Release Evidence Packet** — `agents-shipgate-reports/packet.{md,json,html}` (and `packet.pdf` with the `[pdf]` extras). Reviewer-shaped synthesis with fixed sections, including the compact evidence matrix plus tool-surface and action-surface diffs when available. Packet outputs are locally redacted by default; see [STABILITY.md §Release Evidence Packet](STABILITY.md#release-evidence-packet-v06).
+When a PR changes what your agent can do, the verify loop writes these
+artifacts — in read order:
+
+- **`agents-shipgate-reports/verifier.json`** — the **primary, agent-facing artifact**. A coding agent reads `merge_verdict` (`mergeable | human_review_required | insufficient_evidence | blocked | unknown`), `can_merge_without_human`, `first_next_action`, and `fix_task` to decide whether to continue, repair, or stop for a human. See [`docs/agent-contract-current.md`](docs/agent-contract-current.md) for the field contract.
+- **`agents-shipgate-reports/pr-comment.md`** — the **human PR surface**: the same verdict and capability changes, shaped for a reviewer.
+- **Gate source of truth** — `report.json.release_decision.decision` (`passed | review_required | insufficient_evidence | blocked`). `merge_verdict` is a deterministic projection of it; the report stays the one decision engine.
+- **Tool-Use Readiness Report** (supporting) — `agents-shipgate-reports/report.{md,json,sarif}`. Markdown for human release review, JSON for tools and coding agents, SARIF for GitHub code-scanning workflows. This is the underlying check domain the verdict summarizes.
+- **Release Evidence Packet** (supporting) — `agents-shipgate-reports/packet.{md,json,html}` (and `packet.pdf` with the `[pdf]` extras). Reviewer-shaped synthesis with fixed sections, including the compact evidence matrix plus tool-surface and action-surface diffs when available. Packet outputs are locally redacted by default; see [STABILITY.md §Release Evidence Packet](STABILITY.md#release-evidence-packet-v06).
 
 ## Exit codes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,180 +2,101 @@
 
 > **Naming.** This project is **Agents Shipgate** (display name) / `agents-shipgate` (package, CLI, repo). See [`AGENTS.md` § Naming (canonical)](AGENTS.md#naming-canonical) for the full convention.
 
-Agents Shipgate is preparing the `v0.11.0` release. Releases `v0.2` through
-`v0.8` are complete and retained here as release history. Active public
-planning continues with incremental source-provenance enrichment after the
-v0.8 release-decision close-out.
+**Latest release: `v0.11.0`** — the AI-coding-workflow **verifier cycle**.
 
-## Completed
+## What Agents Shipgate is
 
-### v0.2
+Agents Shipgate is the deterministic merge gate for AI-generated agent
+capability changes. When a coding agent (Codex, Claude Code, Cursor — or a
+human) opens a PR that changes what an AI agent can *do*, Shipgate compiles the
+diff into a capability delta, evaluates it against a protected release policy,
+and returns a machine-readable verdict — `merge_verdict`,
+`can_merge_without_human`, `first_next_action`, `fix_task` — so the agent knows
+whether to **continue, repair, or stop for human authority**.
 
-- Improved onboarding with `agents-shipgate init`, `doctor`, `self-check`, fixtures, and richer examples.
-- Stabilized JSON report compatibility, finding fingerprints, and agent-friendly JSON command output.
-- Added baseline save/apply workflow for strict CI adoption.
-- Hardened OpenAPI, MCP, plugin-loader, YAML resource-limit, and coverage test paths.
-- Added SBOM generation, release signing workflow, and dependency audit checks.
-- Expanded manifest-aware checks and severity overrides.
+The release gate is one decision engine: `report.json.release_decision.decision`.
+Every agent-facing field in `verifier.json` is a deterministic projection of it;
+nothing gates independently.
 
-### v0.3
+## Direction
 
-- Added Google ADK static adapter MVP for Tool-Use Readiness:
-  - Supported `google_adk` as a manifest tool source.
-  - Parsed ADK Agent Config YAML and statically extracted Python `Agent` / `LlmAgent` definitions, function tools, `OpenAPIToolset`, `McpToolset`, callbacks, plugins, sub-agents, eval references, and explicit local inventories.
-  - Normalized discovered ADK tools into the existing `Tool` schema and reused MCP/OpenAPI loaders where possible.
-  - Added ADK checks for dynamic or unresolved toolsets, unfiltered MCP toolsets, missing function-tool metadata, long-running tool contracts, guardrail evidence, and eval coverage.
-- Added SARIF output.
-- Added baseline diff mode for PRs.
-- Added optional trace normalization.
-- Added GitLab CI, CircleCI, and Jenkins examples.
+The engine pivoted to the verifier in `v0.11.0`. The next leg is to make the
+**agent-native authority protocol explicit** and to turn real coding-agent runs
+into replayable evidence. Active themes, in priority order:
 
-### v0.4
+1. **Agent-Native Merge Contract, documented.** One page that maps the eight
+   contracts — trigger, capability change, merge verdict, repair, forbidden
+   action, human authority, trust root, attestation — to the artifacts that
+   already implement them (`docs/triggers.json`, `capability_change`,
+   `merge_verdict`, `fix_task`, the `SHIP-VERIFY-*` trust-root checks,
+   `human_ack`, `verifier.json`). Document the protocol substrate that already
+   exists; do not invent new architecture.
 
-- Added external policy/check packs:
-  - Declarative YAML policy packs under `checks.policy_packs`.
-  - CLI and GitHub Action policy-pack overrides for CI.
-  - Policy-pack findings flow through suppressions, severity overrides, baselines, Markdown, JSON, and SARIF.
-- Hardened multi-framework adapter support:
-  - Introduced a shared framework adapter interface where it reduces duplication.
-  - Stabilized ADK report schema fields.
-  - Documented explicit runtime inventory as a future trust-gated command; it is not part of default CI.
-  - Kept TypeScript, Go, and Java ADK support as post-Python-MVP investigation items.
-- Split bundled OpenAI API operational readiness findings into atomic check IDs.
-- Removed the legacy top-level `check_severity_overrides` alias.
-- Revisited container image distribution and kept it deferred until there is an exercised build-and-test path.
+2. **Workflow-evidence flywheel.** Extend `feedback export` beyond the verdict
+   into an opt-in, locally redacted *Agent Workflow Evidence* capture: diff,
+   agent transcript, repair attempt, verifier-before/after, and the human
+   decision. Every real pilot PR becomes a replayable benchmark scenario, so the
+   deterministic verdict is regression-tested against real agent behavior — not
+   just synthetic archetypes.
 
-### v0.5.0 LangChain/CrewAI And Focused CI
+3. **Pre-emptive authority surface.** Today the trust root is enforced
+   *reactively* — a weakening shows up in the diff, and Shipgate escalates.
+   Surface the boundary *before* the agent acts: a standing forbidden-action /
+   protected-surface projection in `verifier.json`, and a `verify --preview`
+   pre-flight, so an agent learns what it must not touch without first tripping
+   the gate.
 
-- Added static Python coverage for LangChain/LangGraph and CrewAI while preserving the default static trust model.
-- Promoted GitLab CI and CircleCI from examples to first-class integration recipes:
-  - documented strict/advisory gating;
-  - baseline artifact handling;
-  - SARIF or native security report guidance where supported;
-  - copy-pasteable workflows for monorepos and multi-manifest scans.
-- Added a framework adapter checklist so new platform support is consistent:
-  - static extraction only by default;
-  - no agent execution, model call, tool call, network call, or MCP connection;
-  - deterministic tool inventory normalization;
-  - source warnings for dynamic or unresolved tools;
-  - framework surface summary in JSON, Markdown, and SARIF-compatible metadata.
-- Bumped the additive report schema to `report_schema_version: "0.5"` while
-  keeping manifest `version: "0.1"`.
+4. **Local attestation.** A JSON-first, local attestation per verdict —
+   base/head SHA, changed capability IDs, policy-snapshot hash, CLI version,
+   verdict, `human_ack` / waiver / baseline state, and artifact hashes — as the
+   durable record of *which* capability was released, under *which* verdict,
+   acknowledged by *whom*.
 
-### v0.6.0 Agent-Friendly Adoption
+5. **Source-provenance enrichment (incremental).** Thread origin (file path,
+   line index for JSONL, list index for arrays) through finding evidence to
+   expand the mechanical-patch catalog — never approval, confirmation, or
+   idempotency evidence, which stay manual permanently.
 
-Goal: compress the 5-step setup (install → init → edit YAML → scan →
-read findings → wire CI) into a single tool-using turn for AI coding
-agents.
+### Explicit non-goals
 
-- Added `agents-shipgate detect` for read-only workspace classification
-  (which framework, which agent-name candidates, which suggested
-  sources).
-- Made `agents-shipgate init` auto-detect by default; framework-specific
-  manifests are produced for LangChain, CrewAI, Google ADK, OpenAI
-  Agents SDK, Anthropic, and OpenAI API. `--minimal` preserves the
-  pre-v0.6 template byte-exact.
-- Added `agents-shipgate init --ci` for opt-in workflow generation,
-  with cross-workflow shipgate detection.
-- Added `agents-shipgate scan --suggest-patches` and
-  `agents-shipgate apply-patches` for machine-applicable manifest fixes
-  (stale-manifest removals at high confidence; scope-coverage appends
-  at medium confidence opt-in).
-- Bumped report schema to v0.6 (additive: per-finding `patches`,
-  top-level `manifest_dir`).
+- **More framework adapters is not the roadmap.** The moat is the deterministic
+  trust root and reward-hacking resistance, not breadth of input parsers. New
+  adapters (AutoGen, Semantic Kernel, LlamaIndex, additional language surfaces)
+  are accepted only when a real workflow needs one — they do not advance the
+  core thesis and are not a priority.
+- **No second verdict.** Nothing gates independently of
+  `release_decision.decision`. Every new surface is a projection of it.
+- **No agent execution, LLM calls, MCP connections, network access, or scanner
+  telemetry** in the default static path. Runtime inventory stays an explicit,
+  trust-gated, opt-in command — never part of default CI.
 
-### v0.7.0 Adoption Activation
+## Release history
 
-Goal: make the v0.6 features visible to humans and AI coding agents
-on real repos, plus expose per-check remediation metadata so agents
-can decide what's safe to auto-fix.
+Releases `v0.2` through `v0.11.0` are complete. Highlights:
 
-- Added `AGENTS.md` "Should I run Shipgate?" trigger table with the
-  soft-stop rule (don't skip MCP/OpenAPI-only repos).
-- Added `docs/agent-recipes.md`, `docs/autofix-policy.md`, and
-  `docs/minimal-real-configs.md` as the agent-facing surface.
-- Extended `CheckMetadata` with `autofix_safe`,
-  `requires_human_review`, `suggested_patch_kind`, populated
-  `docs_url` for all 45 entries (PR 2 — catalog-conservative
-  defaults; per-check generator targets documented).
-- Added the same four optional fields to `Finding`, plus the
-  derivation policy: when `Finding.patches` is non-empty, derive
-  from actual patches (`autofix_safe=True` only when EVERY patch
-  is non-manual AND high confidence); otherwise seed from
-  `CheckMetadata`. Unknown check IDs (policy packs, plugins) get
-  the safe-closed fallback. Three patch states (None / [] /
-  non-empty) handled distinctly.
-- Bumped report schema to v0.7 (additive over v0.6 — four new
-  optional Finding fields). v0.6 schema retained as a frozen
-  reference.
-- `_run_id` excludes the four new derived fields plus `patches`;
-  scan run_id is identical with or without `--suggest-patches`.
-- Plugin-loading isolation: every code path that reads the catalog
-  during scan honors the scan's `plugins_enabled` setting, so
-  `--no-plugins` is respected even when
-  `AGENTS_SHIPGATE_ENABLE_PLUGINS=1` is set in the environment.
-- Onboarding prompt rewritten to lead with the v0.6 4-call flow;
-  byte-parity test enforces dual-copy synchrony between
-  `prompts/` and `skills/agents-shipgate/prompts/`.
+- **`v0.11.0` — Verifier cycle.** `agents-shipgate verify`; `verifier.json`
+  (`merge_verdict`, `can_merge_without_human`, `first_next_action`, `fix_task`,
+  `capability_review`); `pr-comment.md`; diff-aware trust-root checks
+  (`SHIP-VERIFY-*`: policy-weakened, baseline/waiver-expanded, CI-gate-removed,
+  agent-instructions-weakened, capability-scope-broadened); `human_ack`;
+  `capability_change`; and the agent-adoption harness with
+  adversarial-obedience and verify-restraint scoring.
+- **`v0.8.0` — Release decision engine.** `release_decision.decision` as the
+  single, baseline-aware gating signal across CLI, JSON, Markdown, PR comments,
+  and Action outputs.
+- **`v0.6.0`–`v0.7.0` — Agent-friendly adoption.** `detect`, auto-detecting
+  `init`, `--suggest-patches` / `apply-patches`, and per-check autofix metadata
+  (`autofix_safe`, `requires_human_review`).
+- **`v0.3.0`–`v0.5.0` — Static framework coverage.** Google ADK,
+  LangChain/LangGraph, CrewAI, SARIF output, external policy packs, and baseline
+  diff mode — static-by-default throughout.
+- **`v0.2` — Onboarding and CI.** `init`, `doctor`, `self-check`, fixtures,
+  baseline save/apply, SBOM generation, and release signing.
 
-### v0.8.0 Release Decision Engine
+## Static-by-default principles
 
-Closed v0.8 around a baseline-aware release decision over agent tool
-surfaces, not broader framework or runtime surface area.
-
-- Made `release_decision.decision` the recommended release-gating signal for
-  JSON consumers, CLI output, Markdown, PR comments, and GitHub Action
-  outputs.
-- Preserved `summary.status` as baseline-blind compatibility for v0.7
-  consumers.
-- Kept the verdict path deterministic and static: no LLM calls, agent
-  execution, MCP connections, network access, runtime inventory, telemetry, or
-  new framework adapters in the v0.8 close-out.
-- Hardened real-repo detection so local/private state, virtualenv fixture
-  installs, generated reports, and gitignored worktrees do not create false
-  framework or source signals.
-- Kept Tool-Use Readiness as the public wedge: OpenAI Agents SDK, MCP exports,
-  and OpenAPI specs are the clearest first path; other supported frameworks
-  remain documented inputs.
-
-## Open
-
-### Source-Provenance Enrichment (incremental)
-
-Once we have origin (file path, line index for JSONL, list index for
-arrays) threaded through finding evidence, expand the patch generator
-catalog beyond manifest-only. Candidate generators:
-
-- `SHIP-API-RETRY-POLICY-MISSING` and `SHIP-API-TIMEOUT-MISSING`
-  targeting policy-rule files (likely with a new `create_file` patch
-  kind).
-- Trace-event metadata enrichments — but never approval/confirmation
-  flips, which stay manual permanently.
-
-### Later Candidates
-
-- Expand agent-platform coverage beyond the v0.5 framework adapters:
-  - AutoGen multi-agent tool surfaces;
-  - Semantic Kernel plugins/functions;
-  - LlamaIndex tools and workflows;
-  - TypeScript/JavaScript agent frameworks where static extraction is practical;
-  - additional Google ADK language surfaces after the Python adapter remains stable.
-- Optional trust-gated runtime inventory export as an explicit command, separate from default static CI.
-- Cross-platform CI expansion after v0.8 stabilizes:
-  - Jenkins;
-  - Buildkite;
-  - Azure Pipelines;
-  - Bitbucket Pipelines;
-  - local pre-commit / pre-push usage;
-  - generic POSIX shell integration for unsupported CI systems.
-- Container image distribution if the image has CI coverage, security scanning, and release signing.
-- Homebrew or other package-manager distribution if CLI usage warrants it.
-- Public versions of the private release-readiness research themes once they are shaped into concrete checks and schema changes.
-
-## Google ADK Support Principles
-
-ADK support is read-only by default: local file parsing only; no `adk run`,
-`adk web`, `adk eval`, MCP connection, tool call, model call, or network call.
-ADK callbacks and plugins are static guardrail evidence only, not proof of
-runtime enforcement. Dynamic toolsets must produce warnings or findings unless
-the user provides explicit MCP, OpenAPI, or tool inventory inputs.
+All adapters are read-only: local file parsing only; no agent run, model call,
+tool call, MCP connection, or network access. Callbacks, plugins, and guardrail
+declarations are static evidence, not proof of runtime enforcement. Dynamic
+toolsets must produce warnings or `insufficient_evidence` findings unless the
+user supplies explicit MCP, OpenAPI, or tool-inventory inputs.

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -93,6 +93,12 @@ In `agents-shipgate-reports/verifier.json`, read these additive fields
   `insufficient_evidence`→`insufficient_evidence`, `blocked`→`blocked`, missing
   decision→`unknown`). It cannot disagree with the gate; switch on the enum with
   an `unknown`/`human_review_required` fallback for future values.
+- `applicability` (v0.11.0+) — `"verified"` / `"not_applicable"` / `"unknown"`.
+  Disambiguates a `mergeable` verdict: `"verified"` means Shipgate evaluated the
+  change and produced a release decision; `"not_applicable"` means the head scan
+  was skipped (nothing to gate — do **not** read this as "verified safe");
+  `"unknown"` means the scan could not complete. Orthogonal to `merge_verdict`;
+  additive and locked to `"verified"` whenever a `release_decision` is present.
 - `can_merge_without_human` — `bool`.
 - `decision` — mirror of `release_decision.decision` (or `null` when no scan ran).
 - `headline` — single-sentence, PR-comment-friendly summary (or `null`).

--- a/docs/verifier-schema.v0.1.json
+++ b/docs/verifier-schema.v0.1.json
@@ -268,6 +268,16 @@
       "default": null,
       "title": "Agent Summary"
     },
+    "applicability": {
+      "default": "unknown",
+      "enum": [
+        "verified",
+        "not_applicable",
+        "unknown"
+      ],
+      "title": "Applicability",
+      "type": "string"
+    },
     "artifacts": {
       "additionalProperties": {
         "type": "string"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -978,6 +978,12 @@ In `agents-shipgate-reports/verifier.json`, read these additive fields
   `insufficient_evidence`→`insufficient_evidence`, `blocked`→`blocked`, missing
   decision→`unknown`). It cannot disagree with the gate; switch on the enum with
   an `unknown`/`human_review_required` fallback for future values.
+- `applicability` (v0.11.0+) — `"verified"` / `"not_applicable"` / `"unknown"`.
+  Disambiguates a `mergeable` verdict: `"verified"` means Shipgate evaluated the
+  change and produced a release decision; `"not_applicable"` means the head scan
+  was skipped (nothing to gate — do **not** read this as "verified safe");
+  `"unknown"` means the scan could not complete. Orthogonal to `merge_verdict`;
+  additive and locked to `"verified"` whenever a `release_decision` is present.
 - `can_merge_without_human` — `bool`.
 - `decision` — mirror of `release_decision.decision` (or `null` when no scan ran).
 - `headline` — single-sentence, PR-comment-friendly summary (or `null`).

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -24,6 +24,7 @@ from agents_shipgate.schemas.verifier import (
     VerifierFixTask,
     VerifierHumanReview,
     VerifierNextAction,
+    applicability_for,
     merge_verdict_for,
 )
 from agents_shipgate.triggers import evaluate
@@ -730,6 +731,7 @@ def _build_verifier(
     )
     decision = release_decision_model.decision if release_decision_model else None
     merge_verdict = merge_verdict_for(decision=decision, head_status=head_status)
+    applicability = applicability_for(decision=decision, head_status=head_status)
     agent_summary_model = report.agent_summary if report is not None else None
     capability_review = build_capability_review(report) if report is not None else None
     human_review = _human_review(
@@ -781,6 +783,7 @@ def _build_verifier(
         ),
         decision=decision,
         merge_verdict=merge_verdict,
+        applicability=applicability,
         can_merge_without_human=_can_merge_without_human(
             merge_verdict=merge_verdict,
             release_decision=release_decision_model,

--- a/src/agents_shipgate/schemas/verifier.py
+++ b/src/agents_shipgate/schemas/verifier.py
@@ -226,6 +226,30 @@ class VerifierArtifact(BaseModel):
     fix_task: VerifierFixTask | None = None
     artifacts: dict[str, str] = Field(default_factory=dict)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_absent_applicability(cls, data: Any) -> Any:
+        """Backward-compatible default for ``applicability`` (additive in schema 0.1).
+
+        An artifact written before this field existed — or any caller that does
+        not set it — may carry a ``release_decision`` but omit
+        ``applicability``. Derive it from the substrate so
+        ``model_validate(...)`` round-trips an older ``verifier.json`` instead
+        of tripping the consistency lock below. Only an *absent* value is
+        filled; an explicit (possibly contradictory) value is left for the
+        after-validator to reject. Keyed on ``release_decision`` presence so the
+        derived value always satisfies that lock.
+        """
+        if isinstance(data, dict) and "applicability" not in data:
+            if data.get("release_decision") is not None:
+                derived = "verified"
+            elif data.get("head_status", "skipped") == "skipped":
+                derived = "not_applicable"
+            else:
+                derived = "unknown"
+            data = {**data, "applicability": derived}
+        return data
+
     @model_validator(mode="after")
     def _verdict_projects_release_decision(self) -> VerifierArtifact:
         """Lock the one-decision-engine contract structurally.
@@ -262,10 +286,12 @@ class VerifierArtifact(BaseModel):
 
         A present head ``release_decision`` means Shipgate evaluated the change
         and produced a determination, so ``applicability`` MUST be
-        ``"verified"``. Skipped / failed / preview runs have no
-        ``release_decision`` substrate and are left to ``applicability_for``,
-        exactly like ``merge_verdict``. Construction-time enforcement makes a
-        ``mergeable``-but-``not_applicable`` lie impossible to emit.
+        ``"verified"``. An *absent* value was already backfilled by
+        ``_derive_absent_applicability``; this lock therefore only rejects an
+        *explicit* contradiction (e.g. ``"not_applicable"`` passed alongside a
+        release decision). Skipped / failed / preview runs have no
+        ``release_decision`` substrate and are left unconstrained, exactly like
+        ``merge_verdict``.
         """
         if self.release_decision is None:
             return self

--- a/src/agents_shipgate/schemas/verifier.py
+++ b/src/agents_shipgate/schemas/verifier.py
@@ -25,6 +25,11 @@ MergeVerdict = Literal[
     "blocked",
     "unknown",
 ]
+# Whether Shipgate actually evaluated the change — orthogonal to the verdict.
+# Disambiguates a ``mergeable`` verdict: "verified" (Shipgate ran and reached a
+# determination) vs "not_applicable" (skipped — nothing to gate) vs "unknown"
+# (scan could not complete). Never read "mergeable" alone as "verified safe".
+Applicability = Literal["verified", "not_applicable", "unknown"]
 CapabilityChangeBucket = Literal["added", "modified", "removed"]
 CapabilityReleaseImpact = Literal[
     "blocks_release",
@@ -74,6 +79,22 @@ def merge_verdict_for(*, decision: str | None, head_status: str) -> MergeVerdict
     if decision is not None:
         return map_merge_verdict(decision)
     return "mergeable" if head_status == "skipped" else "unknown"
+
+
+def applicability_for(*, decision: str | None, head_status: str) -> Applicability:
+    """Whether Shipgate actually evaluated this change — orthogonal to the verdict.
+
+    A produced ``decision`` means Shipgate was applicable and reached a
+    determination (``"verified"`` — regardless of pass/block). A *skipped* head
+    means there was nothing to gate (``"not_applicable"``). Anything else — scan
+    failed, or not yet run — is ``"unknown"``. This is the field that keeps a
+    ``merge_verdict`` of ``"mergeable"`` from being read as "verified safe" when
+    Shipgate in fact did not need to run. Mirrors ``merge_verdict_for`` so the
+    two stay in lock-step.
+    """
+    if decision is not None:
+        return "verified"
+    return "not_applicable" if head_status == "skipped" else "unknown"
 
 
 class VerifierNextAction(BaseModel):
@@ -197,6 +218,7 @@ class VerifierArtifact(BaseModel):
     mode: str = "advisory"
     decision: str | None = None
     merge_verdict: MergeVerdict = "unknown"
+    applicability: Applicability = "unknown"
     can_merge_without_human: bool = False
     headline: str | None = None
     human_review: VerifierHumanReview | None = None
@@ -234,8 +256,30 @@ class VerifierArtifact(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _applicability_projects_release_decision(self) -> VerifierArtifact:
+        """Lock applicability to the substrate, mirroring the verdict lock.
+
+        A present head ``release_decision`` means Shipgate evaluated the change
+        and produced a determination, so ``applicability`` MUST be
+        ``"verified"``. Skipped / failed / preview runs have no
+        ``release_decision`` substrate and are left to ``applicability_for``,
+        exactly like ``merge_verdict``. Construction-time enforcement makes a
+        ``mergeable``-but-``not_applicable`` lie impossible to emit.
+        """
+        if self.release_decision is None:
+            return self
+        if self.applicability != "verified":
+            raise ValueError(
+                "VerifierArtifact.applicability must be 'verified' when a head "
+                "release_decision is present (Shipgate was applicable); got "
+                f"{self.applicability!r}."
+            )
+        return self
+
 
 __all__ = [
+    "Applicability",
     "CapabilityChangeBucket",
     "CapabilityReleaseImpact",
     "MergeVerdict",
@@ -247,6 +291,7 @@ __all__ = [
     "VerifierHeadStatus",
     "VerifierHumanReview",
     "VerifierNextAction",
+    "applicability_for",
     "map_merge_verdict",
     "merge_verdict_for",
 ]

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -104,7 +104,7 @@ VERSION_LITERAL_TARGETS = (
     ),
     (
         "ROADMAP.md",
-        re.compile(r"preparing the\s+`v(\d+\.\d+\.\d+)`\s+release"),
+        re.compile(r"Latest release:\s*`v(\d+\.\d+\.\d+)`"),
     ),
 )
 # Forbidden public/display forms. Case-sensitive on purpose: `Agents
@@ -645,8 +645,8 @@ def test_shipgate_version_inputs_match_pyproject_version(relpath):
 def test_version_literals_match_pyproject_version(relpath, pattern):
     """Plain release-version literals on these public surfaces (the
     bug-report placeholder, distribution.md's release-tag list,
-    faq.md's 'latest released version' line, ROADMAP.md's lead
-    paragraph) must move with pyproject.toml on every bump. The
+    faq.md's 'latest released version' line, ROADMAP.md's latest-release
+    line) must move with pyproject.toml on every bump. The
     Action / pip / shipgate_version pin tests don't catch these
     because the literals aren't pins."""
     expected = _load_pyproject_version()

--- a/tests/test_verdict_contract.py
+++ b/tests/test_verdict_contract.py
@@ -28,6 +28,7 @@ from agents_shipgate.schemas.report import (
 from agents_shipgate.schemas.verifier import (
     _DECISION_TO_VERDICT,
     VerifierArtifact,
+    applicability_for,
     map_merge_verdict,
     merge_verdict_for,
 )
@@ -116,6 +117,30 @@ def test_merge_verdict_for_matrix(decision, head_status, expected) -> None:
     assert merge_verdict_for(decision=decision, head_status=head_status) == expected
 
 
+@pytest.mark.parametrize(
+    "decision, head_status, expected",
+    [
+        ("passed", "succeeded", "verified"),
+        ("review_required", "succeeded", "verified"),
+        ("insufficient_evidence", "succeeded", "verified"),
+        ("blocked", "succeeded", "verified"),
+        (None, "skipped", "not_applicable"),  # nothing to gate
+        (None, "succeeded", "unknown"),  # ran but produced no decision
+        (None, "failed", "unknown"),  # scan failed
+    ],
+)
+def test_applicability_for_matrix(decision, head_status, expected) -> None:
+    assert applicability_for(decision=decision, head_status=head_status) == expected
+
+
+def test_applicability_disambiguates_mergeable_skip() -> None:
+    # The reason the field exists: a skipped head projects merge_verdict
+    # "mergeable" but applicability "not_applicable" — never let an agent read
+    # "Shipgate verified this is safe" off a run where Shipgate did not run.
+    assert merge_verdict_for(decision=None, head_status="skipped") == "mergeable"
+    assert applicability_for(decision=None, head_status="skipped") == "not_applicable"
+
+
 # --- The artifact cannot disagree with its substrate (structural lock) ------
 
 
@@ -126,6 +151,11 @@ def _artifact(**overrides) -> VerifierArtifact:
         "head_status": "succeeded",
     }
     base.update(overrides)
+    # When a release decision is present, applicability is locked to "verified"
+    # (Shipgate evaluated the change). Inject it so callers that only exercise
+    # the merge_verdict projection don't trip the applicability lock.
+    if base.get("release_decision") is not None and "applicability" not in base:
+        base["applicability"] = "verified"
     return VerifierArtifact(**base)
 
 
@@ -165,3 +195,18 @@ def test_artifact_without_release_decision_is_unconstrained() -> None:
         release_decision=None, head_status="skipped", merge_verdict="mergeable"
     )
     assert art2.merge_verdict == "mergeable"
+
+
+def test_artifact_rejects_applicability_inconsistent_with_substrate() -> None:
+    # A present release_decision means Shipgate was applicable; claiming
+    # "not_applicable" is the exact lie this lock prevents.
+    with pytest.raises(ValidationError):
+        VerifierArtifact(
+            workspace="/tmp/w",
+            config="shipgate.yaml",
+            head_status="succeeded",
+            release_decision={"decision": "passed"},
+            decision="passed",
+            merge_verdict="mergeable",
+            applicability="not_applicable",
+        )

--- a/tests/test_verdict_contract.py
+++ b/tests/test_verdict_contract.py
@@ -151,11 +151,6 @@ def _artifact(**overrides) -> VerifierArtifact:
         "head_status": "succeeded",
     }
     base.update(overrides)
-    # When a release decision is present, applicability is locked to "verified"
-    # (Shipgate evaluated the change). Inject it so callers that only exercise
-    # the merge_verdict projection don't trip the applicability lock.
-    if base.get("release_decision") is not None and "applicability" not in base:
-        base["applicability"] = "verified"
     return VerifierArtifact(**base)
 
 
@@ -210,3 +205,31 @@ def test_artifact_rejects_applicability_inconsistent_with_substrate() -> None:
             merge_verdict="mergeable",
             applicability="not_applicable",
         )
+
+
+def test_artifact_model_validate_backfills_applicability_for_old_payloads() -> None:
+    # An older verifier.json (schema 0.1) carries release_decision but no
+    # applicability key. model_validate must round-trip it — backfilling
+    # "verified" via the before-validator — instead of tripping the lock.
+    art = VerifierArtifact.model_validate(
+        {
+            "workspace": "/tmp/w",
+            "config": "shipgate.yaml",
+            "head_status": "succeeded",
+            "release_decision": {"decision": "blocked"},
+            "decision": "blocked",
+            "merge_verdict": "blocked",
+        }
+    )
+    assert art.applicability == "verified"
+    # A skipped older artifact backfills "not_applicable" — never a bare
+    # "mergeable" that an agent could read as "verified safe".
+    skipped = VerifierArtifact.model_validate(
+        {
+            "workspace": "/tmp/w",
+            "config": "shipgate.yaml",
+            "head_status": "skipped",
+            "merge_verdict": "mergeable",
+        }
+    )
+    assert skipped.applicability == "not_applicable"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -327,7 +327,6 @@ def test_capability_review_pr_comment_leads_with_top_changes_and_trust_root() ->
         release_decision={"decision": "blocked"},
         decision="blocked",
         merge_verdict="blocked",
-        applicability="verified",
         headline="This PR adds a refund action without approval evidence.",
         capability_review=build_capability_review(report),
         fix_task=VerifierFixTask(
@@ -377,7 +376,6 @@ def test_capability_review_pr_comment_uses_merge_verdict_vocabulary() -> None:
         release_decision={"decision": "review_required"},
         decision="review_required",
         merge_verdict="human_review_required",
-        applicability="verified",
         capability_review=build_capability_review(report),
         artifacts={"verifier_json": "agents-shipgate-reports/verifier.json"},
     )
@@ -400,7 +398,6 @@ def test_capability_review_pr_comment_does_not_double_blank_without_headline() -
         release_decision={"decision": "review_required"},
         decision="review_required",
         merge_verdict="human_review_required",
-        applicability="verified",
         headline="",
         capability_review=build_capability_review(report),
         artifacts={"verifier_json": "agents-shipgate-reports/verifier.json"},

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -327,6 +327,7 @@ def test_capability_review_pr_comment_leads_with_top_changes_and_trust_root() ->
         release_decision={"decision": "blocked"},
         decision="blocked",
         merge_verdict="blocked",
+        applicability="verified",
         headline="This PR adds a refund action without approval evidence.",
         capability_review=build_capability_review(report),
         fix_task=VerifierFixTask(
@@ -376,6 +377,7 @@ def test_capability_review_pr_comment_uses_merge_verdict_vocabulary() -> None:
         release_decision={"decision": "review_required"},
         decision="review_required",
         merge_verdict="human_review_required",
+        applicability="verified",
         capability_review=build_capability_review(report),
         artifacts={"verifier_json": "agents-shipgate-reports/verifier.json"},
     )
@@ -398,6 +400,7 @@ def test_capability_review_pr_comment_does_not_double_blank_without_headline() -
         release_decision={"decision": "review_required"},
         decision="review_required",
         merge_verdict="human_review_required",
+        applicability="verified",
         headline="",
         capability_review=build_capability_review(report),
         artifacts={"verifier_json": "agents-shipgate-reports/verifier.json"},


### PR DESCRIPTION
## Summary

- Align the public/agent surfaces with the `v0.11.0` **verifier pivot** and remove one semantic ambiguity in `verifier.json`. The engine already produces merge verdicts; the docs, roadmap, and one artifact field still read like the pre-verifier era.
- **README "What it produces"** now leads with `verifier.json` (primary, agent-facing) → `pr-comment.md` (human PR surface) → `report.json.release_decision.decision` (gate source of truth), and demotes the **Tool-Use Readiness Report** and **Release Evidence Packet** to *supporting*.
- **ROADMAP** rewritten around the verifier / trust-root / evidence-flywheel direction. "More framework adapters" is now an **explicit non-goal**; the stale "preparing `v0.11.0`" lead becomes "Latest release: `v0.11.0`".
- New additive **`verifier.json.applicability`** (`verified | not_applicable | unknown`) so a `mergeable` verdict is never read as "verified safe" when Shipgate merely had nothing to gate (skipped) or could not complete (unknown). It is orthogonal to `merge_verdict`, projected by `applicability_for()` in lock-step with `merge_verdict_for()`, and **structurally locked** to `"verified"` whenever a head `release_decision` is present — it never becomes a second gate.
- **CONTRIBUTING** note on stale shadow installs (a globally pinned `0.8.0` shadowing a worktree makes new subcommands look "missing") pointing at pinned `uvx`/`pipx run` and `agents-shipgate contract --json`.

## Type

- [x] Report, schema, or SARIF output — additive `applicability` field in `verifier.json` (schema regenerated; `verifier_schema_version` stays `"0.1"`)
- [x] Documentation only — README, ROADMAP, CONTRIBUTING, `docs/agent-contract-current.md`, `.well-known`

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full suite (`pytest -m "not perf"`) green on this worktree.
- `scripts/generate_schemas.py` regenerated `docs/verifier-schema.v0.1.json`; `tests/test_schema_roundtrip.py` green.
- `scripts/build-llms-full.py` rebuilt `llms-full.txt` (sources include `docs/agent-contract-current.md`).
- All three `applicability` states exercised: `verified` (refund fixture → blocked PR), `not_applicable` (verdict-contract matrix), `unknown` (live `verify --preview`, staying consistent with `merge_verdict`).

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (no new check IDs)
- [x] Report/schema changes are additive or documented in `STABILITY.md` — `applicability` is additive; `verifier_schema_version` stays `"0.1"` per the verifier-schema additive-in-place convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
