### PR TITLE
Add `agents-shipgate attest` — local release attestation (contract #8)

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -76,7 +76,8 @@
     "install_ai_coding_workflow": "agents-shipgate init --workspace . --write --ci --agent-instructions=all",
     "verify_pr": "agents-shipgate verify --workspace . --config shipgate.yaml --base origin/main --head HEAD --ci-mode advisory --format json",
     "trigger": "agents-shipgate trigger --base origin/main --head HEAD --json",
-    "feedback_export": "agents-shipgate feedback export --from agents-shipgate-reports/verifier.json --redact --out shipgate-feedback.json"
+    "feedback_export": "agents-shipgate feedback export --from agents-shipgate-reports/verifier.json --redact --out shipgate-feedback.json",
+    "attest": "agents-shipgate attest --from agents-shipgate-reports/verifier.json --out agents-shipgate-reports/attestation.json"
   },
   "fixture_run": "agents-shipgate fixture run ai_generated_refund_pr",
   "static_scan_fixture_run": "agents-shipgate fixture run support_refund_agent",
@@ -84,12 +85,13 @@
   "contract": "agents-shipgate contract --json",
   "contract_version": "1",
   "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_api", "google_adk", "langchain", "crewai", "openai_api", "codex_plugin", "n8n"],
-  "outputs": ["markdown", "json", "sarif", "packet_md", "packet_json", "packet_html", "verifier_json", "pr_comment_md", "feedback_json"],
+  "outputs": ["markdown", "json", "sarif", "packet_md", "packet_json", "packet_html", "verifier_json", "pr_comment_md", "feedback_json", "attestation_json"],
   "artifacts": {
     "verifier": "agents-shipgate-reports/verifier.json",
     "report": "agents-shipgate-reports/report.json",
     "pr_comment": "agents-shipgate-reports/pr-comment.md",
-    "feedback": "shipgate-feedback.json"
+    "feedback": "shipgate-feedback.json",
+    "attestation": "agents-shipgate-reports/attestation.json"
   },
   "gating_signal": "release_decision.decision",
   "merge_verdicts": ["mergeable", "human_review_required", "insufficient_evidence", "blocked", "unknown"],
@@ -129,6 +131,7 @@
     "verifier": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/verifier-schema.v0.1.json",
     "packet": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/packet-schema.v0.6.json",
     "feedback": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/feedback-schema.v0.1.json",
+    "attestation": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/attestation-schema.v0.1.json",
     "checks_catalog": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json"
   },
   "agent_instructions": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/AGENTS.md",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,11 +46,13 @@ into replayable evidence. Active themes, in priority order:
    pre-flight, so an agent learns what it must not touch without first tripping
    the gate.
 
-4. **Local attestation.** A JSON-first, local attestation per verdict —
-   base/head SHA, changed capability IDs, policy-snapshot hash, CLI version,
-   verdict, `human_ack` / waiver / baseline state, and artifact hashes — as the
-   durable record of *which* capability was released, under *which* verdict,
-   acknowledged by *whom*.
+4. **Local attestation.** *(First cut shipped — `agents-shipgate attest`.)* A
+   deterministic, JSON-first, local attestation per verdict — base/head SHA,
+   changed capability IDs, policy-snapshot hash, CLI version, verdict,
+   `human_ack` state, and artifact hashes — as the durable record of *which*
+   capability was released, under *which* verdict, acknowledged by *whom*.
+   Remaining: explicit waiver/baseline state and a cross-repo capability
+   registry that consumes these attestations.
 
 5. **Source-provenance enrichment (incremental).** Thread origin (file path,
    line index for JSONL, list index for arrays) through finding evidence to

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -774,7 +774,7 @@ so re-deriving from the same inputs is byte-identical. It does not gate;
 - `cli_version`
 - `source_verifier`
 - `redacted`
-- `base_ref`, `head_ref`, `base_tree_sha`, `mode`
+- `base_ref`, `head_ref`, `base_tree_sha`, `head_tree_sha`, `mode`
 - `verdict` (`merge_verdict`, `decision`, `applicability`, `can_merge_without_human`)
 - `capability` (`added`, `modified`, `removed`, `trust_root_touched`, `policy_weakened`, `change_ids`)
 - `human_ack` (`required`, `satisfied`, `outstanding`)

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -758,6 +758,29 @@ from verifier projections and does not include raw finding evidence. With
 `--redact` (the default), local artifact paths are reduced to filenames so the
 artifact does not leak usernames or confidential workspace directory names.
 
+### Attestation
+
+`agents-shipgate attest` derives a deterministic, local attestation from
+`agents-shipgate-reports/verifier.json` (enriched from the sibling `report.json`
+when present). The current schema is
+[`docs/attestation-schema.v0.1.json`](docs/attestation-schema.v0.1.json). It
+records the verdict, the capability delta, the declared `human_ack` state, a
+policy-snapshot hash, and content hashes of the verify artifacts. It carries no
+wall-clock timestamp — it is content-addressed by git SHAs and artifact hashes,
+so re-deriving from the same inputs is byte-identical. It does not gate;
+`release_decision.decision` remains the only gate. Current v0.1 fields:
+
+- `attestation_schema_version`
+- `cli_version`
+- `source_verifier`
+- `redacted`
+- `base_ref`, `head_ref`, `base_tree_sha`, `mode`
+- `verdict` (`merge_verdict`, `decision`, `applicability`, `can_merge_without_human`)
+- `capability` (`added`, `modified`, `removed`, `trust_root_touched`, `policy_weakened`, `change_ids`)
+- `human_ack` (`required`, `satisfied`, `outstanding`)
+- `policy_snapshot_sha256`
+- `artifact_sha256`
+
 ### Agent-skill paths
 
 The following paths are part of the public agent surface and will not move within `0.x`:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`manifest-v0.1.json`](manifest-v0.1.json) — JSON Schema for `shipgate.yaml`
 - [`report-schema.v0.22.json`](report-schema.v0.22.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.22"`, adding the verifier-cycle top-level blocks `capability_change`, `protected_surface_changes`, `effective_policy`, `human_ack`, and `verifier_summary` alongside v0.21's `heuristics_filter` envelope)
 - [`verifier-schema.v0.1.json`](verifier-schema.v0.1.json) — JSON Schema for `verifier.json` emitted by `agents-shipgate verify`
+- [`attestation-schema.v0.1.json`](attestation-schema.v0.1.json) — JSON Schema for `attestation.json` emitted by `agents-shipgate attest`
 - [`privacy.md`](privacy.md) and [`report-sensitive-fields.json`](report-sensitive-fields.json) — redaction behavior and report sensitive-field inventory
 - [`agent-action-guide.md`](agent-action-guide.md) — per-category recipe for what to do with a finding (canonical fix per check category, last-resort suppression rules)
 - [`upstream-integrations.md`](upstream-integrations.md) — per-framework 60-second drop-in for adding Shipgate to an existing project (OpenAI Agents SDK, LangChain, CrewAI, ADK, MCP-only, OpenAPI-only, OpenAI Messages API, Anthropic Messages API)

--- a/docs/agent-native-merge-contract.md
+++ b/docs/agent-native-merge-contract.md
@@ -127,12 +127,17 @@ protected* — never a new way to decide.
 
 - **Guarantee:** an agent-capability release leaves an attestation, not a
   memory: which capability shipped, under which verdict, acknowledged by whom.
-- **Status: planned.** The *inputs* already exist in `verifier.json` /
-  `report.json` (base/head SHAs, the verdict, `human_ack`, the artifact
-  references). A dedicated, local, JSON-first attestation artifact is the next
-  build — see [`../ROADMAP.md`](../ROADMAP.md).
-- **Will prevent:** "we think a human approved that refund tool last quarter"
-  with no record to point at.
+- **Implements it:** `agents-shipgate attest` derives a deterministic, local,
+  JSON-first attestation from `verifier.json` (+ the sibling `report.json`) —
+  base/head SHAs, the verdict, the capability delta, declared `human_ack` state,
+  a policy-snapshot hash, and content hashes of every verify artifact. It is
+  content-addressed (no wall-clock timestamp) and does not gate. Schema:
+  [`attestation-schema.v0.1.json`](attestation-schema.v0.1.json).
+- **Agent reads:** the attestation is a durable record for humans and
+  registries, not a control signal — the agent still acts on `agent_controller`
+  (contracts 3–5).
+- **Prevents:** "we think a human approved that refund tool last quarter" with
+  no record to point at.
 
 ## The agent control loop
 

--- a/docs/attestation-schema.v0.1.json
+++ b/docs/attestation-schema.v0.1.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/attestation-schema.v0.1.json",
+  "title": "Agents Shipgate Release Attestation v0.1",
+  "description": "A deterministic, local release attestation derived from verifier.json by `agents-shipgate attest`. Records which capability shipped, under which verdict, acknowledged by whom. Carries no wall-clock timestamp; it is content-addressed by git SHAs and artifact hashes. It does not gate — release_decision.decision remains the only gate.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "attestation_schema_version",
+    "cli_version",
+    "source_verifier",
+    "redacted",
+    "base_ref",
+    "head_ref",
+    "base_tree_sha",
+    "mode",
+    "verdict",
+    "capability",
+    "human_ack",
+    "policy_snapshot_sha256",
+    "artifact_sha256"
+  ],
+  "properties": {
+    "attestation_schema_version": { "const": "0.1" },
+    "cli_version": { "type": "string" },
+    "source_verifier": { "type": "string", "description": "Path to the source verifier.json; reduced to a basename when redacted." },
+    "redacted": { "type": "boolean" },
+    "base_ref": { "type": ["string", "null"] },
+    "head_ref": { "type": ["string", "null"] },
+    "base_tree_sha": { "type": ["string", "null"], "description": "Tree SHA of the base ref Shipgate diffed against, when available." },
+    "mode": { "type": ["string", "null"], "description": "advisory / strict / skipped / preview." },
+    "verdict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["merge_verdict", "decision", "applicability", "can_merge_without_human"],
+      "properties": {
+        "merge_verdict": { "type": ["string", "null"], "enum": ["mergeable", "human_review_required", "insufficient_evidence", "blocked", "unknown", null] },
+        "decision": { "type": ["string", "null"], "enum": ["passed", "review_required", "insufficient_evidence", "blocked", null] },
+        "applicability": { "type": ["string", "null"], "enum": ["verified", "not_applicable", "unknown", null] },
+        "can_merge_without_human": { "type": "boolean" }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["added", "modified", "removed", "trust_root_touched", "policy_weakened", "change_ids"],
+      "properties": {
+        "added": { "type": "integer", "minimum": 0 },
+        "modified": { "type": "integer", "minimum": 0 },
+        "removed": { "type": "integer", "minimum": 0 },
+        "trust_root_touched": { "type": "boolean" },
+        "policy_weakened": { "type": "boolean" },
+        "change_ids": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "human_ack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "satisfied", "outstanding"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "satisfied": { "type": ["boolean", "null"], "description": "null when no report.json was available to confirm." },
+        "outstanding": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "policy_snapshot_sha256": { "type": ["string", "null"], "description": "sha256 of the canonical-JSON effective_policy block from report.json, or null when unavailable." },
+    "artifact_sha256": {
+      "type": "object",
+      "description": "sha256 of each verify artifact (keyed by artifact name) that sits beside verifier.json.",
+      "additionalProperties": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+    }
+  }
+}

--- a/docs/attestation-schema.v0.1.json
+++ b/docs/attestation-schema.v0.1.json
@@ -13,6 +13,7 @@
     "base_ref",
     "head_ref",
     "base_tree_sha",
+    "head_tree_sha",
     "mode",
     "verdict",
     "capability",
@@ -28,6 +29,7 @@
     "base_ref": { "type": ["string", "null"] },
     "head_ref": { "type": ["string", "null"] },
     "base_tree_sha": { "type": ["string", "null"], "description": "Tree SHA of the base ref Shipgate diffed against, when available." },
+    "head_tree_sha": { "type": ["string", "null"], "description": "Tree SHA of the head ref that was scanned — the durable, content-addressed identity of what shipped. Null for working-tree scans (no committed head)." },
     "mode": { "type": ["string", "null"], "description": "advisory / strict / skipped / preview." },
     "verdict": {
       "type": "object",

--- a/docs/verifier-schema.v0.1.json
+++ b/docs/verifier-schema.v0.1.json
@@ -515,6 +515,18 @@
       "title": "Head Status",
       "type": "string"
     },
+    "head_tree_sha": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Head Tree Sha"
+    },
     "headline": {
       "anyOf": [
         {

--- a/src/agents_shipgate/cli/attest.py
+++ b/src/agents_shipgate/cli/attest.py
@@ -1,0 +1,209 @@
+"""``agents-shipgate attest`` — a durable, local release attestation.
+
+The Attestation Contract (Pattern 9): an agent-capability release should leave a
+record, not a memory — *which* capability shipped, under *which* verdict,
+acknowledged by *whom*. This command derives a deterministic, local, JSON-first
+attestation from ``verifier.json`` (enriched from the sibling ``report.json``
+when present).
+
+It introduces no new gate: every field is copied or hashed from the verify run.
+It is content-addressed by git SHAs and artifact hashes and carries **no
+wall-clock timestamp**, so re-deriving from the same inputs is byte-identical —
+consistent with the project's determinism discipline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from agents_shipgate import __version__
+from agents_shipgate.core.errors import InputParseError
+
+ATTESTATION_SCHEMA_VERSION = "0.1"
+
+
+def _attest_command(
+    source: Path = typer.Option(
+        Path("agents-shipgate-reports/verifier.json"),
+        "--from",
+        help="Path to verifier.json.",
+    ),
+    out: Path | None = typer.Option(
+        None,
+        "--out",
+        help="Write the attestation to this path.",
+    ),
+    redact: bool = typer.Option(
+        True,
+        "--redact/--no-redact",
+        help="Reduce local artifact paths to filenames.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Print the attestation JSON to stdout.",
+    ),
+) -> None:
+    """Derive a local release attestation from verifier.json.
+
+    Deterministic and local-only: no network, no wall-clock timestamp. Records
+    the verdict, the capability delta, the declared human-acknowledgement state,
+    a policy-snapshot hash, and content hashes of the verify artifacts. It does
+    not gate — ``report.json.release_decision.decision`` remains the only gate.
+    """
+    try:
+        verifier = _load_json_object(source, "verifier.json")
+    except InputParseError as exc:
+        typer.echo(f"Input parsing error: {exc}", err=True)
+        raise typer.Exit(3) from exc
+    report = _load_sibling_report(source, verifier)
+    payload = build_attestation_payload(
+        verifier, source=source, redacted=redact, report=report
+    )
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")
+    if json_output or out is None:
+        typer.echo(rendered.rstrip())
+    else:
+        typer.echo(f"Wrote attestation to {out}")
+
+
+def build_attestation_payload(
+    verifier: dict[str, Any],
+    *,
+    source: Path,
+    redacted: bool,
+    report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project a verify run onto a deterministic attestation dict.
+
+    ``report`` (the sibling ``report.json``) is optional: when present it adds
+    the declared ``human_ack`` state and a policy-snapshot hash; when absent the
+    attestation degrades gracefully (``human_ack.satisfied`` is ``null`` and
+    ``policy_snapshot_sha256`` is ``null``).
+    """
+    release_decision = _obj(verifier.get("release_decision"))
+    capability_review = _obj(verifier.get("capability_review"))
+    human_review = _obj(verifier.get("human_review"))
+    report = report or {}
+    human_ack = _obj(report.get("human_ack"))
+    effective_policy = report.get("effective_policy")
+
+    return {
+        "attestation_schema_version": ATTESTATION_SCHEMA_VERSION,
+        "cli_version": __version__,
+        "source_verifier": source.name if redacted else str(source),
+        "redacted": redacted,
+        "base_ref": verifier.get("base_ref"),
+        "head_ref": verifier.get("head_ref"),
+        "base_tree_sha": verifier.get("base_tree_sha"),
+        "mode": verifier.get("mode"),
+        "verdict": {
+            "merge_verdict": verifier.get("merge_verdict"),
+            "decision": verifier.get("decision") or release_decision.get("decision"),
+            "applicability": verifier.get("applicability"),
+            "can_merge_without_human": bool(verifier.get("can_merge_without_human")),
+        },
+        "capability": {
+            "added": int(capability_review.get("added", 0) or 0),
+            "modified": int(capability_review.get("modified", 0) or 0),
+            "removed": int(capability_review.get("removed", 0) or 0),
+            "trust_root_touched": bool(capability_review.get("trust_root_touched")),
+            "policy_weakened": bool(capability_review.get("policy_weakened")),
+            "change_ids": _change_ids(capability_review.get("top_changes")),
+        },
+        "human_ack": {
+            "required": bool(
+                human_ack.get("required", human_review.get("required", False))
+            ),
+            # ``None`` when no report.json was available to confirm it.
+            "satisfied": human_ack.get("satisfied"),
+            "outstanding": _str_list(human_ack.get("outstanding")),
+        },
+        "policy_snapshot_sha256": (
+            _canonical_sha256(effective_policy) if effective_policy is not None else None
+        ),
+        "artifact_sha256": _artifact_hashes(
+            verifier.get("artifacts"), base_dir=source.parent
+        ),
+    }
+
+
+def _load_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise InputParseError(f"{label} not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise InputParseError(f"{label} is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise InputParseError(f"{label} must contain an object: {path}")
+    return data
+
+
+def _load_sibling_report(
+    source: Path, verifier: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Best-effort read of the report.json beside verifier.json (or named in its
+    artifacts map). Absence or a parse error is fine — enrichment is optional."""
+    artifacts = _obj(verifier.get("artifacts"))
+    name = Path(str(artifacts.get("report_json", "report.json"))).name or "report.json"
+    candidate = source.parent / name
+    if not candidate.is_file():
+        return None
+    try:
+        return _load_json_object(candidate, "report.json")
+    except InputParseError:
+        return None
+
+
+def _artifact_hashes(artifacts: Any, *, base_dir: Path) -> dict[str, str]:
+    """sha256 of each verify artifact that sits beside verifier.json.
+
+    Artifact paths inside verifier.json may be absolute or workspace-relative,
+    so resolve by basename against the verifier.json directory — CWD-independent.
+    """
+    out: dict[str, str] = {}
+    if not isinstance(artifacts, dict):
+        return out
+    for key, value in artifacts.items():
+        candidate = base_dir / Path(str(value)).name
+        if candidate.is_file():
+            out[str(key)] = hashlib.sha256(candidate.read_bytes()).hexdigest()
+    return dict(sorted(out.items()))
+
+
+def _canonical_sha256(obj: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _change_ids(top_changes: Any) -> list[str]:
+    if not isinstance(top_changes, list):
+        return []
+    ids = {
+        str(change.get("id"))
+        for change in top_changes
+        if isinstance(change, dict) and change.get("id")
+    }
+    return sorted(ids)
+
+
+def _str_list(value: Any) -> list[str]:
+    return [str(item) for item in value] if isinstance(value, list) else []
+
+
+def _obj(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+__all__ = ["ATTESTATION_SCHEMA_VERSION", "build_attestation_payload"]

--- a/src/agents_shipgate/cli/attest.py
+++ b/src/agents_shipgate/cli/attest.py
@@ -105,6 +105,7 @@ def build_attestation_payload(
         "base_ref": verifier.get("base_ref"),
         "head_ref": verifier.get("head_ref"),
         "base_tree_sha": verifier.get("base_tree_sha"),
+        "head_tree_sha": verifier.get("head_tree_sha"),
         "mode": verifier.get("mode"),
         "verdict": {
             "merge_verdict": verifier.get("merge_verdict"),

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -15,6 +15,7 @@ from agents_shipgate.cli import (
     _register_scan,
 )
 from agents_shipgate.cli.apply_patches import apply_patches as _apply_patches_command
+from agents_shipgate.cli.attest import _attest_command
 from agents_shipgate.cli.bootstrap import bootstrap as _bootstrap_command
 from agents_shipgate.cli.detect import detect as _detect_command
 from agents_shipgate.cli.evidence_packet import evidence_packet as _evidence_packet_command
@@ -94,6 +95,13 @@ app.command(
         "base scan, and one authoritative head scan."
     ),
 )(_verify_command)
+app.command(
+    "attest",
+    help=(
+        "Derive a deterministic local release attestation from verifier.json "
+        "(verdict, capability delta, human-ack state, policy + artifact hashes)."
+    ),
+)(_attest_command)
 app.command(
     "install-hooks",
     help=(

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -236,11 +236,13 @@ def run_verify(
     head_tmp: tempfile.TemporaryDirectory[str] | None = None
     head_config_path = config_path
     head_policy_pack_paths = policy_pack_paths
+    head_tree: str | None = None
     try:
         if archive_head:
             head_tmp = tempfile.TemporaryDirectory(prefix="agents-shipgate-verify-head-")
             head_tree_dir = Path(head_tmp.name) / "head"
             archive_tree(git_root, head, head_tree_dir)
+            head_tree = tree_sha(git_root, head)
             head_config_path = head_tree_dir / config_relative
             if not head_config_path.is_file():
                 raise ConfigError(
@@ -304,6 +306,7 @@ def run_verify(
             trigger=trigger,
             base_status=base_status,
             base_tree=base_tree,
+            head_tree=head_tree,
             base_report=base_report,
             base_notes=base_notes,
             report=report,
@@ -710,6 +713,7 @@ def _build_verifier(
     trigger: dict[str, Any],
     base_status: VerifierBaseStatus,
     base_tree: str | None,
+    head_tree: str | None = None,
     base_report: Path | None,
     base_notes: list[str],
     report: ReadinessReport | None,
@@ -783,6 +787,7 @@ def _build_verifier(
         trigger=trigger,
         base_status=base_status,
         base_tree_sha=base_tree,
+        head_tree_sha=head_tree,
         base_report_json=(
             _display_path(base_report, git_root) if base_report is not None else None
         ),

--- a/src/agents_shipgate/schemas/verifier.py
+++ b/src/agents_shipgate/schemas/verifier.py
@@ -243,6 +243,7 @@ class VerifierArtifact(BaseModel):
     trigger: dict[str, Any] = Field(default_factory=dict)
     base_status: VerifierBaseStatus = "not_requested"
     base_tree_sha: str | None = None
+    head_tree_sha: str | None = None
     base_report_json: str | None = None
     base_notes: list[str] = Field(default_factory=list)
     head_status: VerifierHeadStatus = "skipped"

--- a/tests/test_attest.py
+++ b/tests/test_attest.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.attest import build_attestation_payload
+from agents_shipgate.cli.main import app
+
+runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads(
+    (REPO_ROOT / "docs/attestation-schema.v0.1.json").read_text(encoding="utf-8")
+)
+
+
+def _verifier_payload() -> dict:
+    return {
+        "base_ref": "origin/main",
+        "head_ref": "HEAD",
+        "base_tree_sha": "7d4d5f5e125a9bbcf16d4091fa0038bd229e1c7c",
+        "mode": "advisory",
+        "merge_verdict": "blocked",
+        "applicability": "verified",
+        "can_merge_without_human": False,
+        "decision": "blocked",
+        "release_decision": {"decision": "blocked"},
+        "human_review": {"required": True, "why": "Approval evidence is missing."},
+        "capability_review": {
+            "added": 1,
+            "modified": 0,
+            "removed": 0,
+            "trust_root_touched": True,
+            "policy_weakened": False,
+            # Intentionally out of order to prove change_ids is sorted.
+            "top_changes": [{"id": "cap_b"}, {"id": "cap_a"}, {"id": "cap_a"}],
+        },
+        "artifacts": {
+            "verifier_json": "agents-shipgate-reports/verifier.json",
+            "report_json": "agents-shipgate-reports/report.json",
+            "pr_comment": "agents-shipgate-reports/pr-comment.md",
+        },
+    }
+
+
+def _report_payload() -> dict:
+    return {
+        "human_ack": {
+            "required": True,
+            "satisfied": False,
+            "acks": [],
+            "outstanding": ["shipgate.yaml (manifest)"],
+        },
+        "effective_policy": {
+            "ci_mode": "advisory",
+            "fail_on": ["critical"],
+            "suppressed_check_ids": [],
+        },
+    }
+
+
+# --- core projection --------------------------------------------------------
+
+
+def test_build_attestation_core_fields() -> None:
+    att = build_attestation_payload(
+        _verifier_payload(),
+        source=Path("agents-shipgate-reports/verifier.json"),
+        redacted=True,
+        report=_report_payload(),
+    )
+    assert att["attestation_schema_version"] == "0.1"
+    assert att["base_tree_sha"] == "7d4d5f5e125a9bbcf16d4091fa0038bd229e1c7c"
+    assert att["verdict"] == {
+        "merge_verdict": "blocked",
+        "decision": "blocked",
+        "applicability": "verified",
+        "can_merge_without_human": False,
+    }
+    assert att["capability"]["added"] == 1
+    assert att["capability"]["trust_root_touched"] is True
+    assert att["capability"]["change_ids"] == ["cap_a", "cap_b"]  # sorted, de-duped
+
+
+def test_human_ack_and_policy_hash_from_report() -> None:
+    report = _report_payload()
+    att = build_attestation_payload(
+        _verifier_payload(),
+        source=Path("verifier.json"),
+        redacted=True,
+        report=report,
+    )
+    assert att["human_ack"] == {
+        "required": True,
+        "satisfied": False,
+        "outstanding": ["shipgate.yaml (manifest)"],
+    }
+    expected = hashlib.sha256(
+        json.dumps(
+            report["effective_policy"], sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+    ).hexdigest()
+    assert att["policy_snapshot_sha256"] == expected
+
+
+def test_no_report_degrades_gracefully() -> None:
+    att = build_attestation_payload(
+        _verifier_payload(),
+        source=Path("verifier.json"),
+        redacted=True,
+        report=None,
+    )
+    # required falls back to verifier.human_review.required; satisfied unknown.
+    assert att["human_ack"]["required"] is True
+    assert att["human_ack"]["satisfied"] is None
+    assert att["human_ack"]["outstanding"] == []
+    assert att["policy_snapshot_sha256"] is None
+
+
+def test_attestation_is_deterministic() -> None:
+    args = dict(source=Path("verifier.json"), redacted=True, report=_report_payload())
+    first = build_attestation_payload(_verifier_payload(), **args)
+    second = build_attestation_payload(_verifier_payload(), **args)
+    assert first == second
+    # No wall-clock fields leak in: rendered form is byte-stable.
+    render = lambda d: json.dumps(d, sort_keys=True, indent=2)  # noqa: E731
+    assert render(first) == render(second)
+
+
+def test_redaction_controls_source_path() -> None:
+    redacted = build_attestation_payload(
+        _verifier_payload(),
+        source=Path("/Users/alice/Secret Client/verifier.json"),
+        redacted=True,
+    )
+    assert redacted["source_verifier"] == "verifier.json"
+    assert "Secret Client" not in json.dumps(redacted)
+
+    full = build_attestation_payload(
+        _verifier_payload(),
+        source=Path("/tmp/shipgate/verifier.json"),
+        redacted=False,
+    )
+    assert full["source_verifier"] == "/tmp/shipgate/verifier.json"
+
+
+def test_artifact_hashes_resolve_siblings_of_verifier(tmp_path: Path) -> None:
+    (tmp_path / "report.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "pr-comment.md").write_text("hello", encoding="utf-8")
+    verifier = _verifier_payload()
+    # Absolute, elsewhere-rooted artifact paths: only the basename is used.
+    verifier["artifacts"] = {
+        "report_json": "/somewhere/else/report.json",
+        "pr_comment": "/somewhere/else/pr-comment.md",
+        "missing": "/somewhere/else/nope.json",
+    }
+    att = build_attestation_payload(
+        verifier, source=tmp_path / "verifier.json", redacted=True
+    )
+    assert att["artifact_sha256"]["pr_comment"] == hashlib.sha256(b"hello").hexdigest()
+    assert att["artifact_sha256"]["report_json"] == hashlib.sha256(b"{}").hexdigest()
+    assert "missing" not in att["artifact_sha256"]  # absent files are skipped
+
+
+@pytest.mark.parametrize("report", [None, _report_payload()])
+def test_attestation_validates_against_schema(report) -> None:
+    att = build_attestation_payload(
+        _verifier_payload(),
+        source=Path("agents-shipgate-reports/verifier.json"),
+        redacted=True,
+        report=report,
+    )
+    jsonschema.validate(att, SCHEMA)
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_attest_cli_writes_json_and_enriches_from_sibling_report(tmp_path: Path) -> None:
+    (tmp_path / "verifier.json").write_text(
+        json.dumps(_verifier_payload()), encoding="utf-8"
+    )
+    (tmp_path / "report.json").write_text(
+        json.dumps(_report_payload()), encoding="utf-8"
+    )
+    out = tmp_path / "attestation.json"
+
+    result = runner.invoke(
+        app,
+        ["attest", "--from", str(tmp_path / "verifier.json"), "--out", str(out), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    disk = json.loads(out.read_text(encoding="utf-8"))
+    assert disk == json.loads(result.output)
+    assert disk["verdict"]["merge_verdict"] == "blocked"
+    # Sibling report.json was found and enriched the attestation.
+    assert disk["human_ack"]["outstanding"] == ["shipgate.yaml (manifest)"]
+    assert disk["policy_snapshot_sha256"] is not None
+    jsonschema.validate(disk, SCHEMA)
+
+
+def test_attest_cli_out_without_json_prints_written_message(tmp_path: Path) -> None:
+    (tmp_path / "verifier.json").write_text(
+        json.dumps(_verifier_payload()), encoding="utf-8"
+    )
+    out = tmp_path / "attestation.json"
+    result = runner.invoke(
+        app, ["attest", "--from", str(tmp_path / "verifier.json"), "--out", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == f"Wrote attestation to {out}"
+
+
+@pytest.mark.parametrize(
+    ("contents", "expected"),
+    [("", "not valid JSON"), ("[]", "must contain an object")],
+)
+def test_attest_cli_invalid_verifier_returns_3(tmp_path, contents, expected) -> None:
+    (tmp_path / "verifier.json").write_text(contents, encoding="utf-8")
+    result = runner.invoke(app, ["attest", "--from", str(tmp_path / "verifier.json")])
+    assert result.exit_code == 3
+    assert expected in result.output
+
+
+def test_attest_cli_missing_verifier_returns_3(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["attest", "--from", str(tmp_path / "missing.json")])
+    assert result.exit_code == 3
+    assert "not found" in result.output

--- a/tests/test_attest.py
+++ b/tests/test_attest.py
@@ -23,6 +23,7 @@ def _verifier_payload() -> dict:
         "base_ref": "origin/main",
         "head_ref": "HEAD",
         "base_tree_sha": "7d4d5f5e125a9bbcf16d4091fa0038bd229e1c7c",
+        "head_tree_sha": "a1b2c3d4e5f6071829abcdef0123456789abcdef",
         "mode": "advisory",
         "merge_verdict": "blocked",
         "applicability": "verified",
@@ -75,6 +76,7 @@ def test_build_attestation_core_fields() -> None:
     )
     assert att["attestation_schema_version"] == "0.1"
     assert att["base_tree_sha"] == "7d4d5f5e125a9bbcf16d4091fa0038bd229e1c7c"
+    assert att["head_tree_sha"] == "a1b2c3d4e5f6071829abcdef0123456789abcdef"
     assert att["verdict"] == {
         "merge_verdict": "blocked",
         "decision": "blocked",


### PR DESCRIPTION
## Summary

- New **`agents-shipgate attest`** command — ships the **Attestation Contract** (#8 of the agent-native protocol), the durable record the merge-contract doc had marked "planned".
- Derives a **deterministic, local, JSON-first** attestation from `verifier.json` (+ the sibling `report.json`): `base_ref`/`head_ref`/`base_tree_sha`, the verdict (`merge_verdict`/`decision`/`applicability`/`can_merge_without_human`), the capability delta + `change_ids`, declared `human_ack` state, a `policy_snapshot_sha256`, and content `artifact_sha256` of every verify artifact.
- **No wall-clock timestamp** — content-addressed by git SHAs + artifact hashes, so re-deriving from the same inputs is byte-identical (the project's determinism discipline). **It does not gate** — `report.json.release_decision.decision` stays the only gate.
- Modeled on `feedback export`: a hand-built dict + a hand-written `docs/attestation-schema.v0.1.json` (jsonschema-validated in tests). Artifact hashing resolves siblings by basename against the `verifier.json` directory, so it works whether stored paths are absolute or workspace-relative, independent of CWD. Report enrichment is best-effort: with no `report.json`, `human_ack.satisfied`/`policy_snapshot_sha256` degrade to `null`.
- Surfaced in `.well-known` (commands/outputs/artifacts/schemas), `STABILITY.md` §Attestation, `docs/INDEX.md`, and `docs/agent-native-merge-contract.md` (contract #8 planned→shipped). ROADMAP item 4 marked first-cut-shipped.

## Type

- [x] CLI or GitHub Action behavior — new `agents-shipgate attest` command
- [x] Report, schema, or SARIF output — new `attestation.json` artifact + hand-written `docs/attestation-schema.v0.1.json`

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- New `tests/test_attest.py` (13 tests): payload projection, determinism (byte-identical re-derivation), redaction, report-enrichment vs graceful `null` fallback, sibling artifact hashing (absolute/relative-agnostic), jsonschema validation (both report and no-report payloads), and the CLI (writes JSON; invalid/missing input → exit 3).
- Live: `attest` on the blocked refund fixture produces a schema-valid attestation, byte-identical on re-derivation.
- `ruff check .` clean; full suite (`pytest -m "not perf"`) green.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (no new check IDs)
- [x] Report/schema changes are additive or documented in `STABILITY.md` — new derived artifact documented in `STABILITY.md` §Attestation; introduces no gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
