### PR TITLE
Add accepted-debt exception workflow (Phase 4: organizational governance)

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -206,7 +206,7 @@
     "3": "input_parse_error",
     "4": "other_error",
     "6": "baseline_integrity_failure",
-    "20": "strict_gate_failure"
+    "20": "gate_failure (strict-mode scan/verify; or opt-in governance gates: baseline status --require-owner/--require-expiry/--max-age-days, audit --host --drift --fail-on-drift)"
   },
   "agent_mode_env_var": "AGENTS_SHIPGATE_AGENT_MODE",
   "plugin_opt_in_env_var": "AGENTS_SHIPGATE_ENABLE_PLUGINS"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,8 +331,15 @@ checks:
 ### Task 4 · Save a baseline before enabling strict CI
 
 ```bash
-agents-shipgate baseline save -c shipgate.yaml --out .agents-shipgate/baseline.json
+agents-shipgate baseline save -c shipgate.yaml --out .agents-shipgate/baseline.json \
+  --owner <human> --reason "<why accepted>" --expires <YYYY-MM-DD>
 ```
+
+`--owner`/`--reason`/`--expires` (v0.13+) record who accepted the debt, why,
+and the review-by date on newly-accepted entries. They are human-declared
+values: an agent must ask the user, never invent them, and blank values are
+rejected. `--apply-to-existing` fills the fields into existing entries that
+lack them without overwriting previously-set values.
 
 Then in CI:
 
@@ -343,6 +350,11 @@ agents-shipgate scan -c shipgate.yaml \
 ```
 
 Strict mode fails CI only on **new** findings (those not in the baseline).
+`agents-shipgate baseline status --json` reports accepted-debt aging
+(owner, age, expiry); with `--require-owner` / `--require-expiry` /
+`--max-age-days N` it exits `20` on violations (advisory exit `0` without
+gate flags) — parse `violations[]` from the JSON, then route to a human:
+acknowledging debt is a human decision.
 
 ### Task 5 · Explain a check or a specific finding
 
@@ -468,7 +480,8 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate trigger` | `--workspace`, `--changed-files`, `--diff`, `--base`, `--head`, `--manifest-present`/`--no-manifest-present`, `--user-requested`, `--list-rules`, `--json` |
 | `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
-| `agents-shipgate baseline save` | `-c`, `--out` |
+| `agents-shipgate baseline save` | `-c`, `--out`, `--owner`, `--reason`, `--expires`, `--apply-to-existing` |
+| `agents-shipgate baseline status` | `--baseline`, `--as-of`, `--require-owner`, `--require-expiry`, `--max-age-days`, `--json` (gate flags exit `20` on violations) |
 | `agents-shipgate fixture` | `list`, `run`, `copy`, `verify` |
 | `agents-shipgate self-check` | `--json` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 0.13.0 - Unreleased
 
+- **Accepted-debt exception workflow (baseline schema 0.6).** `baseline save`
+  gains `--owner`, `--reason`, and `--expires` so the approval metadata the
+  v0.5 provenance contract documented as "reviewer-set" is finally settable
+  without hand-editing the file (which trips the integrity hash). Metadata is
+  stamped on newly-accepted entries; `--apply-to-existing` fills the fields
+  into existing entries that lack them — never overwriting a previously-set
+  value and preserving each entry's original `recorded_at`/`run_id` history.
+  Approval is declared, never inferred, matching the `human_ack` contract.
+  New `baseline status` reports accepted-debt aging (owner, age, expiry,
+  expiring-soon/expired/unowned summary; `--as-of` pins the date for
+  reproducible CI output) and turns into an org governance gate with
+  `--require-owner` / `--require-expiry` / `--max-age-days N` — exit 20 on
+  violations, advisory exit 0 without gate flags. Expired entries violate
+  `--require-expiry`, and entries without provenance fail every active gate
+  (unknown history is ungoverned debt, not exempt debt). Legacy 0.2–0.5
+  baselines still load; re-saving upgrades them to 0.6.
 - **Host-grant drift detection.** `audit --host --save-baseline` records the
   current coding-agent host grants (MCP servers, Claude Code permission rules
   and hooks, workflow scopes, Codex config presence) as the acknowledged state

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -30,8 +30,9 @@ These commands and flags are stable across all `0.x.y` releases. They will only 
 | `agents-shipgate capability export` | `--config`/`-c`, `--out`, `--report-out`, `--report-copy`/`--no-report-copy`, `--json`, `--no-plugins`, `--verbose` |
 | `agents-shipgate capability diff` | `--base`, `--head`, `--out`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
-| `agents-shipgate baseline save` | `-c`, `--config`, `--out` |
+| `agents-shipgate baseline save` | `-c`, `--config`, `--out`, `--owner` (v0.13+), `--reason` (v0.13+), `--expires` (v0.13+), `--apply-to-existing` (v0.13+) |
 | `agents-shipgate baseline verify` (v0.11+) | `--baseline`, `--audit-log`, `--strict`, `--json`, `--verbose` |
+| `agents-shipgate baseline status` (v0.13+) | `--baseline`, `--as-of`, `--require-owner`, `--require-expiry`, `--max-age-days`, `--json` — advisory exit `0` with no gate flags; any gate flag exits `20` on violations |
 | `agents-shipgate fixture list` | `--json` |
 | `agents-shipgate fixture run` | `<name>`, `--ci-mode`, `--out` |
 | `agents-shipgate fixture copy` | `<name>`, `--to` |
@@ -67,7 +68,7 @@ not agent-repairable authority gaps.
 | `3` | Input parse error (malformed YAML/JSON, file too large, path traversal blocked) |
 | `4` | Other Agents Shipgate error |
 | `6` | Baseline integrity failure (v0.11+) — `agents-shipgate baseline verify --strict` detected `SHIP-BASELINE-INTEGRITY-MISMATCH`. Only the standalone `baseline verify` command emits this code; `scan` continues to use `20` for gate failure regardless of integrity-mode. |
-| `20` | Strict-mode gate failure (≥ 1 unsuppressed finding hit `fail_on`, or ≥ 1 active unbaselined finding sets `blocks_release`) |
+| `20` | Gate failure. Strict-mode scan/verify: ≥ 1 unsuppressed finding hit `fail_on`, or ≥ 1 active unbaselined finding sets `blocks_release`. Also emitted by opt-in governance gate flags (v0.13+): `baseline status --require-owner`/`--require-expiry`/`--max-age-days` on violations, and `audit --host --drift --fail-on-drift` on host-grant drift. Without those flags the commands are advisory and exit `0`. |
 
 ### Runtime contract JSON
 

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -8,16 +8,49 @@ after findings already exist.
 ```bash
 agents-shipgate baseline save \
   --config shipgate.yaml \
-  --out .agents-shipgate/baseline.json
+  --out .agents-shipgate/baseline.json \
+  --owner alice --reason "accepted pending Q3 fix" --expires 2026-09-30
 ```
 
 The baseline contains active, unsuppressed findings only. Suppressed findings
 are intentionally excluded because they already carry an explicit review reason
 in `shipgate.yaml`.
 
+`--owner`, `--reason`, and `--expires` (v0.6) record exception metadata on
+**newly-accepted** entries: who approved this debt, why, and by when it must
+be reviewed again. They are declared, never inferred — the same contract as
+`human_ack` (a coding agent must not manufacture approval). Entries already
+in the baseline keep their original metadata on re-save. To acknowledge
+**existing** unowned debt in one pass, add `--apply-to-existing`: it fills
+the given fields into entries that lack them, never overwrites a
+previously-set value, and preserves each entry's original
+`recorded_at`/`run_id` history. Use the CLI rather than hand-editing the
+JSON — hand-edits trip the integrity hash
+(`SHIP-BASELINE-INTEGRITY-MISMATCH`).
+
 Severity values in the baseline are the report-visible severities after
 `checks.severity_overrides` are applied. Matching still uses fingerprints, not
 severity, so changing an override does not create a new baseline identity.
+
+## Debt Status And Governance Gates
+
+```bash
+agents-shipgate baseline status --json          # aging report, advisory
+agents-shipgate baseline status \
+  --require-owner --require-expiry --max-age-days 180   # org gate: exit 20
+```
+
+`baseline status` reports accepted-debt aging per entry (owner, reason, age,
+days until expiry) plus a summary (owned/unowned, expired, expiring soon,
+oldest entry). With no gate flags it is advisory and always exits 0; with any
+of `--require-owner`, `--require-expiry`, or `--max-age-days N` it exits 20
+when entries violate the requirement — wire it into a scheduled workflow next
+to the host-grant drift gate to keep accepted debt owned and time-bound.
+An expired entry violates `--require-expiry` (an expired exception is no
+longer a valid exception), and entries without provenance (legacy 0.2–0.4
+files never re-saved) fail every active gate: unknown history is ungoverned
+debt, not exempt debt. `--as-of YYYY-MM-DD` pins the reference date for
+reproducible CI output.
 
 ## Apply The Baseline
 
@@ -71,9 +104,13 @@ public fingerprints.
 
 ## Baseline Schema Versions
 
-`agents-shipgate baseline save` now writes baseline schema `0.4`. It preserves
-the existing finding fields, keeps the optional `tool_surface_facts` snapshot
-from schema `0.3`, and adds an optional `action_surface_facts` snapshot so
+`agents-shipgate baseline save` now writes baseline schema `0.6`, which adds
+the optional `provenance.owner` approver field alongside the reviewer-set
+`reason`/`expires` (all settable from `baseline save` flags). Schema `0.5`
+added per-entry provenance (`scanner_version`, `run_id`, `recorded_at`).
+Schema `0.4` preserves the existing finding fields, keeps the optional
+`tool_surface_facts` snapshot from schema `0.3`, and adds an optional
+`action_surface_facts` snapshot so
 `agents-shipgate scan --baseline .agents-shipgate/baseline.json` can also show
 tool-surface and action-surface diffs when `--diff-from` is not supplied.
 

--- a/docs/errors.json
+++ b/docs/errors.json
@@ -12,7 +12,7 @@
     "3": "input parse error (input_parse_error)",
     "4": "other agents-shipgate error (other_error, internal_error)",
     "5": "apply-patches containment violation (covered by other_error in agent mode)",
-    "20": "strict-mode gate failure"
+    "20": "gate failure: strict-mode scan/verify, or an opt-in governance gate flag (baseline status --require-owner/--require-expiry/--max-age-days on violations; audit --host --drift --fail-on-drift on host-grant drift). Without those flags the commands are advisory and exit 0."
   },
   "errors": [
     {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -356,8 +356,15 @@ checks:
 ### Task 4 · Save a baseline before enabling strict CI
 
 ```bash
-agents-shipgate baseline save -c shipgate.yaml --out .agents-shipgate/baseline.json
+agents-shipgate baseline save -c shipgate.yaml --out .agents-shipgate/baseline.json \
+  --owner <human> --reason "<why accepted>" --expires <YYYY-MM-DD>
 ```
+
+`--owner`/`--reason`/`--expires` (v0.13+) record who accepted the debt, why,
+and the review-by date on newly-accepted entries. They are human-declared
+values: an agent must ask the user, never invent them, and blank values are
+rejected. `--apply-to-existing` fills the fields into existing entries that
+lack them without overwriting previously-set values.
 
 Then in CI:
 
@@ -368,6 +375,11 @@ agents-shipgate scan -c shipgate.yaml \
 ```
 
 Strict mode fails CI only on **new** findings (those not in the baseline).
+`agents-shipgate baseline status --json` reports accepted-debt aging
+(owner, age, expiry); with `--require-owner` / `--require-expiry` /
+`--max-age-days N` it exits `20` on violations (advisory exit `0` without
+gate flags) — parse `violations[]` from the JSON, then route to a human:
+acknowledging debt is a human decision.
 
 ### Task 5 · Explain a check or a specific finding
 
@@ -493,7 +505,8 @@ Promised to not break in `0.x` minor versions. See [STABILITY.md](STABILITY.md) 
 | `agents-shipgate trigger` | `--workspace`, `--changed-files`, `--diff`, `--base`, `--head`, `--manifest-present`/`--no-manifest-present`, `--user-requested`, `--list-rules`, `--json` |
 | `agents-shipgate bootstrap` | `--workspace`, `--confidence`, `--no-ci`, `--no-apply`, `--json` |
 | `agents-shipgate list-checks` | `--json`, `--no-plugins` |
-| `agents-shipgate baseline save` | `-c`, `--out` |
+| `agents-shipgate baseline save` | `-c`, `--out`, `--owner`, `--reason`, `--expires`, `--apply-to-existing` |
+| `agents-shipgate baseline status` | `--baseline`, `--as-of`, `--require-owner`, `--require-expiry`, `--max-age-days`, `--json` (gate flags exit `20` on violations) |
 | `agents-shipgate fixture` | `list`, `run`, `copy`, `verify` |
 | `agents-shipgate self-check` | `--json` |
 

--- a/src/agents_shipgate/cli/_register_baseline.py
+++ b/src/agents_shipgate/cli/_register_baseline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import typer
@@ -9,7 +10,13 @@ from agents_shipgate.checks.baseline_integrity import has_hash_mismatch
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.cli.scan.path_helpers import _resolve_audit_log_path
 from agents_shipgate.config.loader import load_manifest
-from agents_shipgate.core.baseline import verify_baseline, write_baseline
+from agents_shipgate.core.baseline import (
+    baseline_status_payload,
+    baseline_status_violations,
+    load_baseline,
+    verify_baseline,
+    write_baseline,
+)
 from agents_shipgate.core.errors import AgentsShipgateError, ConfigError, InputParseError
 from agents_shipgate.core.logging import configure_logging
 
@@ -34,9 +41,52 @@ def register(app: typer.Typer) -> None:
             "--out",
             help="Baseline JSON path to write.",
         ),
+        owner: str | None = typer.Option(
+            None,
+            "--owner",
+            help=(
+                "Human approver recorded on newly-accepted entries "
+                "(exception metadata; never inferred)."
+            ),
+        ),
+        reason: str | None = typer.Option(
+            None,
+            "--reason",
+            help="Why this debt was accepted; recorded on newly-accepted entries.",
+        ),
+        expires: str | None = typer.Option(
+            None,
+            "--expires",
+            help="Review-by date (YYYY-MM-DD) recorded on newly-accepted entries.",
+        ),
+        apply_to_existing: bool = typer.Option(
+            False,
+            "--apply-to-existing",
+            help=(
+                "Also fill --owner/--reason/--expires into existing entries "
+                "that lack them. Never overwrites a previously-set value and "
+                "preserves each entry's original recorded_at."
+            ),
+        ),
         verbose: bool = typer.Option(False, "--verbose", help="Enable debug logs."),
     ) -> None:
         """Save active unsuppressed findings as the current accepted baseline."""
+        expires_date: date | None = None
+        if expires is not None:
+            try:
+                expires_date = date.fromisoformat(expires)
+            except ValueError:
+                typer.echo(
+                    f"--expires must be an ISO date (YYYY-MM-DD), got {expires!r}.",
+                    err=True,
+                )
+                raise typer.Exit(2) from None
+        if apply_to_existing and not (owner or reason or expires_date):
+            typer.echo(
+                "--apply-to-existing needs at least one of --owner/--reason/--expires.",
+                err=True,
+            )
+            raise typer.Exit(2)
         try:
             configure_logging(verbose=verbose)
             report, _ = run_scan(
@@ -47,7 +97,15 @@ def register(app: typer.Typer) -> None:
             )
             manifest = load_manifest(config)
             audit_log = _resolve_audit_log_path(manifest, out)
-            baseline = write_baseline(report, out, audit_log_path=audit_log)
+            baseline = write_baseline(
+                report,
+                out,
+                audit_log_path=audit_log,
+                owner=owner,
+                reason=reason,
+                expires=expires_date,
+                apply_to_existing=apply_to_existing,
+            )
         except ConfigError as exc:
             typer.echo(f"Config error: {exc}", err=True)
             raise typer.Exit(2) from exc
@@ -150,6 +208,117 @@ def register(app: typer.Typer) -> None:
                     )
         if strict and has_hash_mismatch(issues):
             raise typer.Exit(BASELINE_INTEGRITY_EXIT_CODE)
+
+    @baseline_app.command("status")
+    def baseline_status(
+        baseline: Path = typer.Option(
+            Path(".agents-shipgate/baseline.json"),
+            "--baseline",
+            help="Baseline JSON path to report on.",
+        ),
+        as_of: str | None = typer.Option(
+            None,
+            "--as-of",
+            help="Compute ages/expiry as of this ISO date (default: today UTC).",
+        ),
+        require_owner: bool = typer.Option(
+            False,
+            "--require-owner",
+            help="Governance gate: every entry must name an owner.",
+        ),
+        require_expiry: bool = typer.Option(
+            False,
+            "--require-expiry",
+            help="Governance gate: every entry must carry an unexpired review-by date.",
+        ),
+        max_age_days: int | None = typer.Option(
+            None,
+            "--max-age-days",
+            help="Governance gate: no entry may be older than this many days.",
+        ),
+        json_output: bool = typer.Option(
+            False, "--json", help="Emit JSON instead of text."
+        ),
+    ) -> None:
+        """Accepted-debt aging report; gate flags exit 20 on violations.
+
+        Advisory with no gate flags. Entries without provenance fail every
+        active gate (unknown history is ungoverned debt, not exempt debt).
+        """
+        as_of_date: date
+        if as_of is not None:
+            try:
+                as_of_date = date.fromisoformat(as_of)
+            except ValueError:
+                typer.echo(
+                    f"--as-of must be an ISO date (YYYY-MM-DD), got {as_of!r}.",
+                    err=True,
+                )
+                raise typer.Exit(2) from None
+        else:
+            as_of_date = datetime.now(UTC).date()
+        try:
+            baseline_file = load_baseline(baseline)
+        except InputParseError as exc:
+            typer.echo(f"Input parsing error: {exc}", err=True)
+            raise typer.Exit(3) from exc
+        payload = baseline_status_payload(baseline_file, as_of=as_of_date)
+        violations = baseline_status_violations(
+            payload,
+            require_owner=require_owner,
+            require_expiry=require_expiry,
+            max_age_days=max_age_days,
+        )
+        payload["violations"] = violations
+        gating = require_owner or require_expiry or max_age_days is not None
+        if json_output:
+            typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            summary = payload["summary"]
+            typer.echo(f"Accepted debt as of {payload['as_of']}: {summary['total']} entries")
+            typer.echo(
+                f"  owned: {summary['owned']} · unowned: {summary['unowned']} · "
+                f"no expiry: {summary['no_expiry']} · expired: {summary['expired']} · "
+                f"expiring within {payload['expiring_within_days']}d: "
+                f"{summary['expiring_within_days']}"
+            )
+            if summary["oldest_age_days"] is not None:
+                typer.echo(f"  oldest entry: {summary['oldest_age_days']} days")
+            if summary["no_provenance"]:
+                typer.echo(
+                    f"  no provenance: {summary['no_provenance']} "
+                    "(legacy entries; re-save to stamp)"
+                )
+            for entry in payload["entries"]:
+                marks = []
+                if entry["expired"]:
+                    marks.append("EXPIRED")
+                if entry["unowned"]:
+                    marks.append("unowned")
+                if entry["no_expiry"]:
+                    marks.append("no-expiry")
+                suffix = f"  [{', '.join(marks)}]" if marks else ""
+                owner_text = entry["owner"] or "—"
+                age_text = (
+                    f"{entry['age_days']}d" if entry["age_days"] is not None else "?"
+                )
+                typer.echo(
+                    f"  {entry['fingerprint'][:16]}  {entry['check_id']}  "
+                    f"owner={owner_text}  age={age_text}{suffix}"
+                )
+            if violations:
+                typer.echo(f"Governance violations: {len(violations)}")
+                for violation in violations:
+                    typer.echo(
+                        f"  {violation['kind']}: {violation['fingerprint'][:16]}"
+                    )
+                typer.echo(
+                    "Re-acknowledge after review: agents-shipgate baseline save "
+                    "--owner <name> --reason <why> --expires <YYYY-MM-DD> "
+                    "--apply-to-existing"
+                )
+        if gating and violations:
+            raise typer.Exit(20)
 
     app.add_typer(baseline_app, name="baseline")
 

--- a/src/agents_shipgate/cli/_register_baseline.py
+++ b/src/agents_shipgate/cli/_register_baseline.py
@@ -71,6 +71,19 @@ def register(app: typer.Typer) -> None:
         verbose: bool = typer.Option(False, "--verbose", help="Enable debug logs."),
     ) -> None:
         """Save active unsuppressed findings as the current accepted baseline."""
+        # Blank approval metadata is rejected, not normalized away silently:
+        # declared human authority cannot be blank (human_ack contract), and
+        # a blank owner must never satisfy `status --require-owner`.
+        for flag_name, value in (("--owner", owner), ("--reason", reason)):
+            if value is not None and not value.strip():
+                typer.echo(
+                    f"{flag_name} cannot be blank — declared human authority "
+                    "requires a non-empty value.",
+                    err=True,
+                )
+                raise typer.Exit(2)
+        owner = owner.strip() if owner is not None else None
+        reason = reason.strip() if reason is not None else None
         expires_date: date | None = None
         if expires is not None:
             try:

--- a/src/agents_shipgate/core/baseline.py
+++ b/src/agents_shipgate/core/baseline.py
@@ -248,8 +248,11 @@ def baseline_status_payload(
         provenance = finding.provenance
         recorded = _recorded_date(provenance)
         expires = provenance.expires if provenance is not None else None
-        owner = provenance.owner if provenance is not None else None
-        reason = provenance.reason if provenance is not None else None
+        # Blank/whitespace metadata is treated as missing: the CLI rejects
+        # it at save time, but files can be produced by other means and a
+        # blank owner must never satisfy --require-owner.
+        owner = (provenance.owner or "").strip() or None if provenance else None
+        reason = (provenance.reason or "").strip() or None if provenance else None
         age_days = (as_of - recorded).days if recorded is not None else None
         days_until_expiry = (expires - as_of).days if expires is not None else None
         entries.append(

--- a/src/agents_shipgate/core/baseline.py
+++ b/src/agents_shipgate/core/baseline.py
@@ -39,21 +39,31 @@ def baseline_from_report(
     scanner_version: str | None = None,
     prior_baseline: BaselineFile | None = None,
     now: str | None = None,
+    owner: str | None = None,
+    reason: str | None = None,
+    expires: date | None = None,
+    apply_to_existing: bool = False,
 ) -> BaselineFile:
-    """Build a v0.5 baseline file from a scan report.
+    """Build a baseline file from a scan report.
 
     Provenance handling:
 
     - When ``prior_baseline`` is provided and an entry's fingerprint
       already appears there with a populated ``provenance``, the prior
-      provenance is preserved verbatim — only newly-added fingerprints
-      get a fresh provenance stamp. This keeps re-saves idempotent for
-      the audit log and lets reviewer-set ``reason`` / ``expires`` survive
-      subsequent saves.
+      provenance is preserved — only newly-added fingerprints get a
+      fresh provenance stamp. This keeps re-saves idempotent for the
+      audit log and lets reviewer-set ``owner`` / ``reason`` /
+      ``expires`` survive subsequent saves.
     - When the prior entry has no provenance (loaded from a 0.2/0.3/0.4
       baseline), the entry is upgraded with a fresh provenance stamp.
       This is the migration path: re-saving a legacy baseline stamps
       provenance on every entry as of the next scan.
+
+    Exception metadata (v0.6): ``owner`` / ``reason`` / ``expires`` are
+    stamped on newly-added entries. With ``apply_to_existing=True`` they
+    are also FILLED IN on prior entries that lack them — a previously
+    set value is never overwritten and ``recorded_at`` / ``run_id`` are
+    preserved, so acknowledging legacy debt does not rewrite its history.
 
     ``scanner_version`` and ``now`` are injectable for deterministic
     testing. In production they default to the package version and UTC
@@ -73,11 +83,22 @@ def baseline_from_report(
         prior_entry = prior_by_fp.get(fingerprint)
         if prior_entry is not None and prior_entry.provenance is not None:
             provenance = prior_entry.provenance
+            if apply_to_existing:
+                provenance = provenance.model_copy(
+                    update={
+                        "owner": provenance.owner or owner,
+                        "reason": provenance.reason or reason,
+                        "expires": provenance.expires or expires,
+                    }
+                )
         else:
             provenance = BaselineProvenance(
                 scanner_version=scanner_version,
                 run_id=report.run_id,
                 recorded_at=recorded_at,
+                owner=owner,
+                reason=reason,
+                expires=expires,
             )
         findings.append(
             BaselineFinding(
@@ -106,8 +127,12 @@ def write_baseline(
     *,
     scanner_version: str | None = None,
     audit_log_path: Path | None = None,
+    owner: str | None = None,
+    reason: str | None = None,
+    expires: date | None = None,
+    apply_to_existing: bool = False,
 ) -> BaselineFile:
-    """Write a v0.5 baseline + append a row to the audit log.
+    """Write a baseline + append a row to the audit log.
 
     The audit log defaults to ``<path.parent>/baseline-audit.log``. Pass
     ``audit_log_path`` explicitly to override (tests use a tmp path).
@@ -118,6 +143,9 @@ def write_baseline(
     that change nothing still produce an audit row with empty
     ``added_fingerprints`` / ``removed_fingerprints`` — that is the
     intended ledger semantics.
+
+    ``owner`` / ``reason`` / ``expires`` / ``apply_to_existing`` carry the
+    reviewer's exception metadata; see :func:`baseline_from_report`.
     """
     scanner_version = scanner_version or _SCANNER_VERSION
     prior_baseline = _try_load_baseline(path)
@@ -125,6 +153,10 @@ def write_baseline(
         report,
         scanner_version=scanner_version,
         prior_baseline=prior_baseline,
+        owner=owner,
+        reason=reason,
+        expires=expires,
+        apply_to_existing=apply_to_existing,
     )
     baseline = _preserve_created_at_when_content_matches(baseline, prior_baseline)
     hash_before: str | None = None
@@ -180,6 +212,122 @@ def load_baseline(path: Path) -> BaselineFile:
         return BaselineFile.model_validate_json(path.read_text(encoding="utf-8"))
     except (OSError, ValidationError, ValueError) as exc:
         raise InputParseError(f"Invalid baseline file {path}: {exc}") from exc
+
+
+# --- Debt status (exception-workflow reporting and gating) ----------------
+
+DEBT_STATUS_SCHEMA_VERSION = "0.1"
+
+
+def _recorded_date(provenance: BaselineProvenance | None) -> date | None:
+    if provenance is None or not provenance.recorded_at:
+        return None
+    try:
+        return date.fromisoformat(provenance.recorded_at[:10])
+    except ValueError:
+        return None
+
+
+def baseline_status_payload(
+    baseline: BaselineFile,
+    *,
+    as_of: date,
+    expiring_within_days: int = 30,
+) -> dict[str, object]:
+    """Deterministic accepted-debt aging report for a baseline file.
+
+    ``as_of`` is injected (CLI defaults to today UTC, ``--as-of`` pins it)
+    so the payload is reproducible. Entries without provenance (legacy
+    0.2–0.4 files never re-saved) report ``age_days=None`` and count as
+    unowned / no-expiry: unknown history is ungoverned debt, not exempt
+    debt.
+    """
+
+    entries: list[dict[str, object]] = []
+    for finding in sorted(baseline.findings, key=lambda item: item.fingerprint):
+        provenance = finding.provenance
+        recorded = _recorded_date(provenance)
+        expires = provenance.expires if provenance is not None else None
+        owner = provenance.owner if provenance is not None else None
+        reason = provenance.reason if provenance is not None else None
+        age_days = (as_of - recorded).days if recorded is not None else None
+        days_until_expiry = (expires - as_of).days if expires is not None else None
+        entries.append(
+            {
+                "fingerprint": finding.fingerprint,
+                "check_id": finding.check_id,
+                "severity": finding.severity,
+                "title": finding.title,
+                "tool_name": finding.tool_name,
+                "owner": owner,
+                "reason": reason,
+                "recorded_at": (
+                    provenance.recorded_at if provenance is not None else None
+                ),
+                "age_days": age_days,
+                "expires": expires.isoformat() if expires is not None else None,
+                "days_until_expiry": days_until_expiry,
+                "expired": days_until_expiry is not None and days_until_expiry < 0,
+                "unowned": owner is None,
+                "no_expiry": expires is None,
+            }
+        )
+    ages = [entry["age_days"] for entry in entries if entry["age_days"] is not None]
+    summary = {
+        "total": len(entries),
+        "owned": sum(1 for entry in entries if not entry["unowned"]),
+        "unowned": sum(1 for entry in entries if entry["unowned"]),
+        "with_expiry": sum(1 for entry in entries if not entry["no_expiry"]),
+        "no_expiry": sum(1 for entry in entries if entry["no_expiry"]),
+        "expired": sum(1 for entry in entries if entry["expired"]),
+        "expiring_within_days": sum(
+            1
+            for entry in entries
+            if entry["days_until_expiry"] is not None
+            and 0 <= entry["days_until_expiry"] <= expiring_within_days  # type: ignore[operator]
+        ),
+        "no_provenance": sum(1 for entry in entries if entry["age_days"] is None),
+        "oldest_age_days": max(ages) if ages else None,
+    }
+    return {
+        "debt_status_schema_version": DEBT_STATUS_SCHEMA_VERSION,
+        "baseline_schema_version": baseline.schema_version,
+        "as_of": as_of.isoformat(),
+        "expiring_within_days": expiring_within_days,
+        "summary": summary,
+        "entries": entries,
+    }
+
+
+def baseline_status_violations(
+    payload: dict[str, object],
+    *,
+    require_owner: bool = False,
+    require_expiry: bool = False,
+    max_age_days: int | None = None,
+) -> list[dict[str, str]]:
+    """Evaluate org governance requirements against a status payload.
+
+    Entries without provenance fail every active requirement (fail
+    closed: unknown history cannot satisfy a governance bar). Expired
+    entries violate ``require_expiry`` — an expired exception is no
+    longer a valid exception.
+    """
+
+    violations: list[dict[str, str]] = []
+    for entry in payload["entries"]:  # type: ignore[union-attr]
+        fingerprint = str(entry["fingerprint"])
+        if require_owner and entry["unowned"]:
+            violations.append({"fingerprint": fingerprint, "kind": "unowned"})
+        if require_expiry and entry["no_expiry"]:
+            violations.append({"fingerprint": fingerprint, "kind": "no_expiry"})
+        if require_expiry and entry["expired"]:
+            violations.append({"fingerprint": fingerprint, "kind": "expired"})
+        if max_age_days is not None:
+            age = entry["age_days"]
+            if age is None or age > max_age_days:  # type: ignore[operator]
+                violations.append({"fingerprint": fingerprint, "kind": "age_exceeded"})
+    return violations
 
 
 def apply_baseline(

--- a/src/agents_shipgate/core/baseline.py
+++ b/src/agents_shipgate/core/baseline.py
@@ -33,6 +33,22 @@ from agents_shipgate.schemas.common import Severity
 from agents_shipgate.schemas.report import BaselineSummary, Finding, ReadinessReport
 
 
+def _filled_text(existing: str | None, replacement: str | None) -> str | None:
+    """Fill-only merge for reviewer-set text metadata.
+
+    An existing value counts only when it has non-whitespace content —
+    the same blank-as-missing rule ``baseline_status_payload`` applies —
+    so the recommended ``--apply-to-existing`` repair can fix a
+    blank/whitespace owner that would otherwise keep failing
+    ``--require-owner``. A real (non-blank) existing value is never
+    overwritten.
+    """
+
+    if existing is not None and existing.strip():
+        return existing
+    return replacement
+
+
 def baseline_from_report(
     report: ReadinessReport,
     *,
@@ -86,8 +102,8 @@ def baseline_from_report(
             if apply_to_existing:
                 provenance = provenance.model_copy(
                     update={
-                        "owner": provenance.owner or owner,
-                        "reason": provenance.reason or reason,
+                        "owner": _filled_text(provenance.owner, owner),
+                        "reason": _filled_text(provenance.reason, reason),
                         "expires": provenance.expires or expires,
                     }
                 )

--- a/src/agents_shipgate/schemas/baseline.py
+++ b/src/agents_shipgate/schemas/baseline.py
@@ -8,12 +8,17 @@ from pydantic import BaseModel, ConfigDict, Field
 from agents_shipgate.schemas.common import Severity
 from agents_shipgate.schemas.surfaces import ActionSurfaceFacts, ToolSurfaceFacts
 
-BASELINE_SCHEMA_VERSION = "0.5"
-# v0.5 self-describing entry provenance. Older versions (0.2/0.3/0.4)
-# load with `BaselineFinding.provenance = None`; the integrity check
-# then flags them as `SHIP-BASELINE-ENTRY-STALE` (kind="legacy_no_provenance")
-# in warn/strict modes. Re-saving with `baseline save` upgrades the
-# file to 0.5 and stamps provenance on every entry.
+BASELINE_SCHEMA_VERSION = "0.6"
+# v0.6 adds optional `provenance.owner` — the human who accepted the
+# debt — settable via `baseline save --owner/--reason/--expires`
+# (v0.5 documented reviewer-set `reason`/`expires` but offered no CLI
+# path, and hand-editing the file breaks the integrity hash).
+# v0.5 added self-describing entry provenance. Older versions
+# (0.2/0.3/0.4) load with `BaselineFinding.provenance = None`; the
+# integrity check then flags them as `SHIP-BASELINE-ENTRY-STALE`
+# (kind="legacy_no_provenance") in warn/strict modes. Re-saving with
+# `baseline save` upgrades the file to the current version and stamps
+# provenance on every entry.
 
 
 class BaselineProvenance(BaseModel):
@@ -23,10 +28,11 @@ class BaselineProvenance(BaseModel):
     in the baseline. Existing fingerprints keep their original provenance
     on re-save; only newly-added ones get a fresh `recorded_at` / `run_id`.
 
-    `expires` is optional and reviewer-controlled: when set, the
-    integrity check emits `SHIP-BASELINE-ENTRY-EXPIRED` past that date.
-    `reason` is free-form; reviewers should set it when the entry was
-    deliberately accepted (not just snapshotted).
+    `owner`, `reason`, and `expires` are reviewer-controlled exception
+    metadata, set via `baseline save --owner/--reason/--expires` — never
+    inferred (declared human authority cannot be synthesized, matching
+    the `human_ack` contract). When `expires` is set, the integrity check
+    emits `SHIP-BASELINE-ENTRY-EXPIRED` past that date.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -34,6 +40,7 @@ class BaselineProvenance(BaseModel):
     scanner_version: str
     run_id: str
     recorded_at: str
+    owner: str | None = None
     reason: str | None = None
     expires: date | None = None
 
@@ -55,7 +62,7 @@ class BaselineFinding(BaseModel):
 class BaselineFile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.2", "0.3", "0.4", "0.5"] = BASELINE_SCHEMA_VERSION
+    schema_version: Literal["0.2", "0.3", "0.4", "0.5", "0.6"] = BASELINE_SCHEMA_VERSION
     project: dict[str, object] = Field(default_factory=dict)
     agent: dict[str, object] = Field(default_factory=dict)
     created_at: str

--- a/tests/test_baseline_integrity.py
+++ b/tests/test_baseline_integrity.py
@@ -147,7 +147,7 @@ def test_baseline_from_report_stamps_provenance_on_new_entries():
     baseline = baseline_from_report(
         report, scanner_version="9.9.9", now="2026-01-01T00:00:00Z"
     )
-    assert baseline.schema_version == "0.5"
+    assert baseline.schema_version == "0.6"
     assert all(entry.provenance is not None for entry in baseline.findings)
     p = baseline.findings[0].provenance
     assert p.scanner_version == "9.9.9"

--- a/tests/test_baseline_status.py
+++ b/tests/test_baseline_status.py
@@ -333,23 +333,49 @@ def test_blank_owner_is_unowned_and_fails_require_owner(tmp_path: Path) -> None:
 
 
 def test_apply_to_existing_fills_blank_owner(tmp_path: Path) -> None:
-    # Blank metadata counts as missing for the fill-only pass too, so a
-    # later acknowledged save can repair it.
+    # Blank metadata counts as missing for the fill-only pass too — same
+    # rule as `baseline status` — so the recommended repair path actually
+    # clears --require-owner. Whitespace-only is the trap: it is truthy,
+    # so a bare `or` keeps it while status treats it as unowned.
+    report = _stub_report(("SHIP-X", "tool_a"))
+    for hollow in ("", "   "):
+        first = baseline_from_report(
+            report, scanner_version="1.0.0", now="2026-01-01T00:00:00Z"
+        )
+        first.findings[0].provenance.owner = hollow
+
+        second = baseline_from_report(
+            report,
+            scanner_version="1.0.1",
+            prior_baseline=first,
+            now="2026-06-01T00:00:00Z",
+            owner="alice",
+            apply_to_existing=True,
+        )
+        assert second.findings[0].provenance.owner == "alice", repr(hollow)
+
+        payload = baseline_status_payload(second, as_of=date(2026, 6, 12))
+        assert baseline_status_violations(payload, require_owner=True) == []
+
+
+def test_apply_to_existing_keeps_padded_real_owner(tmp_path: Path) -> None:
+    # A real value with incidental padding is content, not a hollow
+    # approval — fill-only must not overwrite it.
     report = _stub_report(("SHIP-X", "tool_a"))
     first = baseline_from_report(
         report, scanner_version="1.0.0", now="2026-01-01T00:00:00Z"
     )
-    first.findings[0].provenance.owner = ""
+    first.findings[0].provenance.owner = "  alice  "
 
     second = baseline_from_report(
         report,
         scanner_version="1.0.1",
         prior_baseline=first,
         now="2026-06-01T00:00:00Z",
-        owner="alice",
+        owner="bob",
         apply_to_existing=True,
     )
-    assert second.findings[0].provenance.owner == "alice"
+    assert second.findings[0].provenance.owner == "  alice  "
 
 
 def test_cli_save_blank_owner_or_reason_exits_2(tmp_path: Path) -> None:

--- a/tests/test_baseline_status.py
+++ b/tests/test_baseline_status.py
@@ -1,0 +1,328 @@
+"""Exception-workflow tests: baseline approval metadata + debt status.
+
+Covers the v0.6 provenance contract (`owner` + CLI-settable
+`reason`/`expires`), the fill-only `--apply-to-existing` semantics, and
+the `baseline status` aging report with its governance gates.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.baseline import (
+    baseline_from_report,
+    baseline_status_payload,
+    baseline_status_violations,
+)
+from agents_shipgate.schemas.baseline import (
+    BaselineFile,
+    BaselineFinding,
+    BaselineProvenance,
+)
+from agents_shipgate.schemas.report import (
+    Finding,
+    ReadinessReport,
+    ReportSummary,
+    ToolSurfaceSummary,
+)
+
+runner = CliRunner()
+
+
+def _stub_report(*finding_pairs: tuple[str, str]) -> ReadinessReport:
+    findings = []
+    for index, (check_id, tool_name) in enumerate(finding_pairs):
+        findings.append(
+            Finding(
+                check_id=check_id,
+                title=f"{check_id} on {tool_name}",
+                severity="high",
+                category="test",
+                tool_name=tool_name,
+                evidence={"i": index},
+                confidence="high",
+                provenance_kind="static_declaration",
+                recommendation="stub",
+                fingerprint=f"fp_test_{index:04d}",
+                id=f"fp_test_{index:04d}",
+            )
+        )
+    return ReadinessReport(
+        run_id="run_stub",
+        project={"name": "stub"},
+        agent={"name": "test", "id": "agent:test"},
+        environment={"target": "staging"},
+        summary=ReportSummary(status="advisory_pass"),
+        tool_surface=ToolSurfaceSummary(total_tools=0, high_risk_tools=0),
+        findings=findings,
+    )
+
+
+def _provenance(**overrides: object) -> BaselineProvenance:
+    payload: dict[str, object] = {
+        "scanner_version": "1.0.0",
+        "run_id": "run_a",
+        "recorded_at": "2026-01-01T00:00:00Z",
+    }
+    payload.update(overrides)
+    return BaselineProvenance.model_validate(payload)
+
+
+def _baseline(*findings: BaselineFinding) -> BaselineFile:
+    return BaselineFile(
+        created_at="2026-01-01T00:00:00Z",
+        source_report_run_id="run_a",
+        findings=list(findings),
+    )
+
+
+def _entry(
+    fingerprint: str, provenance: BaselineProvenance | None
+) -> BaselineFinding:
+    return BaselineFinding(
+        fingerprint=fingerprint,
+        check_id="SHIP-TEST",
+        severity="high",
+        title="Example",
+        provenance=provenance,
+    )
+
+
+# --- provenance stamping ----------------------------------------------------
+
+
+def test_save_metadata_stamped_on_new_entries() -> None:
+    report = _stub_report(("SHIP-X", "tool_a"))
+    baseline = baseline_from_report(
+        report,
+        scanner_version="9.9.9",
+        now="2026-06-12T00:00:00Z",
+        owner="alice",
+        reason="accepted pending Q3 fix",
+        expires=date(2026, 9, 30),
+    )
+    assert baseline.schema_version == "0.6"
+    provenance = baseline.findings[0].provenance
+    assert provenance.owner == "alice"
+    assert provenance.reason == "accepted pending Q3 fix"
+    assert provenance.expires == date(2026, 9, 30)
+
+
+def test_resave_without_flags_preserves_owner() -> None:
+    report = _stub_report(("SHIP-X", "tool_a"))
+    first = baseline_from_report(
+        report, scanner_version="1.0.0", now="2026-01-01T00:00:00Z", owner="alice"
+    )
+    second = baseline_from_report(
+        report, scanner_version="1.0.1", prior_baseline=first, now="2026-06-01T00:00:00Z"
+    )
+    assert second.findings[0].provenance.owner == "alice"
+    assert second.findings[0].provenance.recorded_at == "2026-01-01T00:00:00Z"
+
+
+def test_apply_to_existing_fills_missing_never_overwrites() -> None:
+    report = _stub_report(("SHIP-X", "tool_a"), ("SHIP-Y", "tool_b"))
+    first = baseline_from_report(
+        report, scanner_version="1.0.0", now="2026-01-01T00:00:00Z"
+    )
+    # Give entry 0 an owner already; entry 1 stays unowned.
+    first.findings[0].provenance.owner = "alice"
+
+    second = baseline_from_report(
+        report,
+        scanner_version="1.0.1",
+        prior_baseline=first,
+        now="2026-06-01T00:00:00Z",
+        owner="bob",
+        reason="quarterly acknowledgement",
+        expires=date(2026, 12, 31),
+        apply_to_existing=True,
+    )
+    by_fp = {entry.fingerprint: entry for entry in second.findings}
+    # Pre-set owner never overwritten; missing fields filled.
+    assert by_fp["fp_test_0000"].provenance.owner == "alice"
+    assert by_fp["fp_test_0000"].provenance.reason == "quarterly acknowledgement"
+    # Unowned entry gains the new owner; history preserved exactly.
+    assert by_fp["fp_test_0001"].provenance.owner == "bob"
+    assert by_fp["fp_test_0001"].provenance.recorded_at == "2026-01-01T00:00:00Z"
+    assert by_fp["fp_test_0001"].provenance.run_id == "run_stub"
+    assert by_fp["fp_test_0001"].provenance.scanner_version == "1.0.0"
+
+
+def test_legacy_baseline_without_owner_still_loads() -> None:
+    legacy = {
+        "schema_version": "0.5",
+        "created_at": "2026-01-01T00:00:00Z",
+        "source_report_run_id": "run-1",
+        "findings": [
+            {
+                "fingerprint": "abc",
+                "check_id": "SHIP-TEST",
+                "severity": "high",
+                "title": "Example",
+                "provenance": {
+                    "scanner_version": "1.0.0",
+                    "run_id": "run-1",
+                    "recorded_at": "2026-01-01T00:00:00Z",
+                },
+            }
+        ],
+    }
+    baseline = BaselineFile.model_validate(legacy)
+    assert baseline.findings[0].provenance.owner is None
+
+
+# --- status payload ---------------------------------------------------------
+
+
+def test_status_payload_ages_and_expiry() -> None:
+    baseline = _baseline(
+        _entry("fp_owned", _provenance(owner="alice", expires=date(2026, 7, 1))),
+        _entry("fp_expired", _provenance(owner="bob", expires=date(2026, 5, 1))),
+        _entry("fp_bare", _provenance()),
+        _entry("fp_legacy", None),
+    )
+    payload = baseline_status_payload(baseline, as_of=date(2026, 6, 12))
+    entries = {entry["fingerprint"]: entry for entry in payload["entries"]}
+
+    assert entries["fp_owned"]["age_days"] == 162
+    assert entries["fp_owned"]["days_until_expiry"] == 19
+    assert entries["fp_owned"]["expired"] is False
+    assert entries["fp_expired"]["expired"] is True
+    assert entries["fp_bare"]["unowned"] is True
+    assert entries["fp_bare"]["no_expiry"] is True
+    assert entries["fp_legacy"]["age_days"] is None
+
+    summary = payload["summary"]
+    assert summary["total"] == 4
+    assert summary["owned"] == 2
+    assert summary["unowned"] == 2
+    assert summary["expired"] == 1
+    assert summary["expiring_within_days"] == 1
+    assert summary["no_provenance"] == 1
+    assert summary["oldest_age_days"] == 162
+
+
+def test_status_violations_fail_closed_for_legacy_entries() -> None:
+    baseline = _baseline(
+        _entry("fp_good", _provenance(owner="alice", expires=date(2026, 12, 31))),
+        _entry("fp_bare", _provenance()),
+        _entry("fp_legacy", None),
+        _entry("fp_expired", _provenance(owner="bob", expires=date(2026, 1, 1))),
+    )
+    payload = baseline_status_payload(baseline, as_of=date(2026, 6, 12))
+    violations = baseline_status_violations(
+        payload, require_owner=True, require_expiry=True, max_age_days=30
+    )
+    kinds = {(v["fingerprint"], v["kind"]) for v in violations}
+    assert ("fp_bare", "unowned") in kinds
+    assert ("fp_bare", "no_expiry") in kinds
+    assert ("fp_legacy", "unowned") in kinds
+    assert ("fp_legacy", "age_exceeded") in kinds  # unknown age fails closed
+    assert ("fp_expired", "expired") in kinds
+    assert ("fp_good", "age_exceeded") in kinds  # recorded 2026-01-01, >30d old
+    assert not any(fp == "fp_good" and k != "age_exceeded" for fp, k in kinds)
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _write_baseline_file(tmp_path: Path, baseline: BaselineFile) -> Path:
+    path = tmp_path / "baseline.json"
+    path.write_text(
+        baseline.model_dump_json(indent=2, exclude_none=False) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_cli_status_advisory_exit_0_and_json_deterministic(tmp_path: Path) -> None:
+    path = _write_baseline_file(
+        tmp_path, _baseline(_entry("fp_bare", _provenance()))
+    )
+    args = [
+        "baseline",
+        "status",
+        "--baseline",
+        str(path),
+        "--as-of",
+        "2026-06-12",
+        "--json",
+    ]
+    one = runner.invoke(app, args)
+    two = runner.invoke(app, args)
+    assert one.exit_code == 0, one.output  # advisory without gate flags
+    assert one.output == two.output
+    payload = json.loads(one.output)
+    assert payload["debt_status_schema_version"] == "0.1"
+    assert payload["violations"] == []
+
+
+def test_cli_status_gate_exits_20_then_0_after_acknowledgement(tmp_path: Path) -> None:
+    path = _write_baseline_file(
+        tmp_path, _baseline(_entry("fp_bare", _provenance()))
+    )
+    gated = [
+        "baseline",
+        "status",
+        "--baseline",
+        str(path),
+        "--as-of",
+        "2026-06-12",
+        "--require-owner",
+    ]
+    result = runner.invoke(app, gated)
+    assert result.exit_code == 20
+    assert "unowned" in result.output
+    assert "--apply-to-existing" in result.output  # re-acknowledge hint
+
+    acknowledged = _baseline(_entry("fp_bare", _provenance(owner="alice")))
+    _write_baseline_file(tmp_path, acknowledged)
+    result = runner.invoke(app, gated)
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_status_invalid_as_of_exits_2(tmp_path: Path) -> None:
+    path = _write_baseline_file(tmp_path, _baseline())
+    result = runner.invoke(
+        app,
+        ["baseline", "status", "--baseline", str(path), "--as-of", "junk"],
+    )
+    assert result.exit_code == 2
+
+
+def test_cli_status_missing_baseline_exits_3(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["baseline", "status", "--baseline", str(tmp_path / "missing.json")],
+    )
+    assert result.exit_code == 3
+
+
+def test_cli_save_invalid_expires_exits_2(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["baseline", "save", "-c", str(tmp_path / "shipgate.yaml"), "--expires", "soon"],
+    )
+    assert result.exit_code == 2
+    assert "ISO date" in result.output
+
+
+def test_cli_save_apply_to_existing_requires_metadata(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "baseline",
+            "save",
+            "-c",
+            str(tmp_path / "shipgate.yaml"),
+            "--apply-to-existing",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "--apply-to-existing" in result.output

--- a/tests/test_baseline_status.py
+++ b/tests/test_baseline_status.py
@@ -304,6 +304,64 @@ def test_cli_status_missing_baseline_exits_3(tmp_path: Path) -> None:
     assert result.exit_code == 3
 
 
+def test_blank_owner_is_unowned_and_fails_require_owner(tmp_path: Path) -> None:
+    # A blank/whitespace owner must never satisfy --require-owner (PR #205
+    # review). The CLI rejects blank flags at save time; this covers files
+    # produced by any other means.
+    baseline = _baseline(
+        _entry("fp_empty", _provenance(owner="")),
+        _entry("fp_spaces", _provenance(owner="   ")),
+    )
+    payload = baseline_status_payload(baseline, as_of=date(2026, 6, 12))
+    assert all(entry["unowned"] for entry in payload["entries"])
+    assert all(entry["owner"] is None for entry in payload["entries"])
+
+    path = _write_baseline_file(tmp_path, baseline)
+    result = runner.invoke(
+        app,
+        [
+            "baseline",
+            "status",
+            "--baseline",
+            str(path),
+            "--as-of",
+            "2026-06-12",
+            "--require-owner",
+        ],
+    )
+    assert result.exit_code == 20
+
+
+def test_apply_to_existing_fills_blank_owner(tmp_path: Path) -> None:
+    # Blank metadata counts as missing for the fill-only pass too, so a
+    # later acknowledged save can repair it.
+    report = _stub_report(("SHIP-X", "tool_a"))
+    first = baseline_from_report(
+        report, scanner_version="1.0.0", now="2026-01-01T00:00:00Z"
+    )
+    first.findings[0].provenance.owner = ""
+
+    second = baseline_from_report(
+        report,
+        scanner_version="1.0.1",
+        prior_baseline=first,
+        now="2026-06-01T00:00:00Z",
+        owner="alice",
+        apply_to_existing=True,
+    )
+    assert second.findings[0].provenance.owner == "alice"
+
+
+def test_cli_save_blank_owner_or_reason_exits_2(tmp_path: Path) -> None:
+    for flag, value in (("--owner", ""), ("--owner", "   "), ("--reason", " ")):
+        result = runner.invoke(
+            app,
+            ["baseline", "save", "-c", str(tmp_path / "shipgate.yaml"), flag, value],
+        )
+        assert result.exit_code == 2, (flag, value, result.output)
+        assert "cannot be blank" in result.output
+
+
 def test_cli_save_invalid_expires_exits_2(tmp_path: Path) -> None:
     result = runner.invoke(
         app,

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -743,7 +743,7 @@ def test_baseline_save_and_scan_matches_existing_findings(tmp_path):
         baseline_path=baseline_path,
     )
 
-    assert baseline.schema_version == "0.5"
+    assert baseline.schema_version == "0.6"
     assert baseline.tool_surface_facts is not None
     assert baseline.action_surface_facts is not None
     assert first_report.run_id == second_report.run_id

--- a/tests/test_schema_boundaries.py
+++ b/tests/test_schema_boundaries.py
@@ -234,7 +234,7 @@ def test_representative_schema_payloads_keep_wire_fields() -> None:
         ],
     )
     assert baseline.model_dump(mode="json") == {
-        "schema_version": "0.5",
+        "schema_version": "0.6",
         "project": {},
         "agent": {},
         "created_at": "2026-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary

- **Phase 4 ("make Shipgate organizational"), built selectively.** The roadmap's own discipline says org features are earned, not presumed — so this PR ships the one Phase 4 item that strengthens governance even for a single repo: the **exception workflow with approval requirements**, on the baseline (accepted-debt) mechanism.
- **The gap was real and sharp:** the v0.5 provenance contract *documented* reviewer-set `reason`/`expires`, but `baseline save` offered **no flags to set them**, and hand-editing the JSON trips the integrity hash (`SHIP-BASELINE-INTEGRITY-MISMATCH`) — the documented exception workflow was effectively unusable. And unlike the sibling exception mechanisms (`human_ack`, severity-override acknowledgements), baseline entries carried **no approver identity at all**.
- **Baseline schema 0.6** adds optional `provenance.owner`; legacy 0.2–0.5 files still load, and re-saving upgrades them.

## What's new

**Approval metadata, settable through the CLI (never inferred):**
```bash
agents-shipgate baseline save --owner alice --reason "accepted pending Q3 fix" --expires 2026-09-30
```
Stamped on newly-accepted entries; flagless re-saves preserve prior metadata verbatim. `--apply-to-existing` fills the fields into existing entries that lack them — **never overwrites a previously-set value and preserves each entry's original `recorded_at`/`run_id`**, so acknowledging legacy debt doesn't rewrite its history. Approval is declared, never inferred — the `human_ack` contract.

**Debt aging report + org governance gate:**
```bash
agents-shipgate baseline status --json                                  # advisory
agents-shipgate baseline status --require-owner --require-expiry --max-age-days 180   # exit 20 on violations
```
Per-entry owner/reason/age/expiry with expired/unowned/no-expiry flags and a summary (expiring-soon, oldest entry). `--as-of YYYY-MM-DD` pins the date for reproducible CI output.

## Design decisions a reviewer should weigh

- **Gate-by-CLI-flags, not manifest knobs** — same pattern as `audit --host --drift --fail-on-drift` (#204): org enforcement composes in a scheduled workflow without new manifest surface, new check IDs (no three-place registration), or a second decision engine. Advisory by default; exit 20 only when a gate flag is passed.
- **Expired entries violate `--require-expiry`** — an expired exception is no longer a valid exception.
- **Entries without provenance fail every active gate** — unknown history is *ungoverned* debt, not exempt debt (fail closed, consistent with the trust model).
- **Fill-only `--apply-to-existing`** — bulk acknowledgement cannot silently re-attribute debt someone else approved.

## Deliberately NOT built (org plane stays earned-only)

Hosted/cross-repo aggregation, GitHub App, signing, a per-entry `baseline annotate <fingerprint>` command (the per-save batch + fill-only covers the real workflow; granular ownership is a follow-up if a team actually needs split ownership), and manifest governance knobs.

## Type

- [ ] Check or risk-model change
- [x] CLI or GitHub Action behavior (`baseline save` flags, new `baseline status`)
- [x] Report, schema, or SARIF output (baseline schema 0.5 → 0.6, additive `provenance.owner`; documented in `docs/baseline.md`; no report-schema change)

## Verification

CI is authoritative for `ruff`, `compileall`, and `pytest`.

Additional local checks run:

- New `tests/test_baseline_status.py` (12 tests): stamping on new entries, flagless re-save preservation, fill-only/never-overwrite semantics with history preservation, legacy-file load, status math (ages, expiry windows, summary counts), fail-closed legacy gating, CLI advisory/gate exit codes (0/20), `--as-of` validation (2), missing baseline (3), determinism
- Updated the three version-literal assertions (0.5 → 0.6); the stale `docs/baseline.md` schema-version paragraph (said 0.4) corrected
- Full suite `pytest -n auto -m "not perf"` — green (exit 0); `ruff check .`, `compileall`, `scripts/generate_schemas.py --check` — clean
- Manual end-to-end on `samples/support_refund_agent`: save with metadata → status advisory → gates exit 0 → time-travel `--as-of` past expiry → exit 20 → flagless re-save preserves owner → gate exit 0

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` (n/a — no check IDs added)
- [x] Report/schema changes are additive or documented (baseline 0.6 additive `owner`; documented in `docs/baseline.md` + CHANGELOG; legacy versions load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)