### PR TITLE
Add durable capability vocabulary substrate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,8 +246,10 @@ the typed accessors; legacy callers may migrate incrementally.
 vocabulary on top of `Scope`, `SideEffect`, and `Action`. The main type,
 `CapabilityFactV1`, groups stable semantic identity, normalized effect,
 authority, controls, source evidence, risk tags, and separate identity /
-effect / authority / control / schema hashes. It is intended to become
-the substrate for future capability lockfiles, richer capability diffs,
+effect / authority / control / schema / risk / evidence hashes. The
+hashes use capability-specific canonical JSON so they do not inherit the
+finding fingerprint exclusion list. It is intended to become the
+substrate for future capability lockfiles, richer capability diffs,
 policy matching, and governance benchmark assertions.
 
 **Boundary.** `CapabilityFactV1` is not emitted in `report.json`, does

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,6 +240,26 @@ The existing string-based predicates in `core/risk_hints.py`
 public API used by every check in `checks/`. New code should prefer
 the typed accessors; legacy callers may migrate incrementally.
 
+## Internal capability substrate: `CapabilityFactV1`
+
+`core/capabilities.py` defines an internal, non-wire durable capability
+vocabulary on top of `Scope`, `SideEffect`, and `Action`. The main type,
+`CapabilityFactV1`, groups stable semantic identity, normalized effect,
+authority, controls, source evidence, risk tags, and separate identity /
+effect / authority / control / schema hashes. It is intended to become
+the substrate for future capability lockfiles, richer capability diffs,
+policy matching, and governance benchmark assertions.
+
+**Boundary.** `CapabilityFactV1` is not emitted in `report.json`, does
+not bump `report_schema_version`, and does not gate release. The release
+decision remains `release_decision.decision`; current public surfaces
+(`action_surface_facts`, `tool_surface_facts`, `capability_change`,
+`verifier.json`, and the Action outputs) remain projections of the
+existing scan pipeline. Phase-0 capability facts are built from typed
+`Action` objects via `build_capability_facts(...)` so they reuse the
+same provider, operation, scope, effect, approval, safeguard, and
+evidence semantics as Action Surface Diff.
+
 ## Reviewer surfaces: five lenses + three audit envelopes
 
 The emitted `report.json` and the Release Evidence Packet expose

--- a/src/agents_shipgate/core/capabilities.py
+++ b/src/agents_shipgate/core/capabilities.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agents_shipgate.core.domain import Action, Scope, Tool
+from agents_shipgate.core.findings.identity import _canonicalize_for_fingerprint
+from agents_shipgate.core.lenses.action_surface import build_action
+from agents_shipgate.schemas.capability_change import CapabilitySubjectKind
+from agents_shipgate.schemas.common import Confidence, ProvenanceKind
+from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.surfaces import ActionEffect
+
+
+class CapabilityIdentity(BaseModel):
+    """Stable semantic identity for an agent capability.
+
+    This is an internal, non-wire substrate. Source location, evidence,
+    controls, and schema details intentionally live outside identity so
+    unrelated file moves or metadata edits do not churn capability ids.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    agent_id: str
+    tool_id: str
+    tool_name: str
+    provider: str
+    operation: str
+    subject_kind: CapabilitySubjectKind = "action"
+    resource: str | None = None
+    scope: str | None = None
+
+
+class CapabilityEffect(BaseModel):
+    """Normalized side-effect view derived from ``SideEffect``."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    effect: ActionEffect
+    externally_visible: bool = False
+    handles_sensitive_data: bool = False
+    financial: bool = False
+    code_execution: bool = False
+    reversibility: Literal["reversible", "irreversible", "unknown"] = "unknown"
+    idempotency_known: bool | None = None
+    high_risk: bool = False
+
+
+class CapabilityAuthority(BaseModel):
+    """Authority source and scope facts for a capability."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    auth_type: str | None = None
+    credential_mode: str | None = None
+    source: str | None = None
+    scopes: tuple[str, ...] = Field(default_factory=tuple)
+    broad_scopes: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class CapabilityControls(BaseModel):
+    """Policy and safeguard controls already known to the action surface."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    approval_required: bool | None = None
+    approval_threshold: str | None = None
+    confirmation_required: bool | None = None
+    safeguard_idempotency: bool | None = None
+    safeguard_audit_log: bool | None = None
+    safeguard_rollback: bool | None = None
+    safeguard_dry_run: bool | None = None
+    evidence_owner: str | None = None
+    evidence_runbook: str | None = None
+    evidence_approval_ticket: str | None = None
+
+
+class CapabilityEvidence(BaseModel):
+    """Structured source provenance for a capability fact."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source_type: str
+    source_id: str | None = None
+    source_ref: str | None = None
+    source_location: str | None = None
+    source_path: str | None = None
+    source_start_line: int | None = None
+    source_end_line: int | None = None
+    source_start_column: int | None = None
+    source_pointer: str | None = None
+    provenance_kind: ProvenanceKind = "static_declaration"
+    confidence: Confidence = "medium"
+
+
+class CapabilityHashes(BaseModel):
+    """Separate hashes for the future lock/diff substrate."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    identity_hash: str
+    effect_hash: str
+    authority_hash: str
+    control_hash: str
+    schema_hash: str
+
+
+class CapabilityFactV1(BaseModel):
+    """Internal durable capability fact.
+
+    Phase 0 deliberately keeps this out of report.json and CLI output. It
+    is the substrate future lockfiles, policy matching, and governance
+    benchmarks can build on without changing the current release gate.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str
+    identity: CapabilityIdentity
+    effect: CapabilityEffect
+    authority: CapabilityAuthority
+    controls: CapabilityControls
+    evidence: CapabilityEvidence
+    risk_tags: tuple[str, ...] = Field(default_factory=tuple)
+    hashes: CapabilityHashes
+
+
+def capability_fact_from_action(
+    action: Action,
+    tool: Tool | None,
+    *,
+    confirmation_required: bool | None = None,
+) -> CapabilityFactV1:
+    """Build one internal capability fact from a typed action.
+
+    The public two-argument call shape stays simple for tests and future
+    callers; ``build_capability_facts`` supplies manifest-derived
+    confirmation policy when it has that context.
+    """
+
+    identity = CapabilityIdentity(
+        agent_id=action.agent_id,
+        tool_id=action.tool_id,
+        tool_name=action.tool_name,
+        provider=action.provider,
+        operation=action.operation,
+        subject_kind="action",
+        resource=_resource_identity(action.scopes),
+        scope=_scope_identity(action.scopes),
+    )
+    effect = _capability_effect(action)
+    authority = _capability_authority(action, tool)
+    controls = _capability_controls(
+        action,
+        confirmation_required=confirmation_required,
+    )
+    evidence = _capability_evidence(action, tool)
+    hashes = CapabilityHashes(
+        identity_hash=_stable_hash(identity.model_dump(mode="json")),
+        effect_hash=_stable_hash(effect.model_dump(mode="json")),
+        authority_hash=_stable_hash(authority.model_dump(mode="json")),
+        control_hash=_stable_hash(controls.model_dump(mode="json")),
+        schema_hash=_stable_hash(
+            {
+                "input_schema": action.input_schema,
+                "parameters": action.parameters_for_hash,
+            }
+        ),
+    )
+    return CapabilityFactV1(
+        id=f"cap_{hashes.identity_hash}",
+        identity=identity,
+        effect=effect,
+        authority=authority,
+        controls=controls,
+        evidence=evidence,
+        risk_tags=tuple(sorted(set(action.risk_tags))),
+        hashes=hashes,
+    )
+
+
+def build_capability_facts(
+    manifest: AgentsShipgateManifest,
+    *,
+    agent_id: str,
+    tools: list[Tool],
+) -> list[CapabilityFactV1]:
+    """Build deterministic internal capability facts for a tool list."""
+
+    declarations = {entry.tool: entry for entry in manifest.action_surface.actions}
+    confirmation_tools = manifest.policies.confirmation_tools()
+    facts: list[CapabilityFactV1] = []
+    for tool in sorted(tools, key=lambda item: (item.name, item.id)):
+        action = build_action(
+            manifest,
+            agent_id=agent_id,
+            tool=tool,
+            declaration=declarations.get(tool.name),
+        )
+        facts.append(
+            capability_fact_from_action(
+                action,
+                tool,
+                confirmation_required=tool.name in confirmation_tools,
+            )
+        )
+    return sorted(facts, key=_capability_sort_key)
+
+
+def _capability_sort_key(
+    fact: CapabilityFactV1,
+) -> tuple[str, str, str, str, str, str]:
+    identity = fact.identity
+    return (
+        identity.agent_id,
+        identity.provider,
+        identity.operation,
+        identity.tool_name,
+        identity.scope or "",
+        fact.id,
+    )
+
+
+def _capability_effect(action: Action) -> CapabilityEffect:
+    side_effect = action.side_effect
+    return CapabilityEffect(
+        effect=side_effect.effect,
+        externally_visible=side_effect.externally_visible,
+        handles_sensitive_data=side_effect.handles_sensitive_data,
+        financial=side_effect.financial,
+        code_execution=side_effect.code_execution,
+        reversibility=side_effect.reversibility,
+        idempotency_known=side_effect.idempotency_known,
+        high_risk=side_effect.is_high_risk,
+    )
+
+
+def _capability_authority(action: Action, tool: Tool | None) -> CapabilityAuthority:
+    scopes = tuple(sorted(set(action.scope_strings)))
+    return CapabilityAuthority(
+        auth_type=tool.auth.type if tool else None,
+        credential_mode=tool.auth.credential_mode if tool else None,
+        source=tool.auth.source if tool else None,
+        scopes=scopes,
+        broad_scopes=tuple(sorted(scope.raw for scope in action.scopes if scope.is_broad())),
+    )
+
+
+def _capability_controls(
+    action: Action,
+    *,
+    confirmation_required: bool | None,
+) -> CapabilityControls:
+    return CapabilityControls(
+        approval_required=action.approval_required,
+        approval_threshold=action.approval_threshold,
+        confirmation_required=confirmation_required,
+        safeguard_idempotency=action.safeguard_idempotency,
+        safeguard_audit_log=action.safeguard_audit_log,
+        safeguard_rollback=action.safeguard_rollback,
+        safeguard_dry_run=action.safeguard_dry_run,
+        evidence_owner=action.evidence_owner,
+        evidence_runbook=action.evidence_runbook,
+        evidence_approval_ticket=action.evidence_approval_ticket,
+    )
+
+
+def _capability_evidence(action: Action, tool: Tool | None) -> CapabilityEvidence:
+    if tool is None:
+        return CapabilityEvidence(
+            source_type=action.source_type,
+            source_id=action.source_id,
+            confidence="medium",
+        )
+    return CapabilityEvidence(
+        source_type=tool.source_type,
+        source_id=tool.source_id,
+        source_ref=tool.source_ref,
+        source_location=tool.source_location,
+        source_path=tool.source_path,
+        source_start_line=tool.source_start_line,
+        source_end_line=tool.source_end_line,
+        source_start_column=tool.source_start_column,
+        source_pointer=tool.source_pointer,
+        provenance_kind=_provenance_kind(tool),
+        confidence=tool.extraction_confidence,
+    )
+
+
+def _provenance_kind(tool: Tool) -> ProvenanceKind:
+    if tool.source_type in _AST_SOURCE_TYPES:
+        return "ast_extraction"
+    return "static_declaration"
+
+
+def _scope_identity(scopes: list[Scope]) -> str | None:
+    values = sorted({scope.raw for scope in scopes if scope.raw})
+    return "\n".join(values) if values else None
+
+
+def _resource_identity(scopes: list[Scope]) -> str | None:
+    values = sorted({scope.resource for scope in scopes if scope.resource})
+    return "\n".join(values) if values else None
+
+
+def _stable_hash(value: Any) -> str:
+    canonical = _canonicalize_for_fingerprint(value)
+    payload = json.dumps(canonical, sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+_AST_SOURCE_TYPES = frozenset(
+    {
+        "sdk_function",
+        "openai_agents_sdk",
+        "google_adk_function",
+        "langchain_function",
+        "langchain_structured_tool",
+        "crewai_function",
+        "crewai_class_tool",
+    }
+)
+
+
+__all__ = [
+    "CapabilityAuthority",
+    "CapabilityControls",
+    "CapabilityEffect",
+    "CapabilityEvidence",
+    "CapabilityFactV1",
+    "CapabilityHashes",
+    "CapabilityIdentity",
+    "build_capability_facts",
+    "capability_fact_from_action",
+]

--- a/src/agents_shipgate/core/capabilities.py
+++ b/src/agents_shipgate/core/capabilities.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from agents_shipgate.core.domain import Action, Scope, Tool
-from agents_shipgate.core.findings.identity import _canonicalize_for_fingerprint
+from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.lenses.action_surface import build_action
 from agents_shipgate.schemas.capability_change import CapabilitySubjectKind
 from agents_shipgate.schemas.common import Confidence, ProvenanceKind
@@ -31,8 +31,8 @@ class CapabilityIdentity(BaseModel):
     provider: str
     operation: str
     subject_kind: CapabilitySubjectKind = "action"
-    resource: str | None = None
-    scope: str | None = None
+    resource: tuple[str, ...] = Field(default_factory=tuple)
+    scope: tuple[str, ...] = Field(default_factory=tuple)
 
 
 class CapabilityEffect(BaseModel):
@@ -69,7 +69,7 @@ class CapabilityControls(BaseModel):
 
     approval_required: bool | None = None
     approval_threshold: str | None = None
-    confirmation_required: bool | None = None
+    confirmation_required: bool = False
     safeguard_idempotency: bool | None = None
     safeguard_audit_log: bool | None = None
     safeguard_rollback: bool | None = None
@@ -107,6 +107,8 @@ class CapabilityHashes(BaseModel):
     authority_hash: str
     control_hash: str
     schema_hash: str
+    risk_hash: str
+    evidence_hash: str
 
 
 class CapabilityFactV1(BaseModel):
@@ -133,7 +135,7 @@ def capability_fact_from_action(
     action: Action,
     tool: Tool | None,
     *,
-    confirmation_required: bool | None = None,
+    confirmation_required: bool = False,
 ) -> CapabilityFactV1:
     """Build one internal capability fact from a typed action.
 
@@ -160,16 +162,18 @@ def capability_fact_from_action(
     )
     evidence = _capability_evidence(action, tool)
     hashes = CapabilityHashes(
-        identity_hash=_stable_hash(identity.model_dump(mode="json")),
-        effect_hash=_stable_hash(effect.model_dump(mode="json")),
-        authority_hash=_stable_hash(authority.model_dump(mode="json")),
-        control_hash=_stable_hash(controls.model_dump(mode="json")),
-        schema_hash=_stable_hash(
+        identity_hash=_capability_stable_hash(identity.model_dump(mode="json")),
+        effect_hash=_capability_stable_hash(effect.model_dump(mode="json")),
+        authority_hash=_capability_stable_hash(authority.model_dump(mode="json")),
+        control_hash=_capability_stable_hash(controls.model_dump(mode="json")),
+        schema_hash=_capability_stable_hash(
             {
                 "input_schema": action.input_schema,
                 "parameters": action.parameters_for_hash,
             }
         ),
+        risk_hash=_capability_stable_hash({"risk_tags": sorted(set(action.risk_tags))}),
+        evidence_hash=_capability_stable_hash(evidence.model_dump(mode="json")),
     )
     return CapabilityFactV1(
         id=f"cap_{hashes.identity_hash}",
@@ -194,7 +198,7 @@ def build_capability_facts(
     declarations = {entry.tool: entry for entry in manifest.action_surface.actions}
     confirmation_tools = manifest.policies.confirmation_tools()
     facts: list[CapabilityFactV1] = []
-    for tool in sorted(tools, key=lambda item: (item.name, item.id)):
+    for tool in tools:
         action = build_action(
             manifest,
             agent_id=agent_id,
@@ -208,6 +212,7 @@ def build_capability_facts(
                 confirmation_required=tool.name in confirmation_tools,
             )
         )
+    _validate_unique_capability_ids(facts)
     return sorted(facts, key=_capability_sort_key)
 
 
@@ -220,7 +225,7 @@ def _capability_sort_key(
         identity.provider,
         identity.operation,
         identity.tool_name,
-        identity.scope or "",
+        "\n".join(identity.scope),
         fact.id,
     )
 
@@ -253,7 +258,7 @@ def _capability_authority(action: Action, tool: Tool | None) -> CapabilityAuthor
 def _capability_controls(
     action: Action,
     *,
-    confirmation_required: bool | None,
+    confirmation_required: bool,
 ) -> CapabilityControls:
     return CapabilityControls(
         approval_required=action.approval_required,
@@ -267,6 +272,24 @@ def _capability_controls(
         evidence_runbook=action.evidence_runbook,
         evidence_approval_ticket=action.evidence_approval_ticket,
     )
+
+
+def _validate_unique_capability_ids(facts: list[CapabilityFactV1]) -> None:
+    by_id: dict[str, list[str]] = {}
+    for fact in facts:
+        by_id.setdefault(fact.id, []).append(fact.identity.tool_name)
+    duplicates = {
+        capability_id: sorted(tool_names)
+        for capability_id, tool_names in by_id.items()
+        if len(tool_names) > 1
+    }
+    if not duplicates:
+        return
+    details = "; ".join(
+        f"{capability_id!r} used by {', '.join(tool_names)}"
+        for capability_id, tool_names in sorted(duplicates.items())
+    )
+    raise ConfigError(f"Duplicate capability ids are not allowed: {details}.")
 
 
 def _capability_evidence(action: Action, tool: Tool | None) -> CapabilityEvidence:
@@ -297,31 +320,58 @@ def _provenance_kind(tool: Tool) -> ProvenanceKind:
     return "static_declaration"
 
 
-def _scope_identity(scopes: list[Scope]) -> str | None:
-    values = sorted({scope.raw for scope in scopes if scope.raw})
-    return "\n".join(values) if values else None
+def _scope_identity(scopes: list[Scope]) -> tuple[str, ...]:
+    return tuple(sorted({scope.raw for scope in scopes if scope.raw}))
 
 
-def _resource_identity(scopes: list[Scope]) -> str | None:
-    values = sorted({scope.resource for scope in scopes if scope.resource})
-    return "\n".join(values) if values else None
+def _resource_identity(scopes: list[Scope]) -> tuple[str, ...]:
+    return tuple(sorted({scope.resource for scope in scopes if scope.resource}))
 
 
-def _stable_hash(value: Any) -> str:
-    canonical = _canonicalize_for_fingerprint(value)
+def _capability_stable_hash(value: Any) -> str:
+    canonical = _canonicalize_for_capability_hash(value)
     payload = json.dumps(canonical, sort_keys=True, default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
+def _canonicalize_for_capability_hash(value: Any) -> Any:
+    """Canonical JSON-like shape for capability hashes.
+
+    Deliberately separate from finding fingerprint canonicalization:
+    capability hashes must not inherit the finding-specific exclusion
+    list for keys such as ``observed`` or ``source_provenance``.
+    """
+
+    if isinstance(value, dict):
+        return {
+            key: _canonicalize_for_capability_hash(value[key])
+            for key in sorted(value)
+        }
+    if isinstance(value, list):
+        items = [_canonicalize_for_capability_hash(item) for item in value]
+        return sorted(
+            items,
+            key=lambda item: json.dumps(item, sort_keys=True, default=str),
+        )
+    if isinstance(value, tuple | set):
+        return _canonicalize_for_capability_hash(list(value))
+    return value
+
+
 _AST_SOURCE_TYPES = frozenset(
     {
-        "sdk_function",
-        "openai_agents_sdk",
+        # Python/static-AST extracted tools. Declarative inventories and
+        # workflow JSON surfaces (``*_inventory``, n8n, MCP, OpenAPI,
+        # OpenAI/Anthropic API artifacts) intentionally stay
+        # ``static_declaration``.
+        "crewai_class_tool",
+        "crewai_function",
+        "crewai_prebuilt_tool",
         "google_adk_function",
         "langchain_function",
         "langchain_structured_tool",
-        "crewai_function",
-        "crewai_class_tool",
+        "openai_agents_sdk",
+        "sdk_function",
     }
 )
 

--- a/src/agents_shipgate/core/lenses/tool_surface.py
+++ b/src/agents_shipgate/core/lenses/tool_surface.py
@@ -958,6 +958,12 @@ def _diff_base(reference: ToolSurfaceDiffReference | None) -> ToolSurfaceDiffBas
 
 
 def _stable_hash(value: Any) -> str:
+    # Follow-up: action/tool-surface hashes still use the finding
+    # fingerprint canonicalizer, which drops finding-specific evidence
+    # keys (for example ``observed`` and ``source_provenance``). The
+    # internal capability substrate intentionally uses its own
+    # canonicalizer; migrate this public hash path separately because it
+    # changes emitted ActionFact/ToolSurface hashes.
     canonical = _canonicalize_for_fingerprint(value)
     payload = json.dumps(canonical, sort_keys=True, default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]

--- a/tests/test_capability_domain.py
+++ b/tests/test_capability_domain.py
@@ -13,6 +13,7 @@ from agents_shipgate.core.domain import (
     ToolParameter,
     ToolRiskHint,
 )
+from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.lenses.action_surface import action_to_fact, build_action
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
 from agents_shipgate.schemas.report import ReadinessReport
@@ -48,6 +49,7 @@ def _tool(
     scopes: list[str] | None = None,
     hints: list[tuple[str, str]] | None = None,
     parameters: list[ToolParameter] | None = None,
+    input_schema: dict[str, object] | None = None,
     source_path: str | None = "tools/support.openapi.yaml",
     source_start_line: int | None = 12,
 ) -> Tool:
@@ -61,6 +63,7 @@ def _tool(
         source_start_line=source_start_line,
         source_pointer=f"/paths/{name}",
         annotations=annotations or {},
+        input_schema=input_schema or {},
         auth=AuthInfo(
             type="oauth",
             credential_mode="delegated",
@@ -114,7 +117,7 @@ def test_scope_and_broad_scope_facts_reuse_scope_parser() -> None:
         ],
     )[0]
 
-    assert fact.identity.scope == "stripe:*\nstripe:refunds:write"
+    assert fact.identity.scope == ("stripe:*", "stripe:refunds:write")
     assert fact.authority.scopes == ("stripe:*", "stripe:refunds:write")
     assert fact.authority.broad_scopes == tuple(
         scope
@@ -219,6 +222,19 @@ def test_controls_map_from_action_and_manifest_confirmation_policy() -> None:
     assert fact.controls.evidence_approval_ticket == "SEC-42"
 
 
+def test_default_confirmation_hash_matches_batch_builder_without_policy() -> None:
+    manifest = _manifest()
+    tool = _tool("messaging.preview_email", annotations={"httpMethod": "GET"})
+    action = build_action(manifest, agent_id="agent:one", tool=tool, declaration=None)
+
+    direct = capability_fact_from_action(action, tool)
+    batch = build_capability_facts(manifest, agent_id="agent:one", tools=[tool])[0]
+
+    assert direct.controls.confirmation_required is False
+    assert batch.controls.confirmation_required is False
+    assert direct.hashes.control_hash == batch.hashes.control_hash
+
+
 def test_capability_facts_sort_stably_regardless_of_tool_input_order() -> None:
     alpha = _tool("alpha.read", annotations={"httpMethod": "GET"}, scopes=["alpha:read"])
     beta = _tool(
@@ -233,6 +249,122 @@ def test_capability_facts_sort_stably_regardless_of_tool_input_order() -> None:
 
     assert [fact.id for fact in first] == [fact.id for fact in second]
     assert [fact.identity.tool_name for fact in first] == ["alpha.read", "beta.write"]
+
+
+def test_capability_schema_hash_does_not_drop_finding_evidence_keys() -> None:
+    manifest = _manifest()
+    base = _tool(
+        "cases.search",
+        annotations={"httpMethod": "POST"},
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    with_observed = _tool(
+        "cases.search",
+        annotations={"httpMethod": "POST"},
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "observed": {"type": "string"},
+                "source_provenance": {"type": "string"},
+            },
+            "default_severity": "high",
+        },
+    )
+
+    base_fact = build_capability_facts(manifest, agent_id="agent:one", tools=[base])[0]
+    observed_fact = build_capability_facts(
+        manifest,
+        agent_id="agent:one",
+        tools=[with_observed],
+    )[0]
+
+    assert base_fact.id == observed_fact.id
+    assert base_fact.hashes.schema_hash != observed_fact.hashes.schema_hash
+
+
+def test_risk_hash_tracks_raw_risk_tag_changes_without_effect_change() -> None:
+    manifest = _manifest()
+    base = _tool(
+        "cases.update",
+        annotations={"httpMethod": "POST"},
+        hints=[("write", "high")],
+    )
+    with_extra_tag = _tool(
+        "cases.update",
+        annotations={"httpMethod": "POST"},
+        hints=[("write", "high"), ("filesystem_write", "medium")],
+    )
+
+    base_fact = build_capability_facts(manifest, agent_id="agent:one", tools=[base])[0]
+    tagged_fact = build_capability_facts(
+        manifest,
+        agent_id="agent:one",
+        tools=[with_extra_tag],
+    )[0]
+
+    assert base_fact.id == tagged_fact.id
+    assert base_fact.effect.effect == tagged_fact.effect.effect
+    assert base_fact.hashes.effect_hash == tagged_fact.hashes.effect_hash
+    assert base_fact.hashes.risk_hash != tagged_fact.hashes.risk_hash
+
+
+def test_capability_evidence_provenance_classifies_ast_and_static_sources() -> None:
+    manifest = _manifest()
+    prebuilt = _tool("crew.file_read", source_type="crewai_prebuilt_tool")
+    adk_container = _tool("adk.container", source_type="google_adk")
+    adk_function = _tool("adk.lookup", source_type="google_adk_function")
+    inventory = _tool("lc.search", source_type="langchain_inventory")
+    workflow = _tool("n8n.mcp", source_type="n8n_mcp_client_tool")
+
+    facts = {
+        fact.identity.tool_name: fact
+        for fact in build_capability_facts(
+            manifest,
+            agent_id="agent:one",
+            tools=[prebuilt, adk_container, adk_function, inventory, workflow],
+        )
+    }
+
+    assert facts["crew.file_read"].evidence.provenance_kind == "ast_extraction"
+    assert facts["adk.container"].evidence.provenance_kind == "static_declaration"
+    assert facts["adk.lookup"].evidence.provenance_kind == "ast_extraction"
+    assert facts["lc.search"].evidence.provenance_kind == "static_declaration"
+    assert facts["n8n.mcp"].evidence.provenance_kind == "static_declaration"
+
+
+def test_capability_fact_from_action_supports_missing_tool_context() -> None:
+    manifest = _manifest()
+    tool = _tool(
+        "cases.update",
+        annotations={"httpMethod": "POST"},
+        scopes=["cases:write"],
+        hints=[("write", "high")],
+    )
+    action = build_action(manifest, agent_id="agent:one", tool=tool, declaration=None)
+
+    fact = capability_fact_from_action(action, None)
+
+    assert fact.identity.tool_name == "cases.update"
+    assert fact.authority.auth_type is None
+    assert fact.authority.scopes == ("cases:write",)
+    assert fact.evidence.source_type == "openapi"
+    assert fact.evidence.source_id == "support_api"
+
+
+def test_duplicate_capability_ids_raise() -> None:
+    tool = _tool("cases.update", annotations={"httpMethod": "POST"})
+
+    try:
+        build_capability_facts(
+            _manifest(),
+            agent_id="agent:one",
+            tools=[tool, tool.model_copy(deep=True)],
+        )
+    except ConfigError as exc:
+        assert "Duplicate capability ids" in str(exc)
+    else:  # pragma: no cover - defensive assertion path.
+        raise AssertionError("expected duplicate capability id failure")
 
 
 def test_building_capability_facts_does_not_change_action_fact_output() -> None:

--- a/tests/test_capability_domain.py
+++ b/tests/test_capability_domain.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+
+from agents_shipgate.core.capabilities import (
+    build_capability_facts,
+    capability_fact_from_action,
+)
+from agents_shipgate.core.domain import (
+    AuthInfo,
+    Scope,
+    Tool,
+    ToolParameter,
+    ToolRiskHint,
+)
+from agents_shipgate.core.lenses.action_surface import action_to_fact, build_action
+from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.report import ReadinessReport
+
+
+def _manifest(**updates: object) -> AgentsShipgateManifest:
+    data: dict[str, object] = {
+        "version": "0.1",
+        "project": {"name": "capability-domain"},
+        "agent": {
+            "name": "support-agent",
+            "declared_purpose": ["Support customer account workflows."],
+        },
+        "environment": {"target": "local"},
+        "tool_sources": [
+            {
+                "id": "support_api",
+                "type": "openapi",
+                "path": "tools/support.openapi.yaml",
+            }
+        ],
+    }
+    data.update(updates)
+    return AgentsShipgateManifest.model_validate(data)
+
+
+def _tool(
+    name: str,
+    *,
+    source_type: str = "openapi",
+    source_id: str | None = "support_api",
+    annotations: dict[str, object] | None = None,
+    scopes: list[str] | None = None,
+    hints: list[tuple[str, str]] | None = None,
+    parameters: list[ToolParameter] | None = None,
+    source_path: str | None = "tools/support.openapi.yaml",
+    source_start_line: int | None = 12,
+) -> Tool:
+    return Tool(
+        id=f"tool:{name}",
+        name=name,
+        description=f"{name} test tool",
+        source_type=source_type,
+        source_id=source_id,
+        source_path=source_path,
+        source_start_line=source_start_line,
+        source_pointer=f"/paths/{name}",
+        annotations=annotations or {},
+        auth=AuthInfo(
+            type="oauth",
+            credential_mode="delegated",
+            source="manifest",
+            scopes=scopes or [],
+        ),
+        risk_hints=[
+            ToolRiskHint(tag=tag, source="test", confidence=confidence)
+            for tag, confidence in (hints or [])
+        ],
+        parameters=parameters or [],
+        owner="support-platform",
+        extraction_confidence="high",
+    )
+
+
+def _dump_facts(tools: list[Tool]) -> str:
+    facts = build_capability_facts(_manifest(), agent_id="agent:one", tools=tools)
+    return json.dumps(
+        [fact.model_dump(mode="json") for fact in facts],
+        sort_keys=True,
+    )
+
+
+def test_capability_facts_are_deterministic_for_repeated_builds() -> None:
+    tool = _tool(
+        "stripe.create_refund",
+        annotations={"httpMethod": "POST"},
+        scopes=["stripe:refunds:write"],
+        hints=[("write", "high"), ("financial_action", "high")],
+        parameters=[ToolParameter(name="amount", type="number", required=True)],
+    )
+
+    first = _dump_facts([tool])
+    second = _dump_facts([tool.model_copy(deep=True)])
+
+    assert first == second
+    assert '"id": "cap_' in first
+
+
+def test_scope_and_broad_scope_facts_reuse_scope_parser() -> None:
+    fact = build_capability_facts(
+        _manifest(),
+        agent_id="agent:one",
+        tools=[
+            _tool(
+                "stripe.refund_admin",
+                scopes=["stripe:*", "stripe:refunds:write"],
+                hints=[("write", "high")],
+            )
+        ],
+    )[0]
+
+    assert fact.identity.scope == "stripe:*\nstripe:refunds:write"
+    assert fact.authority.scopes == ("stripe:*", "stripe:refunds:write")
+    assert fact.authority.broad_scopes == tuple(
+        scope
+        for scope in fact.authority.scopes
+        if Scope.parse(scope).is_broad()
+    )
+
+
+def test_source_location_does_not_change_capability_identity() -> None:
+    manifest = _manifest()
+    original = _tool(
+        "cases.list",
+        annotations={"httpMethod": "GET"},
+        scopes=["cases:read"],
+        source_path="tools/one.yaml",
+        source_start_line=10,
+    )
+    moved = _tool(
+        "cases.list",
+        annotations={"httpMethod": "GET"},
+        scopes=["cases:read"],
+        source_path="tools/two.yaml",
+        source_start_line=200,
+    )
+
+    first = build_capability_facts(manifest, agent_id="agent:one", tools=[original])[0]
+    second = build_capability_facts(manifest, agent_id="agent:one", tools=[moved])[0]
+
+    assert first.id == second.id
+    assert first.hashes.identity_hash == second.hashes.identity_hash
+    assert first.evidence.source_path != second.evidence.source_path
+    assert first.evidence.source_start_line != second.evidence.source_start_line
+
+
+def test_effect_classification_matches_typed_action_side_effect() -> None:
+    manifest = _manifest()
+    tool = _tool(
+        "stripe.create_refund",
+        annotations={"httpMethod": "POST"},
+        scopes=["stripe:refunds:write"],
+        hints=[("write", "high"), ("financial_action", "high")],
+    )
+    action = build_action(manifest, agent_id="agent:one", tool=tool, declaration=None)
+    fact = capability_fact_from_action(action, tool)
+
+    assert fact.effect.effect == action.effect
+    assert fact.effect.high_risk == action.side_effect.is_high_risk
+    assert fact.effect.financial is True
+    assert fact.effect.externally_visible is True
+
+
+def test_controls_map_from_action_and_manifest_confirmation_policy() -> None:
+    manifest = _manifest(
+        policies={
+            "require_approval_for_tools": ["messaging.send_customer_email"],
+            "require_confirmation_for_tools": ["messaging.send_customer_email"],
+            "require_idempotency_for_tools": ["messaging.send_customer_email"],
+        },
+        action_surface={
+            "actions": [
+                {
+                    "tool": "messaging.send_customer_email",
+                    "approval": {"threshold": "manager"},
+                    "safeguards": {
+                        "audit_log": True,
+                        "rollback": True,
+                        "dry_run": False,
+                    },
+                    "evidence": {
+                        "owner": "support-ops",
+                        "runbook": "RUNBOOK-12",
+                        "approval_ticket": "SEC-42",
+                    },
+                }
+            ]
+        },
+    )
+    fact = build_capability_facts(
+        manifest,
+        agent_id="agent:one",
+        tools=[
+            _tool(
+                "messaging.send_customer_email",
+                hints=[
+                    ("write", "high"),
+                    ("customer_communication", "high"),
+                    ("external_write", "high"),
+                ],
+            )
+        ],
+    )[0]
+
+    assert fact.controls.approval_required is True
+    assert fact.controls.approval_threshold == "manager"
+    assert fact.controls.confirmation_required is True
+    assert fact.controls.safeguard_idempotency is True
+    assert fact.controls.safeguard_audit_log is True
+    assert fact.controls.safeguard_rollback is True
+    assert fact.controls.safeguard_dry_run is False
+    assert fact.controls.evidence_owner == "support-ops"
+    assert fact.controls.evidence_runbook == "RUNBOOK-12"
+    assert fact.controls.evidence_approval_ticket == "SEC-42"
+
+
+def test_capability_facts_sort_stably_regardless_of_tool_input_order() -> None:
+    alpha = _tool("alpha.read", annotations={"httpMethod": "GET"}, scopes=["alpha:read"])
+    beta = _tool(
+        "beta.write",
+        annotations={"httpMethod": "POST"},
+        scopes=["beta:write"],
+        hints=[("write", "high")],
+    )
+
+    first = build_capability_facts(_manifest(), agent_id="agent:one", tools=[beta, alpha])
+    second = build_capability_facts(_manifest(), agent_id="agent:one", tools=[alpha, beta])
+
+    assert [fact.id for fact in first] == [fact.id for fact in second]
+    assert [fact.identity.tool_name for fact in first] == ["alpha.read", "beta.write"]
+
+
+def test_building_capability_facts_does_not_change_action_fact_output() -> None:
+    manifest = _manifest()
+    tool = _tool(
+        "billing.charge",
+        annotations={"httpMethod": "POST"},
+        scopes=["billing:charges:write"],
+        hints=[("write", "high"), ("financial_action", "high")],
+    )
+    before = action_to_fact(
+        build_action(manifest, agent_id="agent:one", tool=tool, declaration=None)
+    ).model_dump(mode="json")
+
+    build_capability_facts(manifest, agent_id="agent:one", tools=[tool])
+
+    after = action_to_fact(
+        build_action(manifest, agent_id="agent:one", tool=tool, declaration=None)
+    ).model_dump(mode="json")
+    assert before == after
+
+
+def test_phase_zero_does_not_bump_report_schema_version() -> None:
+    assert ReadinessReport.model_fields["report_schema_version"].default == "0.22"


### PR DESCRIPTION
## Summary
- Add an internal-only `CapabilityFactV1` substrate on top of existing `Scope`, `SideEffect`, and `Action` types.
- Build deterministic capability facts from typed actions with stable identity, effect, authority, controls, evidence, and hashes.
- Document the new capability substrate boundary in the architecture guide without changing public report schema or release gating.

## Testing
- Added unit coverage for deterministic IDs and hashes, source-location stability, effect/control mapping, stable ordering, and ActionFact parity.
- Verified the new capability-domain tests alongside existing action-surface and verifier scenario tests.
- Confirmed schema and public-surface contract tests still pass.