### PR TITLE
verify: warn when generated reports are staged for commit (WS-D / D4)

### DIFF
--- a/src/agents_shipgate/cli/verify/command.py
+++ b/src/agents_shipgate/cli/verify/command.py
@@ -19,7 +19,7 @@ from agents_shipgate.core.errors import AgentsShipgateError, ConfigError, InputP
 from agents_shipgate.core.logging import configure_logging
 from agents_shipgate.schemas.diagnostics import NextAction
 
-from .git import staged_paths_under
+from .git import ensure_git_workspace, staged_paths_under
 from .orchestrator import run_preview, run_verify
 
 logger = logging.getLogger(__name__)
@@ -318,14 +318,21 @@ def _warn_if_reports_staged(workspace: Path, out: Path | None) -> None:
     stdout JSON contract. Silent outside a git checkout.
     """
 
+    # verify resolves the reports dir relative to the GIT ROOT (run_verify),
+    # so probe the root, not --workspace: a subdirectory --workspace would
+    # otherwise miss root-level staged reports.
+    try:
+        root = ensure_git_workspace(workspace)
+    except ConfigError:
+        return
     if out is None:
         target = REPORTS_DIR_NAME
     else:
         try:
-            target = out.resolve().relative_to(workspace.resolve()).as_posix()
+            target = out.resolve().relative_to(root).as_posix()
         except ValueError:
             target = out.name
-    staged = staged_paths_under(workspace, target)
+    staged = staged_paths_under(root, target)
     if not staged:
         return
     shown = ", ".join(staged[:3]) + (" …" if len(staged) > 3 else "")

--- a/src/agents_shipgate/cli/verify/command.py
+++ b/src/agents_shipgate/cli/verify/command.py
@@ -14,10 +14,12 @@ from agents_shipgate.cli._helpers import (
 )
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error, is_agent_mode
 from agents_shipgate.cli.diagnostics import top_next_actions
+from agents_shipgate.cli.discovery.gitignore_block import REPORTS_DIR_NAME
 from agents_shipgate.core.errors import AgentsShipgateError, ConfigError, InputParseError
 from agents_shipgate.core.logging import configure_logging
 from agents_shipgate.schemas.diagnostics import NextAction
 
+from .git import staged_paths_under
 from .orchestrator import run_preview, run_verify
 
 logger = logging.getLogger(__name__)
@@ -284,6 +286,8 @@ def verify(
         typer.echo(f"Internal error: {exc}", err=True)
         raise typer.Exit(4) from exc
 
+    _warn_if_reports_staged(workspace, out)
+
     if stdout_format == "agent":
         agent_result = build_agent_result(verifier=verifier, report=_report)
         typer.echo(
@@ -302,6 +306,36 @@ def verify(
         typer.echo(f"Base status: {verifier.base_status}")
         typer.echo(f"Exit code: {exit_code}")
     raise typer.Exit(exit_code)
+
+
+def _warn_if_reports_staged(workspace: Path, out: Path | None) -> None:
+    """Advisory nudge when generated reports are staged for commit.
+
+    Agents that run verify and then ``git add .`` stage the generated
+    reports directory — a blocker in 7/31 W24 adoption cells. ``init``
+    gitignores it; this warns when an existing checkout has it staged.
+    Written to stderr only: never affects the verdict, exit code, or the
+    stdout JSON contract. Silent outside a git checkout.
+    """
+
+    if out is None:
+        target = REPORTS_DIR_NAME
+    else:
+        try:
+            target = out.resolve().relative_to(workspace.resolve()).as_posix()
+        except ValueError:
+            target = out.name
+    staged = staged_paths_under(workspace, target)
+    if not staged:
+        return
+    shown = ", ".join(staged[:3]) + (" …" if len(staged) > 3 else "")
+    typer.echo(
+        f"warning: {len(staged)} generated Agents Shipgate report file(s) staged "
+        f"for commit ({shown}). These are build artifacts — unstage them with "
+        f"`git restore --staged {target}/` (agents-shipgate init gitignores this "
+        f"directory).",
+        err=True,
+    )
 
 
 def _resolve_verify_format(

--- a/src/agents_shipgate/cli/verify/git.py
+++ b/src/agents_shipgate/cli/verify/git.py
@@ -158,6 +158,32 @@ def _run_git(
     )
 
 
+def staged_paths_under(workspace: Path, subdir: str) -> list[str]:
+    """Return staged (index) paths under ``subdir``, relative to ``workspace``.
+
+    Reads the git index only (``git diff --cached --name-only --relative``);
+    never fetches or writes. Used to warn when generated Agents Shipgate
+    reports have been staged for commit — they are generated artifacts that
+    ``init`` already gitignores. Returns ``[]`` outside a git checkout.
+
+    Defined below ``_run_git`` so the line-pinned static-only allowlist entry
+    for that subprocess call-site (``tests/test_adapter_static_only.py``)
+    stays stable.
+    """
+
+    prefix = subdir.rstrip("/") + "/"
+    result = _run_git(
+        workspace, ["diff", "--cached", "--name-only", "--relative"], check=False
+    )
+    if result.returncode != 0:
+        return []
+    return [
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip().startswith(prefix)
+    ]
+
+
 def _safe_extract(tar: tarfile.TarFile, destination: Path) -> None:
     root = destination.resolve()
     for member in tar.getmembers():
@@ -176,6 +202,7 @@ __all__ = [
     "git_path",
     "read_file_at_ref",
     "ref_exists",
+    "staged_paths_under",
     "tree_sha",
     "working_tree_context",
 ]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -135,6 +135,49 @@ def test_verify_warns_when_reports_directory_is_staged(tmp_path: Path) -> None:
     assert "git restore --staged" in result.output
 
 
+def test_verify_warns_on_staged_reports_from_subdirectory_workspace(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _commit_all(repo, "base")
+    _set_origin_main(repo)
+    (repo / "README.md").write_text("docs only\n", encoding="utf-8")
+    _commit_all(repo, "docs")
+
+    # Reports staged at the GIT ROOT, where verify writes them...
+    reports = repo / "agents-shipgate-reports"
+    reports.mkdir()
+    (reports / "report.json").write_text("{}\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "agents-shipgate-reports/report.json"], cwd=repo, check=True
+    )
+
+    # ...but verify is invoked with a subdirectory --workspace. The nudge must
+    # still resolve to the git root rather than probing only the subdirectory.
+    subdir = repo / "service"
+    subdir.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(subdir),
+            "--base",
+            "origin/main",
+            "--head",
+            "HEAD",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "warning:" in result.output
+    assert "agents-shipgate-reports/" in result.output
+
+
 def test_verify_no_staged_reports_warning_and_stdout_json_is_clean(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -95,6 +95,80 @@ def test_verify_trigger_skip_writes_lightweight_artifacts(tmp_path: Path) -> Non
     assert payload["base_status"] == "skipped"
 
 
+def test_verify_warns_when_reports_directory_is_staged(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _commit_all(repo, "base")
+    _set_origin_main(repo)
+    (repo / "README.md").write_text("docs only\n", encoding="utf-8")
+    _commit_all(repo, "docs")
+
+    # Simulate the W24 footgun: the agent ran a scan/verify and then
+    # `git add`-ed the generated reports directory.
+    reports = repo / "agents-shipgate-reports"
+    reports.mkdir()
+    (reports / "report.json").write_text("{}\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "agents-shipgate-reports/report.json"], cwd=repo, check=True
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(repo),
+            "--base",
+            "origin/main",
+            "--head",
+            "HEAD",
+            "--format",
+            "json",
+        ],
+    )
+
+    # Advisory only: the staged-reports nudge never changes the verdict or
+    # the exit code (this is a trigger-skip, so exit 0 is unchanged).
+    assert result.exit_code == 0, result.output
+    assert "warning:" in result.output
+    assert "agents-shipgate-reports/" in result.output
+    assert "git restore --staged" in result.output
+
+
+def test_verify_no_staged_reports_warning_and_stdout_json_is_clean(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _commit_all(repo, "base")
+    _set_origin_main(repo)
+    (repo / "README.md").write_text("docs only\n", encoding="utf-8")
+    _commit_all(repo, "docs")
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(repo),
+            "--base",
+            "origin/main",
+            "--head",
+            "HEAD",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # Verify writes verifier.json/pr-comment.md into the reports dir during
+    # the run, but never stages them, so no nudge fires and stdout stays
+    # pure JSON for agent consumers.
+    assert "report file(s) staged" not in result.output
+    payload = json.loads(result.output)
+    assert payload["head_status"] == "skipped"
+
+
 def test_verify_missing_base_without_manifest_is_unknown_not_mergeable(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Closes a measured W24 adoption gap: agents run scan/verify and then `git add` the generated `agents-shipgate-reports/` directory (the `avoids_committing_reports` blocker fired in **7/31** behavioural cells). `init` already writes the `.gitignore` entry for it; this adds the missing **verify-side nudge**.
- `verify` now emits an advisory **stderr** warning when the reports directory is staged, naming the staged files and the exact unstage command (`git restore --staged agents-shipgate-reports/`).
- **stderr only** — never affects the verdict, the exit code, or the stdout JSON contract. Smoke-tested that stdout stays clean JSON while the nudge goes to stderr.

Part of Phase 1 WS-D (deletion & first-run hygiene). Small and self-contained.

## Implementation notes

- `git.staged_paths_under()` is an index-only read (`git diff --cached --name-only --relative`); it never fetches or writes and returns `[]` outside a git checkout. It reuses the existing `_run_git` helper (no new subprocess call-site) and is placed **below** `_run_git` so the line-pinned static-only allowlist entry in `tests/test_adapter_static_only.py` stays stable — zero trust-anchor churn.
- The check uses `--cached`, so it only catches files the agent explicitly staged, never `verify`'s own freshly written `verifier.json` / `pr-comment.md`.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `pytest tests/test_verify.py tests/test_verify_auto_base.py` — green (incl. 2 new tests: warning fires on staged reports with exit code unchanged; clean repo emits no warning and stdout stays parseable JSON).
- `pytest tests/test_adapter_static_only.py` — green (the new helper added no forbidden surface; `subprocess.run` remains on its allowlisted line).
- Real-CLI smoke: `verify --format json 2>/dev/null` emits clean JSON on stdout; the nudge appears only on stderr.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths (index-only local git read)
- [x] New or changed check IDs are documented in `docs/checks.md` (n/a — no check changes; advisory stderr nudge, not a finding)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (n/a — no schema change)