### PR TITLE
test: make the committed mined corpus load-bearing (WS-P hardening)

### DIFF
--- a/tests/test_miner_corpus.py
+++ b/tests/test_miner_corpus.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from benchmark.miner.labels import WORKSHEET_COLUMNS
+from benchmark.miner.labels import WORKSHEET_COLUMNS, build_worksheet
 from benchmark.miner.rows import (
     CSV_COLUMNS,
     STATUS_ERROR,
@@ -70,28 +70,46 @@ def test_committed_corpus_is_well_formed(jsonl_path: Path) -> None:
             )
 
 
+def _csv_shape(row) -> dict[str, str]:
+    """How write_csv serializes a row: None → "", everything else → str."""
+
+    return {key: ("" if value is None else str(value)) for key, value in row.to_json().items()}
+
+
 @pytest.mark.parametrize("jsonl_path", _mined_jsonl_files(), ids=lambda p: p.name)
 def test_csv_and_jsonl_agree(jsonl_path: Path) -> None:
     csv_path = jsonl_path.with_suffix(".csv")
     assert csv_path.is_file(), f"missing CSV sibling for {jsonl_path.name}"
     jsonl_rows = read_jsonl(jsonl_path)
+    expected = {row.pr_url: _csv_shape(row) for row in jsonl_rows}
+    assert len(expected) == len(jsonl_rows), f"{jsonl_path.name}: duplicate pr_url"
+
     with csv_path.open(encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
         assert tuple(reader.fieldnames or ()) == CSV_COLUMNS, (
             f"{csv_path.name} header drifted from the row schema"
         )
         csv_rows = list(reader)
+
     assert len(csv_rows) == len(jsonl_rows), (
         f"{csv_path.name} has {len(csv_rows)} rows; "
         f"{jsonl_path.name} has {len(jsonl_rows)} — regenerate both together"
     )
-    jsonl_urls = sorted(r.pr_url for r in jsonl_rows)
-    csv_urls = sorted(r["pr_url"] for r in csv_rows)
-    assert csv_urls == jsonl_urls, f"CSV/JSONL pr_url sets differ for {jsonl_path.stem}"
+    # Full-content comparison: a half-regenerated pair with the same PRs but a
+    # changed status / head_decision / verify_* / count must fail, not pass.
+    for csv_row in csv_rows:
+        url = csv_row["pr_url"]
+        assert url in expected, f"{csv_path.name}: pr_url {url} absent from {jsonl_path.name}"
+        normalized = {key: csv_row.get(key, "") for key in CSV_COLUMNS}
+        assert normalized == expected[url], (
+            f"{csv_path.stem}: row {url} differs between CSV and JSONL\n"
+            f"  csv:   {normalized}\n  jsonl: {expected[url]}"
+        )
 
 
 @pytest.mark.parametrize("jsonl_path", _mined_jsonl_files(), ids=lambda p: p.name)
 def test_committed_corpus_files_are_lf_only(jsonl_path: Path) -> None:
+    assert b"\r" not in jsonl_path.read_bytes(), f"{jsonl_path.name} has CRLF (git diff --check)"
     csv_path = jsonl_path.with_suffix(".csv")
     assert b"\r" not in csv_path.read_bytes(), f"{csv_path.name} has CRLF (git diff --check)"
 
@@ -101,18 +119,26 @@ def test_labels_template_matches_its_corpus() -> None:
     corpus = RESULTS_DIR / "2026-W24-mined.jsonl"
     if not template.is_file():
         pytest.skip("no committed labels template")
-    corpus_urls = {r.pr_url for r in read_jsonl(corpus)}
+    assert b"\r" not in template.read_bytes(), "labels template has CRLF (git diff --check)"
+
+    # The committed template must be exactly the worksheet the corpus generates —
+    # no omitted engine-engaged rows, no duplicates, no stale extras.
+    expected_urls = [w["pr_url"] for w in build_worksheet(read_jsonl(corpus))]
     with template.open(encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
         assert tuple(reader.fieldnames or ()) == WORKSHEET_COLUMNS
         template_rows = list(reader)
-    assert template_rows, "labels template is empty"
+    template_urls = [r["pr_url"] for r in template_rows]
+
+    assert len(template_urls) == len(set(template_urls)), "duplicate rows in labels template"
+    assert sorted(template_urls) == sorted(expected_urls), (
+        "labels template is out of sync with the corpus worksheet "
+        "(regenerate with `python -m benchmark.miner labels`)"
+    )
     for record in template_rows:
-        assert record["pr_url"] in corpus_urls, (
-            f"template pr_url {record['pr_url']} is not in the corpus"
-        )
         # The committed template is blank — labels belong in an adjudicated file.
         assert record["label"] == "", "committed template must not carry labels"
+        assert record["rationale"] == "", "committed template must not carry rationales"
 
 
 def test_w24_headline_numbers_reproduce_from_committed_data() -> None:

--- a/tests/test_miner_corpus.py
+++ b/tests/test_miner_corpus.py
@@ -1,0 +1,130 @@
+"""Integrity guard for the committed mined corpus.
+
+The benchmark claims (trigger-noise bound, IE rate, the labeling worksheet)
+all rest on the committed ``benchmark/miner/results/*`` artifacts. These
+tests make those artifacts load-bearing: a hand-edit, a half-regenerated run,
+or a CSV/JSONL that drift apart fails CI instead of silently publishing a
+wrong number. Network-free — reads only the committed files.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from benchmark.miner.labels import WORKSHEET_COLUMNS
+from benchmark.miner.rows import (
+    CSV_COLUMNS,
+    STATUS_ERROR,
+    STATUS_EVALUATED,
+    STATUS_INIT_SKIP,
+    STATUS_SCAN_FAILED,
+    STATUS_TRIGGER_SKIP,
+    read_jsonl,
+    summarize,
+)
+
+RESULTS_DIR = Path(__file__).resolve().parent.parent / "benchmark" / "miner" / "results"
+
+KNOWN_STATUSES = {
+    STATUS_EVALUATED,
+    STATUS_TRIGGER_SKIP,
+    STATUS_INIT_SKIP,
+    STATUS_SCAN_FAILED,
+    STATUS_ERROR,
+}
+VALID_VERDICTS = {
+    "passed",
+    "review_required",
+    "insufficient_evidence",
+    "blocked",
+}
+
+
+def _mined_jsonl_files() -> list[Path]:
+    return sorted(RESULTS_DIR.glob("*-mined.jsonl"))
+
+
+def test_at_least_one_committed_run_exists() -> None:
+    assert _mined_jsonl_files(), "no committed mined corpus under benchmark/miner/results/"
+
+
+@pytest.mark.parametrize("jsonl_path", _mined_jsonl_files(), ids=lambda p: p.name)
+def test_committed_corpus_is_well_formed(jsonl_path: Path) -> None:
+    rows = read_jsonl(jsonl_path)
+    assert rows, f"{jsonl_path.name} is empty"
+    seen: set[tuple[str, int]] = set()
+    for row in rows:
+        assert row.status in KNOWN_STATUSES, f"unknown status {row.status!r} in {jsonl_path.name}"
+        assert row.pr_url, f"row with no pr_url in {jsonl_path.name}"
+        key = (row.repo, row.pr_number)
+        assert key not in seen, f"duplicate {key} in {jsonl_path.name}"
+        seen.add(key)
+        # An evaluated row, by definition, produced a release decision.
+        if row.status == STATUS_EVALUATED:
+            assert row.head_decision in VALID_VERDICTS, (
+                f"{jsonl_path.name}: evaluated {key} has head_decision "
+                f"{row.head_decision!r} (not a valid verdict)"
+            )
+
+
+@pytest.mark.parametrize("jsonl_path", _mined_jsonl_files(), ids=lambda p: p.name)
+def test_csv_and_jsonl_agree(jsonl_path: Path) -> None:
+    csv_path = jsonl_path.with_suffix(".csv")
+    assert csv_path.is_file(), f"missing CSV sibling for {jsonl_path.name}"
+    jsonl_rows = read_jsonl(jsonl_path)
+    with csv_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        assert tuple(reader.fieldnames or ()) == CSV_COLUMNS, (
+            f"{csv_path.name} header drifted from the row schema"
+        )
+        csv_rows = list(reader)
+    assert len(csv_rows) == len(jsonl_rows), (
+        f"{csv_path.name} has {len(csv_rows)} rows; "
+        f"{jsonl_path.name} has {len(jsonl_rows)} — regenerate both together"
+    )
+    jsonl_urls = sorted(r.pr_url for r in jsonl_rows)
+    csv_urls = sorted(r["pr_url"] for r in csv_rows)
+    assert csv_urls == jsonl_urls, f"CSV/JSONL pr_url sets differ for {jsonl_path.stem}"
+
+
+@pytest.mark.parametrize("jsonl_path", _mined_jsonl_files(), ids=lambda p: p.name)
+def test_committed_corpus_files_are_lf_only(jsonl_path: Path) -> None:
+    csv_path = jsonl_path.with_suffix(".csv")
+    assert b"\r" not in csv_path.read_bytes(), f"{csv_path.name} has CRLF (git diff --check)"
+
+
+def test_labels_template_matches_its_corpus() -> None:
+    template = RESULTS_DIR / "2026-W24-mined.labels.template.csv"
+    corpus = RESULTS_DIR / "2026-W24-mined.jsonl"
+    if not template.is_file():
+        pytest.skip("no committed labels template")
+    corpus_urls = {r.pr_url for r in read_jsonl(corpus)}
+    with template.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        assert tuple(reader.fieldnames or ()) == WORKSHEET_COLUMNS
+        template_rows = list(reader)
+    assert template_rows, "labels template is empty"
+    for record in template_rows:
+        assert record["pr_url"] in corpus_urls, (
+            f"template pr_url {record['pr_url']} is not in the corpus"
+        )
+        # The committed template is blank — labels belong in an adjudicated file.
+        assert record["label"] == "", "committed template must not carry labels"
+
+
+def test_w24_headline_numbers_reproduce_from_committed_data() -> None:
+    """Pin the published 2026-W24 headline to the committed corpus.
+
+    Update these alongside the README when a new run is committed — that is
+    the point: the numbers in the docs must come from the data on disk.
+    """
+    rows = read_jsonl(RESULTS_DIR / "2026-W24-mined.jsonl")
+    summary = summarize(rows)
+    assert summary["rows"] == 121
+    assert summary["by_status"][STATUS_TRIGGER_SKIP] == 108
+    assert summary["by_status"][STATUS_EVALUATED] == 7
+    # IE on decided = 3/7 (the first measured real-world extraction-coverage gap).
+    assert summary["ie_rate_on_decided"] == round(3 / 7, 3)


### PR DESCRIPTION
## Summary

The benchmark claims — the trigger-noise bound, the IE rate, the labeling worksheet — all rest on the committed `benchmark/miner/results/*` artifacts. Right now those are just files: a hand-edit (the exact risk the labels-file review flagged), a half-regenerated run, or a CSV/JSONL that drift apart would silently publish a wrong number. This makes them **load-bearing** — such drift now fails CI.

Hardening only — no new product surface, no `src/` change. Network-free (reads the committed files).

## What it checks (per committed `*-mined.jsonl` run)

- **Well-formed:** parses via `read_jsonl`; every row has a known `status`, a `pr_url`, and a unique `(repo, pr_number)`; `evaluated` rows carry a valid `head_decision`.
- **CSV/JSONL agree:** the CSV header matches the row schema, and the two artifacts have the same row count and `pr_url` set — catches them drifting apart.
- **LF-only:** `git diff --check` clean.

Plus, for the W24 run specifically:
- the labels template stays consistent with its corpus and carries **no** labels (labels belong in an adjudicated file);
- the published headline (**121 rows, 108 trigger-skip, IE-on-decided 3/7**) reproduces from the committed data — so the numbers in the README must come from the data on disk.

## Context

This is the responsible capstone on WS-P now that all three mining-found engine bugs are fixed on main (#214, #215, plus the #212 symlink fix). The remaining WS-P work — the labeled accuracy benchmark — is gated on the human labeling pass, and a `70-hooks-installed` activation experiment is gated on a paid harness run; neither is built speculatively here (see the PR discussion for the harness-detector consideration the investigation surfaced).

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only *(tests over benchmark artifacts; no `src/` change)*

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

- `tests/test_miner_corpus.py` (6) green on clean main.
- Full miner suite (`test_miner` + `test_miner_labels` + `test_miner_corpus`, 25 tests) green; ruff clean.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths (reads committed files only)
- [x] New or changed check IDs documented (n/a)
- [x] Report/schema changes are additive or documented (n/a — tests only)