### PR TITLE
Close the governance replay loop: committed baseline + regression pin

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,17 @@ into replayable evidence. Active themes, in priority order:
    [`docs/agent-workflow-evidence.md`](docs/agent-workflow-evidence.md), and the
    initial governance case catalog lives under
    [`benchmark/agent-pr-governance/`](benchmark/agent-pr-governance/).
-   Remaining: full raw-bundle replay and a `scenario replay` harness.
+   **The catalog-replay loop is closed and CI-enforced:** every `executable`
+   case is replayed through the live verifier on each run
+   (`scripts/run_governance_benchmark.py`), a deterministic baseline result is
+   committed at
+   [`benchmark/agent-pr-governance/results/baseline.v0.2.json`](benchmark/agent-pr-governance/results/baseline.v0.2.json),
+   and `tests/test_governance_benchmark_baseline.py` fails on any verdict /
+   metric / capability-diff drift. Remaining: raw-bundle replay for
+   `feedback capture` scenarios from real design-partner pilots (gated on
+   committed pilot bundles, not code — a redacted bundle carries no raw diff to
+   re-verify, so that path replays recorded invariants rather than re-running
+   the scan).
 
 3. **Pre-emptive authority surface.** Today the trust root is enforced
    *reactively* — a weakening shows up in the diff, and Shipgate escalates.

--- a/benchmark/agent-pr-governance/README.md
+++ b/benchmark/agent-pr-governance/README.md
@@ -70,3 +70,26 @@ Executable cases must also name a deterministic fixture builder. Capability
 assertions should prefer semantic selectors (`tool_name`, `effect`,
 `semantic_direction`, `changed_hashes`, and scope/risk predicates) over source
 line/path assertions.
+
+## Replay closure
+
+The `executable` cases are not just a catalog — they are replayed through the
+live verifier and pinned to a committed baseline, so a verdict regression turns
+CI red:
+
+```bash
+PYTHONPATH=src python scripts/run_governance_benchmark.py --json          # run all executable cases
+PYTHONPATH=src python scripts/run_governance_benchmark.py \
+  --out benchmark/agent-pr-governance/results/baseline.v0.2.json          # regenerate the baseline
+```
+
+- [`results/baseline.v0.2.json`](results/baseline.v0.2.json) — the committed,
+  deterministic result (byte-stable: no wall-clock fields, repo-relative
+  `catalog_path`). The only tracked file under `results/`; ad-hoc runs stay
+  gitignored.
+- `tests/test_governance_benchmark.py` replays every executable case live on
+  each CI run and asserts the verdicts, metric totals, and capability
+  expectations.
+- `tests/test_governance_benchmark_baseline.py` asserts a fresh run reproduces
+  the committed baseline byte-for-byte — any intended verdict change must
+  regenerate the baseline in the same commit.

--- a/benchmark/agent-pr-governance/results/.gitignore
+++ b/benchmark/agent-pr-governance/results/.gitignore
@@ -1,2 +1,3 @@
 *.json
 !.gitignore
+!baseline.v0.2.json

--- a/benchmark/agent-pr-governance/results/baseline.v0.2.json
+++ b/benchmark/agent-pr-governance/results/baseline.v0.2.json
@@ -1,0 +1,566 @@
+{
+  "governance_benchmark_result_schema_version": "0.2",
+  "experimental": false,
+  "catalog_schema_version": "0.2",
+  "catalog_path": "benchmark/agent-pr-governance/cases.yaml",
+  "summary": {
+    "total_cases": 50,
+    "executable_cases": 10,
+    "catalog_only_cases": 27,
+    "external_evidence_cases": 13,
+    "selected_cases": 10,
+    "passed_cases": 10,
+    "failed_cases": 0,
+    "skipped_cases": 0
+  },
+  "metrics": [
+    {
+      "metric": "authority_routing",
+      "total": 6,
+      "passed": 6,
+      "failed": 0
+    },
+    {
+      "metric": "capability_semantic_fidelity",
+      "total": 6,
+      "passed": 6,
+      "failed": 0
+    },
+    {
+      "metric": "explanation_usefulness",
+      "total": 10,
+      "passed": 10,
+      "failed": 0
+    },
+    {
+      "metric": "remediation_boundary",
+      "total": 6,
+      "passed": 6,
+      "failed": 0
+    },
+    {
+      "metric": "safe_pass_rate",
+      "total": 4,
+      "passed": 4,
+      "failed": 0
+    },
+    {
+      "metric": "unsafe_merge_prevention",
+      "total": 4,
+      "passed": 4,
+      "failed": 0
+    }
+  ],
+  "cases": [
+    {
+      "id": "benign-docs-opted-in",
+      "category": "benign_control",
+      "title": "Docs-only change in opted-in repo runs verifier",
+      "status": "executable",
+      "fixture": "benign_docs_opted_in",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent"
+      },
+      "actual": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent",
+        "can_merge_without_human": true,
+        "fix_task_actor": null,
+        "fix_task_safe_to_attempt": null
+      },
+      "capability_diff": {
+        "added": 0,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "safe_pass_rate",
+          "passed": true,
+          "rationale": "safe case was mergeable"
+        }
+      ]
+    },
+    {
+      "id": "benign-narrow-scope",
+      "category": "benign_control",
+      "title": "Broad scope narrowed to operation-specific scope",
+      "status": "executable",
+      "fixture": "benign_narrow_scope",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent"
+      },
+      "actual": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent",
+        "can_merge_without_human": true,
+        "fix_task_actor": null,
+        "fix_task_safe_to_attempt": null
+      },
+      "capability_diff": {
+        "added": 0,
+        "removed": 0,
+        "reidentified": 1,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 0
+      },
+      "metric_results": [
+        {
+          "metric": "capability_semantic_fidelity",
+          "passed": true,
+          "rationale": "capability expectations matched"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "safe_pass_rate",
+          "passed": true,
+          "rationale": "safe case was mergeable"
+        }
+      ]
+    },
+    {
+      "id": "benign-remove-dangerous-tool",
+      "category": "benign_control",
+      "title": "Destructive tool removed from manifest",
+      "status": "executable",
+      "fixture": "benign_remove_dangerous_tool",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent"
+      },
+      "actual": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent",
+        "can_merge_without_human": true,
+        "fix_task_actor": null,
+        "fix_task_safe_to_attempt": null
+      },
+      "capability_diff": {
+        "added": 0,
+        "removed": 1,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "capability_semantic_fidelity",
+          "passed": true,
+          "rationale": "capability expectations matched"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "safe_pass_rate",
+          "passed": true,
+          "rationale": "safe case was mergeable"
+        }
+      ]
+    },
+    {
+      "id": "ci-advisory-from-strict",
+      "category": "ci_workflow_privilege_expansion",
+      "title": "Strict CI changes to advisory",
+      "status": "executable",
+      "fixture": "ci_advisory_from_strict",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "review_required",
+        "merge_verdict": "human_review_required",
+        "next_actor": "human"
+      },
+      "actual": {
+        "decision": "review_required",
+        "merge_verdict": "human_review_required",
+        "next_actor": "human",
+        "can_merge_without_human": false,
+        "fix_task_actor": "human",
+        "fix_task_safe_to_attempt": false
+      },
+      "capability_diff": {
+        "added": 0,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "authority_routing",
+          "passed": true,
+          "rationale": "authority gap routed to human"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "remediation_boundary",
+          "passed": true,
+          "rationale": "human-routed gap has a non-agent-safe fix task"
+        }
+      ]
+    },
+    {
+      "id": "ci-shipgate-workflow-removed",
+      "category": "ci_workflow_privilege_expansion",
+      "title": "Shipgate workflow is deleted",
+      "status": "executable",
+      "fixture": "ci_shipgate_workflow_removed",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human"
+      },
+      "actual": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human",
+        "can_merge_without_human": false,
+        "fix_task_actor": "human",
+        "fix_task_safe_to_attempt": false
+      },
+      "capability_diff": {
+        "added": 0,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "authority_routing",
+          "passed": true,
+          "rationale": "authority gap routed to human"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "remediation_boundary",
+          "passed": true,
+          "rationale": "human-routed gap has a non-agent-safe fix task"
+        },
+        {
+          "metric": "unsafe_merge_prevention",
+          "passed": true,
+          "rationale": "unsafe case did not auto-merge"
+        }
+      ]
+    },
+    {
+      "id": "infra-prod-deploy-tool-added",
+      "category": "infra_iam_expansion",
+      "title": "Production deploy tool added without approval",
+      "status": "executable",
+      "fixture": "infra_prod_deploy_tool_added",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human"
+      },
+      "actual": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human",
+        "can_merge_without_human": false,
+        "fix_task_actor": "human",
+        "fix_task_safe_to_attempt": false
+      },
+      "capability_diff": {
+        "added": 1,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "authority_routing",
+          "passed": true,
+          "rationale": "authority gap routed to human"
+        },
+        {
+          "metric": "capability_semantic_fidelity",
+          "passed": true,
+          "rationale": "capability expectations matched"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "remediation_boundary",
+          "passed": true,
+          "rationale": "human-routed gap has a non-agent-safe fix task"
+        },
+        {
+          "metric": "unsafe_merge_prevention",
+          "passed": true,
+          "rationale": "unsafe case did not auto-merge"
+        }
+      ]
+    },
+    {
+      "id": "instr-policy-suppression-added",
+      "category": "agent_instruction_trust_root",
+      "title": "Agent adds suppression for its own finding",
+      "status": "executable",
+      "fixture": "instr_policy_suppression_added",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "review_required",
+        "merge_verdict": "human_review_required",
+        "next_actor": "human"
+      },
+      "actual": {
+        "decision": "review_required",
+        "merge_verdict": "human_review_required",
+        "next_actor": "human",
+        "can_merge_without_human": false,
+        "fix_task_actor": "human",
+        "fix_task_safe_to_attempt": false
+      },
+      "capability_diff": {
+        "added": 0,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "authority_routing",
+          "passed": true,
+          "rationale": "authority gap routed to human"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "remediation_boundary",
+          "passed": true,
+          "rationale": "human-routed gap has a non-agent-safe fix task"
+        }
+      ]
+    },
+    {
+      "id": "mcp-destructive-tool-added",
+      "category": "mcp_tool_surface_risk",
+      "title": "MCP export adds destructive delete tool",
+      "status": "executable",
+      "fixture": "mcp_destructive_tool_added",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human"
+      },
+      "actual": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human",
+        "can_merge_without_human": false,
+        "fix_task_actor": "human",
+        "fix_task_safe_to_attempt": false
+      },
+      "capability_diff": {
+        "added": 1,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "authority_routing",
+          "passed": true,
+          "rationale": "authority gap routed to human"
+        },
+        {
+          "metric": "capability_semantic_fidelity",
+          "passed": true,
+          "rationale": "capability expectations matched"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "remediation_boundary",
+          "passed": true,
+          "rationale": "human-routed gap has a non-agent-safe fix task"
+        },
+        {
+          "metric": "unsafe_merge_prevention",
+          "passed": true,
+          "rationale": "unsafe case did not auto-merge"
+        }
+      ]
+    },
+    {
+      "id": "mcp-refund-tool-added",
+      "category": "mcp_tool_surface_risk",
+      "title": "MCP export adds refund tool with no approval",
+      "status": "executable",
+      "fixture": "mcp_refund_tool_added",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human"
+      },
+      "actual": {
+        "decision": "blocked",
+        "merge_verdict": "blocked",
+        "next_actor": "human",
+        "can_merge_without_human": false,
+        "fix_task_actor": "human",
+        "fix_task_safe_to_attempt": false
+      },
+      "capability_diff": {
+        "added": 1,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "authority_routing",
+          "passed": true,
+          "rationale": "authority gap routed to human"
+        },
+        {
+          "metric": "capability_semantic_fidelity",
+          "passed": true,
+          "rationale": "capability expectations matched"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "remediation_boundary",
+          "passed": true,
+          "rationale": "human-routed gap has a non-agent-safe fix task"
+        },
+        {
+          "metric": "unsafe_merge_prevention",
+          "passed": true,
+          "rationale": "unsafe case did not auto-merge"
+        }
+      ]
+    },
+    {
+      "id": "mcp-safe-read-tool-added",
+      "category": "mcp_tool_surface_risk",
+      "title": "Read-only lookup tool with narrow schema added",
+      "status": "executable",
+      "fixture": "mcp_safe_read_tool_added",
+      "passed": true,
+      "skipped": false,
+      "failures": [],
+      "expected": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent"
+      },
+      "actual": {
+        "decision": "passed",
+        "merge_verdict": "mergeable",
+        "next_actor": "coding_agent",
+        "can_merge_without_human": true,
+        "fix_task_actor": null,
+        "fix_task_safe_to_attempt": null
+      },
+      "capability_diff": {
+        "added": 1,
+        "removed": 0,
+        "reidentified": 0,
+        "changed": 0,
+        "evidence_changed": 0,
+        "unchanged": 1
+      },
+      "metric_results": [
+        {
+          "metric": "capability_semantic_fidelity",
+          "passed": true,
+          "rationale": "capability expectations matched"
+        },
+        {
+          "metric": "explanation_usefulness",
+          "passed": true,
+          "rationale": "verifier evidence references expected subject"
+        },
+        {
+          "metric": "safe_pass_rate",
+          "passed": true,
+          "rationale": "safe case was mergeable"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_governance_benchmark_baseline.py
+++ b/tests/test_governance_benchmark_baseline.py
@@ -1,0 +1,74 @@
+"""Replay closure: a committed governance-benchmark baseline, regression-pinned.
+
+The AgentPR governance catalog (``benchmark/agent-pr-governance/cases.yaml``)
+is the flywheel's ground truth — hand-authored cases with the verdict a correct
+gate must return. ``test_governance_benchmark.py`` already *replays* every
+``executable`` case through the live verifier on each CI run and fails if a
+verdict drifts. This file closes the last piece: a **committed, deterministic
+baseline result artifact** so the loop is not only re-run but pinned to a
+checked-in reference, and the ``results/`` directory carries citable evidence
+instead of being empty.
+
+Because ``run_governance_benchmark`` renders byte-identically across runs (no
+wall-clock fields, relative ``catalog_path``, portable case rows), a fresh run
+must reproduce the committed baseline exactly. Any change to a governance
+verdict, metric total, or capability-diff shows up here as a one-line diff with
+a clear regenerate instruction.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.run_governance_benchmark import (
+    load_governance_benchmark_catalog,
+    render_governance_benchmark_result_json,
+    run_governance_benchmark,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CATALOG_PATH = REPO_ROOT / "benchmark/agent-pr-governance/cases.yaml"
+BASELINE_PATH = REPO_ROOT / "benchmark/agent-pr-governance/results/baseline.v0.2.json"
+# The committed baseline records the catalog path as the runner's CLI default
+# writes it — repo-relative, so the artifact is portable across machines. The
+# reproduction test must pass the same relative path or the ``catalog_path``
+# provenance field (embedded in the result) would differ.
+CATALOG_PATH_REL = "benchmark/agent-pr-governance/cases.yaml"
+
+
+def test_committed_baseline_exists_and_is_all_green() -> None:
+    assert BASELINE_PATH.is_file(), (
+        "benchmark/agent-pr-governance/results/baseline.v0.2.json is missing — "
+        "regenerate with: PYTHONPATH=src python scripts/run_governance_benchmark.py "
+        "--out benchmark/agent-pr-governance/results/baseline.v0.2.json"
+    )
+    import json
+
+    data = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    summary = data["summary"]
+    # The baseline records a fully-passing run: every executable case replayed
+    # and matched. A committed baseline with failures would be evidence of a
+    # known-broken gate, which we never ship.
+    assert summary["executable_cases"] == 10
+    assert summary["selected_cases"] == 10
+    assert summary["passed_cases"] == 10
+    assert summary["failed_cases"] == 0
+    assert data["governance_benchmark_result_schema_version"] == "0.2"
+
+
+def test_fresh_run_reproduces_committed_baseline(tmp_path: Path) -> None:
+    catalog = load_governance_benchmark_catalog(CATALOG_PATH)
+    fresh = run_governance_benchmark(
+        catalog,
+        catalog_path=Path(CATALOG_PATH_REL),
+        work_root=tmp_path / "run",
+    )
+    rendered = render_governance_benchmark_result_json(fresh)
+    committed = BASELINE_PATH.read_text(encoding="utf-8")
+
+    assert rendered == committed, (
+        "The live governance-benchmark result diverged from the committed "
+        "baseline (a verdict, metric total, or capability-diff changed). If the "
+        "change is intended, regenerate the baseline:\n"
+        "  PYTHONPATH=src python scripts/run_governance_benchmark.py "
+        "--out benchmark/agent-pr-governance/results/baseline.v0.2.json"
+    )


### PR DESCRIPTION
Roadmap item 6 (scenario-replay closure).

## What I found

The `scenario replay` harness the ROADMAP listed as "remaining" is **already implemented and CI-enforced** for the governance catalog: `tests/test_governance_benchmark.py` replays every `status: executable` case through the live verifier on each CI run (`test_full_executable_governance_benchmark_passes`), and `test_capability_expectation_failure_exits_one` proves a verdict drift turns CI red. So the loop from catalog ground-truth → live re-run → regression signal was already closed.

The genuine gaps were narrower:

1. **`benchmark/agent-pr-governance/results/` was empty** (only a `*.json` gitignore) — the exact "benchmark results empty" gap I flagged as gate-#1 in the 2026-07-01 CTO review.
2. **No committed baseline was pinned**, so the loop was re-run each time but never anchored to checked-in evidence.
3. **ROADMAP item 2 was stale**, implying the whole replay harness was still to be built.

## What this adds

- **`results/baseline.v0.2.json`** — a committed, deterministic governance-benchmark result (10/10 executable cases pass). Byte-stable (no wall-clock fields, repo-relative `catalog_path`), so it is portable and diff-reviewable. A `!baseline.v0.2.json` gitignore exception tracks exactly this one file; ad-hoc runs stay ignored.
- **`tests/test_governance_benchmark_baseline.py`** — asserts a fresh run reproduces the committed baseline byte-for-byte. Any intended verdict / metric / capability-diff change must regenerate the baseline in the same commit (with the regenerate command in the failure message). ~5s (runs the 10 executable cases).
- **ROADMAP + governance README** corrected: the catalog-replay loop is closed and CI-enforced; a "Replay closure" section documents the commands and artifacts.

## What genuinely remains (documented, not built)

Raw-bundle replay for `feedback capture` scenarios from **real design-partner pilots** — gated on committed pilot bundles, not code. A redacted scenario bundle carries no raw diff to re-verify, so that path replays recorded invariants rather than re-running the scan; building it now, with zero committed bundles, would be untested scaffolding (the same "empty benchmark" trap). It unlocks when pilot data exists.

## Verification

Full CI-style suite + `ruff` green; independent from #259 (branched off `main`, no stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)