### PR TITLE
Zero-config first look on bare `shipgate` (WS-D / D1)

### DIFF
--- a/src/agents_shipgate/cli/first_look.py
+++ b/src/agents_shipgate/cli/first_look.py
@@ -1,0 +1,149 @@
+"""Zero-config "first look" for a bare ``shipgate`` invocation.
+
+Running ``shipgate`` with no subcommand prints a short, read-only
+orientation: the working-tree boundary verdict (the instant-value moment),
+a repo classification, a host-grant summary, and the single best next
+command. It requires no ``shipgate.yaml`` and writes nothing.
+
+This is a router, not a gate — the gates remain ``check`` (local diff) and
+``verify`` (committed PR). It composes three existing read-only surfaces
+(``detect``, the agent-native boundary ``check``, and ``audit --host``) so
+it adds no new analysis and no new public command. Every step is wrapped so
+a partial environment (no git, unreadable config) degrades to a shorter
+summary rather than an error: a first look must never hard-fail.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from agents_shipgate import __version__
+
+
+def run_first_look(workspace: Path) -> None:
+    """Print the zero-config orientation summary for ``workspace``."""
+
+    root = workspace.resolve()
+    typer.echo(f"Agents Shipgate {__version__} · first look (read-only, no manifest needed)")
+
+    typer.echo(f"  working tree:  {_working_tree_line(root)}")
+
+    classification, has_agent_surface = _classification_line(root)
+    typer.echo(f"  repo:          {classification}")
+
+    host_line, has_host = _host_grants_line(root)
+    if host_line is not None:
+        typer.echo(f"  host grants:   {host_line}")
+
+    has_manifest = (root / "shipgate.yaml").is_file()
+    typer.echo(
+        "  manifest:      "
+        + ("shipgate.yaml present" if has_manifest else "none (Shipgate runs without one)")
+    )
+
+    typer.echo("")
+    typer.echo("→ " + _next_command(has_manifest, has_agent_surface, has_host))
+
+
+def _working_tree_line(workspace: Path) -> str:
+    """Boundary verdict for the local uncommitted diff, or a clean/skip note."""
+
+    from agents_shipgate.cli.agent_result import build_codex_agent_result, git_diff_text
+
+    try:
+        diff_text = git_diff_text(workspace=workspace, base=None, head=None)
+    except (OSError, RuntimeError):
+        return "not a git checkout — skipped"
+    if not diff_text.strip():
+        return "clean — no uncommitted changes to check"
+    try:
+        result = build_codex_agent_result(
+            agent="claude-code",
+            workspace=workspace,
+            diff_text=diff_text,
+            config=workspace / "shipgate.yaml",
+            policy=None,
+        )
+    except Exception:  # noqa: BLE001 - a first look must never hard-fail.
+        return "uncommitted changes present (run `shipgate check` for the verdict)"
+    count = len(result.changed_files)
+    files = f"{count} changed file{'s' if count != 1 else ''}"
+    if result.decision == "allow":
+        return f"allow — {files}, no boundary issues"
+    return f"{result.decision} — {files}; {result.summary}"
+
+
+def _classification_line(workspace: Path) -> tuple[str, bool]:
+    """Repo classification plus whether any agent tool surface was found."""
+
+    from agents_shipgate.cli.discovery import detect_workspace
+
+    try:
+        result = detect_workspace(workspace, max_python_files=1000)
+    except Exception:  # noqa: BLE001 - classification is best-effort.
+        return "classification unavailable", False
+    has_surface = bool(
+        result.is_agent_project
+        or result.suggested_sources
+        or result.codex_plugin_candidates
+    )
+    if result.is_agent_project:
+        frameworks = ", ".join(f.type for f in result.frameworks[:3])
+        label = f"agent project ({frameworks})" if frameworks else "agent project"
+    elif result.suggested_sources or result.codex_plugin_candidates:
+        label = "Shipgate-compatible tool artifacts found"
+    else:
+        label = "no strong agent-framework signals"
+    return label, has_surface
+
+
+def _host_grants_line(workspace: Path) -> tuple[str | None, bool]:
+    """One-line count of coding-agent host grants, or ``None`` when there are none."""
+
+    from agents_shipgate.cli.host_audit import host_audit_inventory
+
+    try:
+        inventory = host_audit_inventory(workspace)
+    except Exception:  # noqa: BLE001 - host audit is best-effort here.
+        return None, False
+    parts: list[str] = []
+    for key, label in (
+        ("mcp_servers", "MCP server"),
+        ("permission_rules", "permission rule"),
+        ("hooks", "hook"),
+        ("workflows", "workflow"),
+    ):
+        count = len(inventory.get(key) or [])
+        if count:
+            parts.append(f"{count} {label}{'s' if count != 1 else ''}")
+    if inventory.get("codex_config_present"):
+        parts.append("codex config")
+    if not parts:
+        return None, False
+    return ", ".join(parts) + " (run `shipgate audit --host` for the inventory)", True
+
+
+def _next_command(has_manifest: bool, has_agent_surface: bool, has_host: bool) -> str:
+    """The single highest-value next command for this repo's state."""
+
+    if has_manifest:
+        return "Next: `shipgate verify --base origin/main --head HEAD` to gate your PR."
+    if has_agent_surface:
+        return (
+            "Next: `shipgate init` to set up the gate, or `shipgate check` to "
+            "check your working tree now."
+        )
+    if has_host:
+        return (
+            "Next: `shipgate audit --host` to inventory what your coding agent "
+            "can do here."
+        )
+    return (
+        "Next: no agent tool surface or host config detected — Shipgate may not "
+        "apply here. Run `shipgate detect` for the full classification."
+    )
+
+
+__all__ = ["run_first_look"]

--- a/src/agents_shipgate/cli/first_look.py
+++ b/src/agents_shipgate/cli/first_look.py
@@ -48,15 +48,29 @@ def run_first_look(workspace: Path) -> None:
 
 
 def _working_tree_line(workspace: Path) -> str:
-    """Boundary verdict for the local uncommitted diff, or a clean/skip note."""
+    """Boundary verdict for the local uncommitted diff, or a clean/skip note.
 
-    from agents_shipgate.cli.agent_result import build_codex_agent_result, git_diff_text
+    Uses the same ``git diff HEAD`` body that ``shipgate check`` evaluates, but
+    also keeps the changed-path list so an untracked-only working tree (common
+    on first adoption, when new tool files have not been ``git add``-ed) is not
+    misreported as clean — their content is intentionally absent from the diff
+    body, so they surface as "stage and run check" rather than a verdict.
+    """
+
+    from agents_shipgate.cli.agent_result import build_codex_agent_result
+    from agents_shipgate.cli.verify.git import working_tree_context
 
     try:
-        diff_text = git_diff_text(workspace=workspace, base=None, head=None)
-    except (OSError, RuntimeError):
+        changed_paths, diff_text = working_tree_context(workspace)
+    except Exception:  # noqa: BLE001 - not a git checkout / no HEAD to diff.
         return "not a git checkout — skipped"
     if not diff_text.strip():
+        if changed_paths:
+            count = len(changed_paths)
+            return (
+                f"{count} untracked file{'s' if count != 1 else ''} not yet "
+                "checkable — stage them and run `shipgate check`"
+            )
         return "clean — no uncommitted changes to check"
     try:
         result = build_codex_agent_result(

--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import typer
 
@@ -40,7 +41,9 @@ from agents_shipgate.core.logging import configure_logging
 app = typer.Typer(
     name="agents-shipgate",
     help="The deterministic merge gate for AI-generated agent capability changes.",
-    no_args_is_help=True,
+    # Bare `shipgate` runs a zero-config first look (see the root callback),
+    # not a help dump — so off, not True.
+    no_args_is_help=False,
     invoke_without_command=True,
 )
 app.command(
@@ -176,8 +179,9 @@ logger = logging.getLogger(__name__)
 
 
 @app.callback()
-def _version(
-    version: bool = typer.Option(False, "--version", help="Show version and exit.")
+def _root(
+    ctx: typer.Context,
+    version: bool = typer.Option(False, "--version", help="Show version and exit."),
 ) -> None:
     # Logging state is per-invocation, not per-process: reset to the
     # default (WARNING, plain formatter) before every command so a
@@ -189,4 +193,13 @@ def _version(
     configure_logging(force=True)
     if version:
         typer.echo(f"Agents Shipgate {__version__}")
+        raise typer.Exit(0)
+    # Bare `shipgate` (no subcommand) runs a zero-config, read-only first
+    # look instead of dumping --help, so a fresh repo gets a verdict and a
+    # next step without a manifest. Named subcommands and `--help` are
+    # unaffected: this branch only fires when no subcommand was matched.
+    if ctx.invoked_subcommand is None:
+        from agents_shipgate.cli.first_look import run_first_look
+
+        run_first_look(Path("."))
         raise typer.Exit(0)

--- a/tests/test_first_look.py
+++ b/tests/test_first_look.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.first_look import _next_command
+from agents_shipgate.cli.main import app
+
+runner = CliRunner()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@e.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    return repo
+
+
+def _commit(repo: Path, message: str = "init") -> None:
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", message], cwd=repo, check=True)
+
+
+def test_bare_invocation_runs_first_look(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    _commit(repo)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0, result.output
+    assert "first look" in result.output
+    assert "working tree:" in result.output
+    assert "→ Next:" in result.output
+
+
+def test_first_look_routes_to_verify_when_manifest_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "shipgate.yaml").write_text("version: '0.1'\n", encoding="utf-8")
+    _commit(repo)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0, result.output
+    assert "shipgate.yaml present" in result.output
+    assert "shipgate verify" in result.output
+
+
+def test_first_look_reports_host_grants(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / ".mcp.json").write_text(
+        '{"mcpServers": {"docs": {"command": "docs-server"}}}\n', encoding="utf-8"
+    )
+    _commit(repo)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0, result.output
+    assert "host grants:" in result.output
+    assert "MCP server" in result.output
+
+
+def test_bare_invocation_outside_git_does_not_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "plain"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0, result.output
+    assert "not a git checkout" in result.output
+
+
+def test_named_subcommand_is_not_hijacked_by_first_look(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    _commit(repo)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["detect", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"is_agent_project"' in result.output
+    assert "first look" not in result.output
+
+
+def test_version_flag_still_short_circuits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert "Agents Shipgate" in result.output
+    assert "first look" not in result.output
+
+
+def test_next_command_routing_priority() -> None:
+    # Manifest present wins regardless of the other signals.
+    assert "verify" in _next_command(True, True, True)
+    assert "verify" in _next_command(True, False, False)
+    # No manifest, but an agent tool surface: set up the gate / check now.
+    assert "init" in _next_command(False, True, False)
+    assert "check" in _next_command(False, True, False)
+    # No manifest, no agent surface, but host grants: route to the host audit.
+    assert "audit --host" in _next_command(False, False, True)
+    # Nothing relevant: say so plainly.
+    assert "may not apply" in _next_command(False, False, False)

--- a/tests/test_first_look.py
+++ b/tests/test_first_look.py
@@ -74,6 +74,27 @@ def test_first_look_reports_host_grants(
     assert "MCP server" in result.output
 
 
+def test_first_look_reports_untracked_files_as_not_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    _commit(repo)
+    # A new tool file the agent created but never `git add`-ed. Its content is
+    # absent from the diff body, but it is uncommitted work — not "clean".
+    (repo / "new_tool.py").write_text("# new tool\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0, result.output
+    working_tree_line = next(
+        line for line in result.output.splitlines() if "working tree:" in line
+    )
+    assert "untracked" in working_tree_line
+    assert "clean" not in working_tree_line
+
+
 def test_bare_invocation_outside_git_does_not_crash(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Directly attacks the sharpest W24 finding: a present `shipgate.yaml` **lowered** adoption scores (mean **45** vs **67.5** with just an AGENTS.md snippet) — the manifest-first onboarding and `CHANGE_ME` wall make the first run *worse*. This makes bare `shipgate` (no subcommand) deliver value with **no manifest**, instead of dumping `--help`.
- Bare `shipgate` now prints a ≤10-line, **verdict-first**, read-only first look and the single best next command:

```
Agents Shipgate 0.13.0 · first look (read-only, no manifest needed)
  working tree:  allow — 1 changed file, no boundary issues
  repo:          agent project (openai_agents_sdk, langchain, crewai)
  host grants:   4 workflows (run `shipgate audit --host` for the inventory)
  manifest:      shipgate.yaml present

→ Next: `shipgate verify --base origin/main --head HEAD` to gate your PR.
```

## Implementation notes

- New `cli/first_look.py` **composes three existing read-only surfaces** — `detect` (classification), the agent-native boundary `check` (working-tree verdict), and `audit --host` (host-grant summary). It writes nothing, requires no manifest, and **never hard-fails**: each step is wrapped so a partial environment (no git, unreadable config) degrades to a shorter line rather than an error.
- `main.py`: `no_args_is_help` is now off; the root callback runs the first look when `ctx.invoked_subcommand is None`. Named subcommands, `--help`, and `--version` are unaffected (smoke-tested).
- Per the new **surface-discipline gate** (`CONTRIBUTING.md`): this is **not** a new public surface — no new command, schema, or summary block. It reuses existing surfaces. The metric it moves is **time-to-first-verdict / activation**.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- **Full suite** `pytest -n auto -m "not perf"` — green (this changes the root callback, so the whole CLI-dispatch surface was exercised).
- New `tests/test_first_look.py` (7 tests): bare invocation runs the first look (exit 0); manifest routes to `verify`; host config surfaces grants; non-git degrades cleanly; named subcommands are not hijacked; `--version` short-circuits; routing-priority unit test.
- Real-CLI smoke: bare `shipgate`, `--version`, `--help`, and `detect --json` all behave correctly.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths (local git read + existing read-only cores)
- [x] New or changed check IDs are documented in `docs/checks.md` (n/a — no check changes)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (n/a — no schema change)