### PR TITLE
P2: dedupe the blocked verifier headline + canonical read-order fork

### DIFF
--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -18,6 +18,24 @@ agents-shipgate contract --json
 - Frozen-reference report schemas: [`v0.21`](report-schema.v0.21.json), [`v0.20`](report-schema.v0.20.json), [`v0.19`](report-schema.v0.19.json), [`v0.18`](report-schema.v0.18.json), [`v0.17`](report-schema.v0.17.json), [`v0.16`](report-schema.v0.16.json), [`v0.15`](report-schema.v0.15.json), [`v0.14`](report-schema.v0.14.json), [`v0.13`](report-schema.v0.13.json), [`v0.12`](report-schema.v0.12.json), [`v0.11`](report-schema.v0.11.json), [`v0.10`](report-schema.v0.10.json), [`v0.9`](report-schema.v0.9.json), [`v0.8`](report-schema.v0.8.json), [`v0.7`](report-schema.v0.7.json), [`v0.6`](report-schema.v0.6.json), older
 - Frozen-reference packet schemas live in [`docs/INDEX.md`](INDEX.md#reference).
 
+## Two read entry points
+
+There are two correct "read first" paths; which one applies depends on who is
+reading. They are not two decisions — they are two entry points into the same
+one decision engine.
+
+- **PR / controller flow** — an autonomous coding agent deciding *continue,
+  repair, or stop*. Read `agents-shipgate-reports/verifier.json`: start with
+  `agent_controller`, then `merge_verdict` (see "In `verifier.json`, read these
+  additive fields" below). `.well-known/agents-shipgate.json` → `verifier_read_order`
+  is the machine-readable form.
+- **Gate / CI flow** — deciding pass/fail, or any raw `report.json` consumer.
+  Read `agents-shipgate-reports/report.json` → `release_decision.decision` (the
+  next section). `.well-known` → `gating_signal` names this signal.
+
+`merge_verdict` is a deterministic projection of `release_decision.decision`, so
+the two can never disagree.
+
 ## Read these first for release gating
 
 In `agents-shipgate-reports/report.json`:

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -25,10 +25,11 @@ reading. They are not two decisions — they are two entry points into the same
 one decision engine.
 
 - **PR / controller flow** — an autonomous coding agent deciding *continue,
-  repair, or stop*. Read `agents-shipgate-reports/verifier.json`: start with
-  `agent_controller`, then `merge_verdict` (see "In `verifier.json`, read these
-  additive fields" below). `.well-known/agents-shipgate.json` → `verifier_read_order`
-  is the machine-readable form.
+  repair, or stop*. Read `agents-shipgate-reports/verifier.json`: lead with
+  `merge_verdict`, then read `agent_controller` for the imperative controls (see
+  "In `verifier.json`, read these additive fields" below).
+  `.well-known/agents-shipgate.json` → `verifier_read_order` is the
+  machine-readable form of this order.
 - **Gate / CI flow** — deciding pass/fail, or any raw `report.json` consumer.
   Read `agents-shipgate-reports/report.json` → `release_decision.decision` (the
   next section). `.well-known` → `gating_signal` names this signal.

--- a/docs/report-reading-for-agents.md
+++ b/docs/report-reading-for-agents.md
@@ -8,6 +8,8 @@ A reader's primer for `agents-shipgate-reports/report.json`. Walks the file in t
 
 ## TL;DR
 
+**This primer is the `report.json` / CI-gate read path.** If you are a PR/controller consumer — an autonomous coding agent deciding *continue, repair, or stop* — read `agents-shipgate-reports/verifier.json` first (`agent_controller`, then `merge_verdict`, a deterministic projection of the gate). See [`agent-contract-current.md` § Two read entry points](agent-contract-current.md#two-read-entry-points).
+
 **Read `release_decision.decision` first.** It is the gating signal — `"blocked" | "review_required" | "insufficient_evidence" | "passed"`, baseline-aware, stable since v0.8 (`insufficient_evidence` added v0.14). Switch on the enum with a `review_required` fallback for unknown future values per the [STABILITY.md additivity contract](../STABILITY.md#what-may-change-additively-in-any-minor-release). Everything else in the report is detail you reach for *after* the gate decision is captured.
 
 ```python

--- a/docs/report-reading-for-agents.md
+++ b/docs/report-reading-for-agents.md
@@ -8,7 +8,7 @@ A reader's primer for `agents-shipgate-reports/report.json`. Walks the file in t
 
 ## TL;DR
 
-**This primer is the `report.json` / CI-gate read path.** If you are a PR/controller consumer — an autonomous coding agent deciding *continue, repair, or stop* — read `agents-shipgate-reports/verifier.json` first (`agent_controller`, then `merge_verdict`, a deterministic projection of the gate). See [`agent-contract-current.md` § Two read entry points](agent-contract-current.md#two-read-entry-points).
+**This primer is the `report.json` / CI-gate read path.** If you are a PR/controller consumer — an autonomous coding agent deciding *continue, repair, or stop* — read `agents-shipgate-reports/verifier.json` first — `merge_verdict` (a deterministic projection of the gate), then `agent_controller` for imperative controls. See [`agent-contract-current.md` § Two read entry points](agent-contract-current.md#two-read-entry-points).
 
 **Read `release_decision.decision` first.** It is the gating signal — `"blocked" | "review_required" | "insufficient_evidence" | "passed"`, baseline-aware, stable since v0.8 (`insufficient_evidence` added v0.14). Switch on the enum with a `review_required` fallback for unknown future values per the [STABILITY.md additivity contract](../STABILITY.md#what-may-change-additively-in-any-minor-release). Everything else in the report is detail you reach for *after* the gate decision is captured.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -910,10 +910,11 @@ reading. They are not two decisions — they are two entry points into the same
 one decision engine.
 
 - **PR / controller flow** — an autonomous coding agent deciding *continue,
-  repair, or stop*. Read `agents-shipgate-reports/verifier.json`: start with
-  `agent_controller`, then `merge_verdict` (see "In `verifier.json`, read these
-  additive fields" below). `.well-known/agents-shipgate.json` → `verifier_read_order`
-  is the machine-readable form.
+  repair, or stop*. Read `agents-shipgate-reports/verifier.json`: lead with
+  `merge_verdict`, then read `agent_controller` for the imperative controls (see
+  "In `verifier.json`, read these additive fields" below).
+  `.well-known/agents-shipgate.json` → `verifier_read_order` is the
+  machine-readable form of this order.
 - **Gate / CI flow** — deciding pass/fail, or any raw `report.json` consumer.
   Read `agents-shipgate-reports/report.json` → `release_decision.decision` (the
   next section). `.well-known` → `gating_signal` names this signal.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -903,6 +903,24 @@ agents-shipgate contract --json
 - Frozen-reference report schemas: [`v0.21`](report-schema.v0.21.json), [`v0.20`](report-schema.v0.20.json), [`v0.19`](report-schema.v0.19.json), [`v0.18`](report-schema.v0.18.json), [`v0.17`](report-schema.v0.17.json), [`v0.16`](report-schema.v0.16.json), [`v0.15`](report-schema.v0.15.json), [`v0.14`](report-schema.v0.14.json), [`v0.13`](report-schema.v0.13.json), [`v0.12`](report-schema.v0.12.json), [`v0.11`](report-schema.v0.11.json), [`v0.10`](report-schema.v0.10.json), [`v0.9`](report-schema.v0.9.json), [`v0.8`](report-schema.v0.8.json), [`v0.7`](report-schema.v0.7.json), [`v0.6`](report-schema.v0.6.json), older
 - Frozen-reference packet schemas live in [`docs/INDEX.md`](INDEX.md#reference).
 
+## Two read entry points
+
+There are two correct "read first" paths; which one applies depends on who is
+reading. They are not two decisions — they are two entry points into the same
+one decision engine.
+
+- **PR / controller flow** — an autonomous coding agent deciding *continue,
+  repair, or stop*. Read `agents-shipgate-reports/verifier.json`: start with
+  `agent_controller`, then `merge_verdict` (see "In `verifier.json`, read these
+  additive fields" below). `.well-known/agents-shipgate.json` → `verifier_read_order`
+  is the machine-readable form.
+- **Gate / CI flow** — deciding pass/fail, or any raw `report.json` consumer.
+  Read `agents-shipgate-reports/report.json` → `release_decision.decision` (the
+  next section). `.well-known` → `gating_signal` names this signal.
+
+`merge_verdict` is a deterministic projection of `release_decision.decision`, so
+the two can never disagree.
+
 ## Read these first for release gating
 
 In `agents-shipgate-reports/report.json`:

--- a/src/agents_shipgate/core/findings/agent_summary.py
+++ b/src/agents_shipgate/core/findings/agent_summary.py
@@ -117,6 +117,11 @@ def build_agent_summary(
                 else "."
             )
         )
+        # The blocked release_decision.reason is always "{n} active findings
+        # block release." — exactly the blocker count this headline already
+        # leads with. Appending it just restates the count (and the headline's
+        # review-item clause is strictly more informative), so skip it.
+        append_reason = False
     elif verdict == "review_required":
         if needs_review > 0:
             head = f"{needs_review} finding(s) require human review"

--- a/tests/test_agent_action_summary.py
+++ b/tests/test_agent_action_summary.py
@@ -414,6 +414,32 @@ def test_build_agent_summary_blocked_recommends_apply_when_auto_appliable():
     assert "apply-patches" in (summary.first_recommended_action.command or "")
 
 
+def test_build_agent_summary_blocked_headline_does_not_duplicate_count():
+    # Regression: the blocked release_decision.reason ("{n} active findings block
+    # release.") restates the blocker count the headline already leads with, so
+    # it must not be appended a second time.
+    blocker = _make_finding(
+        check_id="SHIP-POLICY-APPROVAL-MISSING",
+        severity="critical",
+        agent_action="escalate_to_human",
+    )
+    summary = build_agent_summary(
+        findings=[blocker],
+        release_decision=_make_release_decision(
+            decision="blocked",
+            blockers=["SHIP-POLICY-APPROVAL-MISSING"],
+            reason="1 active finding blocks release.",
+        ),
+        json_report_path="/abs/agents-shipgate-reports/report.json",
+    )
+    assert summary.verdict == "blocked"
+    assert "1 active finding(s) block release" in summary.headline
+    # The "release" phrase appears exactly once — the reason is not re-appended
+    # after the headline already states the blocker count.
+    assert summary.headline.count("release") == 1, summary.headline
+    assert "blocks release" not in summary.headline  # the reason's verb form
+
+
 def test_first_recommended_action_uses_actual_json_report_path():
     """When the scan wrote its JSON to a custom path (e.g. via
     ``scan --out custom-reports``), the recommended apply-patches


### PR DESCRIPTION
## Summary

Two P2 agent-facing read-path fixes (one commit each, independently reviewable):

- **Dedupe the blocked verifier headline.** The blocked `agent_summary.headline` appended `release_decision.reason` even though it already led with the same blocker count — e.g. `"4 active finding(s) block release; 5 review item(s) accepted as debt. 4 active findings block release."` It now reads `"4 active finding(s) block release; 5 review item(s) accepted as debt."` The blocked reason is *always* exactly the count (`_decision_reason`), and the headline's review-item clause is strictly more informative, so skipping the append is lossless — matching the `review_required` branches that already suppress it. Regression test added.

- **Make the verifier-vs-gate read order an explicit fork.** Two correct "read first" paths exist — *controller* (`verifier.json` → `agent_controller`/`merge_verdict`) and *gate/CI* (`report.json` → `release_decision.decision`) — but they were stated in separate sections without an upfront fork, so a reader landing on one could take it as THE answer. Added a canonical **"Two read entry points"** section to `docs/agent-contract-current.md` and a pointer at the top of `docs/report-reading-for-agents.md`, framing them as two entry points into the same one decision engine (`merge_verdict` is a deterministic projection of `release_decision.decision`, so they never disagree). `llms-full.txt` rebuilt.

## Type

- [x] Report, schema, or SARIF output — `agent_summary.headline` is a text change to an existing field (no schema change)
- [x] Documentation only — the read-order fork docs

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- New regression test (`test_build_agent_summary_blocked_headline_does_not_duplicate_count`) pins the deduped headline; live refund fixture now emits the single-count headline.
- `tests/test_public_surface_contract.py` (the `agent-contract-current.md` canonical-doc check) and `tests/test_docs_links.py` green; `llms-full.txt` rebuilt from the changed source.
- `ruff check .` clean; full suite (`pytest -m "not perf"`) green.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A (no check changes)
- [x] Report/schema changes are additive or documented in `STABILITY.md` — N/A; the headline is a text change to an existing field, no schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
