### PR TITLE
Hide niche commands from --help; lock the visibility policy (WS-D / D2)

### DIFF
--- a/src/agents_shipgate/cli/main.py
+++ b/src/agents_shipgate/cli/main.py
@@ -75,6 +75,9 @@ app.command(
 )(_apply_patches_command)
 app.command(
     "evidence-packet",
+    # Hidden from --help (niche re-render utility), still fully invokable —
+    # see the visibility policy note above the sub-app block below.
+    hidden=True,
     help=(
         "Re-render a Release Evidence Packet from an existing packet.json "
         "into md, html, and/or pdf."
@@ -168,13 +171,19 @@ _register_explain.register(app)
 _register_init.register(app)
 _register_doctor.register(app)
 _register_baseline.register(app)
+# Visibility policy (WS-D): `--help` shows the core loop — detect / check /
+# verify / init / scan / audit and their direct companions. Niche or
+# maintainer-facing surfaces (`hidden=True` here and on `evidence-packet`
+# above) stay fully invokable and documented — hiding is presentation only,
+# not deprecation, so STABILITY.md is unaffected. `fixture` stays visible
+# because the README's 60-second demo leads with `fixture run`.
 app.add_typer(fixture_app, name="fixture")
-app.add_typer(feedback_app, name="feedback")
-app.add_typer(scenario_app, name="scenario")
-app.add_typer(skill_app, name="skill")
+app.add_typer(feedback_app, name="feedback", hidden=True)
+app.add_typer(scenario_app, name="scenario", hidden=True)
+app.add_typer(skill_app, name="skill", hidden=True)
 app.add_typer(capability_app, name="capability")
 app.add_typer(mcp_app, name="mcp")
-app.add_typer(registry_app, name="registry")
+app.add_typer(registry_app, name="registry", hidden=True)
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -370,6 +370,45 @@ def test_cli_scan_help_hides_deferred_flags():
     assert "--policy-pack" in public_options
 
 
+# WS-D visibility policy: --help shows the core loop; niche/maintainer
+# surfaces are hidden but stay fully invokable (presentation, not
+# deprecation — STABILITY.md is unaffected).
+HIDDEN_TOP_LEVEL_COMMANDS = {
+    "evidence-packet",
+    "feedback",
+    "registry",
+    "scenario",
+    "skill",
+}
+VISIBLE_CORE_COMMANDS = {
+    "detect",
+    "check",
+    "verify",
+    "init",
+    "scan",
+    "audit",
+    "doctor",
+    "self-check",
+    "fixture",  # the README 60-second demo leads with `fixture run`
+}
+
+
+def test_cli_help_hides_niche_commands_but_keeps_them_invokable():
+    root = get_command(app)
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+
+    for name in HIDDEN_TOP_LEVEL_COMMANDS:
+        assert root.commands[name].hidden, f"{name} should be hidden from --help"
+        assert f" {name} " not in result.output
+        # Hidden, not removed: the command still resolves and answers --help.
+        invoked = runner.invoke(app, [name, "--help"])
+        assert invoked.exit_code == 0, f"{name} must remain invokable: {invoked.output}"
+
+    for name in VISIBLE_CORE_COMMANDS:
+        assert not root.commands[name].hidden, f"{name} must stay visible"
+
+
 def test_cli_tool_surface_summary_detects_no_changes():
     from agents_shipgate.cli._helpers import _tool_surface_diff_has_changes
 


### PR DESCRIPTION
## Summary

- `--help` listed **28** top-level commands; the first-run reader needs the core loop. This hides **five** niche/maintainer surfaces from `--help` via Typer `hidden=True`: `evidence-packet`, `feedback`, `scenario`, `skill`, `registry`. The list drops to 23.
- **Presentation, not deprecation**: every hidden command remains fully invokable and documented (smoke-tested `feedback --help`, `registry --help`), so `STABILITY.md` is untouched — this is exactly the "deleting/consolidating surface" case the surface-discipline gate exempts from metric justification while still honoring compatibility rules.
- One deliberate divergence from the earlier proposed set: **`fixture` stays visible** — the README's 60-second demo leads with `uvx agents-shipgate fixture run …`, and hiding the command the front door showcases would be a contradiction.
- A new test locks the policy in both directions: the five must be hidden *and* still answer `--help`; the core set (`detect`/`check`/`verify`/`init`/`scan`/`audit`/`doctor`/`self-check`/`fixture`) must stay visible.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full suite `pytest -n auto -m "not perf"` — green.
- `tests/test_cli.py::test_cli_help_hides_niche_commands_but_keeps_them_invokable` — asserts hidden + invokable + core-visible.
- Real-CLI smoke: `--help` renders 23 commands; hidden commands execute normally.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` (n/a)
- [x] Report/schema changes are additive or documented in `STABILITY.md` (n/a — visibility only; no command removed or renamed)