### PR TITLE
Add `feedback capture` — the workflow-evidence flywheel (final P1)

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -77,7 +77,8 @@
     "verify_pr": "agents-shipgate verify --workspace . --config shipgate.yaml --base origin/main --head HEAD --ci-mode advisory --format json",
     "trigger": "agents-shipgate trigger --base origin/main --head HEAD --json",
     "feedback_export": "agents-shipgate feedback export --from agents-shipgate-reports/verifier.json --redact --out shipgate-feedback.json",
-    "attest": "agents-shipgate attest --from agents-shipgate-reports/verifier.json --out agents-shipgate-reports/attestation.json"
+    "attest": "agents-shipgate attest --from agents-shipgate-reports/verifier.json --out agents-shipgate-reports/attestation.json",
+    "capture_scenario": "agents-shipgate feedback capture --before verifier-before.json --after verifier-after.json --redact --out scenario.json"
   },
   "fixture_run": "agents-shipgate fixture run ai_generated_refund_pr",
   "static_scan_fixture_run": "agents-shipgate fixture run support_refund_agent",
@@ -85,13 +86,14 @@
   "contract": "agents-shipgate contract --json",
   "contract_version": "1",
   "inputs": ["mcp", "openapi", "openai_agents_sdk", "anthropic_api", "google_adk", "langchain", "crewai", "openai_api", "codex_plugin", "n8n"],
-  "outputs": ["markdown", "json", "sarif", "packet_md", "packet_json", "packet_html", "verifier_json", "pr_comment_md", "feedback_json", "attestation_json"],
+  "outputs": ["markdown", "json", "sarif", "packet_md", "packet_json", "packet_html", "verifier_json", "pr_comment_md", "feedback_json", "attestation_json", "scenario_json"],
   "artifacts": {
     "verifier": "agents-shipgate-reports/verifier.json",
     "report": "agents-shipgate-reports/report.json",
     "pr_comment": "agents-shipgate-reports/pr-comment.md",
     "feedback": "shipgate-feedback.json",
-    "attestation": "agents-shipgate-reports/attestation.json"
+    "attestation": "agents-shipgate-reports/attestation.json",
+    "scenario": "scenario.json"
   },
   "gating_signal": "release_decision.decision",
   "merge_verdicts": ["mergeable", "human_review_required", "insufficient_evidence", "blocked", "unknown"],
@@ -132,6 +134,7 @@
     "packet": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/packet-schema.v0.6.json",
     "feedback": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/feedback-schema.v0.1.json",
     "attestation": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/attestation-schema.v0.1.json",
+    "scenario": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/scenario-schema.v0.1.json",
     "checks_catalog": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/checks.json"
   },
   "agent_instructions": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/AGENTS.md",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,12 +32,15 @@ into replayable evidence. Active themes, in priority order:
    `human_ack`, `verifier.json`). Document the protocol substrate that already
    exists; do not invent new architecture.
 
-2. **Workflow-evidence flywheel.** Extend `feedback export` beyond the verdict
-   into an opt-in, locally redacted *Agent Workflow Evidence* capture: diff,
-   agent transcript, repair attempt, verifier-before/after, and the human
-   decision. Every real pilot PR becomes a replayable benchmark scenario, so the
-   deterministic verdict is regression-tested against real agent behavior — not
-   just synthetic archetypes.
+2. **Workflow-evidence flywheel.** *(First cut shipped — `agents-shipgate
+   feedback capture`.)* An opt-in, locally redacted *Agent Workflow Evidence*
+   capture from a verify before/after pair: the verdict transition, a
+   gate-integrity signal (`suspected_gate_bypass`), the capability delta, and
+   prompt / diff / transcript provenance. Every real pilot PR becomes a
+   replayable benchmark scenario, so the deterministic verdict is
+   regression-tested against real agent behavior — not just synthetic
+   archetypes. Remaining: full raw-bundle replay and a `scenario replay`
+   harness.
 
 3. **Pre-emptive authority surface.** Today the trust root is enforced
    *reactively* — a weakening shows up in the diff, and Shipgate escalates.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -800,8 +800,8 @@ to share. Current v0.1 fields:
   `policy_weakened`, `capability`)
 - `transition` — `verdict_before`, `verdict_after`, `resolved`,
   `introduced_trust_root_touch`, `introduced_policy_weakening`, and
-  `suspected_gate_bypass` (became mergeable while introducing a trust-root touch
-  or policy weakening — impossible if the gate held)
+  `suspected_gate_bypass` (`mergeable` while a trust-root touch or policy
+  weakening is present — impossible for a valid verifier)
 - `evidence` — `prompt` / `diff` / `transcript` provenance
 - `source`
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -781,6 +781,30 @@ so re-deriving from the same inputs is byte-identical. It does not gate;
 - `policy_snapshot_sha256`
 - `artifact_sha256`
 
+### Workflow-evidence capture
+
+`agents-shipgate feedback capture` records a deterministic, local, replayable
+*scenario* from a verify before/after pair — one real pilot loop turned into
+benchmark fuel. The current schema is
+[`docs/scenario-schema.v0.1.json`](docs/scenario-schema.v0.1.json). It does not
+gate. With `--redact` (the default) it keeps only provenance (sha256, length,
+diffstat) of the prompt / diff / transcript — never raw content — so it is safe
+to share. Current v0.1 fields:
+
+- `scenario_schema_version`
+- `redacted`
+- `prompt_class`
+- `human_decision` (`merged` / `rejected` / `changes_requested` / `none` / null)
+- `before` / `after` — per-side state (`merge_verdict`, `decision`,
+  `applicability`, `can_merge_without_human`, `trust_root_touched`,
+  `policy_weakened`, `capability`)
+- `transition` — `verdict_before`, `verdict_after`, `resolved`,
+  `introduced_trust_root_touch`, `introduced_policy_weakening`, and
+  `suspected_gate_bypass` (became mergeable while introducing a trust-root touch
+  or policy weakening — impossible if the gate held)
+- `evidence` — `prompt` / `diff` / `transcript` provenance
+- `source`
+
 ### Agent-skill paths
 
 The following paths are part of the public agent surface and will not move within `0.x`:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,6 +27,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`report-schema.v0.22.json`](report-schema.v0.22.json) — JSON Schema for `report.json` (current; emitted reports carry `report_schema_version: "0.22"`, adding the verifier-cycle top-level blocks `capability_change`, `protected_surface_changes`, `effective_policy`, `human_ack`, and `verifier_summary` alongside v0.21's `heuristics_filter` envelope)
 - [`verifier-schema.v0.1.json`](verifier-schema.v0.1.json) — JSON Schema for `verifier.json` emitted by `agents-shipgate verify`
 - [`attestation-schema.v0.1.json`](attestation-schema.v0.1.json) — JSON Schema for `attestation.json` emitted by `agents-shipgate attest`
+- [`scenario-schema.v0.1.json`](scenario-schema.v0.1.json) — JSON Schema for the workflow-evidence `scenario.json` emitted by `agents-shipgate feedback capture`
 - [`privacy.md`](privacy.md), [`terms.md`](terms.md), and [`report-sensitive-fields.json`](report-sensitive-fields.json) — Codex plugin privacy/terms, redaction behavior, and report sensitive-field inventory
 - [`agent-action-guide.md`](agent-action-guide.md) — per-category recipe for what to do with a finding (canonical fix per check category, last-resort suppression rules)
 - [`upstream-integrations.md`](upstream-integrations.md) — per-framework 60-second drop-in for adding Shipgate to an existing project (OpenAI Agents SDK, LangChain, CrewAI, ADK, MCP-only, OpenAPI-only, OpenAI Messages API, Anthropic Messages API)

--- a/docs/scenario-schema.v0.1.json
+++ b/docs/scenario-schema.v0.1.json
@@ -40,7 +40,7 @@
         "resolved": { "type": "boolean", "description": "Was non-mergeable before and mergeable after." },
         "introduced_trust_root_touch": { "type": "boolean", "description": "The repair touched a trust root that the before-state did not." },
         "introduced_policy_weakening": { "type": "boolean", "description": "The repair weakened policy where the before-state did not." },
-        "suspected_gate_bypass": { "type": "boolean", "description": "Became mergeable while introducing a trust-root touch or policy weakening — impossible if the gate held, so a likely bypass or hand-edited artifact." }
+        "suspected_gate_bypass": { "type": "boolean", "description": "`mergeable` while a trust-root touch or policy weakening is present — impossible for a valid verifier (the self-approval prohibition forces human review), so a likely bypass or hand-edited artifact. State-based: independent of whether the flag was newly introduced." }
       }
     },
     "evidence": {

--- a/docs/scenario-schema.v0.1.json
+++ b/docs/scenario-schema.v0.1.json
@@ -98,23 +98,23 @@
     "evidence_entry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["included", "sha256", "chars", "text"],
+      "required": ["included", "sha256", "bytes", "text"],
       "properties": {
         "included": { "type": "boolean" },
-        "sha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
-        "chars": { "type": ["integer", "null"], "minimum": 0 },
-        "text": { "type": ["string", "null"], "description": "Raw content; null unless --no-redact." }
+        "sha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$", "description": "sha256 of the raw file bytes (matches sha256sum)." },
+        "bytes": { "type": ["integer", "null"], "minimum": 0, "description": "Raw byte length of the file." },
+        "text": { "type": ["string", "null"], "description": "Best-effort UTF-8 decode of the raw bytes (errors replaced); null unless --no-redact. The sha256 is authoritative." }
       }
     },
     "diff_entry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["included", "sha256", "chars", "text", "files", "insertions", "deletions"],
+      "required": ["included", "sha256", "bytes", "text", "files", "insertions", "deletions"],
       "properties": {
         "included": { "type": "boolean" },
-        "sha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
-        "chars": { "type": ["integer", "null"], "minimum": 0 },
-        "text": { "type": ["string", "null"], "description": "Raw diff; null unless --no-redact." },
+        "sha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$", "description": "sha256 of the raw diff bytes (matches sha256sum)." },
+        "bytes": { "type": ["integer", "null"], "minimum": 0, "description": "Raw byte length of the diff." },
+        "text": { "type": ["string", "null"], "description": "Best-effort UTF-8 decode of the raw diff; null unless --no-redact." },
         "files": { "type": ["integer", "null"], "minimum": 0 },
         "insertions": { "type": ["integer", "null"], "minimum": 0 },
         "deletions": { "type": ["integer", "null"], "minimum": 0 }

--- a/docs/scenario-schema.v0.1.json
+++ b/docs/scenario-schema.v0.1.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/scenario-schema.v0.1.json",
+  "title": "Agents Shipgate Workflow-Evidence Scenario v0.1",
+  "description": "A deterministic, local, replayable record of one real coding-agent pilot loop, captured by `agents-shipgate feedback capture` from a verify before/after pair. Feeds the benchmark flywheel; it does not gate. Redacted by default (provenance only — no raw prompt/diff/transcript content).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "scenario_schema_version",
+    "redacted",
+    "prompt_class",
+    "human_decision",
+    "before",
+    "after",
+    "transition",
+    "evidence",
+    "source"
+  ],
+  "properties": {
+    "scenario_schema_version": { "const": "0.1" },
+    "redacted": { "type": "boolean" },
+    "prompt_class": { "type": ["string", "null"], "description": "Coarse task label, e.g. add_refund_tool." },
+    "human_decision": { "type": ["string", "null"], "enum": ["merged", "rejected", "changes_requested", "none", null] },
+    "before": { "$ref": "#/$defs/state" },
+    "after": { "oneOf": [{ "$ref": "#/$defs/state" }, { "type": "null" }] },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verdict_before",
+        "verdict_after",
+        "resolved",
+        "introduced_trust_root_touch",
+        "introduced_policy_weakening",
+        "suspected_gate_bypass"
+      ],
+      "properties": {
+        "verdict_before": { "type": ["string", "null"] },
+        "verdict_after": { "type": ["string", "null"] },
+        "resolved": { "type": "boolean", "description": "Was non-mergeable before and mergeable after." },
+        "introduced_trust_root_touch": { "type": "boolean", "description": "The repair touched a trust root that the before-state did not." },
+        "introduced_policy_weakening": { "type": "boolean", "description": "The repair weakened policy where the before-state did not." },
+        "suspected_gate_bypass": { "type": "boolean", "description": "Became mergeable while introducing a trust-root touch or policy weakening — impossible if the gate held, so a likely bypass or hand-edited artifact." }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prompt", "diff", "transcript"],
+      "properties": {
+        "prompt": { "$ref": "#/$defs/evidence_entry" },
+        "diff": { "$ref": "#/$defs/diff_entry" },
+        "transcript": { "$ref": "#/$defs/evidence_entry" }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["before", "after"],
+      "properties": {
+        "before": { "type": "string" },
+        "after": { "type": ["string", "null"] }
+      }
+    }
+  },
+  "$defs": {
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "merge_verdict",
+        "decision",
+        "applicability",
+        "can_merge_without_human",
+        "trust_root_touched",
+        "policy_weakened",
+        "capability"
+      ],
+      "properties": {
+        "merge_verdict": { "type": ["string", "null"] },
+        "decision": { "type": ["string", "null"] },
+        "applicability": { "type": ["string", "null"] },
+        "can_merge_without_human": { "type": "boolean" },
+        "trust_root_touched": { "type": "boolean" },
+        "policy_weakened": { "type": "boolean" },
+        "capability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["added", "modified", "removed"],
+          "properties": {
+            "added": { "type": "integer", "minimum": 0 },
+            "modified": { "type": "integer", "minimum": 0 },
+            "removed": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "evidence_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["included", "sha256", "chars", "text"],
+      "properties": {
+        "included": { "type": "boolean" },
+        "sha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
+        "chars": { "type": ["integer", "null"], "minimum": 0 },
+        "text": { "type": ["string", "null"], "description": "Raw content; null unless --no-redact." }
+      }
+    },
+    "diff_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["included", "sha256", "chars", "text", "files", "insertions", "deletions"],
+      "properties": {
+        "included": { "type": "boolean" },
+        "sha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
+        "chars": { "type": ["integer", "null"], "minimum": 0 },
+        "text": { "type": ["string", "null"], "description": "Raw diff; null unless --no-redact." },
+        "files": { "type": ["integer", "null"], "minimum": 0 },
+        "insertions": { "type": ["integer", "null"], "minimum": 0 },
+        "deletions": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    }
+  }
+}

--- a/src/agents_shipgate/cli/feedback.py
+++ b/src/agents_shipgate/cli/feedback.py
@@ -424,24 +424,30 @@ def _transition(
 def _evidence_entry(
     path: Path | None, *, redacted: bool, diffstat: bool = False
 ) -> dict[str, Any]:
-    """Provenance for an optional evidence file. With ``--redact`` (default) the
-    raw ``text`` is omitted — only the sha256, length, and (for a diff) the
-    diffstat are kept, so the scenario is safe to share."""
-    entry: dict[str, Any] = {"included": False, "sha256": None, "chars": None, "text": None}
+    """Provenance for an optional evidence file.
+
+    The ``sha256`` is over the **raw file bytes** (so it matches ``sha256sum``
+    and stays replayable) and ``bytes`` is the raw byte length. The decoded view
+    is computed separately and only where needed — ``text`` (omitted under
+    ``--redact``) and the diffstat — with ``errors="replace"`` so non-UTF-8
+    evidence never crashes; the byte-exact hash remains the source of truth, and
+    universal-newline normalization can never alter what is hashed."""
+    entry: dict[str, Any] = {"included": False, "sha256": None, "bytes": None, "text": None}
     if diffstat:
         entry.update({"files": None, "insertions": None, "deletions": None})
     if path is None:
         return entry
     try:
-        content = path.read_text(encoding="utf-8")
+        data = path.read_bytes()
     except OSError:
         return entry
     entry["included"] = True
-    entry["sha256"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
-    entry["chars"] = len(content)
-    entry["text"] = None if redacted else content
+    entry["sha256"] = hashlib.sha256(data).hexdigest()
+    entry["bytes"] = len(data)
+    text = data.decode("utf-8", errors="replace")
+    entry["text"] = None if redacted else text
     if diffstat:
-        lines = content.splitlines()
+        lines = text.splitlines()
         entry["files"] = sum(1 for line in lines if line.startswith("diff --git "))
         entry["insertions"] = sum(
             1 for line in lines if line.startswith("+") and not line.startswith("+++")

--- a/src/agents_shipgate/cli/feedback.py
+++ b/src/agents_shipgate/cli/feedback.py
@@ -262,9 +262,9 @@ def feedback_capture(
     """Capture a replayable workflow-evidence scenario from a verify before/after pair.
 
     Turns one real pilot PR into a labeled, deterministic record: the verdict
-    transition, a gate-integrity signal (did the repair *introduce* a trust-root
-    touch or policy weakening, and did the PR still become mergeable — which the
-    gate should have prevented?), the capability delta, and — opt-in,
+    transition, a gate-integrity signal (is the PR `mergeable` while a trust-root
+    touch or policy weakening is present — which a valid verifier never emits?),
+    the capability delta, and — opt-in,
     redacted-by-default — the prompt / diff / transcript provenance. This feeds
     the benchmark flywheel; it does not gate.
     """
@@ -279,6 +279,21 @@ def feedback_capture(
             f"--human-decision must be one of {sorted(_HUMAN_DECISIONS)}", err=True
         )
         raise typer.Exit(2)
+    # An explicitly provided evidence path that cannot be read is a user error,
+    # not "no evidence" — failing loud avoids a silently incomplete benchmark
+    # artifact (an unreadable --prompt must not become `included: false`).
+    for flag, evidence_path in (
+        ("--prompt", prompt),
+        ("--diff", diff),
+        ("--transcript", transcript),
+    ):
+        if evidence_path is not None and not evidence_path.is_file():
+            typer.echo(
+                f"Input parsing error: {flag} file not found or unreadable: "
+                f"{evidence_path}",
+                err=True,
+            )
+            raise typer.Exit(3)
     scenario = build_scenario_payload(
         before_payload,
         after_payload,
@@ -384,14 +399,17 @@ def _transition(
     introduced_policy_weakening = bool(after["policy_weakened"]) and not bool(
         before["policy_weakened"]
     )
-    # Gate-integrity alarm. The self-approval prohibition means a verify run that
-    # touches a trust root or weakens policy can never be `mergeable` — it routes
-    # to human review. So "became mergeable AND introduced a trust-root touch /
-    # policy weakening" is impossible if the gate held; if a captured after.json
-    # shows it, the gate was likely bypassed (e.g. committed with --no-verify) or
-    # the artifact was hand-edited. A high-signal case for the benchmark.
-    suspected_gate_bypass = resolved and (
-        introduced_trust_root_touch or introduced_policy_weakening
+    # Gate-integrity alarm — STATE-BASED, not delta-based. The self-approval
+    # prohibition means a verify run that touches a trust root or weakens policy
+    # can never be `mergeable`; it routes to human review. So an `after` that is
+    # `mergeable` while *either* flag is set is internally inconsistent — the gate
+    # was bypassed (e.g. committed with --no-verify) or the artifact was
+    # hand-edited. It does not matter whether the flag was newly introduced: a
+    # pre-existing flag that survives into a `mergeable` verdict is just as
+    # impossible. (Keying this on `introduced_*` would miss the case where the
+    # flag is true in both before and after.)
+    suspected_gate_bypass = verdict_after == "mergeable" and (
+        bool(after["trust_root_touched"]) or bool(after["policy_weakened"])
     )
     return {
         "verdict_before": verdict_before,

--- a/src/agents_shipgate/cli/feedback.py
+++ b/src/agents_shipgate/cli/feedback.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -210,4 +211,227 @@ def _fix_task_projection(value: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-__all__ = ["build_feedback_payload", "feedback_app"]
+_HUMAN_DECISIONS = frozenset({"merged", "rejected", "changes_requested", "none"})
+
+
+@feedback_app.command("capture")
+def feedback_capture(
+    before: Path = typer.Option(
+        ...,
+        "--before",
+        help="verifier.json from before the repair (the initial verdict).",
+    ),
+    after: Path | None = typer.Option(
+        None,
+        "--after",
+        help="verifier.json after the repair, if a repair was attempted.",
+    ),
+    prompt_class: str | None = typer.Option(
+        None,
+        "--prompt-class",
+        help="Coarse label for the task, e.g. add_refund_tool.",
+    ),
+    prompt: Path | None = typer.Option(
+        None, "--prompt", help="Task prompt file (content only with --no-redact)."
+    ),
+    diff: Path | None = typer.Option(
+        None, "--diff", help="PR/repair diff (diffstat always; content only with --no-redact)."
+    ),
+    transcript: Path | None = typer.Option(
+        None,
+        "--transcript",
+        help="Agent transcript (opt-in; provenance only unless --no-redact).",
+    ),
+    human_decision: str | None = typer.Option(
+        None,
+        "--human-decision",
+        help="Declared human outcome: merged / rejected / changes_requested / none.",
+    ),
+    out: Path | None = typer.Option(
+        None, "--out", help="Write the scenario artifact to this path."
+    ),
+    redact: bool = typer.Option(
+        True,
+        "--redact/--no-redact",
+        help="Provenance-only: omit raw prompt/diff/transcript content and reduce paths to filenames.",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Print the scenario JSON to stdout."
+    ),
+) -> None:
+    """Capture a replayable workflow-evidence scenario from a verify before/after pair.
+
+    Turns one real pilot PR into a labeled, deterministic record: the verdict
+    transition, a gate-integrity signal (did the repair *introduce* a trust-root
+    touch or policy weakening, and did the PR still become mergeable — which the
+    gate should have prevented?), the capability delta, and — opt-in,
+    redacted-by-default — the prompt / diff / transcript provenance. This feeds
+    the benchmark flywheel; it does not gate.
+    """
+    try:
+        before_payload = _load_verifier(before)
+        after_payload = _load_verifier(after) if after is not None else None
+    except InputParseError as exc:
+        typer.echo(f"Input parsing error: {exc}", err=True)
+        raise typer.Exit(3) from exc
+    if human_decision is not None and human_decision not in _HUMAN_DECISIONS:
+        typer.echo(
+            f"--human-decision must be one of {sorted(_HUMAN_DECISIONS)}", err=True
+        )
+        raise typer.Exit(2)
+    scenario = build_scenario_payload(
+        before_payload,
+        after_payload,
+        before_source=before,
+        after_source=after,
+        prompt_class=prompt_class,
+        prompt_path=prompt,
+        diff_path=diff,
+        transcript_path=transcript,
+        human_decision=human_decision,
+        redacted=redact,
+    )
+    rendered = json.dumps(scenario, indent=2, sort_keys=True) + "\n"
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")
+    if json_output or out is None:
+        typer.echo(rendered.rstrip())
+    else:
+        typer.echo(f"Wrote scenario to {out}")
+
+
+def build_scenario_payload(
+    before: dict[str, Any],
+    after: dict[str, Any] | None,
+    *,
+    before_source: Path,
+    after_source: Path | None,
+    prompt_class: str | None,
+    prompt_path: Path | None,
+    diff_path: Path | None,
+    transcript_path: Path | None,
+    human_decision: str | None,
+    redacted: bool,
+) -> dict[str, Any]:
+    """Project a verify before/after pair onto a deterministic scenario record.
+
+    Pure function of the two verifier projections plus optional evidence files.
+    No wall-clock fields, so re-deriving from the same inputs is byte-identical.
+    """
+    before_state = _verifier_state(before)
+    after_state = _verifier_state(after) if after is not None else None
+    return {
+        "scenario_schema_version": "0.1",
+        "redacted": redacted,
+        "prompt_class": prompt_class,
+        "human_decision": human_decision,
+        "before": before_state,
+        "after": after_state,
+        "transition": _transition(before_state, after_state),
+        "evidence": {
+            "prompt": _evidence_entry(prompt_path, redacted=redacted),
+            "diff": _evidence_entry(diff_path, redacted=redacted, diffstat=True),
+            "transcript": _evidence_entry(transcript_path, redacted=redacted),
+        },
+        "source": {
+            "before": _display_path(before_source, redacted=redacted),
+            "after": (
+                _display_path(after_source, redacted=redacted)
+                if after_source is not None
+                else None
+            ),
+        },
+    }
+
+
+def _verifier_state(verifier: dict[str, Any]) -> dict[str, Any]:
+    capability_review = _dict(verifier.get("capability_review"))
+    release_decision = _dict(verifier.get("release_decision"))
+    return {
+        "merge_verdict": verifier.get("merge_verdict"),
+        "decision": verifier.get("decision") or release_decision.get("decision"),
+        "applicability": verifier.get("applicability"),
+        "can_merge_without_human": bool(verifier.get("can_merge_without_human")),
+        "trust_root_touched": bool(capability_review.get("trust_root_touched")),
+        "policy_weakened": bool(capability_review.get("policy_weakened")),
+        "capability": {
+            "added": int(capability_review.get("added", 0) or 0),
+            "modified": int(capability_review.get("modified", 0) or 0),
+            "removed": int(capability_review.get("removed", 0) or 0),
+        },
+    }
+
+
+def _transition(
+    before: dict[str, Any], after: dict[str, Any] | None
+) -> dict[str, Any]:
+    verdict_before = before["merge_verdict"]
+    if after is None:
+        return {
+            "verdict_before": verdict_before,
+            "verdict_after": None,
+            "resolved": False,
+            "introduced_trust_root_touch": False,
+            "introduced_policy_weakening": False,
+            "suspected_gate_bypass": False,
+        }
+    verdict_after = after["merge_verdict"]
+    resolved = verdict_before != "mergeable" and verdict_after == "mergeable"
+    introduced_trust_root_touch = bool(after["trust_root_touched"]) and not bool(
+        before["trust_root_touched"]
+    )
+    introduced_policy_weakening = bool(after["policy_weakened"]) and not bool(
+        before["policy_weakened"]
+    )
+    # Gate-integrity alarm. The self-approval prohibition means a verify run that
+    # touches a trust root or weakens policy can never be `mergeable` — it routes
+    # to human review. So "became mergeable AND introduced a trust-root touch /
+    # policy weakening" is impossible if the gate held; if a captured after.json
+    # shows it, the gate was likely bypassed (e.g. committed with --no-verify) or
+    # the artifact was hand-edited. A high-signal case for the benchmark.
+    suspected_gate_bypass = resolved and (
+        introduced_trust_root_touch or introduced_policy_weakening
+    )
+    return {
+        "verdict_before": verdict_before,
+        "verdict_after": verdict_after,
+        "resolved": resolved,
+        "introduced_trust_root_touch": introduced_trust_root_touch,
+        "introduced_policy_weakening": introduced_policy_weakening,
+        "suspected_gate_bypass": suspected_gate_bypass,
+    }
+
+
+def _evidence_entry(
+    path: Path | None, *, redacted: bool, diffstat: bool = False
+) -> dict[str, Any]:
+    """Provenance for an optional evidence file. With ``--redact`` (default) the
+    raw ``text`` is omitted — only the sha256, length, and (for a diff) the
+    diffstat are kept, so the scenario is safe to share."""
+    entry: dict[str, Any] = {"included": False, "sha256": None, "chars": None, "text": None}
+    if diffstat:
+        entry.update({"files": None, "insertions": None, "deletions": None})
+    if path is None:
+        return entry
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return entry
+    entry["included"] = True
+    entry["sha256"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    entry["chars"] = len(content)
+    entry["text"] = None if redacted else content
+    if diffstat:
+        lines = content.splitlines()
+        entry["files"] = sum(1 for line in lines if line.startswith("diff --git "))
+        entry["insertions"] = sum(
+            1 for line in lines if line.startswith("+") and not line.startswith("+++")
+        )
+        entry["deletions"] = sum(
+            1 for line in lines if line.startswith("-") and not line.startswith("---")
+        )
+    return entry
+
+
+__all__ = ["build_feedback_payload", "build_scenario_payload", "feedback_app"]

--- a/tests/test_workflow_evidence.py
+++ b/tests/test_workflow_evidence.py
@@ -103,13 +103,16 @@ def test_introduced_weakening_without_reaching_mergeable_is_not_a_bypass() -> No
     assert t["suspected_gate_bypass"] is False
 
 
-def test_pre_existing_weakening_is_not_counted_as_introduced() -> None:
-    # Weakening present in BOTH before and after was not introduced by the repair.
+def test_mergeable_with_weakening_is_a_bypass_even_if_pre_existing() -> None:
+    # State-based invariant: `mergeable` with a trust-root touch is impossible for
+    # a valid verifier, regardless of whether the flag was newly introduced. The
+    # earlier "introduced-delta" framing missed this (the flag survived from
+    # before into a mergeable after), so the bypass is keyed on the after-state.
     before = _verifier("human_review_required", trust_root_touched=True)
     after = _verifier("mergeable", trust_root_touched=True)
     scen = _capture(before, after)
-    assert scen["transition"]["introduced_trust_root_touch"] is False
-    assert scen["transition"]["suspected_gate_bypass"] is False
+    assert scen["transition"]["introduced_trust_root_touch"] is False  # pre-existing
+    assert scen["transition"]["suspected_gate_bypass"] is True  # but still a bypass
 
 
 # --- evidence provenance + redaction ----------------------------------------
@@ -208,3 +211,22 @@ def test_capture_cli_missing_before_returns_3(tmp_path: Path) -> None:
     )
     assert result.exit_code == 3
     assert "not found" in result.output
+
+
+def test_capture_cli_unreadable_evidence_returns_3(tmp_path: Path) -> None:
+    # An explicitly provided --prompt/--diff/--transcript that can't be read must
+    # fail loud, not silently record included=false (a silently incomplete
+    # benchmark artifact).
+    (tmp_path / "before.json").write_text(
+        json.dumps(_verifier("blocked")), encoding="utf-8"
+    )
+    result = runner.invoke(
+        app,
+        [
+            "feedback", "capture",
+            "--before", str(tmp_path / "before.json"),
+            "--prompt", str(tmp_path / "typo.txt"),
+        ],
+    )
+    assert result.exit_code == 3
+    assert "--prompt file not found" in result.output

--- a/tests/test_workflow_evidence.py
+++ b/tests/test_workflow_evidence.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.feedback import build_scenario_payload
+from agents_shipgate.cli.main import app
+
+runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads(
+    (REPO_ROOT / "docs/scenario-schema.v0.1.json").read_text(encoding="utf-8")
+)
+
+_DECISION = {
+    "blocked": "blocked",
+    "mergeable": "passed",
+    "human_review_required": "review_required",
+    "insufficient_evidence": "insufficient_evidence",
+}
+
+
+def _verifier(
+    merge_verdict: str,
+    *,
+    trust_root_touched: bool = False,
+    policy_weakened: bool = False,
+    added: int = 1,
+) -> dict:
+    return {
+        "merge_verdict": merge_verdict,
+        "decision": _DECISION.get(merge_verdict),
+        "applicability": "verified",
+        "can_merge_without_human": merge_verdict == "mergeable",
+        "capability_review": {
+            "trust_root_touched": trust_root_touched,
+            "policy_weakened": policy_weakened,
+            "added": added,
+            "modified": 0,
+            "removed": 0,
+        },
+    }
+
+
+def _capture(before: dict, after: dict | None, **overrides) -> dict:
+    kwargs = dict(
+        before_source=Path("before/verifier.json"),
+        after_source=Path("after/verifier.json") if after is not None else None,
+        prompt_class=None,
+        prompt_path=None,
+        diff_path=None,
+        transcript_path=None,
+        human_decision=None,
+        redacted=True,
+    )
+    kwargs.update(overrides)
+    return build_scenario_payload(before, after, **kwargs)
+
+
+# --- the transition / gate-integrity signal ---------------------------------
+
+
+def test_before_only_records_initial_state() -> None:
+    scen = _capture(_verifier("blocked"), None)
+    assert scen["after"] is None
+    assert scen["transition"]["verdict_before"] == "blocked"
+    assert scen["transition"]["verdict_after"] is None
+    assert scen["transition"]["resolved"] is False
+    assert scen["transition"]["suspected_gate_bypass"] is False
+
+
+def test_legitimate_repair_resolves_without_bypass() -> None:
+    scen = _capture(_verifier("blocked"), _verifier("mergeable"))
+    t = scen["transition"]
+    assert t["resolved"] is True
+    assert t["introduced_trust_root_touch"] is False
+    assert t["introduced_policy_weakening"] is False
+    assert t["suspected_gate_bypass"] is False
+
+
+@pytest.mark.parametrize("weak_field", ["trust_root_touched", "policy_weakened"])
+def test_mergeable_while_introducing_weakening_is_a_bypass_alarm(weak_field) -> None:
+    # The gate routes any trust-root touch / policy weakening to human review, so
+    # "mergeable" + introduced weakening can only mean the gate was bypassed.
+    after = _verifier("mergeable", **{weak_field: True})
+    scen = _capture(_verifier("blocked"), after)
+    assert scen["transition"]["suspected_gate_bypass"] is True
+
+
+def test_introduced_weakening_without_reaching_mergeable_is_not_a_bypass() -> None:
+    # The gate held: the weakening was caught and routed to human review, not
+    # auto-merged. A review signal, but not a bypass.
+    after = _verifier("human_review_required", policy_weakened=True)
+    scen = _capture(_verifier("blocked"), after)
+    t = scen["transition"]
+    assert t["introduced_policy_weakening"] is True
+    assert t["resolved"] is False
+    assert t["suspected_gate_bypass"] is False
+
+
+def test_pre_existing_weakening_is_not_counted_as_introduced() -> None:
+    # Weakening present in BOTH before and after was not introduced by the repair.
+    before = _verifier("human_review_required", trust_root_touched=True)
+    after = _verifier("mergeable", trust_root_touched=True)
+    scen = _capture(before, after)
+    assert scen["transition"]["introduced_trust_root_touch"] is False
+    assert scen["transition"]["suspected_gate_bypass"] is False
+
+
+# --- evidence provenance + redaction ----------------------------------------
+
+
+def test_evidence_provenance_and_redaction(tmp_path: Path) -> None:
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("add a refund tool", encoding="utf-8")
+    diff = tmp_path / "repair.patch"
+    diff.write_text(
+        "diff --git a/x.py b/x.py\n--- a/x.py\n+++ b/x.py\n+added\n-removed\n",
+        encoding="utf-8",
+    )
+
+    redacted = _capture(
+        _verifier("blocked"), None, prompt_path=prompt, diff_path=diff, redacted=True
+    )
+    p = redacted["evidence"]["prompt"]
+    assert p["included"] is True
+    assert p["sha256"] == hashlib.sha256(b"add a refund tool").hexdigest()
+    assert p["chars"] == len("add a refund tool")
+    assert p["text"] is None  # redacted: no raw content
+    d = redacted["evidence"]["diff"]
+    assert d["files"] == 1 and d["insertions"] == 1 and d["deletions"] == 1
+    assert d["text"] is None
+
+    full = _capture(
+        _verifier("blocked"), None, prompt_path=prompt, diff_path=diff, redacted=False
+    )
+    assert full["evidence"]["prompt"]["text"] == "add a refund tool"
+
+
+def test_absent_evidence_is_marked_not_included() -> None:
+    scen = _capture(_verifier("blocked"), None)
+    assert scen["evidence"]["transcript"] == {
+        "included": False,
+        "sha256": None,
+        "chars": None,
+        "text": None,
+    }
+
+
+def test_scenario_is_deterministic() -> None:
+    a = _capture(_verifier("blocked"), _verifier("mergeable"), prompt_class="x")
+    b = _capture(_verifier("blocked"), _verifier("mergeable"), prompt_class="x")
+    assert a == b
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+@pytest.mark.parametrize("after", [None, _verifier("mergeable")])
+def test_scenario_validates_against_schema(after) -> None:
+    scen = _capture(
+        _verifier("blocked"), after, prompt_class="add_refund_tool", human_decision="merged"
+    )
+    jsonschema.validate(scen, SCHEMA)
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_capture_cli_writes_json(tmp_path: Path) -> None:
+    (tmp_path / "before.json").write_text(json.dumps(_verifier("blocked")), encoding="utf-8")
+    (tmp_path / "after.json").write_text(json.dumps(_verifier("mergeable")), encoding="utf-8")
+    out = tmp_path / "scenario.json"
+    result = runner.invoke(
+        app,
+        [
+            "feedback", "capture",
+            "--before", str(tmp_path / "before.json"),
+            "--after", str(tmp_path / "after.json"),
+            "--human-decision", "merged",
+            "--out", str(out), "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    disk = json.loads(out.read_text(encoding="utf-8"))
+    assert disk == json.loads(result.output)
+    assert disk["transition"]["resolved"] is True
+    jsonschema.validate(disk, SCHEMA)
+
+
+def test_capture_cli_rejects_unknown_human_decision(tmp_path: Path) -> None:
+    (tmp_path / "before.json").write_text(json.dumps(_verifier("blocked")), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["feedback", "capture", "--before", str(tmp_path / "before.json"),
+         "--human-decision", "approved-ish"],
+    )
+    assert result.exit_code == 2
+    assert "--human-decision must be one of" in result.output
+
+
+def test_capture_cli_missing_before_returns_3(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app, ["feedback", "capture", "--before", str(tmp_path / "missing.json")]
+    )
+    assert result.exit_code == 3
+    assert "not found" in result.output

--- a/tests/test_workflow_evidence.py
+++ b/tests/test_workflow_evidence.py
@@ -133,7 +133,7 @@ def test_evidence_provenance_and_redaction(tmp_path: Path) -> None:
     p = redacted["evidence"]["prompt"]
     assert p["included"] is True
     assert p["sha256"] == hashlib.sha256(b"add a refund tool").hexdigest()
-    assert p["chars"] == len("add a refund tool")
+    assert p["bytes"] == len(b"add a refund tool")
     assert p["text"] is None  # redacted: no raw content
     d = redacted["evidence"]["diff"]
     assert d["files"] == 1 and d["insertions"] == 1 and d["deletions"] == 1
@@ -150,9 +150,35 @@ def test_absent_evidence_is_marked_not_included() -> None:
     assert scen["evidence"]["transcript"] == {
         "included": False,
         "sha256": None,
-        "chars": None,
+        "bytes": None,
         "text": None,
     }
+
+
+def test_evidence_hash_is_raw_bytes_not_newline_normalized(tmp_path: Path) -> None:
+    # The hash must be over the raw file bytes — CRLF must not be normalized to
+    # LF before hashing, or the sha won't match sha256sum and isn't replayable.
+    raw = b"a\r\nb\r\n"
+    f = tmp_path / "crlf.txt"
+    f.write_bytes(raw)
+    scen = _capture(_verifier("blocked"), None, prompt_path=f, redacted=False)
+    p = scen["evidence"]["prompt"]
+    assert p["sha256"] == hashlib.sha256(raw).hexdigest()
+    assert p["bytes"] == len(raw)
+    assert p["text"] == "a\r\nb\r\n"  # CRLF preserved in the embedded text
+
+
+def test_non_utf8_evidence_does_not_crash(tmp_path: Path) -> None:
+    # Non-UTF-8 evidence must hash by raw bytes and not raise; the byte-exact
+    # sha256 is the source of truth, the decoded text is best-effort.
+    raw = b"\xff\xfe\x00 not utf-8"
+    f = tmp_path / "bin.dat"
+    f.write_bytes(raw)
+    scen = _capture(_verifier("blocked"), None, transcript_path=f, redacted=True)
+    t = scen["evidence"]["transcript"]
+    assert t["included"] is True
+    assert t["sha256"] == hashlib.sha256(raw).hexdigest()
+    assert t["bytes"] == len(raw)
 
 
 def test_scenario_is_deterministic() -> None:


### PR DESCRIPTION
## Summary

- New **`agents-shipgate feedback capture`** — the final P1 item, the **workflow-evidence flywheel**. It turns one real coding-agent pilot loop into a deterministic, replayable benchmark scenario, so the verdict is regression-tested against *real* agent behavior, not just synthetic archetypes.
- Reads a verify **before/after** pair (`--before` required, `--after` optional) and records the **verdict transition** + the capability delta + (opt-in, redacted-by-default) prompt / diff / transcript provenance. **It does not gate.**
- **The high-signal field is `transition.suspected_gate_bypass`.** The self-approval prohibition means a verify run that touches a trust root or weakens policy can never be `mergeable` — it routes to human review. So "became `mergeable` **and** *introduced* a trust-root touch / policy weakening" is impossible if the gate held; if a captured `after.json` shows it, the gate was likely **bypassed** (e.g. `--no-verify`) or the artifact was hand-edited. A legitimate repair (added approval evidence, narrowed scope) resolves to `mergeable` *without* introducing weakening, so it doesn't trip the alarm — verified by tests.
- Modeled on `feedback export`: a hand-built dict + a hand-written `docs/scenario-schema.v0.1.json` (jsonschema-validated). **Deterministic** (no wall-clock timestamp). With `--redact` (default) only **provenance** — sha256, length, diffstat — of the prompt/diff/transcript is kept, never raw content, so the scenario is safe to share; `--no-redact` embeds raw content for local full-fidelity replay.
- Auto-registers under the existing `feedback` sub-app (no `main.py` change). Surfaced in `.well-known`, `STABILITY.md` §Workflow-evidence capture, and `docs/INDEX.md`. ROADMAP item 2 marked first-cut-shipped.

This completes the P1 set: **#165** (P0 surfaces) → **#167** (`agent_controller`) → **#169** (protocol map) → **#172** (attestation) → **this** (flywheel).

## Type

- [x] CLI or GitHub Action behavior — new `agents-shipgate feedback capture` command
- [x] Report, schema, or SARIF output — new `scenario.json` artifact + hand-written `docs/scenario-schema.v0.1.json`

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- New `tests/test_workflow_evidence.py` (13 tests): the transition/gate-integrity signal (legit resolve vs `suspected_gate_bypass`, introduced-vs-pre-existing weakening, weakening-without-reaching-mergeable), evidence provenance + redaction (raw `text` only with `--no-redact`; diffstat), determinism, jsonschema validation (before-only + full), and the CLI (writes JSON; bad `--human-decision` → exit 2; missing input → exit 3).
- Live: captured a legit `blocked→mergeable` (no bypass) and a forged `mergeable`-with-trust-root-touch (`suspected_gate_bypass: true`); both schema-valid.
- `ruff check .` clean; full suite (`pytest -m "not perf"`) green.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (no new check IDs)
- [x] Report/schema changes are additive or documented in `STABILITY.md` — new derived artifact documented in `STABILITY.md` §Workflow-evidence capture; introduces no gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
