### PR TITLE
[codex] Finalize Codex plugin launch metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ suppressions, waivers, baselines, or policy weakening. Never remove Shipgate CI
 or weaken agent instructions just to make the verifier pass.
 ```
 
-## Install the Codex plugin beta
+## Install the Codex plugin
 
 Agents Shipgate now ships a skill-only Codex plugin package at
 [`plugins/agents-shipgate/`](plugins/agents-shipgate/) with a repo marketplace
@@ -227,7 +227,7 @@ Shipgate** from Codex's Plugins view:
 codex plugin marketplace add ThreeMoonsLab/agents-shipgate
 ```
 
-For local beta validation from a checkout:
+For local checkout validation:
 
 ```bash
 codex plugin marketplace add /path/to/agents-shipgate
@@ -256,8 +256,9 @@ python -m pip install -U "agents-shipgate>=0.11"
 agents-shipgate --version
 ```
 
-The staged launch path is workspace sharing from the Codex app or this
-repo-backed marketplace. Public/OpenAI-curated listing remains a later phase.
+The v1 launch channel is workspace sharing from the Codex app or this
+repo-backed marketplace. Public/OpenAI-curated listing remains an optional
+later platform submission.
 
 ## Add the Codex adoption kit
 
@@ -706,6 +707,7 @@ readers and AI search ingest.
 - [JSON report schema v0.22](docs/report-schema.v0.22.json)
 - [Feedback export schema v0.1](docs/feedback-schema.v0.1.json)
 - [Privacy and redaction](docs/privacy.md)
+- [Terms](docs/terms.md)
 - [Trust model](docs/trust-model.md)
 - [AI search summary](docs/ai-search-summary.md)
 - [Design partners](docs/design-partners.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,7 +26,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
 - [`report-schema.v0.22.json`](report-schema.v0.22.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.22"`, adding the verifier-cycle top-level blocks `capability_change`, `protected_surface_changes`, `effective_policy`, `human_ack`, and `verifier_summary` alongside v0.21's `heuristics_filter` envelope)
 - [`verifier-schema.v0.1.json`](verifier-schema.v0.1.json) — JSON Schema for `verifier.json` emitted by `agents-shipgate verify`
-- [`privacy.md`](privacy.md) and [`report-sensitive-fields.json`](report-sensitive-fields.json) — redaction behavior and report sensitive-field inventory
+- [`privacy.md`](privacy.md), [`terms.md`](terms.md), and [`report-sensitive-fields.json`](report-sensitive-fields.json) — Codex plugin privacy/terms, redaction behavior, and report sensitive-field inventory
 - [`agent-action-guide.md`](agent-action-guide.md) — per-category recipe for what to do with a finding (canonical fix per check category, last-resort suppression rules)
 - [`upstream-integrations.md`](upstream-integrations.md) — per-framework 60-second drop-in for adding Shipgate to an existing project (OpenAI Agents SDK, LangChain, CrewAI, ADK, MCP-only, OpenAPI-only, OpenAI Messages API, Anthropic Messages API)
 - [`report-schema.v0.21.json`](report-schema.v0.21.json) — frozen v0.21 reference schema; pre-v0.22 reports validate against this

--- a/docs/agents/use-with-codex.md
+++ b/docs/agents/use-with-codex.md
@@ -21,16 +21,15 @@ Codex Skills under `.agents/skills/<name>/`.
 
 ## Install From Codex
 
-The beta plugin is distributed through this repository's Codex marketplace. In
-Codex, add or select the Agents Shipgate marketplace, install **Agents
-Shipgate**, start a new thread, and invoke:
+The v1 plugin is distributed through this repository's Codex marketplace and
+Codex workspace sharing. In Codex, add or select the Agents Shipgate
+marketplace, install **Agents Shipgate**, start a new thread, and invoke:
 
 ```text
 $agents-shipgate verify this agent PR and summarize the merge verdict.
 ```
 
-For local beta validation before public listing, add this repo as a marketplace
-source, then install from Codex's Plugins view:
+To add the repo-backed marketplace, use:
 
 ```bash
 codex plugin marketplace add ThreeMoonsLab/agents-shipgate
@@ -46,9 +45,9 @@ The plugin can also be shared from the Codex app after installation. Shared
 users install it from **Plugins** > **Shared with you**, then start a new
 thread before invoking `$agents-shipgate`.
 
-Before a public/OpenAI-curated listing, replace the beta `privacyPolicyURL` and
-`termsOfServiceURL` manifest values with dedicated policy and terms pages. The
-current repo URLs are beta placeholders to keep the local manifest valid.
+The plugin manifest points to dedicated privacy and terms pages in this repo.
+Public/OpenAI-curated listing, if pursued later, is a separate platform
+submission using the same skill-only package.
 
 ## Runtime CLI Prerequisite
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -4,6 +4,12 @@ Agents Shipgate is local-first. A scan reads local manifests and tool-surface
 artifacts, then writes local reports under the configured output directory. The
 CLI does not upload tool schemas, prompts, reports, credentials, or telemetry.
 
+The Agents Shipgate Codex plugin is skill-only. It gives Codex workflow
+instructions for running the local `agents-shipgate` CLI; it does not declare
+apps, MCP servers, hooks, bundled credentials, or a hosted service. Any command
+execution happens in the user's Codex workspace and uses the locally installed
+CLI.
+
 Public scan artifacts are redacted by default before they are written:
 
 - `report.json`, `report.md`, and `report.sarif`

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,22 @@
+# Agents Shipgate Codex Plugin Terms
+
+Agents Shipgate is provided under the Apache-2.0 license in this repository.
+The Codex plugin package is a skill-only companion that teaches Codex how to
+install, run, and summarize the local `agents-shipgate` CLI workflows for
+Tool-Use Readiness review.
+
+Using the Codex plugin requires a local `agents-shipgate` CLI installation. The
+plugin does not bundle the scanner binary, provide a hosted service, connect to
+MCP servers, or execute agent tools. Users remain responsible for the commands
+they ask Codex to run and for reviewing any merge, release, suppression,
+baseline, waiver, approval, confirmation, idempotency, or policy decision.
+
+Agents Shipgate reports are static analysis artifacts. They can help identify
+declared tool-use release risks, but they do not prove runtime behavior, model
+correctness, prompt robustness, or adversarial resistance. Treat blocked or
+human-review verdicts as release signals that require the appropriate code,
+configuration, or human-review follow-up.
+
+Privacy and redaction behavior is documented in
+[`docs/privacy.md`](privacy.md). Security disclosures should follow the
+repository's [`SECURITY.md`](../SECURITY.md).

--- a/plugins/agents-shipgate/.codex-plugin/plugin.json
+++ b/plugins/agents-shipgate/.codex-plugin/plugin.json
@@ -32,8 +32,8 @@
       "Triage findings without fabricating human approval"
     ],
     "websiteURL": "https://threemoonslab.com/",
-    "privacyPolicyURL": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/SECURITY.md",
-    "termsOfServiceURL": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/LICENSE",
+    "privacyPolicyURL": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/privacy.md",
+    "termsOfServiceURL": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/terms.md",
     "brandColor": "#2F6FEB",
     "defaultPrompt": "Use $agents-shipgate to add or verify a Tool-Use Readiness release gate for this agent repo."
   }

--- a/tests/test_codex_plugin_launch_package.py
+++ b/tests/test_codex_plugin_launch_package.py
@@ -29,6 +29,8 @@ def test_agents_shipgate_codex_plugin_manifest_is_skill_only() -> None:
     assert interface["displayName"] == "Agents Shipgate"
     assert interface["defaultPrompt"].startswith("Use $agents-shipgate")
     assert "scanner runs through the agents-shipgate CLI" in interface["longDescription"]
+    assert interface["privacyPolicyURL"].endswith("/docs/privacy.md")
+    assert interface["termsOfServiceURL"].endswith("/docs/terms.md")
 
 
 def test_agents_shipgate_codex_plugin_marketplace_entry_is_installable() -> None:


### PR DESCRIPTION
## Summary

- Point the Agents Shipgate Codex plugin manifest at dedicated privacy and terms pages.
- Document the v1 repo-backed marketplace/workspace-sharing launch channel instead of a beta-only placeholder caveat.
- Add a dedicated `docs/terms.md` page and make plugin package tests assert the manifest URLs stay dedicated.

## Launch QA

- Confirmed PR #170 is merged into `origin/main`.
- Installed `agents-shipgate@agents-shipgate-beta` from Codex; cache version is `0.11.0`.
- Confirmed cached plugin manifest points to `docs/privacy.md` and `docs/terms.md`.
- `$agents-shipgate` load smoke returned `LOADED agents-shipgate`.
- Stale CLI QA: with PATH resolving to `agents-shipgate 0.8.0`, Codex loaded the `0.11.0` plugin skill and refused to run a fresh verifier, then summarized existing JSON evidence.
- Fresh verifier QA: with a temporary QA-only wrapper exposing `Agents Shipgate 0.11.0`, Codex ran `AGENTS_SHIPGATE_AGENT_MODE=1 agents-shipgate verify --workspace . --config shipgate.yaml --ci-mode advisory --format json` on the `ai_generated_refund_pr` fixture and reported `merge_verdict: blocked`, `release_decision: blocked`, `can_merge_without_human: false`.

## Validation

- `python3 /Users/pengfeihu/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/agents-shipgate`
- `PYTHONPATH=src python -m pytest tests/test_docs_links.py tests/test_codex_plugin_launch_package.py -q`
- `git diff --check`
- `PYTHONPATH=src AGENTS_SHIPGATE_AGENT_MODE=1 python -m agents_shipgate trigger --workspace . --changed-files /tmp/agents-shipgate-launch-changed-files.txt --user-requested --json` matched `TRIGGER-CODEX-PLUGIN-CHANGED`.