### PR TITLE
Annotate MCP tools as read-only / closed-world

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,11 @@ mcp = [
   # Optional dependency for `agents-shipgate mcp-serve`: a local stdio MCP
   # server exposing read-only Shipgate projection tools; it does not broker
   # general MCP permissions or start implicitly.
-  "mcp>=1.2,<2",
+  # Floor is 1.14: the server registers every tool with `ToolAnnotations`
+  # (readOnlyHint / openWorldHint) via `FastMCP.tool(..., annotations=...)`,
+  # which earlier 1.x releases either lack (ToolAnnotations import fails) or
+  # do not accept on the tool decorator (registration fails).
+  "mcp>=1.14,<2",
 ]
 dev = [
   "build>=1.5.0,<2",

--- a/src/agents_shipgate/mcp_server/server.py
+++ b/src/agents_shipgate/mcp_server/server.py
@@ -164,11 +164,19 @@ def shipgate_handoff(
 def create_server():
     try:
         from mcp.server.fastmcp import FastMCP
+        from mcp.types import ToolAnnotations
     except ImportError as exc:  # pragma: no cover - exercised only without extra.
         raise ConfigError(
             "The MCP server requires the optional [mcp] extra. Install it "
             'with: pip install "agents-shipgate[mcp]"'
         ) from exc
+
+    # Every tool is a deterministic, local, static projection — it does not
+    # modify its environment (``readOnlyHint``) and never reaches an external
+    # system: no git, no network, no tool execution, no outbound MCP
+    # (``openWorldHint=False``). Advertise that in the machine-readable contract
+    # the agent host reads, not just the prose ``instructions`` below.
+    read_only = ToolAnnotations(readOnlyHint=True, openWorldHint=False)
 
     server = FastMCP(
         "agents-shipgate",
@@ -182,7 +190,7 @@ def create_server():
         ),
     )
 
-    @server.tool(name="shipgate.check")
+    @server.tool(name="shipgate.check", annotations=read_only)
     def _shipgate_check(
         agent: str = "codex",
         workspace: str = ".",
@@ -198,7 +206,7 @@ def create_server():
             policy=policy,
         )
 
-    @server.tool(name="shipgate.preflight")
+    @server.tool(name="shipgate.preflight", annotations=read_only)
     def _shipgate_preflight(
         workspace: str = ".",
         config: str = "shipgate.yaml",
@@ -218,7 +226,7 @@ def create_server():
             base_preflight=base_preflight,
         )
 
-    @server.tool(name="shipgate.explain")
+    @server.tool(name="shipgate.explain", annotations=read_only)
     def _shipgate_explain(
         check_id: str | None = None,
         fingerprint: str | None = None,
@@ -232,7 +240,7 @@ def create_server():
             no_plugins=no_plugins,
         )
 
-    @server.tool(name="shipgate.capabilities")
+    @server.tool(name="shipgate.capabilities", annotations=read_only)
     def _shipgate_capabilities(
         config: str = "shipgate.yaml",
         base_lock: str | None = None,
@@ -246,7 +254,7 @@ def create_server():
             no_plugins=no_plugins,
         )
 
-    @server.tool(name="shipgate.handoff")
+    @server.tool(name="shipgate.handoff", annotations=read_only)
     def _shipgate_handoff(
         verifier_path: str = "agents-shipgate-reports/verifier.json",
         report_path: str | None = None,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -197,6 +197,12 @@ def test_build_server_registers_read_only_tools() -> None:
         "shipgate.handoff",
         "shipgate.preflight",
     }
+    # Every tool advertises its read-only, closed-world nature in the
+    # machine-readable contract, not just the server prose instructions.
+    for tool in listed:
+        assert tool.annotations is not None, tool.name
+        assert tool.annotations.readOnlyHint is True, tool.name
+        assert tool.annotations.openWorldHint is False, tool.name
 
 
 def _write_json(path: Path, payload: dict) -> None:


### PR DESCRIPTION
## Summary

- The MCP server is described (in its `instructions` prose) as a "read-only static adapter", but its five tools carried **no `ToolAnnotations`** — so the read-only/closed-world claim was invisible to an agent host that gates tools by their machine-readable annotations.
- Adds a shared `ToolAnnotations(readOnlyHint=True, openWorldHint=False)` to all five tools (`shipgate.check`, `shipgate.preflight`, `shipgate.explain`, `shipgate.capabilities`, `shipgate.handoff`). They are deterministic local projections: no environment mutation (read-only), and no git / network / tool execution / outbound MCP (closed world).
- `ToolAnnotations` is imported lazily next to `FastMCP` inside `create_server`, so the module still imports cleanly without the optional `[mcp]` extra.

## Type

- [x] CLI or GitHub Action behavior (MCP server tool contract)

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `pytest tests/test_mcp_server.py` — green. `test_build_server_registers_read_only_tools` now asserts every listed tool's annotations set `readOnlyHint=True` / `openWorldHint=False`.
- Full suite green; `ruff check` clean.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — N/A
- [x] Report/schema changes are additive or documented in `STABILITY.md` — N/A: MCP tool metadata only; no report/verifier schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)