### PR TITLE
Close the check/verify coverage gap: defer tool-surface changes to verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.13.0 - Unreleased
 
+- **`check` defers tool-surface changes to `verify` (coverage boundary).**
+  `shipgate check` is boundary-scoped and does not compute the capability
+  delta, so a clean boundary result over a diff that changes a
+  manifest-declared `tool_sources[].path` no longer returns `allow` — it
+  returns `decision="warn"` routing `first_next_action` to `verify`, with a
+  `diagnostics[].code="capability_change_requires_verify"` marker and a
+  `trace[].step="coverage"` event. Completion is still allowed, but `check`
+  no longer green-lights a capability change only `verify` gates, so the local
+  loop cannot disagree with `release_decision.decision`. Docs/test/boundary-only
+  diffs are unaffected (still `allow`); no `agent_result_v1` schema change.
 - **Agent-mode auto-detection.** Agent mode now auto-enables when a known
   coding-agent harness environment is detected (Claude Code exports
   `CLAUDECODE=1`, Cursor `CURSOR_TRACE_ID`), so structured `next_action`

--- a/docs/agents/protocol.md
+++ b/docs/agents/protocol.md
@@ -113,6 +113,25 @@ must set `human_review.required=true` and stop the agent.
 `repair.forbidden_shortcuts` is present on every result, including `allow`, so
 agents have the same trust-root boundary even when no finding fires.
 
+## Coverage
+
+`shipgate check` is boundary-scoped: it evaluates host and trust-root surfaces
+(Codex/host config, MCP approvals, the Shipgate CI gate, agent instructions,
+policy, and skills) from the diff. It does **not** compute the tool-use
+capability delta — that is `verify`'s job, and `release_decision.decision`
+remains the one authoritative capability gate.
+
+So that `check` never disagrees with that gate, a clean boundary result over a
+diff that changes a **manifest-declared tool source** (a `tool_sources[].path`
+entry) does not return `allow`. It returns `decision="warn"` with
+`first_next_action.kind="warn"` routing to `verify`, plus a
+`diagnostics[].code="capability_change_requires_verify"` marker and a
+`trace[].step="coverage"` event. Completion is still allowed, but the agent
+must run `verify` for the capability merge gate before reporting done. This
+keeps `check` from green-lighting a capability change it did not evaluate. A
+diff that only touches boundary surfaces or unrelated files (docs, tests)
+still returns `allow`.
+
 ## Human Boundary
 
 The human approval boundary is explicit:

--- a/docs/agents/protocol.md
+++ b/docs/agents/protocol.md
@@ -123,7 +123,9 @@ remains the one authoritative capability gate.
 
 So that `check` never disagrees with that gate, a clean boundary result over a
 diff that changes a **manifest-declared tool source** (a `tool_sources[].path`
-entry) does not return `allow`. It returns `decision="warn"` with
+entry — the changed file equals it, or sits under it when the path is a
+scanned directory like an `openai_agents_sdk` agents folder) does not return
+`allow`. It returns `decision="warn"` with
 `first_next_action.kind="warn"` routing to `verify`, plus a
 `diagnostics[].code="capability_change_requires_verify"` marker and a
 `trace[].step="coverage"` event. Completion is still allowed, but the agent

--- a/src/agents_shipgate/cli/agent_result.py
+++ b/src/agents_shipgate/cli/agent_result.py
@@ -7,6 +7,7 @@ from typing import Any
 from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.codex_boundary import (
     evaluate_codex_boundary_result,
+    is_boundary_path,
     parse_unified_diff,
 )
 from agents_shipgate.schemas.agent_result_v1 import AgentResultV1
@@ -57,6 +58,16 @@ def _declared_tool_surfaces_changed(
     does not, so a clean boundary ``allow`` over one of them must defer to
     ``verify``. Best-effort: an absent or invalid manifest yields no signal so
     the boundary check degrades to its prior behavior rather than failing.
+
+    A declared ``tool_sources[].path`` may be a single file (``mcp``,
+    ``openapi``) or a directory the loader scans recursively
+    (``openai_agents_sdk``, ``google_adk``, ``langchain``, ``crewai``,
+    ``codex_plugin``, ``codex_config``), so a changed file matches when it
+    equals the declared path or sits under it. Two exclusions keep this from
+    becoming noise: a declared path that resolves to the workspace root (e.g.
+    ``codex_config`` with ``path: .``) is dropped — it would otherwise match
+    every file, including docs — and changed files the boundary evaluator
+    already inspects are dropped, since ``check`` did evaluate those.
     """
 
     if not changed_files or not config_path.is_file():
@@ -75,8 +86,18 @@ def _declared_tool_surfaces_changed(
             rel = (manifest_dir / path).resolve().relative_to(workspace).as_posix()
         except ValueError:
             continue
+        if rel in {"", "."}:  # whole-workspace root: matching all files is noise.
+            continue
         declared.add(rel)
-    return sorted(declared.intersection(changed_files))
+    if not declared:
+        return []
+    matched = [
+        changed
+        for changed in changed_files
+        if not is_boundary_path(changed)
+        and any(changed == decl or changed.startswith(f"{decl}/") for decl in declared)
+    ]
+    return sorted(matched)
 
 
 def git_diff_text(

--- a/src/agents_shipgate/cli/agent_result.py
+++ b/src/agents_shipgate/cli/agent_result.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.codex_boundary import (
     evaluate_codex_boundary_result,
     parse_unified_diff,
@@ -36,7 +37,46 @@ def build_codex_agent_result(
         agent=agent,
         policy_path=policy,
         trigger=trigger,
+        capability_surfaces_changed=_declared_tool_surfaces_changed(
+            workspace=workspace,
+            config_path=config_path,
+            changed_files=changed_files,
+        ),
     )
+
+
+def _declared_tool_surfaces_changed(
+    *,
+    workspace: Path,
+    config_path: Path,
+    changed_files: list[str],
+) -> list[str]:
+    """Return changed files the manifest declares as tool sources.
+
+    These are capability surfaces ``verify`` scans but the boundary evaluator
+    does not, so a clean boundary ``allow`` over one of them must defer to
+    ``verify``. Best-effort: an absent or invalid manifest yields no signal so
+    the boundary check degrades to its prior behavior rather than failing.
+    """
+
+    if not changed_files or not config_path.is_file():
+        return []
+    try:
+        manifest = load_manifest(config_path)
+    except Exception:  # noqa: BLE001 - enrichment must never break the check.
+        return []
+    manifest_dir = config_path.parent
+    declared: set[str] = set()
+    for source in getattr(manifest, "tool_sources", None) or []:
+        path = getattr(source, "path", None)
+        if not isinstance(path, str) or not path:
+            continue
+        try:
+            rel = (manifest_dir / path).resolve().relative_to(workspace).as_posix()
+        except ValueError:
+            continue
+        declared.add(rel)
+    return sorted(declared.intersection(changed_files))
 
 
 def git_diff_text(

--- a/src/agents_shipgate/core/codex_boundary.py
+++ b/src/agents_shipgate/core/codex_boundary.py
@@ -1815,3 +1815,22 @@ def _is_codex_skill_path(path: str) -> bool:
         path.endswith("/SKILL.md")
         and (path.startswith(".agents/skills/") or "/.agents/skills/" in path)
     )
+
+
+def is_boundary_path(path: str) -> bool:
+    """True when ``evaluate_codex_boundary_result`` inspects this path.
+
+    These are the host/trust-root surfaces ``check`` fully evaluates, so they
+    are not capability-coverage gaps even when a manifest also declares them as
+    a tool source (e.g. a ``codex_config`` source pointing at ``.codex/``).
+    """
+
+    normalized = path.replace("\\", "/")
+    return (
+        _is_codex_config_path(normalized)
+        or _is_codex_hooks_path(normalized)
+        or _is_agent_instructions_path(normalized)
+        or _is_shipgate_workflow_path(normalized)
+        or _is_codex_boundary_policy_path(normalized)
+        or _is_codex_skill_path(normalized)
+    )

--- a/src/agents_shipgate/core/codex_boundary.py
+++ b/src/agents_shipgate/core/codex_boundary.py
@@ -352,8 +352,18 @@ def evaluate_codex_boundary_result(
     policy_path: Path | None = None,
     trigger: dict[str, Any] | None = None,
     release_decision: dict[str, Any] | None = None,
+    capability_surfaces_changed: list[str] | None = None,
 ) -> AgentResultV1:
-    """Return the local Codex agent-result projection for a unified diff."""
+    """Return the local Codex agent-result projection for a unified diff.
+
+    ``capability_surfaces_changed`` lists changed files that the manifest
+    declares as tool sources. The boundary evaluator does not inspect tool
+    surfaces (only ``verify`` computes the capability delta), so when one
+    changed and the boundary result is otherwise a clean ``allow``, the
+    result is escalated to ``warn`` and routed to ``verify`` rather than
+    green-lighting a capability change ``check`` never evaluated. This keeps
+    ``check`` from disagreeing with the ``release_decision.decision`` gate.
+    """
 
     # Keep this local diff projector aligned with
     # agents_shipgate.ci.agent_result.build_agent_result; both produce
@@ -423,6 +433,17 @@ def evaluate_codex_boundary_result(
 
     violations = _dedupe_violations(violations)
     decision = _decision_for(violations, release_decision=release_decision)
+
+    # Coverage gap: check is boundary-only, so a clean ``allow`` over a diff
+    # that touches a manifest-declared tool surface would silently green-light
+    # a capability change that only ``verify`` gates. Escalate to ``warn`` and
+    # route to verify instead. Gated on ``release_decision is None`` because a
+    # provided release decision means the full capability scan already ran.
+    coverage_surfaces = sorted(dict.fromkeys(capability_surfaces_changed or []))
+    coverage_gap = decision == "allow" and release_decision is None and bool(coverage_surfaces)
+    if coverage_gap:
+        decision = "warn"
+
     risk_level = _risk_for(violations)
     repair = _repair_for(decision, violations, agent)
     human_review = _human_review_for(decision, violations, repair)
@@ -434,6 +455,17 @@ def evaluate_codex_boundary_result(
         finding_fingerprints=finding_fingerprints,
         evaluated_files=evaluated_files,
     )
+    if coverage_gap:
+        first_next_action = _coverage_next_action()
+        summary = _coverage_summary(coverage_surfaces)
+        diagnostics = [*diagnostics, _coverage_diagnostic(coverage_surfaces)]
+        trace = [*_trace_for(policy, decision, violations), _coverage_trace(coverage_surfaces)]
+        suggested_fixes = [_VERIFY_COMMAND]
+    else:
+        first_next_action = _next_action_for(decision, violations, repair)
+        summary = _summary_for(decision, violations)
+        trace = _trace_for(policy, decision, violations)
+        suggested_fixes = [item.recommendation for item in violations[:5]]
     return AgentResultV1(
         agent=agent,  # type: ignore[arg-type]
         subject=AgentResultSubject(agent=agent),
@@ -441,22 +473,22 @@ def evaluate_codex_boundary_result(
         risk_level=risk_level,
         audit_id=audit_id,
         policy_version=policy.version,
-        summary=_summary_for(decision, violations),
+        summary=summary,
         changed_files=changed_files,
         completion_allowed=decision in {"allow", "warn"},
         must_stop=decision in {"require_review", "block"} and not repair.safe_to_attempt,
-        first_next_action=_next_action_for(decision, violations, repair),
+        first_next_action=first_next_action,
         human_review=human_review,
         repair=repair,
         policy=_policy_result(policy),
         violated_rules=violations,
         affected_files=_affected_files_for(violations, changed_files),
         required_reviewers=human_review.required_reviewers,
-        explanation=_summary_for(decision, violations),
-        suggested_fixes=[item.recommendation for item in violations[:5]],
+        explanation=summary,
+        suggested_fixes=suggested_fixes,
         agent_repair_instructions=_agent_repair_instructions(decision, violations),
         diagnostics=diagnostics,
-        trace=_trace_for(policy, decision, violations),
+        trace=trace,
         release_decision=release_decision,
         trigger=trigger,
         finding_fingerprints=finding_fingerprints,
@@ -1276,6 +1308,54 @@ def _risk_for(violations: list[AgentResultViolatedRule]) -> AgentResultRiskLevel
         return "none"
     max_item = max(violations, key=lambda item: _RISK_RANK[item.risk_level])
     return max_item.risk_level
+
+
+# Canonical capability gate. check is boundary-only; verify computes the
+# capability delta and owns release_decision.decision. Bare ``verify --json``
+# auto-detects the base (v0.13) and emits the agent_result_v1 surface, so it
+# works for both the local working tree and committed refs.
+_VERIFY_COMMAND = "agents-shipgate verify --json"
+
+
+def _coverage_next_action() -> AgentResultNextAction:
+    return AgentResultNextAction(
+        actor="coding_agent",
+        kind="warn",
+        command=_VERIFY_COMMAND,
+        why=(
+            "shipgate check is boundary-only and did not evaluate the changed tool "
+            "surface; run verify for the capability merge gate before completing."
+        ),
+    )
+
+
+def _coverage_summary(surfaces: list[str]) -> str:
+    return (
+        "No Codex boundary rule fired, but the diff changes a declared tool surface "
+        f"({', '.join(surfaces[:5])}) that only verify gates. Run verify before "
+        "reporting completion."
+    )
+
+
+def _coverage_diagnostic(surfaces: list[str]) -> AgentResultDiagnostic:
+    return AgentResultDiagnostic(
+        level="warning",
+        code="capability_change_requires_verify",
+        message=(
+            "shipgate check is boundary-only; the changed tool surface(s) "
+            f"{', '.join(surfaces[:5])} are gated by verify, not check."
+        ),
+    )
+
+
+def _coverage_trace(surfaces: list[str]) -> AgentResultTraceEvent:
+    return AgentResultTraceEvent(
+        step="coverage",
+        summary=(
+            f"boundary_only: capability gating for {len(surfaces)} changed tool "
+            "surface(s) deferred to verify."
+        ),
+    )
 
 
 def _summary_for(decision: str, violations: list[AgentResultViolatedRule]) -> str:

--- a/tests/test_codex_boundary_check.py
+++ b/tests/test_codex_boundary_check.py
@@ -155,6 +155,68 @@ def test_check_warns_when_manifest_declares_changed_tool_source(tmp_path: Path) 
     assert result.first_next_action.command.startswith("agents-shipgate verify")
 
 
+def _write_manifest(tmp_path: Path, tool_sources: str) -> None:
+    (tmp_path / "shipgate.yaml").write_text(
+        "version: \"0.1\"\n"
+        "project:\n  name: demo\n"
+        "agent:\n  name: bot\n  declared_purpose:\n    - answer questions\n"
+        "environment:\n  target: production_like\n"
+        f"tool_sources:\n{tool_sources}",
+        encoding="utf-8",
+    )
+
+
+def test_check_warns_on_change_under_declared_directory_source(tmp_path: Path) -> None:
+    # A directory tool source (loaders scan files inside it) must match a
+    # changed file *under* the directory, not only an exact path equal to it.
+    _write_manifest(
+        tmp_path,
+        "  - id: sdk\n    type: mcp\n    path: agents\n    trust: internal\n",
+    )
+    diff = (
+        "diff --git a/agents/refund_agent.py b/agents/refund_agent.py\n"
+        "--- a/agents/refund_agent.py\n"
+        "+++ b/agents/refund_agent.py\n"
+        "@@ -1 +1,2 @@\n"
+        " x = 1\n"
+        "+y = 2\n"
+    )
+    result = build_codex_agent_result(
+        agent="claude-code",
+        workspace=tmp_path,
+        diff_text=diff,
+        config=Path("shipgate.yaml"),
+        policy=None,
+    )
+    assert result.decision == "warn"
+    assert result.first_next_action.command.startswith("agents-shipgate verify")
+
+
+def test_check_does_not_warn_on_broad_root_source(tmp_path: Path) -> None:
+    # A source rooted at the workspace (codex_config path: .) must not turn
+    # every changed file — including docs — into a coverage warn.
+    _write_manifest(
+        tmp_path,
+        "  - id: cfg\n    type: codex_config\n    path: .\n    trust: internal\n",
+    )
+    diff = (
+        "diff --git a/README.md b/README.md\n"
+        "--- a/README.md\n"
+        "+++ b/README.md\n"
+        "@@ -1 +1,2 @@\n"
+        " hello\n"
+        "+world\n"
+    )
+    result = build_codex_agent_result(
+        agent="claude-code",
+        workspace=tmp_path,
+        diff_text=diff,
+        config=Path("shipgate.yaml"),
+        policy=None,
+    )
+    assert result.decision == "allow"
+
+
 def test_check_does_not_warn_on_docs_change_in_opted_in_repo(tmp_path: Path) -> None:
     # The "no noise on docs-only diffs" property must survive the coverage fix.
     (tmp_path / "shipgate.yaml").write_text(

--- a/tests/test_codex_boundary_check.py
+++ b/tests/test_codex_boundary_check.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from jsonschema import Draft202012Validator
 from typer.testing import CliRunner
 
+from agents_shipgate.cli.agent_result import build_codex_agent_result
 from agents_shipgate.cli.main import app
 from agents_shipgate.core.codex_boundary import evaluate_codex_boundary_result
 
@@ -71,6 +72,116 @@ def test_codex_check_audit_id_is_stable(tmp_path: Path) -> None:
     second = json.loads(runner.invoke(app, args).output)
 
     assert first["audit_id"] == second["audit_id"]
+
+
+# --- Coverage gap: check is boundary-only and must not green-light a -------
+# capability change that only verify gates (the check/verify consistency fix).
+
+_TOOL_SOURCE_DIFF = (
+    "diff --git a/mcp-tools.json b/mcp-tools.json\n"
+    "--- a/mcp-tools.json\n"
+    "+++ b/mcp-tools.json\n"
+    "@@ -1 +1 @@\n"
+    '-{"tools": []}\n'
+    '+{"tools": [{"name": "bash_run"}]}\n'
+)
+
+
+def _validate(payload: dict) -> None:
+    Draft202012Validator(json.loads(SCHEMA.read_text(encoding="utf-8"))).validate(payload)
+
+
+def test_declared_tool_surface_change_warns_and_routes_to_verify(tmp_path: Path) -> None:
+    result = evaluate_codex_boundary_result(
+        workspace=tmp_path,
+        diff_text=_TOOL_SOURCE_DIFF,
+        agent="claude-code",
+        capability_surfaces_changed=["mcp-tools.json"],
+    )
+    payload = result.model_dump(mode="json", exclude_none=True)
+    _validate(payload)
+    # Was a bare allow before the fix; now a warn that defers to verify.
+    assert payload["decision"] == "warn"
+    assert payload["completion_allowed"] is True
+    assert payload["must_stop"] is False
+    assert payload["first_next_action"]["kind"] == "warn"
+    assert payload["first_next_action"]["command"].startswith("agents-shipgate verify")
+    assert any(d["code"] == "capability_change_requires_verify" for d in payload["diagnostics"])
+    assert any(t["step"] == "coverage" for t in payload["trace"])
+
+
+def test_no_coverage_signal_keeps_clean_allow(tmp_path: Path) -> None:
+    # Same diff, but nothing declares it a tool source -> unchanged allow.
+    result = evaluate_codex_boundary_result(
+        workspace=tmp_path,
+        diff_text=_TOOL_SOURCE_DIFF,
+        agent="claude-code",
+        capability_surfaces_changed=None,
+    )
+    assert result.decision == "allow"
+    assert result.first_next_action.kind == "continue"
+
+
+def test_coverage_gap_only_escalates_from_allow_never_downgrades_a_block(tmp_path: Path) -> None:
+    # A boundary block plus a tool-surface change must stay blocked, not warn.
+    block_diff = (CORPUS / "mcp_auto_approve_write.diff").read_text(encoding="utf-8")
+    result = evaluate_codex_boundary_result(
+        workspace=tmp_path,
+        diff_text=block_diff,
+        agent="claude-code",
+        capability_surfaces_changed=["mcp-tools.json"],
+    )
+    assert result.decision == "block"
+
+
+def test_check_warns_when_manifest_declares_changed_tool_source(tmp_path: Path) -> None:
+    (tmp_path / "shipgate.yaml").write_text(
+        "version: \"0.1\"\n"
+        "project:\n  name: demo\n"
+        "agent:\n  name: bot\n  declared_purpose:\n    - answer questions\n"
+        "environment:\n  target: production_like\n"
+        "tool_sources:\n  - id: mcp_tools\n    type: mcp\n    path: mcp-tools.json\n"
+        "    trust: internal\n",
+        encoding="utf-8",
+    )
+    result = build_codex_agent_result(
+        agent="claude-code",
+        workspace=tmp_path,
+        diff_text=_TOOL_SOURCE_DIFF,
+        config=Path("shipgate.yaml"),
+        policy=None,
+    )
+    assert result.decision == "warn"
+    assert result.first_next_action.command.startswith("agents-shipgate verify")
+
+
+def test_check_does_not_warn_on_docs_change_in_opted_in_repo(tmp_path: Path) -> None:
+    # The "no noise on docs-only diffs" property must survive the coverage fix.
+    (tmp_path / "shipgate.yaml").write_text(
+        "version: \"0.1\"\n"
+        "project:\n  name: demo\n"
+        "agent:\n  name: bot\n  declared_purpose:\n    - answer questions\n"
+        "environment:\n  target: production_like\n"
+        "tool_sources:\n  - id: mcp_tools\n    type: mcp\n    path: mcp-tools.json\n"
+        "    trust: internal\n",
+        encoding="utf-8",
+    )
+    docs_diff = (
+        "diff --git a/README.md b/README.md\n"
+        "--- a/README.md\n"
+        "+++ b/README.md\n"
+        "@@ -1 +1,2 @@\n"
+        " hello\n"
+        "+world\n"
+    )
+    result = build_codex_agent_result(
+        agent="claude-code",
+        workspace=tmp_path,
+        diff_text=docs_diff,
+        config=Path("shipgate.yaml"),
+        policy=None,
+    )
+    assert result.decision == "allow"
 
 
 def test_codex_check_reads_diff_from_stdin(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Closes the **`check`/`verify` semantic gap** — the Phase 2 correctness item where the agent-native local loop could disagree with the one decision engine.
- `shipgate check` routes only through the boundary evaluator (host/trust-root surfaces: Codex/host config, MCP approvals, CI gate, agent instructions, policy, skills). It never inspects the **tool-use capability surface** — only `verify` computes the capability delta. So a diff that adds a capability to a declared tool source returned `decision="allow"`, `completion_allowed=true` from `check`, while `verify` would block it. That is a second decision engine that can contradict `release_decision.decision`.
- **Fix:** when `check` produces a clean boundary `allow`, has no full-scan `release_decision`, **and** the diff changes a file the manifest declares as a `tool_sources[].path`, escalate `allow → warn` and route `first_next_action` to `verify`, with a `diagnostics[].code="capability_change_requires_verify"` marker and a `trace[].step="coverage"` event. `check` defers capability gating to the one decision engine instead of green-lighting a change it never evaluated.

## Why this design

- **Manifest-declared `tool_sources[].path` is the authoritative signal**, not a heuristic. In an opted-in repo the trigger force-runs on *every* PR (even docs-only), so `should_run` alone would warn on docs and regress the prized "0 docs-only noise" property. Using the manifest's declared tool sources means the warn fires only on genuine capability surfaces — docs/test/boundary-only diffs still return `allow`.
- **`warn`, not `block`.** Completion stays allowed (check isn't the merge gate; verify/CI is), but the agent is told to run the real gate. Blocking every tool-surface edit would be a false positive and make `check` unusable.
- **No second engine.** `check` doesn't try to reproduce the capability scan; it defers to `verify` / `release_decision.decision`.
- **No `agent_result_v1` schema change** — reuses existing fields (`warn` decision, `diagnostics`, `trace`). Best-effort manifest load; an absent/invalid manifest degrades to prior behavior. Covers both the `check` CLI and the MCP server (both route through `build_codex_agent_result`).

## Behavior

| Diff in an opted-in repo | Before | After |
|---|---|---|
| changes a declared `tool_sources[].path` | `allow` | `warn` → `agents-shipgate verify --json` |
| docs/test-only | `allow` | `allow` (unchanged) |
| boundary file (`.codex/config.toml`, policy, CI gate) | `allow`/`block` per rules | unchanged |
| boundary block + tool-surface change | `block` | `block` (coverage only escalates from `allow`) |

## Type

- [x] CLI or GitHub Action behavior (`shipgate check` routing; no schema change)
- [ ] Report, schema, or SARIF output

## Verification

CI is authoritative for `ruff`, `compileall`, and `pytest`.

Additional local checks run:

- New tests in `tests/test_codex_boundary_check.py`: declared tool-source change → warn+verify+diagnostic+`trace.step="coverage"`; no manifest / docs change → allow; boundary block + tool-surface change stays blocked.
- Full suite `pytest -n auto -m "not perf"` — green (exit 0)
- `ruff check .`, `compileall -q src tests`, `scripts/generate_schemas.py --check` — all clean
- Manual repro confirmed: declared tool-source change → warn; README → allow (no noise); `.codex/config.toml` → allow.

## Release-readiness notes

- [x] No user-code import added to default scan paths (best-effort YAML manifest load only)
- [x] No network access added to default scan paths
- [x] New or changed check IDs documented in `docs/checks.md` (n/a — no check IDs added)
- [x] Report/schema changes are additive or documented (n/a — no schema change; reuses existing `agent_result_v1` fields; protocol documented in `docs/agents/protocol.md` → Coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)