### PR TITLE
[codex] Promote Codex plugin marketplace to GA

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "agents-shipgate-beta",
+  "name": "agents-shipgate",
   "interface": {
-    "displayName": "Agents Shipgate Beta"
+    "displayName": "Agents Shipgate"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ The v1 launch channel is workspace sharing from the Codex app or this
 repo-backed marketplace. Public/OpenAI-curated listing remains an optional
 later platform submission.
 
+Early testers who installed the old `agents-shipgate-beta` marketplace should
+remove that marketplace and reinstall from `agents-shipgate`:
+
+```bash
+codex plugin remove agents-shipgate
+codex plugin marketplace remove agents-shipgate-beta
+codex plugin marketplace add ThreeMoonsLab/agents-shipgate
+codex plugin add agents-shipgate@agents-shipgate
+```
+
 ## Add the Codex adoption kit
 
 For OpenAI Codex repos, install both the native `AGENTS.md` trigger block and

--- a/docs/agents/use-with-codex.md
+++ b/docs/agents/use-with-codex.md
@@ -14,7 +14,7 @@ Codex Skills under `.agents/skills/<name>/`.
 | Surface | What it does | Source path in this repo |
 |---|---|---|
 | Codex plugin | Installable plugin package for Codex with the Agents Shipgate skill bundled. | [`plugins/agents-shipgate/`](../../plugins/agents-shipgate/) |
-| Beta marketplace | Repo marketplace entry that lets Codex discover and install the plugin. | [`.agents/plugins/marketplace.json`](../../.agents/plugins/marketplace.json) |
+| Marketplace | Repo marketplace entry that lets Codex discover and install the plugin. | [`.agents/plugins/marketplace.json`](../../.agents/plugins/marketplace.json) |
 | `AGENTS.md` snippet | Tells Codex when Shipgate is relevant and names the canonical commands. | [`docs/target-repo-agent-snippets.md`](../target-repo-agent-snippets.md) §`AGENTS.md` |
 | Codex skill | Repo-scoped skill Codex can invoke explicitly with `$agents-shipgate` or implicitly when the task matches. | [`.agents/skills/agents-shipgate/`](../../.agents/skills/agents-shipgate/) |
 | Reusable prompts | Longer copy-paste recipes for agents that do not use skills. | [`prompts/README.md`](../../prompts/README.md) |
@@ -49,6 +49,18 @@ The plugin manifest points to dedicated privacy and terms pages in this repo.
 Public/OpenAI-curated listing, if pursued later, is a separate platform
 submission using the same skill-only package.
 
+### Migrating From The Beta Marketplace
+
+Early testers may have installed the old `agents-shipgate-beta` marketplace.
+For GA, remove the beta marketplace and install from the GA marketplace name:
+
+```bash
+codex plugin remove agents-shipgate
+codex plugin marketplace remove agents-shipgate-beta
+codex plugin marketplace add ThreeMoonsLab/agents-shipgate
+codex plugin add agents-shipgate@agents-shipgate
+```
+
 ## Runtime CLI Prerequisite
 
 The Codex plugin supplies workflow instructions, not the scanner binary. Before
@@ -79,8 +91,8 @@ with a working Codex CLI/app:
 
 ```bash
 codex plugin marketplace add /path/to/agents-shipgate
-codex plugin list --marketplace agents-shipgate-beta
-codex plugin add agents-shipgate@agents-shipgate-beta
+codex plugin list --marketplace agents-shipgate
+codex plugin add agents-shipgate@agents-shipgate
 agents-shipgate --version
 codex exec --sandbox read-only \
   '$agents-shipgate Do not run shell commands. Do not edit files. Reply with exactly: LOADED agents-shipgate'
@@ -88,8 +100,8 @@ codex exec --sandbox read-only \
 
 Passing evidence:
 
-- `plugin list` shows `agents-shipgate@agents-shipgate-beta`.
-- `plugin add` reports the plugin was added from `agents-shipgate-beta`.
+- `plugin list` shows `agents-shipgate@agents-shipgate`.
+- `plugin add` reports the plugin was added from `agents-shipgate`.
 - `agents-shipgate --version` reports `0.11.0` or newer.
 - the installed plugin cache contains `skills/agents-shipgate/SKILL.md`.
 - the `codex exec` response is `LOADED agents-shipgate`.

--- a/tests/test_codex_plugin_launch_package.py
+++ b/tests/test_codex_plugin_launch_package.py
@@ -36,7 +36,8 @@ def test_agents_shipgate_codex_plugin_manifest_is_skill_only() -> None:
 def test_agents_shipgate_codex_plugin_marketplace_entry_is_installable() -> None:
     marketplace = json.loads(MARKETPLACE_PATH.read_text(encoding="utf-8"))
 
-    assert marketplace["name"] == "agents-shipgate-beta"
+    assert marketplace["name"] == "agents-shipgate"
+    assert marketplace["interface"]["displayName"] == "Agents Shipgate"
     [entry] = marketplace["plugins"]
     assert entry == {
         "name": "agents-shipgate",


### PR DESCRIPTION
## Summary

- Rename the repo-backed Codex marketplace from `agents-shipgate-beta` to `agents-shipgate`.
- Update Codex docs and smoke commands to install `agents-shipgate@agents-shipgate`.
- Add migration steps for early testers who installed the old beta marketplace.
- Update plugin package tests to assert the GA marketplace name and display name.

## Validation

- `PYTHONPATH=src python -m pytest tests/test_docs_links.py tests/test_codex_plugin_launch_package.py -q`
- `python3 /Users/pengfeihu/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/agents-shipgate`
- `git diff --check`
- `PYTHONPATH=src AGENTS_SHIPGATE_AGENT_MODE=1 python -m agents_shipgate trigger --workspace . --changed-files /tmp/agents-shipgate-ga-changed-files.txt --user-requested --json` matched `TRIGGER-CODEX-PLUGIN-CHANGED`.

## Codex Smoke

- `codex plugin marketplace list` shows marketplace `agents-shipgate`.
- `codex plugin add agents-shipgate@agents-shipgate` installed cache path `/Users/pengfeihu/.codex/plugins/cache/agents-shipgate/agents-shipgate/0.11.0`.
- `codex plugin list --marketplace agents-shipgate` shows `agents-shipgate@agents-shipgate` installed/enabled at version `0.11.0`.
- `$agents-shipgate` load smoke returned `LOADED agents-shipgate`.