### PR TITLE
README: link the MCP-security and least-privilege site pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,8 @@ the same canonical concepts in human-readable, search-optimised form:
 [quickstart](https://threemoonslab.com/quickstart/),
 [check catalog](https://threemoonslab.com/checks/),
 [glossary](https://threemoonslab.com/glossary/),
+[MCP security review](https://threemoonslab.com/use-cases/mcp-security-review/),
+[AI agent least privilege](https://threemoonslab.com/use-cases/ai-agent-least-privilege/),
 [blog](https://threemoonslab.com/blog/), and
 [design partners](https://threemoonslab.com/design-partners/). The in-repo docs
 below are the canonical contract; the marketing pages are sized for first-time


### PR DESCRIPTION
Adds the two use-case pages that just shipped on the marketing site (ThreeMoonsLab/web #41) to the README Docs section's site-link list: [MCP security review](https://threemoonslab.com/use-cases/mcp-security-review/) and [AI agent least privilege](https://threemoonslab.com/use-cases/ai-agent-least-privilege/). Both verified live (HTTP 200).

Two-line diff; `tests/test_public_surface_contract.py` green locally (README is a pinned public surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)