### PR TITLE
Add the any-coding-agent guide; route non-named harnesses explicitly

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -266,7 +266,8 @@
     "target_repo_snippets": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/target-repo-agent-snippets.md",
     "codex": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/use-with-codex.md",
     "claude_code": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/use-with-claude-code.md",
-    "cursor": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/use-with-cursor.md"
+    "cursor": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/use-with-cursor.md",
+    "any_coding_agent": "https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/any-coding-agent.md"
   },
   "coding_agent_surfaces": {
     "codex": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents Shipgate · Agent Instructions
 
-Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aider) working **with** this repository or a project that uses Agents Shipgate.
+Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aider, Cline, Windsurf, Devin, or any other harness — see [`docs/agents/any-coding-agent.md`](docs/agents/any-coding-agent.md)) working **with** this repository or a project that uses Agents Shipgate.
 
 > If you are a human, the README and the [wiki](https://github.com/ThreeMoonsLab/agents-shipgate/wiki) are the right places to start. This file is optimized for agent ingest: short, copy-pasteable, machine-friendly.
 
@@ -60,6 +60,9 @@ The CLI binary is `agents-shipgate`. A short alias `shipgate` is also installed.
 ---
 
 ## Run (canonical)
+
+Handling a capability change right now? Start with **Local control** below —
+run First-time setup only when the repo has no `shipgate.yaml` yet.
 
 **First-time setup** — in a repo that contains an agent and its tools:
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -36,8 +36,11 @@ For committed PR verification, run `agents-shipgate verify`, then read
 
 The normative local protocol is [`protocol.md`](protocol.md). Per-agent compact
 control guides are [`codex.md`](codex.md), [`claude-code.md`](claude-code.md),
-and [`cursor.md`](cursor.md). Full installation and workflow guides live in
-[`use-with-codex.md`](use-with-codex.md),
+and [`cursor.md`](cursor.md). Any other agent — Cline, Windsurf, Devin, Aider,
+OpenHands, or anything with a shell or MCP client — uses
+[`any-coding-agent.md`](any-coding-agent.md) (force agent mode with
+`AGENTS_SHIPGATE_AGENT_MODE=1`, then the same control loop). Full installation
+and workflow guides live in [`use-with-codex.md`](use-with-codex.md),
 [`use-with-claude-code.md`](use-with-claude-code.md), and
 [`use-with-cursor.md`](use-with-cursor.md).
 

--- a/docs/agents/any-coding-agent.md
+++ b/docs/agents/any-coding-agent.md
@@ -1,0 +1,102 @@
+# Any Coding Agent
+
+Compact control guide for coding agents **without** a named integration —
+Cline, Windsurf, Devin, Aider, OpenHands, or anything else that can run a
+shell command or speak MCP. The named guides ([`codex.md`](codex.md),
+[`claude-code.md`](claude-code.md), [`cursor.md`](cursor.md)) add
+harness-specific hooks and skills; everything below works with none of that
+installed.
+
+## Force agent mode
+
+Agent mode auto-enables only inside known harnesses (Claude Code exports
+`CLAUDECODE=1`, Cursor exports `CURSOR_TRACE_ID`). In any other harness,
+export the override so errors carry structured `next_action` /
+`next_actions` payloads instead of prose:
+
+```bash
+export AGENTS_SHIPGATE_AGENT_MODE=1
+```
+
+`AGENTS_SHIPGATE_AGENT_MODE=0` forces it off.
+
+## The control loop
+
+Before reporting an agent-capability change complete, run the local boundary
+check and parse the single stdout JSON object
+(`shipgate.codex_boundary_result/v1`):
+
+```bash
+shipgate check --agent codex --workspace . --format codex-boundary-json
+```
+
+`--agent codex` is the generic profile; use it when your harness has no named
+profile. Switch on `decision`, `completion_allowed`, `must_stop`,
+`first_next_action`, `human_review`, `repair`, and `policy`. Never infer a
+control decision from prose, Markdown, or PR comments.
+
+`check` is boundary-only. If your diff adds dynamic, undeclared, or ambiguous
+tool capability, do not treat `decision="allow"` as merge readiness — run the
+verifier:
+
+```bash
+agents-shipgate verify --workspace . --config shipgate.yaml \
+  --ci-mode advisory --format json
+```
+
+Then read, in order: `agents-shipgate-reports/agent-handoff.json` first
+(`gate.merge_verdict`, then `controller`), `verifier.json` as the
+authoritative controller substrate, and
+`report.json.release_decision.decision` as the release gate. For committed
+PR refs add `--base origin/main --head HEAD`; make the base ref available
+first because `verify` never fetches.
+
+Before changing host grants (MCP servers, permission rules, hooks), capture
+the inventory:
+
+```bash
+shipgate audit --host --json --out agents-shipgate-reports/host-grants.json
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Pass (advisory mode or strict-no-blockers) |
+| `2` | Manifest config error |
+| `3` | Input parse error |
+| `4` | Other Agents Shipgate error |
+| `20` | Strict-mode gate failure |
+
+## No shell? Use the MCP server
+
+If your harness prefers MCP tools over shell commands, install the `[mcp]`
+extra and register the read-only stdio server (`agents-shipgate mcp-serve`).
+It exposes `shipgate.check`, `shipgate.preflight`, `shipgate.explain`,
+`shipgate.capabilities`, and `shipgate.handoff` — the same engine, no shell.
+See [`../mcp-server.md`](../mcp-server.md).
+
+## Forbidden shortcuts
+
+Regardless of harness: do not suppress findings (`checks.ignore`), lower
+severities, expand baselines or waivers, fabricate approval / idempotency /
+confirmation evidence, weaken `shipgate.yaml` or agent instructions, or
+remove Shipgate CI to make a verdict pass. Trust-root and boundary checks
+are suppression-immune; the cheapest reward-hack is also the most visible
+one.
+
+## Report friction
+
+If a verdict looked wrong (false positive, missed capability, unclear
+`first_next_action`) or an adapter could not see your framework, export a
+locally redacted feedback bundle and attach it to an issue:
+
+```bash
+agents-shipgate feedback export \
+  --from agents-shipgate-reports/verifier.json --redact \
+  --out shipgate-feedback.json
+```
+
+Issue template:
+<https://github.com/ThreeMoonsLab/agents-shipgate/issues/new?template=agent_feedback.yml>
+— never attach unredacted reports.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,7 +25,7 @@
 
 # Agents Shipgate · Agent Instructions
 
-Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aider) working **with** this repository or a project that uses Agents Shipgate.
+Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aider, Cline, Windsurf, Devin, or any other harness — see [`docs/agents/any-coding-agent.md`](docs/agents/any-coding-agent.md)) working **with** this repository or a project that uses Agents Shipgate.
 
 > If you are a human, the README and the [wiki](https://github.com/ThreeMoonsLab/agents-shipgate/wiki) are the right places to start. This file is optimized for agent ingest: short, copy-pasteable, machine-friendly.
 
@@ -85,6 +85,9 @@ The CLI binary is `agents-shipgate`. A short alias `shipgate` is also installed.
 ---
 
 ## Run (canonical)
+
+Handling a capability change right now? Start with **Local control** below —
+run First-time setup only when the repo has no `shipgate.yaml` yet.
 
 **First-time setup** — in a repo that contains an agent and its tools:
 

--- a/llms.txt
+++ b/llms.txt
@@ -120,6 +120,7 @@
 - Codex guide: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/use-with-codex.md
 - Claude Code guide: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/use-with-claude-code.md
 - Cursor guide: https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/use-with-cursor.md
+- Any other agent (Cline, Windsurf, Devin, Aider, OpenHands, …): https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/agents/any-coding-agent.md — set `AGENTS_SHIPGATE_AGENT_MODE=1` (agent mode only auto-enables inside Claude Code `CLAUDECODE=1` and Cursor `CURSOR_TRACE_ID`), then run the same control loop.
 
 ## Proactive feedback loop
 

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -1362,6 +1362,11 @@ def test_well_known_links_to_agent_discovery_onramps():
         "codex": "/docs/agents/use-with-codex.md",
         "claude_code": "/docs/agents/use-with-claude-code.md",
         "cursor": "/docs/agents/use-with-cursor.md",
+        # Harness-agnostic on-ramp (Cline, Windsurf, Devin, Aider, …):
+        # the machine-readable discovery map must route agents that are
+        # not one of the three named harnesses, or the "start with
+        # .well-known" instruction strands exactly that audience.
+        "any_coding_agent": "/docs/agents/any-coding-agent.md",
     }
     for key, suffix in expected_onramps.items():
         url = onramps.get(key, "")


### PR DESCRIPTION
## Why

Agent-adoption review finding: the agent-native surface is real but **gated on being one of three named harnesses**. Cline, Windsurf, Devin, Aider, OpenHands get no auto agent-mode (only `CLAUDECODE=1` / `CURSOR_TRACE_ID` auto-enable), the `AGENTS_SHIPGATE_AGENT_MODE=1` override lived only deep in AGENTS.md §errors, `llms.txt` never mentioned it, and `docs/agents/` listed exactly codex/claude-code/cursor. An agent outside the big three that fetched llms.txt had no path to structured errors or a named entry point.

## What

- **`docs/agents/any-coding-agent.md`** (new): the harness-agnostic control guide — force agent mode, the three prominent commands with the agent-handoff-first read order, exit-code table, the MCP-server path for shell-less harnesses, forbidden shortcuts, and the redacted `feedback export` loop with the `agent_feedback.yml` template link. Generic profile documented as `--agent codex`.
- **`docs/agents/README.md` + `llms.txt`**: explicit "any other agent" routing (llms.txt gains its first mention of the agent-mode env var).
- **`AGENTS.md`**: header names the wider harness set; a two-line router atop *Run (canonical)* sends in-flight capability changes to the control loop first (setup only when no `shipgate.yaml`) — closing the last first-command divergence from README's check-first ordering (the read-order half was #251).
- **`llms-full.txt`** regenerated (AGENTS.md is a build source).

## Discipline

Docs-only — no new CLI surface, schema, adapter, or check; deliberately did **not** guess env vars for auto-detecting other harnesses (that would be invented facts; the explicit override is the honest path until verified detection signals exist).

## Verification

`test_public_surface_contract` (120), `test_trigger_command`, `test_packaging` green; ruff clean; `shipgate check --agent claude-code` on this diff (touches the `agent_instructions` trust-root surface): `decision: allow`, `completion_allowed: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)