### PR TITLE
Add the verifier.json agent_controller projection block

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -107,6 +107,7 @@
     "first_next_action",
     "fix_task",
     "capability_review.top_changes",
+    "agent_controller",
     "release_decision.decision"
   ],
   "do_not_auto_assert": [

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -608,6 +608,10 @@ consumer may read:
   `insufficient_evidence`→`insufficient_evidence`, `blocked`→`blocked`, missing
   decision→`unknown`). It cannot disagree with the gate. Switch on the enum with
   an `unknown`/`human_review_required` fallback for unrecognized future values.
+- `applicability` — `"verified"` / `"not_applicable"` / `"unknown"`; whether
+  Shipgate evaluated the change. Disambiguates a `mergeable` verdict
+  (`"not_applicable"` means the head scan was skipped — *not* "verified safe").
+  Locked to `"verified"` whenever a `release_decision` is present.
 - `can_merge_without_human` — `bool`; whether the PR can merge without human
   review.
 - `decision` — mirror of `release_decision.decision` (or `null` when no scan
@@ -630,6 +634,15 @@ consumer may read:
   highest-signal capability deltas with `{id, title, impact, rationale,
   related_finding_ids}`. `impact` mirrors the gate; this block never introduces a
   finding-independent blocker.
+- `agent_controller` — imperative restatement of the verdict for autonomous
+  control (`null` for `--preview`): `{completion_allowed, must_stop, stop_reason,
+  allowed_next_commands[], forbidden_file_edits[], forbidden_actions[],
+  user_message_template}`. `completion_allowed` is locked to
+  `can_merge_without_human` (never a second verdict). `forbidden_file_edits[]` is
+  a standing deny-list of whole-file trust roots (CI gate, agent instructions,
+  policy packs), never an allow-list; it excludes `shipgate.yaml` /
+  `.agents-shipgate` (key-level, covered by `forbidden_actions[]`) and the tool
+  surface under review. Both forbidden lists are present on every verdict.
 - `mode` — `"advisory"` / `"strict"` / `"skipped"` / `"preview"`.
 
 `verifier.json` also carries `trigger` (the run/skip evaluation), `base_status`,

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -111,6 +111,20 @@ In `agents-shipgate-reports/verifier.json`, read these additive fields
   the listed mechanical fix and rerun `verification_command`; `actor: human`
   means the agent must not invent approval, idempotency, policy, waiver,
   baseline, or trust-root evidence to make the gate pass.
+- `agent_controller` (v0.11.0+) — `null` for `--preview`; otherwise the
+  imperative restatement of the verdict for autonomous control:
+  `{completion_allowed, must_stop, stop_reason, allowed_next_commands[],
+  forbidden_file_edits[], forbidden_actions[], user_message_template}`.
+  `completion_allowed` is locked to `can_merge_without_human` (never a second
+  verdict); `must_stop` is `true` only when the agent can neither finish nor
+  safely repair; `stop_reason` ∈ `{self_approval_prohibited, blocked_findings,
+  insufficient_evidence, human_review_required, scan_incomplete}`.
+  `forbidden_file_edits[]` is a standing deny-list of whole-file trust roots (CI
+  gate, agent instructions, policy packs) — **not** an allow-list — and
+  deliberately excludes `shipgate.yaml` / `.agents-shipgate` (key-level, covered
+  by `forbidden_actions[]`) and the tool surface under review. Both forbidden
+  lists are present on every verdict, including `mergeable`, so a passing run is
+  never read as "anything goes".
 - `trust_root_touched` — `bool`; `true` when the PR changed a release-gate trust
   root (`shipgate.yaml`, the Shipgate CI workflow, `AGENTS.md`/`CLAUDE.md`,
   policy packs, prompts, baselines, waivers, etc.). Backed by the

--- a/docs/verifier-schema.v0.1.json
+++ b/docs/verifier-schema.v0.1.json
@@ -1,5 +1,75 @@
 {
   "$defs": {
+    "AgentController": {
+      "additionalProperties": false,
+      "description": "Imperative controller projection for an autonomous coding agent.\n\nA re-shaping of the verdict the agent already has \u2014 ``merge_verdict``,\n``can_merge_without_human``, ``fix_task``, ``capability_review`` \u2014 into the\nfour questions an agent must answer without human interpretation: may I claim\nthe task done (``completion_allowed``), must I stop for a human\n(``must_stop`` / ``stop_reason``), what may I run next\n(``allowed_next_commands``), and what must I never edit or do to get past the\ngate (``forbidden_file_edits`` / ``forbidden_actions``).\n\nIt introduces NO new decision: ``completion_allowed`` is locked to\n``can_merge_without_human`` by ``VerifierArtifact``, and every other field is\na deterministic projection of the head scan. ``forbidden_file_edits`` and\n``forbidden_actions`` are a STANDING negative affordance \u2014 present on every\nverdict, including ``mergeable`` \u2014 so a passing run never reads as \"anything\ngoes\".",
+      "properties": {
+        "allowed_next_commands": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Allowed Next Commands",
+          "type": "array"
+        },
+        "completion_allowed": {
+          "default": false,
+          "title": "Completion Allowed",
+          "type": "boolean"
+        },
+        "forbidden_actions": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Forbidden Actions",
+          "type": "array"
+        },
+        "forbidden_file_edits": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Forbidden File Edits",
+          "type": "array"
+        },
+        "must_stop": {
+          "default": true,
+          "title": "Must Stop",
+          "type": "boolean"
+        },
+        "stop_reason": {
+          "anyOf": [
+            {
+              "enum": [
+                "self_approval_prohibited",
+                "blocked_findings",
+                "insufficient_evidence",
+                "human_review_required",
+                "scan_incomplete"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Stop Reason"
+        },
+        "user_message_template": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "User Message Template"
+        }
+      },
+      "title": "AgentController",
+      "type": "object"
+    },
     "VerifierCapabilityChange": {
       "additionalProperties": false,
       "description": "One reviewer-facing capability change projected for verifier output.",
@@ -255,6 +325,17 @@
   "additionalProperties": false,
   "description": "JSON Schema for verifier.json. Generated from agents_shipgate.schemas.verifier.VerifierArtifact. Do not edit by hand.",
   "properties": {
+    "agent_controller": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AgentController"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
     "agent_summary": {
       "anyOf": [
         {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -996,6 +996,20 @@ In `agents-shipgate-reports/verifier.json`, read these additive fields
   the listed mechanical fix and rerun `verification_command`; `actor: human`
   means the agent must not invent approval, idempotency, policy, waiver,
   baseline, or trust-root evidence to make the gate pass.
+- `agent_controller` (v0.11.0+) — `null` for `--preview`; otherwise the
+  imperative restatement of the verdict for autonomous control:
+  `{completion_allowed, must_stop, stop_reason, allowed_next_commands[],
+  forbidden_file_edits[], forbidden_actions[], user_message_template}`.
+  `completion_allowed` is locked to `can_merge_without_human` (never a second
+  verdict); `must_stop` is `true` only when the agent can neither finish nor
+  safely repair; `stop_reason` ∈ `{self_approval_prohibited, blocked_findings,
+  insufficient_evidence, human_review_required, scan_incomplete}`.
+  `forbidden_file_edits[]` is a standing deny-list of whole-file trust roots (CI
+  gate, agent instructions, policy packs) — **not** an allow-list — and
+  deliberately excludes `shipgate.yaml` / `.agents-shipgate` (key-level, covered
+  by `forbidden_actions[]`) and the tool surface under review. Both forbidden
+  lists are present on every verdict, including `mergeable`, so a passing run is
+  never read as "anything goes".
 - `trust_root_touched` — `bool`; `true` when the PR changed a release-gate trust
   root (`shipgate.yaml`, the Shipgate CI workflow, `AGENTS.md`/`CLAUDE.md`,
   policy packs, prompts, baselines, waivers, etc.). Backed by the

--- a/src/agents_shipgate/cli/verify/agent_controller.py
+++ b/src/agents_shipgate/cli/verify/agent_controller.py
@@ -1,0 +1,137 @@
+"""Deterministic ``agent_controller`` projection for ``agents-shipgate verify``.
+
+The ``agent_controller`` block answers the four questions an autonomous coding
+agent must resolve without human interpretation: may I claim the task done, must
+I stop for a human, what may I run next, and what must I never edit or do to get
+past the gate. It is a pure projection of the verdict the orchestrator already
+computed (``merge_verdict``, ``can_merge_without_human``, ``fix_task``,
+``capability_review``) plus the static trust-root surface list — it introduces
+no new decision, and ``completion_allowed`` is locked to
+``can_merge_without_human`` by ``VerifierArtifact``.
+"""
+
+from __future__ import annotations
+
+from agents_shipgate.checks.verify import TRUST_ROOT_SURFACES
+from agents_shipgate.cli.verify.fix_task import FORBIDDEN_SHORTCUTS
+from agents_shipgate.schemas.verifier import (
+    AgentController,
+    AgentStopReason,
+    MergeVerdict,
+    VerifierCapabilityReview,
+    VerifierFixTask,
+    VerifierHumanReview,
+)
+
+# The deny-list of trust-root files an agent must never edit *to make a verdict
+# pass*. Derived from the canonical ``TRUST_ROOT_SURFACES`` (single source of
+# truth), restricted to the classes whose trust boundary is the WHOLE FILE: the
+# Shipgate CI gate, the agent-instruction surfaces, and policy packs.
+#
+# Deliberately EXCLUDES:
+#   * ``shipgate.yaml`` and ``.agents-shipgate/**`` — their boundary is
+#     *key-level* (editing an action's scope is a legitimate mechanical fix; a
+#     ``checks.ignore`` / baseline / waiver expansion is reward-hacking). A
+#     path-level deny cannot express that, so they are covered by
+#     ``forbidden_actions`` instead.
+#   * the tool-surface declarations (``.mcp.json``, ``SKILL.md``, ``.app.json``,
+#     ``.codex-plugin/**``) — those are the capability surface UNDER review,
+#     which a PR may legitimately edit.
+#
+# There is intentionally NO allow-list: an agent's legitimate mechanical fix
+# edits application code or manifest scope fields that cannot be enumerated
+# ahead of time, so an exhaustive "may edit" list would fight real work.
+_FORBIDDEN_EDIT_CLASSES = frozenset({"ci_gate", "agent_instructions", "policy"})
+PROTECTED_FILE_EDITS: tuple[str, ...] = tuple(
+    pattern for kind, pattern in TRUST_ROOT_SURFACES if kind in _FORBIDDEN_EDIT_CLASSES
+)
+
+
+def build_agent_controller(
+    *,
+    merge_verdict: MergeVerdict,
+    can_merge_without_human: bool,
+    fix_task: VerifierFixTask | None,
+    capability_review: VerifierCapabilityReview | None,
+    human_review: VerifierHumanReview | None,
+    headline: str | None,
+) -> AgentController:
+    """Project the computed verdict onto the imperative agent controller.
+
+    Pure function of values the orchestrator already derived; never an LLM
+    judgment. Not emitted for ``--preview`` (a pre-gate relevance check) — the
+    caller passes ``None`` there.
+    """
+    self_approval = capability_review is not None and (
+        capability_review.policy_weakened or capability_review.trust_root_touched
+    )
+    # The only non-stop, non-done state: every gating gap is mechanical, so the
+    # agent may repair and re-verify (``fix_task`` routed to the coding agent).
+    agent_safe_fix = (
+        fix_task is not None
+        and fix_task.actor == "coding_agent"
+        and fix_task.safe_to_attempt
+    )
+    completion_allowed = can_merge_without_human
+    # Stop only when the agent can neither finish nor safely repair — i.e. the
+    # next move belongs to a human (authority gap, blocker, degraded evidence).
+    must_stop = not completion_allowed and not agent_safe_fix
+
+    stop_reason: AgentStopReason | None = None
+    if must_stop:
+        if self_approval:
+            stop_reason = "self_approval_prohibited"
+        elif merge_verdict == "blocked":
+            stop_reason = "blocked_findings"
+        elif merge_verdict == "insufficient_evidence":
+            stop_reason = "insufficient_evidence"
+        elif merge_verdict == "unknown":
+            stop_reason = "scan_incomplete"
+        else:
+            stop_reason = "human_review_required"
+
+    allowed_next_commands: list[str] = []
+    if agent_safe_fix and fix_task is not None and fix_task.verification_command:
+        # The only command that helps: apply the mechanical fix, then re-verify.
+        allowed_next_commands = [fix_task.verification_command]
+
+    return AgentController(
+        completion_allowed=completion_allowed,
+        must_stop=must_stop,
+        stop_reason=stop_reason,
+        allowed_next_commands=allowed_next_commands,
+        forbidden_file_edits=list(PROTECTED_FILE_EDITS),
+        forbidden_actions=list(FORBIDDEN_SHORTCUTS),
+        user_message_template=_user_message(
+            completion_allowed=completion_allowed,
+            agent_safe_fix=agent_safe_fix,
+            fix_task=fix_task,
+            human_review=human_review,
+            headline=headline,
+        ),
+    )
+
+
+def _user_message(
+    *,
+    completion_allowed: bool,
+    agent_safe_fix: bool,
+    fix_task: VerifierFixTask | None,
+    human_review: VerifierHumanReview | None,
+    headline: str | None,
+) -> str:
+    if completion_allowed:
+        return headline or "No agent-capability changes gate this PR; safe to merge."
+    if agent_safe_fix:
+        cmd = fix_task.verification_command if fix_task is not None else None
+        tail = f" then re-run `{cmd}`" if cmd else " then re-run verify"
+        return (
+            f"Shipgate found mechanical gaps you may fix;{tail}. Do not weaken "
+            "the gate, suppress findings, or invent approval/idempotency evidence."
+        )
+    why = human_review.why if human_review is not None and human_review.why else None
+    base = why or headline or "A human must review this agent-capability change before merge."
+    return f"{base} A coding agent cannot clear this gate itself."
+
+
+__all__ = ["PROTECTED_FILE_EDITS", "build_agent_controller"]

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -29,6 +29,7 @@ from agents_shipgate.schemas.verifier import (
 )
 from agents_shipgate.triggers import evaluate
 
+from .agent_controller import build_agent_controller
 from .capability_review import build_capability_review
 from .fix_task import build_fix_task
 from .git import (
@@ -746,6 +747,32 @@ def _build_verifier(
         base_ref=base,
         head_ref=head,
     )
+    can_merge = _can_merge_without_human(
+        merge_verdict=merge_verdict,
+        release_decision=release_decision_model,
+        capability_review=capability_review,
+    )
+    headline = _verifier_headline(
+        report=report,
+        merge_verdict=merge_verdict,
+        head_status=head_status,
+        capability_review=capability_review,
+    )
+    # Imperative controller projection — a pure restatement of the verdict
+    # above. Not emitted for --preview, which is a pre-gate relevance check
+    # (the agent reads first_next_action there).
+    agent_controller = (
+        None
+        if preview
+        else build_agent_controller(
+            merge_verdict=merge_verdict,
+            can_merge_without_human=can_merge,
+            fix_task=fix_task,
+            capability_review=capability_review,
+            human_review=human_review,
+            headline=headline,
+        )
+    )
     return VerifierArtifact(
         workspace=str(git_root),
         config=_display_path(config_path, git_root),
@@ -784,17 +811,8 @@ def _build_verifier(
         decision=decision,
         merge_verdict=merge_verdict,
         applicability=applicability,
-        can_merge_without_human=_can_merge_without_human(
-            merge_verdict=merge_verdict,
-            release_decision=release_decision_model,
-            capability_review=capability_review,
-        ),
-        headline=_verifier_headline(
-            report=report,
-            merge_verdict=merge_verdict,
-            head_status=head_status,
-            capability_review=capability_review,
-        ),
+        can_merge_without_human=can_merge,
+        headline=headline,
         human_review=human_review,
         first_next_action=_first_next_action(
             merge_verdict=merge_verdict,
@@ -804,6 +822,7 @@ def _build_verifier(
             capability_review=capability_review,
         ),
         fix_task=fix_task,
+        agent_controller=agent_controller,
         artifacts=artifacts,
     )
 

--- a/src/agents_shipgate/schemas/verifier.py
+++ b/src/agents_shipgate/schemas/verifier.py
@@ -185,6 +185,45 @@ class VerifierCapabilityReview(BaseModel):
     notes: list[str] = Field(default_factory=list)
 
 
+AgentStopReason = Literal[
+    "self_approval_prohibited",
+    "blocked_findings",
+    "insufficient_evidence",
+    "human_review_required",
+    "scan_incomplete",
+]
+
+
+class AgentController(BaseModel):
+    """Imperative controller projection for an autonomous coding agent.
+
+    A re-shaping of the verdict the agent already has — ``merge_verdict``,
+    ``can_merge_without_human``, ``fix_task``, ``capability_review`` — into the
+    four questions an agent must answer without human interpretation: may I claim
+    the task done (``completion_allowed``), must I stop for a human
+    (``must_stop`` / ``stop_reason``), what may I run next
+    (``allowed_next_commands``), and what must I never edit or do to get past the
+    gate (``forbidden_file_edits`` / ``forbidden_actions``).
+
+    It introduces NO new decision: ``completion_allowed`` is locked to
+    ``can_merge_without_human`` by ``VerifierArtifact``, and every other field is
+    a deterministic projection of the head scan. ``forbidden_file_edits`` and
+    ``forbidden_actions`` are a STANDING negative affordance — present on every
+    verdict, including ``mergeable`` — so a passing run never reads as "anything
+    goes".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    completion_allowed: bool = False
+    must_stop: bool = True
+    stop_reason: AgentStopReason | None = None
+    allowed_next_commands: list[str] = Field(default_factory=list)
+    forbidden_file_edits: list[str] = Field(default_factory=list)
+    forbidden_actions: list[str] = Field(default_factory=list)
+    user_message_template: str | None = None
+
+
 class VerifierArtifact(BaseModel):
     """Machine-readable artifact emitted by ``agents-shipgate verify``.
 
@@ -224,6 +263,7 @@ class VerifierArtifact(BaseModel):
     human_review: VerifierHumanReview | None = None
     first_next_action: VerifierNextAction | None = None
     fix_task: VerifierFixTask | None = None
+    agent_controller: AgentController | None = None
     artifacts: dict[str, str] = Field(default_factory=dict)
 
     @model_validator(mode="before")
@@ -303,8 +343,31 @@ class VerifierArtifact(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _agent_controller_projects_gate(self) -> VerifierArtifact:
+        """Lock the controller's completion flag to the gate (no second verdict).
+
+        ``agent_controller.completion_allowed`` is the imperative restatement of
+        ``can_merge_without_human``. If they ever disagree, two parts of the
+        artifact disagree about whether the agent may finish — exactly the
+        drift the one-decision-engine discipline forbids. Pin them so the
+        controller can never become a finding-independent second opinion.
+        """
+        if self.agent_controller is None:
+            return self
+        if self.agent_controller.completion_allowed != self.can_merge_without_human:
+            raise ValueError(
+                "AgentController.completion_allowed must equal "
+                "can_merge_without_human (one decision engine): "
+                f"{self.agent_controller.completion_allowed!r} != "
+                f"{self.can_merge_without_human!r}"
+            )
+        return self
+
 
 __all__ = [
+    "AgentController",
+    "AgentStopReason",
     "Applicability",
     "CapabilityChangeBucket",
     "CapabilityReleaseImpact",

--- a/tests/test_agent_controller.py
+++ b/tests/test_agent_controller.py
@@ -1,0 +1,191 @@
+"""Contract tests for the verifier.json ``agent_controller`` projection.
+
+The agent_controller block is the imperative restatement of the verdict an
+autonomous coding agent must act on. These tests pin that it stays a pure
+projection (no second verdict), that its negative affordances are standing and
+correctly scoped (deny-list, not allow-list; key-level surfaces excluded), and
+that its stop-reason routing matches the verdict.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agents_shipgate.cli.verify.agent_controller import (
+    PROTECTED_FILE_EDITS,
+    build_agent_controller,
+)
+from agents_shipgate.cli.verify.fix_task import FORBIDDEN_SHORTCUTS
+from agents_shipgate.schemas.verifier import (
+    AgentController,
+    VerifierArtifact,
+    VerifierCapabilityReview,
+    VerifierFixTask,
+    VerifierHumanReview,
+)
+
+VERIFY_CMD = "agents-shipgate verify --base origin/main --head HEAD --json"
+
+
+def _human_fix(**overrides) -> VerifierFixTask:
+    base = dict(actor="human", safe_to_attempt=False, verification_command=VERIFY_CMD)
+    base.update(overrides)
+    return VerifierFixTask(**base)
+
+
+def _agent_fix(**overrides) -> VerifierFixTask:
+    base = dict(actor="coding_agent", safe_to_attempt=True, verification_command=VERIFY_CMD)
+    base.update(overrides)
+    return VerifierFixTask(**base)
+
+
+# --- completion / stop routing ---------------------------------------------
+
+
+def test_mergeable_allows_completion_and_does_not_stop() -> None:
+    ac = build_agent_controller(
+        merge_verdict="mergeable",
+        can_merge_without_human=True,
+        fix_task=None,
+        capability_review=None,
+        human_review=None,
+        headline="No agent-capability changes gate this PR; safe to merge.",
+    )
+    assert ac.completion_allowed is True
+    assert ac.must_stop is False
+    assert ac.stop_reason is None
+    assert ac.allowed_next_commands == []
+
+
+def test_blocked_authority_gap_stops_for_human() -> None:
+    ac = build_agent_controller(
+        merge_verdict="blocked",
+        can_merge_without_human=False,
+        fix_task=_human_fix(),
+        capability_review=VerifierCapabilityReview(),
+        human_review=VerifierHumanReview(required=True, why="4 active findings block release."),
+        headline="4 active findings block release.",
+    )
+    assert ac.completion_allowed is False
+    assert ac.must_stop is True
+    assert ac.stop_reason == "blocked_findings"
+    assert ac.allowed_next_commands == []  # no agent-safe move; a human must act
+
+
+def test_blocked_mechanical_repairs_without_stopping() -> None:
+    # Every gating gap is mechanical -> the agent may fix and re-verify; not a stop.
+    ac = build_agent_controller(
+        merge_verdict="blocked",
+        can_merge_without_human=False,
+        fix_task=_agent_fix(),
+        capability_review=VerifierCapabilityReview(),
+        human_review=None,
+        headline="2 mechanical gaps.",
+    )
+    assert ac.completion_allowed is False
+    assert ac.must_stop is False
+    assert ac.stop_reason is None
+    assert ac.allowed_next_commands == [VERIFY_CMD]  # apply fix, then re-verify
+
+
+@pytest.mark.parametrize(
+    "merge_verdict, expected_reason",
+    [
+        ("blocked", "blocked_findings"),
+        ("insufficient_evidence", "insufficient_evidence"),
+        ("human_review_required", "human_review_required"),
+        ("unknown", "scan_incomplete"),
+    ],
+)
+def test_stop_reason_tracks_verdict(merge_verdict, expected_reason) -> None:
+    ac = build_agent_controller(
+        merge_verdict=merge_verdict,
+        can_merge_without_human=False,
+        fix_task=_human_fix(),
+        capability_review=VerifierCapabilityReview(),
+        human_review=None,
+        headline=None,
+    )
+    assert ac.must_stop is True
+    assert ac.stop_reason == expected_reason
+
+
+@pytest.mark.parametrize("weak_field", ["trust_root_touched", "policy_weakened"])
+def test_self_approval_takes_precedence_over_verdict(weak_field) -> None:
+    # Editing the rules that judge the change wins the stop_reason, even when
+    # the verdict would otherwise read as a plain human review.
+    ac = build_agent_controller(
+        merge_verdict="human_review_required",
+        can_merge_without_human=False,
+        fix_task=_human_fix(),
+        capability_review=VerifierCapabilityReview(**{weak_field: True}),
+        human_review=None,
+        headline=None,
+    )
+    assert ac.stop_reason == "self_approval_prohibited"
+
+
+# --- standing negative affordance (deny-list, not allow-list) ---------------
+
+
+def test_forbidden_actions_are_standing_even_when_mergeable() -> None:
+    # A passing run must still carry the "do not" list — green is never
+    # "anything goes".
+    ac = build_agent_controller(
+        merge_verdict="mergeable",
+        can_merge_without_human=True,
+        fix_task=None,
+        capability_review=None,
+        human_review=None,
+        headline=None,
+    )
+    assert ac.forbidden_actions == list(FORBIDDEN_SHORTCUTS)
+    assert ac.forbidden_actions  # non-empty
+    assert ac.forbidden_file_edits == list(PROTECTED_FILE_EDITS)
+
+
+def test_forbidden_file_edits_is_a_scoped_deny_list() -> None:
+    joined = "\n".join(PROTECTED_FILE_EDITS)
+    # Whole-file trust roots that judge the change ARE denied.
+    assert any("AGENTS.md" in p for p in PROTECTED_FILE_EDITS)
+    assert any("CLAUDE.md" in p for p in PROTECTED_FILE_EDITS)
+    assert any("agents-shipgate.yml" in p for p in PROTECTED_FILE_EDITS)
+    assert any("policies/" in p for p in PROTECTED_FILE_EDITS)
+    # Key-level surfaces are NOT path-denied (covered by forbidden_actions):
+    # editing a scope field in shipgate.yaml is a legitimate mechanical fix.
+    # (Match the manifest precisely — the CI pattern legitimately ends in
+    # "agents-shipgate.yaml", which contains the substring "shipgate.yaml".)
+    assert "**/shipgate.yaml" not in PROTECTED_FILE_EDITS
+    assert not any(p.endswith("/shipgate.yaml") for p in PROTECTED_FILE_EDITS)
+    assert ".agents-shipgate" not in joined
+    # The capability surface UNDER review is not denied — a PR may edit it.
+    assert ".mcp.json" not in joined
+    assert "SKILL.md" not in joined
+    assert ".codex-plugin" not in joined
+
+
+# --- one decision engine: the controller cannot disagree with the gate ------
+
+
+def test_artifact_locks_completion_allowed_to_can_merge() -> None:
+    with pytest.raises(ValidationError):
+        VerifierArtifact(
+            workspace="/tmp/w",
+            config="shipgate.yaml",
+            head_status="succeeded",
+            can_merge_without_human=False,
+            agent_controller=AgentController(completion_allowed=True),  # lie
+        )
+
+
+def test_artifact_accepts_consistent_controller() -> None:
+    art = VerifierArtifact(
+        workspace="/tmp/w",
+        config="shipgate.yaml",
+        head_status="succeeded",
+        can_merge_without_human=True,
+        agent_controller=AgentController(completion_allowed=True, must_stop=False),
+    )
+    assert art.agent_controller is not None
+    assert art.agent_controller.completion_allowed is True


### PR DESCRIPTION
## Summary

- **`verifier.json` gains an `agent_controller` block** — the imperative restatement of the verdict an autonomous coding agent must act on, so it can decide **continue / repair / stop** without re-deriving control flow from scattered fields (`merge_verdict`, `fix_task`, `capability_review`, …). This is the agent-native "controller surface" P1 item.
- **Pure projection, never a second verdict:** `completion_allowed` is **structurally locked** to `can_merge_without_human` by a `VerifierArtifact` validator. `must_stop` is `true` only when the agent can neither finish nor safely repair. `stop_reason ∈ {self_approval_prohibited, blocked_findings, insufficient_evidence, human_review_required, scan_incomplete}`.
- **`forbidden_file_edits` is a deny-list, not an allow-list.** Derived from `TRUST_ROOT_SURFACES`, restricted to whole-file trust roots (CI gate, agent instructions, policy packs). It deliberately **excludes `shipgate.yaml` / `.agents-shipgate`** — their boundary is *key-level* (a scope edit is a legitimate mechanical fix; a `checks.ignore` / baseline expansion is not), so those are covered by `forbidden_actions` — and **excludes the tool surface under review** (`.mcp.json`, `SKILL.md`, …). There is intentionally no allow-list, because a mechanical fix edits code / scope fields that can't be enumerated ahead of time.
- **`forbidden_actions` + `forbidden_file_edits` are standing** — present on every verdict, including `mergeable`, so a passing run is never read as "anything goes".
- **`allowed_next_commands`** is `[verification_command]` only when there's an agent-safe mechanical fix; otherwise empty.
- Not emitted for `--preview` (a pre-gate relevance check — the agent reads `first_next_action` there).

Implementation: new `cli/verify/agent_controller.py` (`build_agent_controller`, a pure projection); `AgentController` model + `completion_allowed`↔`can_merge_without_human` lock in `schemas/verifier.py`; orchestrator wiring. Drive-by: backfilled the `applicability` field (shipped in 0.11.0) into the STABILITY.md verifier-field list, which the prior PR missed.

## Type

- [x] Report, schema, or SARIF output — additive `agent_controller` block in `verifier.json` (schema regenerated; `verifier_schema_version` stays `"0.1"`)
- [x] CLI or GitHub Action behavior — `agents-shipgate verify` now emits the block

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- New `tests/test_agent_controller.py`: completion/stop routing across all verdict states, `stop_reason` mapping, self-approval precedence, deny-list scoping (excludes `shipgate.yaml`/`.agents-shipgate`/tool-decls; includes `AGENTS.md`/CI/policies), standing forbidden lists, and the `completion_allowed`↔`can_merge_without_human` structural lock.
- `scripts/generate_schemas.py` regenerated `docs/verifier-schema.v0.1.json`; `tests/test_schema_roundtrip.py` green.
- `scripts/build-llms-full.py` rebuilt `llms-full.txt` (contract doc changed).
- `ruff check .` clean; full suite (`pytest -m "not perf"`) green.
- Live blocked refund fixture emits the block: `must_stop: true`, `stop_reason: "blocked_findings"`, scoped deny-list, standing `forbidden_actions`.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (no new check IDs)
- [x] Report/schema changes are additive or documented in `STABILITY.md` — additive `agent_controller` block; `verifier_schema_version` stays `"0.1"`; documented in `STABILITY.md` §Verify Orchestrator and `docs/agent-contract-current.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
