### PR TITLE
Emit standing forbidden lists in preview-mode handoff

### DIFF
--- a/src/agents_shipgate/checks/verify.py
+++ b/src/agents_shipgate/checks/verify.py
@@ -59,6 +59,29 @@ TRUST_ROOT_SURFACES: tuple[tuple[str, str], ...] = (
     ("tool_surface_decl", "**/SKILL.md"),
 )
 
+# The deny-list of trust-root files a coding agent must never edit *to make a
+# verdict pass*, derived from ``TRUST_ROOT_SURFACES`` (single source of truth),
+# restricted to the classes whose trust boundary is the WHOLE FILE: the
+# Shipgate CI gate, the agent-instruction surfaces, and policy packs.
+#
+# Deliberately EXCLUDES:
+#   * ``shipgate.yaml`` and ``.agents-shipgate/**`` — their boundary is
+#     *key-level* (editing an action's scope is a legitimate mechanical fix; a
+#     ``checks.ignore`` / baseline / waiver expansion is reward-hacking). A
+#     path-level deny cannot express that, so they are covered by
+#     ``forbidden_actions`` (``FORBIDDEN_SHORTCUTS``) instead.
+#   * the tool-surface declarations (``.mcp.json``, ``SKILL.md``, ``.app.json``,
+#     ``.codex-plugin/**``) — those are the capability surface UNDER review,
+#     which a PR may legitimately edit.
+#
+# Single home so the verify ``agent_controller`` and the ``agent_handoff``
+# fallback (preview, where no controller is computed) emit the IDENTICAL
+# standing deny-list — a passing/preview verdict never reads as "anything goes".
+_FORBIDDEN_EDIT_CLASSES = frozenset({"ci_gate", "agent_instructions", "policy"})
+PROTECTED_FILE_EDITS: tuple[str, ...] = tuple(
+    pattern for kind, pattern in TRUST_ROOT_SURFACES if kind in _FORBIDDEN_EDIT_CLASSES
+)
+
 
 def run(context: ScanContext) -> list[Finding]:
     verification = context.verification

--- a/src/agents_shipgate/cli/verify/agent_controller.py
+++ b/src/agents_shipgate/cli/verify/agent_controller.py
@@ -12,7 +12,11 @@ no new decision, and ``completion_allowed`` is locked to
 
 from __future__ import annotations
 
-from agents_shipgate.checks.verify import TRUST_ROOT_SURFACES
+# ``PROTECTED_FILE_EDITS`` (the standing whole-file trust-root deny-list) is
+# defined alongside ``TRUST_ROOT_SURFACES`` in ``checks.verify`` so the verify
+# controller here and the ``agent_handoff`` preview fallback share one source.
+# Re-exported for existing consumers/tests that import it from this module.
+from agents_shipgate.checks.verify import PROTECTED_FILE_EDITS
 from agents_shipgate.cli.verify.fix_task import FORBIDDEN_SHORTCUTS
 from agents_shipgate.schemas.verifier import (
     AgentController,
@@ -21,29 +25,6 @@ from agents_shipgate.schemas.verifier import (
     VerifierCapabilityReview,
     VerifierFixTask,
     VerifierHumanReview,
-)
-
-# The deny-list of trust-root files an agent must never edit *to make a verdict
-# pass*. Derived from the canonical ``TRUST_ROOT_SURFACES`` (single source of
-# truth), restricted to the classes whose trust boundary is the WHOLE FILE: the
-# Shipgate CI gate, the agent-instruction surfaces, and policy packs.
-#
-# Deliberately EXCLUDES:
-#   * ``shipgate.yaml`` and ``.agents-shipgate/**`` — their boundary is
-#     *key-level* (editing an action's scope is a legitimate mechanical fix; a
-#     ``checks.ignore`` / baseline / waiver expansion is reward-hacking). A
-#     path-level deny cannot express that, so they are covered by
-#     ``forbidden_actions`` instead.
-#   * the tool-surface declarations (``.mcp.json``, ``SKILL.md``, ``.app.json``,
-#     ``.codex-plugin/**``) — those are the capability surface UNDER review,
-#     which a PR may legitimately edit.
-#
-# There is intentionally NO allow-list: an agent's legitimate mechanical fix
-# edits application code or manifest scope fields that cannot be enumerated
-# ahead of time, so an exhaustive "may edit" list would fight real work.
-_FORBIDDEN_EDIT_CLASSES = frozenset({"ci_gate", "agent_instructions", "policy"})
-PROTECTED_FILE_EDITS: tuple[str, ...] = tuple(
-    pattern for kind, pattern in TRUST_ROOT_SURFACES if kind in _FORBIDDEN_EDIT_CLASSES
 )
 
 

--- a/src/agents_shipgate/core/agent_handoff.py
+++ b/src/agents_shipgate/core/agent_handoff.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from agents_shipgate.checks.verify import PROTECTED_FILE_EDITS
+from agents_shipgate.core.agent_controls import FORBIDDEN_SHORTCUTS
 from agents_shipgate.schemas.agent_handoff import (
     AgentHandoffArtifact,
     AgentHandoffBlockedBy,
@@ -132,8 +134,13 @@ def _controller(
         must_stop=False if operation == "verify_preview" else not gate.can_merge_without_human,
         stop_reason=None,
         allowed_next_commands=allowed_next_commands,
-        forbidden_file_edits=[],
-        forbidden_actions=[],
+        # Standing negative affordance: the forbidden lists are present on EVERY
+        # verdict (per the verifier/handoff contract), including the preview
+        # operation where no agent_controller is computed. Emit the same
+        # canonical deny-lists the verify controller uses so a preview handoff
+        # never reads as "nothing is forbidden".
+        forbidden_file_edits=list(PROTECTED_FILE_EDITS),
+        forbidden_actions=list(FORBIDDEN_SHORTCUTS),
     )
 
 

--- a/tests/test_agent_handoff.py
+++ b/tests/test_agent_handoff.py
@@ -261,3 +261,39 @@ def test_agent_handoff_rejects_invalid_verifier_substrate() -> None:
 
     with pytest.raises(ValidationError):
         build_agent_handoff(verifier=payload)
+
+
+def test_preview_handoff_carries_standing_forbidden_lists() -> None:
+    # verify --preview emits no agent_controller, so the handoff falls back to
+    # deriving the controller. The forbidden lists are a STANDING negative
+    # affordance present on every verdict — they must not be empty in preview,
+    # and must equal the canonical deny-lists the verify controller uses.
+    from agents_shipgate.checks.verify import PROTECTED_FILE_EDITS
+    from agents_shipgate.core.agent_controls import FORBIDDEN_SHORTCUTS
+
+    verifier = {
+        "workspace": "/tmp/repo",
+        "config": "shipgate.yaml",
+        "mode": "preview",
+        "head_status": "skipped",
+        "merge_verdict": "mergeable",
+        "applicability": "not_applicable",
+        "can_merge_without_human": True,
+        "agent_controller": None,
+        "first_next_action": {
+            "actor": "coding_agent",
+            "kind": "continue",
+            "command": None,
+            "why": "Preview: nothing to gate yet.",
+        },
+    }
+
+    handoff = build_agent_handoff(verifier=verifier).model_dump(mode="json")
+
+    assert handoff["operation"] == "verify_preview"
+    controller = handoff["controller"]
+    assert controller["forbidden_actions"] == list(FORBIDDEN_SHORTCUTS)
+    assert controller["forbidden_file_edits"] == list(PROTECTED_FILE_EDITS)
+    # Non-empty: a preview handoff never reads as "anything goes".
+    assert controller["forbidden_actions"]
+    assert controller["forbidden_file_edits"]


### PR DESCRIPTION
## Summary

- `verify --preview` emits no `agent_controller`, so `build_agent_handoff` fell through to a fallback that hardcoded `forbidden_file_edits=[]` / `forbidden_actions=[]`. These lists are a **standing negative affordance** the verifier/handoff contract guarantees on *every* verdict — so the one mode an agent consults **before acting** (preview) reported "nothing is forbidden", the opposite of the intent.
- The fallback now emits the same canonical deny-lists the verify `agent_controller` uses.
- To keep a single source of truth, `PROTECTED_FILE_EDITS` (the whole-file trust-root deny-list) is hoisted next to `TRUST_ROOT_SURFACES` in `checks/verify.py`. `cli/verify/agent_controller.py` imports and re-exports it (its public consumers/tests unchanged); `core/agent_handoff.py` uses it plus `FORBIDDEN_SHORTCUTS` (already a core constant). `core` never imports `cli`, so the handoff sources both standing lists from `core`/`checks`.

## Type

- [x] Report, schema, or SARIF output (the `agent_handoff` artifact's `controller` block)

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `pytest tests/test_agent_handoff.py tests/test_agent_controller.py` — green, incl. a new `test_preview_handoff_carries_standing_forbidden_lists` asserting the preview handoff's forbidden lists are non-empty and equal `FORBIDDEN_SHORTCUTS` / `PROTECTED_FILE_EDITS`.
- Full suite green; `ruff check` clean.
- Confirmed no circular import from the `core → checks.verify` reuse (preflight already establishes that edge).

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A: no check IDs changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — N/A: no schema change; the `agent_handoff` controller fields already exist, this only fills them in the preview fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)