### PR TITLE
Extract shared boundary diff plumbing; add pilot re-engagement kit

### DIFF
--- a/docs/design-partner-reengagement.md
+++ b/docs/design-partner-reengagement.md
@@ -1,0 +1,56 @@
+# Design-Partner Re-engagement: the IE Fix Follow-up
+
+Use this when going back to a pilot that stalled on
+`insufficient_evidence` (the 2026-06-01 pilot's exact failure mode), and
+as the template for new outreach. Personalize the bracketed parts; keep
+it under 150 words.
+
+## The message (email / Slack)
+
+> Subject: The thing that blocked your Shipgate pilot is fixed
+>
+> Hi [name] — quick follow-up on the verifier run we did on [PR /
+> repo]. It returned `insufficient_evidence` because your dynamic
+> toolkit factory hid the tool surface from static analysis, and the
+> verdict gave you nowhere to go. That was our bug, not yours.
+>
+> v0.12.0 changes this in two ways:
+>
+> 1. Every evidence gap now comes with a concrete next action
+>    (`evidence_gaps[]` names the tool, why confidence is low, and the
+>    exact manifest key to fix it), and the scan writes a ready-to-edit
+>    `suggested-inventory.json` skeleton next to the report.
+> 2. If a PR ever *removes or broadens* a config-bound toolkit's
+>    allowlist, that's now a blocking check, not an evidence shrug.
+>
+> Same PR, one command, ~5 minutes: `pipx upgrade agents-shipgate &&
+> agents-shipgate verify --base origin/main --head HEAD --format json`.
+> Could we re-run it this week? I'll be on the call if you want.
+
+## For new prospects: lead with the zero-config audit
+
+No manifest, no CI change, read-only, one command:
+
+```bash
+pipx install agents-shipgate
+agents-shipgate audit --host
+```
+
+One page: every MCP server, permission rule (wildcards flagged), hook,
+and workflow write scope their coding agents currently hold. Reviewing
+it together surfaces the first governance question; the verifier pilot
+([design-partner-verifier-pilot.md](design-partner-verifier-pilot.md))
+is the natural next step.
+
+## What to capture from the re-run
+
+Per the pilot runbook: the verifier artifacts, a redacted
+`feedback export`, and specifically for re-engaged IE pilots —
+
+- Did `evidence_gaps[].next_action` lead to a working inventory without
+  human research? (time-to-green is the metric)
+- Was `suggested-inventory.json` usable as-written, or did entries need
+  manual rework? (skeleton quality)
+- Did the final verdict change category (IE → review_required/blocked)?
+
+These three answers feed directly into the v0.13 priorities.

--- a/marketing/demo-agent-weakens-gate.sh
+++ b/marketing/demo-agent-weakens-gate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Driver for the "agent deletes the gate" demo recording.
+# Record with:  asciinema rec marketing/agent-weakens-gate.cast \
+#                 --command "bash marketing/demo-agent-weakens-gate.sh" --overwrite
+# Script + voiceover beats: marketing/demo-agent-weakens-gate.md
+set -euo pipefail
+
+say() { printf '\n\033[1;36m# %s\033[0m\n' "$1"; sleep "${2:-2}"; }
+run() { printf '\033[1;33m$ %s\033[0m\n' "$1"; sleep 1; eval "$1"; }
+
+clear
+say "Your coding agent's PR fails the release gate." 2
+say "The cheapest way for it to pass? Delete the gate." 2
+say "Watch what happens when it tries:" 1
+
+run "agents-shipgate --version"
+sleep 1
+
+OUT=$(mktemp -d)/reports
+run "agents-shipgate fixture run agent_weakens_gate --out $OUT"
+sleep 2
+
+say "merge_verdict: blocked. can_merge_without_human: false." 2
+say "Why? The PR comment a reviewer would see:" 1
+run "head -40 $OUT/pr-comment.md"
+sleep 3
+
+say "Both gate-removal checks are suppression-immune:" 1
+run "python3 -c \"import json; r=json.load(open('$OUT/report.json')); [print(' -', b['check_id']) for b in r['release_decision']['blockers']]\""
+sleep 2
+
+say "The manifest cannot silence them. Severity floors stop downgrades." 2
+say "The agent cannot approve its own boundary change." 2
+say "" 1
+say "Agents Shipgate — the deterministic merge gate" 1
+say "for AI-generated agent capability changes." 3

--- a/src/agents_shipgate/core/boundary_diff.py
+++ b/src/agents_shipgate/core/boundary_diff.py
@@ -1,0 +1,351 @@
+"""Shared unified-diff plumbing for the boundary check family.
+
+Common diff/text helpers used by ``agents_shipgate.core.codex_boundary``
+and ``agents_shipgate.core.host_boundary``: unified-diff parsing,
+hunk application, changed-file text resolution, and canonical
+hashing/serialization. Semantics-free by design — consumers add their
+own rule evaluation on top.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from agents_shipgate.schemas.agent_result_v1 import AgentResultDiagnostic
+
+
+@dataclass(frozen=True)
+class DiffHunk:
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DiffFile:
+    old_path: str | None
+    new_path: str | None
+    added_lines: list[str] = field(default_factory=list)
+    removed_lines: list[str] = field(default_factory=list)
+    hunks: list[DiffHunk] = field(default_factory=list)
+    is_deleted: bool = False
+    is_new: bool = False
+
+    @property
+    def path(self) -> str:
+        return self.new_path or self.old_path or ""
+
+
+@dataclass(frozen=True)
+class ResolvedFileText:
+    old_text: str | None
+    new_text: str | None
+    source: str
+    old_sha256: str | None
+    new_sha256: str | None
+
+
+def parse_unified_diff(diff_text: str) -> list[DiffFile]:
+    files_out: list[DiffFile] = []
+    current: dict[str, Any] | None = None
+    current_hunk: DiffHunk | None = None
+
+    def finish() -> None:
+        nonlocal current, current_hunk
+        if current is None:
+            return
+        if current_hunk is not None:
+            current.setdefault("hunks", []).append(current_hunk)
+            current_hunk = None
+        files_out.append(
+            DiffFile(
+                old_path=current.get("old_path"),
+                new_path=current.get("new_path"),
+                added_lines=current.get("added_lines", []),
+                removed_lines=current.get("removed_lines", []),
+                hunks=current.get("hunks", []),
+                is_deleted=bool(current.get("is_deleted")),
+                is_new=bool(current.get("is_new")),
+            )
+        )
+        current = None
+
+    for raw_line in diff_text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        if raw_line.startswith("diff --git "):
+            finish()
+            parts = raw_line.split()
+            old_path = _strip_diff_prefix(parts[2]) if len(parts) > 2 else None
+            new_path = _strip_diff_prefix(parts[3]) if len(parts) > 3 else old_path
+            current = {
+                "old_path": old_path,
+                "new_path": new_path,
+                "added_lines": [],
+                "removed_lines": [],
+                "hunks": [],
+                "is_deleted": False,
+                "is_new": False,
+            }
+            current_hunk = None
+            continue
+        if current is None:
+            continue
+        if raw_line.startswith("deleted file mode"):
+            current["is_deleted"] = True
+        elif raw_line.startswith("new file mode"):
+            current["is_new"] = True
+        elif raw_line.startswith("--- "):
+            value = raw_line[4:].strip()
+            current["old_path"] = None if value == "/dev/null" else _strip_diff_prefix(value)
+        elif raw_line.startswith("+++ "):
+            value = raw_line[4:].strip()
+            current["new_path"] = None if value == "/dev/null" else _strip_diff_prefix(value)
+            if value == "/dev/null":
+                current["is_deleted"] = True
+        elif raw_line.startswith("@@ "):
+            if current_hunk is not None:
+                current.setdefault("hunks", []).append(current_hunk)
+            current_hunk = _parse_hunk_header(raw_line)
+        elif raw_line.startswith("+") and not raw_line.startswith("+++"):
+            current["added_lines"].append(raw_line[1:])
+            if current_hunk is not None:
+                current_hunk.lines.append(("+", raw_line[1:]))
+        elif raw_line.startswith("-") and not raw_line.startswith("---"):
+            current["removed_lines"].append(raw_line[1:])
+            if current_hunk is not None:
+                current_hunk.lines.append(("-", raw_line[1:]))
+        elif raw_line.startswith(" ") and current_hunk is not None:
+            current_hunk.lines.append((" ", raw_line[1:]))
+    finish()
+    return files_out
+
+
+def _parse_hunk_header(line: str) -> DiffHunk:
+    match = re.match(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@", line)
+    if not match:
+        return DiffHunk(old_start=0, old_count=0, new_start=0, new_count=0)
+    old_start, old_count, new_start, new_count = match.groups()
+    return DiffHunk(
+        old_start=int(old_start),
+        old_count=int(old_count or "1"),
+        new_start=int(new_start),
+        new_count=int(new_count or "1"),
+    )
+
+
+def _strip_diff_prefix(value: str) -> str:
+    value = value.strip()
+    if value.startswith("a/") or value.startswith("b/"):
+        return value[2:]
+    return value
+
+
+def _resolve_changed_file_text(
+    workspace: Path,
+    diff_file: DiffFile,
+    diagnostics: list[AgentResultDiagnostic],
+) -> ResolvedFileText:
+    path = diff_file.path
+    if diff_file.is_deleted:
+        resolved = ResolvedFileText(
+            old_text=None,
+            new_text=None,
+            source="diff_deleted_file",
+            old_sha256=None,
+            new_sha256=None,
+        )
+        diagnostics.append(_content_source_diagnostic(path, resolved))
+        return resolved
+    if diff_file.is_new:
+        new_text = _new_text_from_hunks(diff_file)
+        resolved = ResolvedFileText(
+            old_text="",
+            new_text=new_text,
+            source="diff_new_file",
+            old_sha256=_sha256_text(""),
+            new_sha256=_sha256_text(new_text),
+        )
+        diagnostics.append(_content_source_diagnostic(path, resolved))
+        return resolved
+
+    head_path = _safe_workspace_path(workspace, path)
+    if head_path is None:
+        resolved = _unresolved_text("path_outside_workspace")
+        diagnostics.append(_content_source_diagnostic(path, resolved, level="warning"))
+        return resolved
+    if not head_path.is_file():
+        resolved = _unresolved_text("workspace_file_missing")
+        diagnostics.append(_content_source_diagnostic(path, resolved, level="warning"))
+        return resolved
+    try:
+        workspace_text = head_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        resolved = _unresolved_text("workspace_read_failed")
+        diagnostics.append(
+            AgentResultDiagnostic(
+                level="warning",
+                code="content_source",
+                message=f"Could not read changed Codex boundary file: {exc}",
+                path=path,
+            )
+        )
+        return resolved
+
+    if _is_insertion_only_change(diff_file):
+        reversed_text = _apply_hunks(workspace_text, diff_file.hunks, direction="reverse")
+        if reversed_text is not None:
+            resolved = ResolvedFileText(
+                old_text=reversed_text,
+                new_text=workspace_text,
+                source="workspace_already_contains_diff_head",
+                old_sha256=_sha256_text(reversed_text),
+                new_sha256=_sha256_text(workspace_text),
+            )
+            diagnostics.append(_content_source_diagnostic(path, resolved))
+            return resolved
+
+    applied = _apply_hunks(workspace_text, diff_file.hunks, direction="forward")
+    if applied is not None:
+        resolved = ResolvedFileText(
+            old_text=workspace_text,
+            new_text=applied,
+            source="diff_applied_to_workspace_base",
+            old_sha256=_sha256_text(workspace_text),
+            new_sha256=_sha256_text(applied),
+        )
+        diagnostics.append(_content_source_diagnostic(path, resolved))
+        return resolved
+
+    reversed_text = _apply_hunks(workspace_text, diff_file.hunks, direction="reverse")
+    if reversed_text is not None:
+        resolved = ResolvedFileText(
+            old_text=reversed_text,
+            new_text=workspace_text,
+            source="workspace_already_contains_diff_head",
+            old_sha256=_sha256_text(reversed_text),
+            new_sha256=_sha256_text(workspace_text),
+        )
+        diagnostics.append(_content_source_diagnostic(path, resolved))
+        return resolved
+
+    resolved = _unresolved_text("diff_workspace_mismatch")
+    diagnostics.append(_content_source_diagnostic(path, resolved, level="warning"))
+    return resolved
+
+
+def _unresolved_text(source: str) -> ResolvedFileText:
+    return ResolvedFileText(
+        old_text=None,
+        new_text=None,
+        source=source,
+        old_sha256=None,
+        new_sha256=None,
+    )
+
+
+def _content_source_diagnostic(
+    path: str,
+    resolved: ResolvedFileText,
+    *,
+    level: str = "info",
+) -> AgentResultDiagnostic:
+    return AgentResultDiagnostic(
+        level=level,  # type: ignore[arg-type]
+        code="content_source",
+        message=f"Evaluated Codex boundary file from {resolved.source}.",
+        path=path,
+    )
+
+
+def _evaluated_file_record(path: str, resolved: ResolvedFileText) -> dict[str, Any]:
+    return {
+        "path": path,
+        "source": resolved.source,
+        "old_sha256": resolved.old_sha256,
+        "new_sha256": resolved.new_sha256,
+    }
+
+
+def _new_text_from_hunks(diff_file: DiffFile) -> str:
+    if diff_file.hunks:
+        lines = [
+            text
+            for hunk in diff_file.hunks
+            for kind, text in hunk.lines
+            if kind in {" ", "+"}
+        ]
+        return _join_lines(lines)
+    if diff_file.added_lines:
+        return _join_lines(diff_file.added_lines)
+    return ""
+
+
+def _apply_hunks(
+    text: str,
+    hunks: list[DiffHunk],
+    *,
+    direction: str,
+) -> str | None:
+    if not hunks:
+        return text
+    lines = text.splitlines()
+    offset = 0
+    for hunk in hunks:
+        if direction == "forward":
+            start = hunk.old_start - 1 if hunk.old_count > 0 else hunk.old_start
+            expected = [value for kind, value in hunk.lines if kind in {" ", "-"}]
+            replacement = [value for kind, value in hunk.lines if kind in {" ", "+"}]
+        else:
+            start = hunk.new_start - 1 if hunk.new_count > 0 else hunk.new_start
+            expected = [value for kind, value in hunk.lines if kind in {" ", "+"}]
+            replacement = [value for kind, value in hunk.lines if kind in {" ", "-"}]
+        index = start + offset
+        if index < 0:
+            return None
+        if index > len(lines):
+            return None
+        if index + len(expected) > len(lines):
+            return None
+        if lines[index : index + len(expected)] != expected:
+            return None
+        lines[index : index + len(expected)] = replacement
+        offset += len(replacement) - len(expected)
+    return _join_lines(lines, final_newline=text.endswith("\n"))
+
+
+def _is_insertion_only_change(diff_file: DiffFile) -> bool:
+    return any(
+        any(kind == "+" for kind, _ in hunk.lines)
+        and not any(kind == "-" for kind, _ in hunk.lines)
+        for hunk in diff_file.hunks
+    )
+
+
+def _join_lines(lines: list[str], *, final_newline: bool = True) -> str:
+    if not lines:
+        return ""
+    text = "\n".join(lines)
+    return f"{text}\n" if final_newline else text
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _safe_workspace_path(workspace: Path, value: str) -> Path | None:
+    candidate = (workspace / value).resolve()
+    try:
+        candidate.relative_to(workspace)
+    except ValueError:
+        return None
+    return candidate

--- a/src/agents_shipgate/core/codex_boundary.py
+++ b/src/agents_shipgate/core/codex_boundary.py
@@ -4,12 +4,36 @@ import hashlib
 import json
 import re
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+# The shared unified-diff plumbing moved to
+# ``agents_shipgate.core.boundary_diff``. These re-exports preserve the
+# pre-split import surface of this module: existing imports such as
+# ``from agents_shipgate.core.codex_boundary import parse_unified_diff``
+# (tests, checks, CLI) keep working unchanged.
+from agents_shipgate.core.boundary_diff import (  # noqa: F401
+    DiffFile,
+    DiffHunk,
+    ResolvedFileText,
+    _apply_hunks,
+    _canonical_json,
+    _content_source_diagnostic,
+    _evaluated_file_record,
+    _is_insertion_only_change,
+    _join_lines,
+    _new_text_from_hunks,
+    _parse_hunk_header,
+    _resolve_changed_file_text,
+    _safe_workspace_path,
+    _sha256_text,
+    _strip_diff_prefix,
+    _unresolved_text,
+    parse_unified_diff,
+)
 from agents_shipgate.schemas.agent_result_v1 import (
     AgentResultDiagnostic,
     AgentResultNextAction,
@@ -182,39 +206,6 @@ _NETWORK_KEYS = {
     "domains",
     "unix_sockets",
 }
-
-
-@dataclass(frozen=True)
-class DiffHunk:
-    old_start: int
-    old_count: int
-    new_start: int
-    new_count: int
-    lines: list[tuple[str, str]] = field(default_factory=list)
-
-
-@dataclass(frozen=True)
-class DiffFile:
-    old_path: str | None
-    new_path: str | None
-    added_lines: list[str] = field(default_factory=list)
-    removed_lines: list[str] = field(default_factory=list)
-    hunks: list[DiffHunk] = field(default_factory=list)
-    is_deleted: bool = False
-    is_new: bool = False
-
-    @property
-    def path(self) -> str:
-        return self.new_path or self.old_path or ""
-
-
-@dataclass(frozen=True)
-class ResolvedFileText:
-    old_text: str | None
-    new_text: str | None
-    source: str
-    old_sha256: str | None
-    new_sha256: str | None
 
 
 @dataclass(frozen=True)
@@ -416,80 +407,6 @@ def evaluate_codex_boundary_result(
         trigger=trigger,
         finding_fingerprints=finding_fingerprints,
     )
-
-
-def parse_unified_diff(diff_text: str) -> list[DiffFile]:
-    files_out: list[DiffFile] = []
-    current: dict[str, Any] | None = None
-    current_hunk: DiffHunk | None = None
-
-    def finish() -> None:
-        nonlocal current, current_hunk
-        if current is None:
-            return
-        if current_hunk is not None:
-            current.setdefault("hunks", []).append(current_hunk)
-            current_hunk = None
-        files_out.append(
-            DiffFile(
-                old_path=current.get("old_path"),
-                new_path=current.get("new_path"),
-                added_lines=current.get("added_lines", []),
-                removed_lines=current.get("removed_lines", []),
-                hunks=current.get("hunks", []),
-                is_deleted=bool(current.get("is_deleted")),
-                is_new=bool(current.get("is_new")),
-            )
-        )
-        current = None
-
-    for raw_line in diff_text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
-        if raw_line.startswith("diff --git "):
-            finish()
-            parts = raw_line.split()
-            old_path = _strip_diff_prefix(parts[2]) if len(parts) > 2 else None
-            new_path = _strip_diff_prefix(parts[3]) if len(parts) > 3 else old_path
-            current = {
-                "old_path": old_path,
-                "new_path": new_path,
-                "added_lines": [],
-                "removed_lines": [],
-                "hunks": [],
-                "is_deleted": False,
-                "is_new": False,
-            }
-            current_hunk = None
-            continue
-        if current is None:
-            continue
-        if raw_line.startswith("deleted file mode"):
-            current["is_deleted"] = True
-        elif raw_line.startswith("new file mode"):
-            current["is_new"] = True
-        elif raw_line.startswith("--- "):
-            value = raw_line[4:].strip()
-            current["old_path"] = None if value == "/dev/null" else _strip_diff_prefix(value)
-        elif raw_line.startswith("+++ "):
-            value = raw_line[4:].strip()
-            current["new_path"] = None if value == "/dev/null" else _strip_diff_prefix(value)
-            if value == "/dev/null":
-                current["is_deleted"] = True
-        elif raw_line.startswith("@@ "):
-            if current_hunk is not None:
-                current.setdefault("hunks", []).append(current_hunk)
-            current_hunk = _parse_hunk_header(raw_line)
-        elif raw_line.startswith("+") and not raw_line.startswith("+++"):
-            current["added_lines"].append(raw_line[1:])
-            if current_hunk is not None:
-                current_hunk.lines.append(("+", raw_line[1:]))
-        elif raw_line.startswith("-") and not raw_line.startswith("---"):
-            current["removed_lines"].append(raw_line[1:])
-            if current_hunk is not None:
-                current_hunk.lines.append(("-", raw_line[1:]))
-        elif raw_line.startswith(" ") and current_hunk is not None:
-            current_hunk.lines.append((" ", raw_line[1:]))
-    finish()
-    return files_out
 
 
 def load_codex_boundary_policy(
@@ -961,202 +878,6 @@ def _evaluate_skill(diff_file: DiffFile, add) -> None:
         )
 
 
-def _resolve_changed_file_text(
-    workspace: Path,
-    diff_file: DiffFile,
-    diagnostics: list[AgentResultDiagnostic],
-) -> ResolvedFileText:
-    path = diff_file.path
-    if diff_file.is_deleted:
-        resolved = ResolvedFileText(
-            old_text=None,
-            new_text=None,
-            source="diff_deleted_file",
-            old_sha256=None,
-            new_sha256=None,
-        )
-        diagnostics.append(_content_source_diagnostic(path, resolved))
-        return resolved
-    if diff_file.is_new:
-        new_text = _new_text_from_hunks(diff_file)
-        resolved = ResolvedFileText(
-            old_text="",
-            new_text=new_text,
-            source="diff_new_file",
-            old_sha256=_sha256_text(""),
-            new_sha256=_sha256_text(new_text),
-        )
-        diagnostics.append(_content_source_diagnostic(path, resolved))
-        return resolved
-
-    head_path = _safe_workspace_path(workspace, path)
-    if head_path is None:
-        resolved = _unresolved_text("path_outside_workspace")
-        diagnostics.append(_content_source_diagnostic(path, resolved, level="warning"))
-        return resolved
-    if not head_path.is_file():
-        resolved = _unresolved_text("workspace_file_missing")
-        diagnostics.append(_content_source_diagnostic(path, resolved, level="warning"))
-        return resolved
-    try:
-        workspace_text = head_path.read_text(encoding="utf-8", errors="replace")
-    except OSError as exc:
-        resolved = _unresolved_text("workspace_read_failed")
-        diagnostics.append(
-            AgentResultDiagnostic(
-                level="warning",
-                code="content_source",
-                message=f"Could not read changed Codex boundary file: {exc}",
-                path=path,
-            )
-        )
-        return resolved
-
-    if _is_insertion_only_change(diff_file):
-        reversed_text = _apply_hunks(workspace_text, diff_file.hunks, direction="reverse")
-        if reversed_text is not None:
-            resolved = ResolvedFileText(
-                old_text=reversed_text,
-                new_text=workspace_text,
-                source="workspace_already_contains_diff_head",
-                old_sha256=_sha256_text(reversed_text),
-                new_sha256=_sha256_text(workspace_text),
-            )
-            diagnostics.append(_content_source_diagnostic(path, resolved))
-            return resolved
-
-    applied = _apply_hunks(workspace_text, diff_file.hunks, direction="forward")
-    if applied is not None:
-        resolved = ResolvedFileText(
-            old_text=workspace_text,
-            new_text=applied,
-            source="diff_applied_to_workspace_base",
-            old_sha256=_sha256_text(workspace_text),
-            new_sha256=_sha256_text(applied),
-        )
-        diagnostics.append(_content_source_diagnostic(path, resolved))
-        return resolved
-
-    reversed_text = _apply_hunks(workspace_text, diff_file.hunks, direction="reverse")
-    if reversed_text is not None:
-        resolved = ResolvedFileText(
-            old_text=reversed_text,
-            new_text=workspace_text,
-            source="workspace_already_contains_diff_head",
-            old_sha256=_sha256_text(reversed_text),
-            new_sha256=_sha256_text(workspace_text),
-        )
-        diagnostics.append(_content_source_diagnostic(path, resolved))
-        return resolved
-
-    resolved = _unresolved_text("diff_workspace_mismatch")
-    diagnostics.append(_content_source_diagnostic(path, resolved, level="warning"))
-    return resolved
-
-
-def _unresolved_text(source: str) -> ResolvedFileText:
-    return ResolvedFileText(
-        old_text=None,
-        new_text=None,
-        source=source,
-        old_sha256=None,
-        new_sha256=None,
-    )
-
-
-def _content_source_diagnostic(
-    path: str,
-    resolved: ResolvedFileText,
-    *,
-    level: str = "info",
-) -> AgentResultDiagnostic:
-    return AgentResultDiagnostic(
-        level=level,  # type: ignore[arg-type]
-        code="content_source",
-        message=f"Evaluated Codex boundary file from {resolved.source}.",
-        path=path,
-    )
-
-
-def _evaluated_file_record(path: str, resolved: ResolvedFileText) -> dict[str, Any]:
-    return {
-        "path": path,
-        "source": resolved.source,
-        "old_sha256": resolved.old_sha256,
-        "new_sha256": resolved.new_sha256,
-    }
-
-
-def _new_text_from_hunks(diff_file: DiffFile) -> str:
-    if diff_file.hunks:
-        lines = [
-            text
-            for hunk in diff_file.hunks
-            for kind, text in hunk.lines
-            if kind in {" ", "+"}
-        ]
-        return _join_lines(lines)
-    if diff_file.added_lines:
-        return _join_lines(diff_file.added_lines)
-    return ""
-
-
-def _apply_hunks(
-    text: str,
-    hunks: list[DiffHunk],
-    *,
-    direction: str,
-) -> str | None:
-    if not hunks:
-        return text
-    lines = text.splitlines()
-    offset = 0
-    for hunk in hunks:
-        if direction == "forward":
-            start = hunk.old_start - 1 if hunk.old_count > 0 else hunk.old_start
-            expected = [value for kind, value in hunk.lines if kind in {" ", "-"}]
-            replacement = [value for kind, value in hunk.lines if kind in {" ", "+"}]
-        else:
-            start = hunk.new_start - 1 if hunk.new_count > 0 else hunk.new_start
-            expected = [value for kind, value in hunk.lines if kind in {" ", "+"}]
-            replacement = [value for kind, value in hunk.lines if kind in {" ", "-"}]
-        index = start + offset
-        if index < 0:
-            return None
-        if index > len(lines):
-            return None
-        if index + len(expected) > len(lines):
-            return None
-        if lines[index : index + len(expected)] != expected:
-            return None
-        lines[index : index + len(expected)] = replacement
-        offset += len(replacement) - len(expected)
-    return _join_lines(lines, final_newline=text.endswith("\n"))
-
-
-def _is_insertion_only_change(diff_file: DiffFile) -> bool:
-    return any(
-        any(kind == "+" for kind, _ in hunk.lines)
-        and not any(kind == "-" for kind, _ in hunk.lines)
-        for hunk in diff_file.hunks
-    )
-
-
-def _join_lines(lines: list[str], *, final_newline: bool = True) -> str:
-    if not lines:
-        return ""
-    text = "\n".join(lines)
-    return f"{text}\n" if final_newline else text
-
-
-def _sha256_text(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def _canonical_json(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-
-
 def _changed_to(
     old_data: dict[str, Any],
     data: dict[str, Any],
@@ -1173,19 +894,6 @@ def _nested_get(data: Any, path: tuple[str, ...]) -> Any:
             return None
         current = current.get(part)
     return current
-
-
-def _parse_hunk_header(line: str) -> DiffHunk:
-    match = re.match(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@", line)
-    if not match:
-        return DiffHunk(old_start=0, old_count=0, new_start=0, new_count=0)
-    old_start, old_count, new_start, new_count = match.groups()
-    return DiffHunk(
-        old_start=int(old_start),
-        old_count=int(old_count or "1"),
-        new_start=int(new_start),
-        new_count=int(new_count or "1"),
-    )
 
 
 def _iter_hook_groups(hooks: Any):
@@ -1376,27 +1084,11 @@ def _load_packaged_default_policy() -> dict[str, Any] | None:
     return None
 
 
-def _safe_workspace_path(workspace: Path, value: str) -> Path | None:
-    candidate = (workspace / value).resolve()
-    try:
-        candidate.relative_to(workspace)
-    except ValueError:
-        return None
-    return candidate
-
-
 def _display_path(path: Path, workspace: Path) -> str:
     try:
         return path.resolve().relative_to(workspace.resolve()).as_posix()
     except ValueError:
         return str(path)
-
-
-def _strip_diff_prefix(value: str) -> str:
-    value = value.strip()
-    if value.startswith("a/") or value.startswith("b/"):
-        return value[2:]
-    return value
 
 
 def _is_allow(value: Any) -> bool:

--- a/src/agents_shipgate/core/host_boundary.py
+++ b/src/agents_shipgate/core/host_boundary.py
@@ -7,11 +7,11 @@ MCP server declarations (``.mcp.json``, ``.cursor/mcp.json``,
 ``.vscode/mcp.json``), and GitHub workflow permission expansion
 (``.github/workflows/*.yml|yaml``).
 
-NOTE: this module is the second consumer of the codex boundary diff
-plumbing (``parse_unified_diff``, ``_resolve_changed_file_text``, the
-canonical-JSON and dedupe helpers). Importing those private helpers from
-the sibling module is deliberate for now; a future split will move the
-shared diff plumbing into a common module.
+NOTE: the shared diff plumbing (``parse_unified_diff``,
+``_resolve_changed_file_text``, the canonical-JSON helper) now lives in
+``agents_shipgate.core.boundary_diff`` and is imported from there. Only
+the policy/decision helpers (rank tables, dedupe, display path) are
+still imported from the sibling ``codex_boundary`` module.
 
 Static-only contract: pure parsing via ``json.loads`` / ``yaml.safe_load``
 only — no subprocess, no network, no exec/eval/importlib. Enforced by
@@ -28,16 +28,18 @@ from urllib.parse import urlsplit
 
 import yaml
 
+from agents_shipgate.core.boundary_diff import (
+    _canonical_json,
+    _resolve_changed_file_text,
+    parse_unified_diff,
+)
 from agents_shipgate.core.codex_boundary import (
     _DECISION_RANK,
     _RISK_BY_ACTION,
     _RISK_RANK,
     DEFAULT_POLICY_VERSION,
-    _canonical_json,
     _dedupe_violations,
     _display_path,
-    _resolve_changed_file_text,
-    parse_unified_diff,
 )
 from agents_shipgate.schemas.agent_result_v1 import (
     AgentResultDiagnostic,


### PR DESCRIPTION
## Summary

- **`core/boundary_diff.py`** (new, 351 lines): the semantics-free unified-diff plumbing shared by the boundary check family — `DiffHunk`/`DiffFile`/`ResolvedFileText`, `parse_unified_diff`, hunk application, text resolution. `codex_boundary.py` shrinks **1,526 → 1,218 lines** and re-exports every moved name (`cb.parse_unified_diff is bd.parse_unified_diff` verified), so the pre-split import surface is unchanged; `host_boundary` now imports the plumbing from the shared module. First step of the codex_boundary split flagged in the strategic review. No behavior change — diagnostic output is byte-identical.
- **`docs/design-partner-reengagement.md`**: the IE-fix follow-up template for stalled pilots (the 2026-06-01 pilot's failure mode is fixed in v0.12.0), the `audit --host` zero-config first touch for new prospects, and the three metrics to capture from a re-run.
- **`marketing/demo-agent-weakens-gate.sh`**: executable asciinema driver for the 90-second gate-removal demo.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

(Internal refactor + docs; no public contract changes.)

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Targeted boundary suites (codex, host, plugin, audit): 58 passed.
- `test_adapter_static_only.py`: 350 passed, no allowlist changes needed.
- Full suite (`-n auto -m "not perf"`): green.
- Re-export identity asserted (`codex_boundary.X is boundary_diff.X` for all 17 moved names).

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` (none)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)