### PR TITLE
fix(init): derive tool_sources ids from the whole path, not the basename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,18 @@
   `openapi.yaml` got an invalid manifest written to disk, and the documented
   next step (`scan`) failed on it with a config error telling the user not to
   re-run `init`. Both renderers now derive the id from the whole
-  workspace-relative path (`openai_sdk_strix_tools_finish_tool`), so an id
-  depends only on the file it names — a positional `_2` suffix would have
-  renumbered existing entries whenever an unrelated file appeared earlier in
-  the walk. Paths that still sanitize to one id (`a-b/` and `a_b/`) each take
-  a digest of their own path rather than one side keeping the plain form, and
-  a deep monorepo path keeps its most specific segments plus a digest so ids
-  stay readable in report output. Verified end to end on the repository from
-  the report: 23 sources, 23 unique ids, `init --write` → `scan` exits 0.
+  workspace-relative path (`openai_sdk_strix_tools_finish_tool`), with no
+  positional component — a `_2` suffix would have renumbered existing entries
+  whenever an unrelated file appeared earlier in the walk. Sanitizing is
+  lossy, so paths that still fold to one id (`a-b/` and `a_b/`) each take a
+  digest of their own path rather than one side keeping the plain form; that
+  group is the one case where adding a file changes an id that already
+  existed, and `init` refuses to overwrite an existing manifest, so ids are
+  assigned once per adoption. A deep monorepo path keeps its most specific
+  segments plus a digest, and the 64-character bound is enforced on the value
+  that ships, disambiguated ones included. Verified end to end on the
+  repository from the report: 23 sources, 23 unique ids, `init --write` →
+  `scan` exits 0.
   Nested sources declared by `--minimal` change id (they had no valid id
   before); ids in an existing `shipgate.yaml` are untouched — `init` refuses
   to overwrite one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+- **`init` no longer fails on a repository that names two files the same.**
+  A generated `tool_sources[].id` was the source type plus the file's
+  basename, so `strix/tools/finish/tool.py`, `strix/tools/respond/tool.py`,
+  and `strix/tools/load_skill/tool.py` all rendered as `openai_sdk_tool` —
+  and the manifest schema, correctly, rejects a manifest whose ids repeat.
+  One `tool.py` per tool package is the conventional Python layout, not an
+  edge case, so on those repositories the primary adoption path failed
+  outright: `init --write` exited 4 with `internal_error` and wrote nothing,
+  and the fallback it routed to (`--minimal`) discards the detection work for
+  a `CHANGE_ME` template. Worse, `--minimal` had the same rule with no
+  validation gate in front of it — two services that each ship
+  `openapi.yaml` got an invalid manifest written to disk, and the documented
+  next step (`scan`) failed on it with a config error telling the user not to
+  re-run `init`. Both renderers now derive the id from the whole
+  workspace-relative path (`openai_sdk_strix_tools_finish_tool`), so an id
+  depends only on the file it names — a positional `_2` suffix would have
+  renumbered existing entries whenever an unrelated file appeared earlier in
+  the walk. Paths that still sanitize to one id (`a-b/` and `a_b/`) each take
+  a digest of their own path rather than one side keeping the plain form, and
+  a deep monorepo path keeps its most specific segments plus a digest so ids
+  stay readable in report output. Verified end to end on the repository from
+  the report: 23 sources, 23 unique ids, `init --write` → `scan` exits 0.
+  Nested sources declared by `--minimal` change id (they had no valid id
+  before); ids in an existing `shipgate.yaml` are untouched — `init` refuses
+  to overwrite one.
+
 - **A protected-surface stop now names the route, and the non-route that looks
   like one.** A human-routed preflight signal said only that a coding agent must
   not self-approve the edit. That leaves the agent to guess how a human decides,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@
   positional component — a `_2` suffix would have renumbered existing entries
   whenever an unrelated file appeared earlier in the walk. Sanitizing is
   lossy, so paths that still fold to one id (`a-b/` and `a_b/`) each take a
-  digest of their own path rather than one side keeping the plain form; that
-  group is the one case where adding a file changes an id that already
-  existed, and `init` refuses to overwrite an existing manifest, so ids are
-  assigned once per adoption. A deep monorepo path keeps its most specific
-  segments plus a digest, and the 64-character bound is enforced on the value
-  that ships, disambiguated ones included. Verified end to end on the
+  digest of their own path rather than one side keeping the plain form; a
+  collision is the one case where adding a file changes an id that already
+  existed, nothing outside it is re-keyed, and `init` refuses to overwrite an
+  existing manifest, so ids are assigned once per adoption. A digest prefix
+  is not treated as a unique key either — two paths in one sanitized class
+  sharing an 8-hex prefix are searchable in seconds — so whatever is still
+  tied moves to a wider digest and the rendered set is unique by
+  construction. A deep monorepo path keeps its most specific segments plus a
+  digest, and the 64-character bound is enforced on the value that ships,
+  disambiguated ones included. Verified end to end on the
   repository from the report: 23 sources, 23 unique ids, `init --write` →
   `scan` exits 0.
   Nested sources declared by `--minimal` change id (they had no valid id

--- a/src/agents_shipgate/cli/discovery/artifacts.py
+++ b/src/agents_shipgate/cli/discovery/artifacts.py
@@ -7,6 +7,7 @@ import subprocess
 import threading
 from pathlib import Path
 
+from agents_shipgate.cli.discovery.source_ids import assign_source_ids
 from agents_shipgate.core.errors import DiscoveryError
 
 OPENAPI_PATTERNS = (
@@ -193,7 +194,7 @@ def discover_tool_sources(workspace: Path) -> list[dict[str, str]]:
     adapters accept. A glob hit that fails the parse probe (e.g. an
     ``mcpServers``-style host config matching ``*mcp*.json``) is dropped:
     writing it would guarantee a ``scan`` input-parse failure."""
-    sources: list[dict[str, str]] = []
+    found: list[tuple[str, str]] = []  # (type, relative path)
     seen: set[Path] = set()
     rejected: set[Path] = set()
     for pattern in OPENAPI_PATTERNS:
@@ -205,13 +206,7 @@ def discover_tool_sources(workspace: Path) -> list[dict[str, str]]:
                 rejected.add(path)
                 continue
             seen.add(path)
-            sources.append(
-                {
-                    "id": _source_id(path, "openapi"),
-                    "type": "openapi",
-                    "path": rel,
-                }
-            )
+            found.append(("openapi", rel))
     for pattern in MCP_PATTERNS:
         for path in _candidate_files_matching(workspace, (pattern,)):
             if path.name == ".mcp.json":
@@ -222,13 +217,7 @@ def discover_tool_sources(workspace: Path) -> list[dict[str, str]]:
             if probe_suggested_source(workspace, rel, "mcp") is not None:
                 continue
             seen.add(path)
-            sources.append(
-                {
-                    "id": _source_id(path, "mcp"),
-                    "type": "mcp",
-                    "path": rel,
-                }
-            )
+            found.append(("mcp", rel))
     for pattern in CONDUCTOR_WORKFLOW_PATTERNS:
         for path in _candidate_files_matching(workspace, (pattern,)):
             if path in seen:
@@ -237,14 +226,14 @@ def discover_tool_sources(workspace: Path) -> list[dict[str, str]]:
             if probe_suggested_source(workspace, rel, "conductor") is not None:
                 continue
             seen.add(path)
-            sources.append(
-                {
-                    "id": _source_id(path, "conductor"),
-                    "type": "conductor",
-                    "path": rel,
-                }
-            )
-    return sources
+            found.append(("conductor", rel))
+    # Ids come from the whole relative path and are assigned for the set,
+    # so two services that both ship ``openapi.yaml`` no longer render one
+    # id twice — a manifest the schema rejects (#307).
+    return [
+        {"id": source_id, "type": source_type, "path": rel}
+        for (source_type, rel), source_id in zip(found, assign_source_ids(found), strict=True)
+    ]
 
 
 def render_manifest_template(workspace: Path) -> str:
@@ -645,8 +634,3 @@ def _relative(path: Path, base: Path) -> str:
         return path.relative_to(base).as_posix()
     except ValueError:
         return path.as_posix()
-
-
-def _source_id(path: Path, source_type: str) -> str:
-    stem = path.stem.lower().replace("-", "_").replace(".", "_")
-    return f"{source_type}_{stem}"

--- a/src/agents_shipgate/cli/discovery/source_ids.py
+++ b/src/agents_shipgate/cli/discovery/source_ids.py
@@ -11,10 +11,22 @@ caught that at its validation gate and wrote nothing; ``--minimal`` had no
 gate and wrote the invalid file, so the documented next step (``scan``)
 failed with a config error. See issue #307.
 
-Ids are derived from the whole workspace-relative path, so an id depends
-only on the file it names. A positional suffix (``_2``, ``_3``) would
-instead renumber existing entries whenever an unrelated file appears
-earlier in the walk, churning anything keyed on the id.
+Ids are derived from the whole workspace-relative path and carry no
+positional component: no ``_2``/``_3`` counter, so a file appearing
+earlier in the walk can never renumber the entries after it.
+
+**Stability guarantee, exactly.** An id is a pure function of its own
+path *unless another declared path sanitizes to the same id* — sanitizing
+is lossy (``a-b/`` and ``a_b/`` both fold to ``a_b``; so do ``a/b_c.py``
+and ``a_b/c.py``). Those groups are disambiguated by digest, so adding
+such a path and regenerating from scratch changes the ids of every member
+of the group, not just the newcomer. Making that case file-local would
+mean putting a digest on *every* id, including the common ones this
+scheme exists to keep readable. The blast radius is bounded: ``init``
+refuses to overwrite an existing ``shipgate.yaml``, so ids are assigned
+once per adoption, and the fold classes are rare in one workspace.
+``tests/test_init_auto.py`` pins both halves — non-colliding siblings
+never shift an id; a colliding one shifts both.
 """
 
 from __future__ import annotations
@@ -40,7 +52,8 @@ SOURCE_ID_PREFIXES: dict[str, str] = {
 
 # Generated ids travel into findings and report output, so a deep monorepo
 # path is truncated to the most specific segments that fit and made unique
-# again by a digest of the full path.
+# again by a digest of the full path. The bound holds for every id this
+# module returns, disambiguated ones included.
 MAX_SOURCE_ID_LENGTH = 64
 
 _DIGEST_LENGTH = 8
@@ -51,15 +64,60 @@ def source_id_for(source_type: str, relative_path: str) -> str:
     """Deterministic id for one detected source file.
 
     ``relative_path`` is the workspace-relative path as written to the
-    manifest's ``path:`` field.
+    manifest's ``path:`` field. Never longer than
+    :data:`MAX_SOURCE_ID_LENGTH`.
     """
+    return _compose(source_type, relative_path, disambiguate=False)
+
+
+def assign_source_ids(entries: Sequence[tuple[str, str]]) -> list[str]:
+    """Ids for ``(source_type, relative_path)`` pairs, unique by construction.
+
+    Distinct paths can still sanitize to one id (``a-b/tools.py`` and
+    ``a_b/tools.py``). Every member of such a group takes a digest of its
+    own path — rather than one side keeping the plain form — so which file
+    was walked first never decides which one gets renamed. See the module
+    docstring for what that costs in stability.
+    """
+    ids = [source_id_for(source_type, path) for source_type, path in entries]
+    collided = {value for value, count in Counter(ids).items() if count > 1}
+    if not collided:
+        return ids
+    resolved = [
+        _compose(source_type, path, disambiguate=True) if value in collided else value
+        for value, (source_type, path) in zip(ids, entries, strict=True)
+    ]
+    if len(set(resolved)) == len(resolved):
+        return resolved
+    # A plain id can equal another entry's disambiguated form when a file
+    # is named after that digest (`a_b_spec_<digest of a-b/spec.yaml>`).
+    # Contrived, but constructible — and `--minimal` has no validation
+    # gate behind it, so give every entry a digest rather than let a
+    # duplicate reach the render.
+    return [
+        _compose(source_type, path, disambiguate=True) for source_type, path in entries
+    ]
+
+
+def _compose(source_type: str, relative_path: str, *, disambiguate: bool) -> str:
     prefix = SOURCE_ID_PREFIXES.get(source_type, source_type)
     segments = _path_segments(relative_path)
-    source_id = "_".join([prefix, *segments]) if segments else f"{prefix}_root"
-    if len(source_id) <= MAX_SOURCE_ID_LENGTH:
-        return source_id
+    plain = "_".join([prefix, *segments]) if segments else f"{prefix}_root"
+    if not disambiguate and len(plain) <= MAX_SOURCE_ID_LENGTH:
+        return plain
+    return _with_digest(prefix, segments, relative_path)
 
+
+def _with_digest(prefix: str, segments: list[str], relative_path: str) -> str:
+    """``prefix`` + the most specific segments that fit + a path digest.
+
+    The digest is what keeps two truncated (or two identically sanitized)
+    paths apart, so the length budget is computed with room for it — a
+    source-type prefix long enough to crowd it out is truncated too, which
+    keeps the bound true for third-party adapter names of any length.
+    """
     digest = _digest(relative_path)
+    prefix = prefix[: MAX_SOURCE_ID_LENGTH - len(digest) - 1]
     budget = MAX_SOURCE_ID_LENGTH - len(prefix) - len(digest) - 2
     kept: list[str] = []
     width = 0
@@ -69,24 +127,6 @@ def source_id_for(source_type: str, relative_path: str) -> str:
         kept.insert(0, segment)
         width += len(segment) + 1
     return "_".join([prefix, *kept, digest])
-
-
-def assign_source_ids(entries: Sequence[tuple[str, str]]) -> list[str]:
-    """Ids for ``(source_type, relative_path)`` pairs, unique by construction.
-
-    Distinct paths can still sanitize to one id (``a-b/tools.py`` and
-    ``a_b/tools.py``). Both sides then take a digest of their own path
-    rather than one side keeping the plain form, so which file was walked
-    first never decides which one gets renamed.
-    """
-    ids = [source_id_for(source_type, path) for source_type, path in entries]
-    collided = {value for value, count in Counter(ids).items() if count > 1}
-    if not collided:
-        return ids
-    return [
-        f"{value}_{_digest(path)}" if value in collided else value
-        for value, (_source_type, path) in zip(ids, entries, strict=True)
-    ]
 
 
 def _path_segments(relative_path: str) -> list[str]:

--- a/src/agents_shipgate/cli/discovery/source_ids.py
+++ b/src/agents_shipgate/cli/discovery/source_ids.py
@@ -16,17 +16,24 @@ positional component: no ``_2``/``_3`` counter, so a file appearing
 earlier in the walk can never renumber the entries after it.
 
 **Stability guarantee, exactly.** An id is a pure function of its own
-path *unless another declared path sanitizes to the same id* — sanitizing
-is lossy (``a-b/`` and ``a_b/`` both fold to ``a_b``; so do ``a/b_c.py``
-and ``a_b/c.py``). Those groups are disambiguated by digest, so adding
-such a path and regenerating from scratch changes the ids of every member
-of the group, not just the newcomer. Making that case file-local would
-mean putting a digest on *every* id, including the common ones this
-scheme exists to keep readable. The blast radius is bounded: ``init``
-refuses to overwrite an existing ``shipgate.yaml``, so ids are assigned
-once per adoption, and the fold classes are rare in one workspace.
-``tests/test_init_auto.py`` pins both halves — non-colliding siblings
-never shift an id; a colliding one shifts both.
+path *unless it collides with another entry's id*. Sanitizing is lossy
+(``a-b/`` and ``a_b/`` both fold to ``a_b``; so do ``a/b_c.py`` and
+``a_b/c.py``), so those groups are disambiguated by digest and adding
+such a path changes the ids of every member of the group, not just the
+newcomer. Making that case file-local would mean putting a digest on
+*every* id, including the common ones this scheme exists to keep
+readable. Nothing outside a collision is ever re-keyed: an entry whose id
+is unique keeps it, whatever else the workspace contains. The blast
+radius is bounded: ``init`` refuses to overwrite an existing
+``shipgate.yaml``, so ids are assigned once per adoption, and the fold
+classes are rare in one workspace. ``tests/test_init_auto.py`` pins every
+half — non-colliding siblings never shift an id, a colliding one shifts
+both, and a bystander is untouched by either.
+
+Uniqueness is a property of the returned list, not a hope: a digest
+prefix is not a unique key (an 8-hex collision inside one sanitized class
+is searchable in seconds), so the assignment re-keys the entries that are
+*still* tied at a wider digest, and finally numbers whatever survives.
 """
 
 from __future__ import annotations
@@ -56,7 +63,10 @@ SOURCE_ID_PREFIXES: dict[str, str] = {
 # module returns, disambiguated ones included.
 MAX_SOURCE_ID_LENGTH = 64
 
-_DIGEST_LENGTH = 8
+# Widths tried, in order, for entries that are still tied. 8 hex characters
+# read well and settle every collision that occurs by accident; a wider one
+# is only reached by paths crafted to share the narrower prefix.
+_DIGEST_WIDTHS = (8, 16, 32)
 _NON_ID_CHARS = re.compile(r"[^a-z0-9]+")
 
 
@@ -67,56 +77,99 @@ def source_id_for(source_type: str, relative_path: str) -> str:
     manifest's ``path:`` field. Never longer than
     :data:`MAX_SOURCE_ID_LENGTH`.
     """
-    return _compose(source_type, relative_path, disambiguate=False)
+    return _compose(source_type, relative_path)
 
 
 def assign_source_ids(entries: Sequence[tuple[str, str]]) -> list[str]:
     """Ids for ``(source_type, relative_path)`` pairs, unique by construction.
 
-    Distinct paths can still sanitize to one id (``a-b/tools.py`` and
+    Distinct paths can sanitize to one id (``a-b/tools.py`` and
     ``a_b/tools.py``). Every member of such a group takes a digest of its
     own path — rather than one side keeping the plain form — so which file
-    was walked first never decides which one gets renamed. See the module
-    docstring for what that costs in stability.
+    was walked first never decides which one gets renamed.
+
+    Each round re-keys *only* the entries whose current id is duplicated,
+    so an entry that never collides keeps the id its own path produced.
+    Whatever is still tied after a round moves to a wider digest, because
+    a digest prefix is not a unique key: two paths in one sanitized class
+    sharing an 8-hex prefix are searchable in seconds, and ``--minimal``
+    has no validation gate to catch the duplicate that used to reach the
+    render.
     """
     ids = [source_id_for(source_type, path) for source_type, path in entries]
-    collided = {value for value, count in Counter(ids).items() if count > 1}
-    if not collided:
-        return ids
-    resolved = [
-        _compose(source_type, path, disambiguate=True) if value in collided else value
-        for value, (source_type, path) in zip(ids, entries, strict=True)
-    ]
-    if len(set(resolved)) == len(resolved):
-        return resolved
-    # A plain id can equal another entry's disambiguated form when a file
-    # is named after that digest (`a_b_spec_<digest of a-b/spec.yaml>`).
-    # Contrived, but constructible — and `--minimal` has no validation
-    # gate behind it, so give every entry a digest rather than let a
-    # duplicate reach the render.
-    return [
-        _compose(source_type, path, disambiguate=True) for source_type, path in entries
-    ]
+    for width in _DIGEST_WIDTHS:
+        duplicated = _duplicated(ids)
+        if not duplicated:
+            return ids
+        ids = [
+            _compose(source_type, path, digest_width=width)
+            if value in duplicated
+            else value
+            for value, (source_type, path) in zip(ids, entries, strict=True)
+        ]
+    duplicated = _duplicated(ids)
+    return _numbered(entries, ids, duplicated) if duplicated else ids
 
 
-def _compose(source_type: str, relative_path: str, *, disambiguate: bool) -> str:
+def _duplicated(ids: Sequence[str]) -> set[str]:
+    return {value for value, count in Counter(ids).items() if count > 1}
+
+
+def _numbered(
+    entries: Sequence[tuple[str, str]], ids: list[str], duplicated: set[str]
+) -> list[str]:
+    """Last resort for entries still tied at the widest digest.
+
+    Reachable only when two distinct paths share a 128-bit digest prefix,
+    which is why it stops widening and numbers instead: the tied paths are
+    ordered by path, so the numbering is a property of the set rather than
+    of the walk, and each candidate is checked against the ids already
+    taken. Uniqueness of the returned list follows from that check, not
+    from an assumption about the hash.
+    """
+    taken = {value for value in ids if value not in duplicated}
+    resolved = list(ids)
+    tied = sorted(
+        (index for index, value in enumerate(ids) if value in duplicated),
+        key=lambda index: entries[index][1],
+    )
+    for index in tied:
+        position = 0
+        while (candidate := _numbered_id(ids[index], position)) in taken:
+            position += 1
+        taken.add(candidate)
+        resolved[index] = candidate
+    return resolved
+
+
+def _numbered_id(base: str, position: int) -> str:
+    suffix = f"_{position}"
+    return f"{base[: MAX_SOURCE_ID_LENGTH - len(suffix)]}{suffix}"
+
+
+def _compose(source_type: str, relative_path: str, *, digest_width: int = 0) -> str:
     prefix = SOURCE_ID_PREFIXES.get(source_type, source_type)
     segments = _path_segments(relative_path)
     plain = "_".join([prefix, *segments]) if segments else f"{prefix}_root"
-    if not disambiguate and len(plain) <= MAX_SOURCE_ID_LENGTH:
+    if not digest_width and len(plain) <= MAX_SOURCE_ID_LENGTH:
         return plain
-    return _with_digest(prefix, segments, relative_path)
+    return _with_digest(
+        prefix, segments, relative_path, digest_width or _DIGEST_WIDTHS[0]
+    )
 
 
-def _with_digest(prefix: str, segments: list[str], relative_path: str) -> str:
+def _with_digest(
+    prefix: str, segments: list[str], relative_path: str, digest_width: int
+) -> str:
     """``prefix`` + the most specific segments that fit + a path digest.
 
     The digest is what keeps two truncated (or two identically sanitized)
     paths apart, so the length budget is computed with room for it — a
     source-type prefix long enough to crowd it out is truncated too, which
-    keeps the bound true for third-party adapter names of any length.
+    keeps the bound true for third-party adapter names of any length and
+    at every digest width.
     """
-    digest = _digest(relative_path)
+    digest = _digest(relative_path, digest_width)
     prefix = prefix[: MAX_SOURCE_ID_LENGTH - len(digest) - 1]
     budget = MAX_SOURCE_ID_LENGTH - len(prefix) - len(digest) - 2
     kept: list[str] = []
@@ -139,5 +192,5 @@ def _slug(value: str) -> str:
     return _NON_ID_CHARS.sub("_", value.lower()).strip("_")
 
 
-def _digest(relative_path: str) -> str:
-    return hashlib.sha256(relative_path.encode("utf-8")).hexdigest()[:_DIGEST_LENGTH]
+def _digest(relative_path: str, width: int) -> str:
+    return hashlib.sha256(relative_path.encode("utf-8")).hexdigest()[:width]

--- a/src/agents_shipgate/cli/discovery/source_ids.py
+++ b/src/agents_shipgate/cli/discovery/source_ids.py
@@ -1,0 +1,103 @@
+"""``tool_sources[].id`` derivation for the two ``init`` renderers.
+
+One helper, shared by the auto renderer (``template.py``) and the legacy
+``--minimal`` renderer (``artifacts.py``), because both had the same
+basename-only rule and therefore the same defect: repeated basenames are
+the norm in Python packages (``strix/tools/finish/tool.py``,
+``strix/tools/respond/tool.py``, several ``*/tools.py`` modules), and one
+id per basename made every such repository render a manifest the schema
+rejects — ``tool_sources[].id values must be unique``. The auto path
+caught that at its validation gate and wrote nothing; ``--minimal`` had no
+gate and wrote the invalid file, so the documented next step (``scan``)
+failed with a config error. See issue #307.
+
+Ids are derived from the whole workspace-relative path, so an id depends
+only on the file it names. A positional suffix (``_2``, ``_3``) would
+instead renumber existing entries whenever an unrelated file appears
+earlier in the walk, churning anything keyed on the id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import Counter
+from collections.abc import Sequence
+from pathlib import PurePosixPath
+
+# Short, stable prefixes so a generated id reads as "which adapter, which
+# file". Unlisted source types (including third-party adapters) use their
+# own type name.
+SOURCE_ID_PREFIXES: dict[str, str] = {
+    "langchain": "lc",
+    "crewai": "crewai",
+    "google_adk": "adk",
+    "openai_agents_sdk": "openai_sdk",
+    "mcp": "mcp",
+    "openapi": "openapi",
+    "codex_plugin": "codex_plugin",
+}
+
+# Generated ids travel into findings and report output, so a deep monorepo
+# path is truncated to the most specific segments that fit and made unique
+# again by a digest of the full path.
+MAX_SOURCE_ID_LENGTH = 64
+
+_DIGEST_LENGTH = 8
+_NON_ID_CHARS = re.compile(r"[^a-z0-9]+")
+
+
+def source_id_for(source_type: str, relative_path: str) -> str:
+    """Deterministic id for one detected source file.
+
+    ``relative_path`` is the workspace-relative path as written to the
+    manifest's ``path:`` field.
+    """
+    prefix = SOURCE_ID_PREFIXES.get(source_type, source_type)
+    segments = _path_segments(relative_path)
+    source_id = "_".join([prefix, *segments]) if segments else f"{prefix}_root"
+    if len(source_id) <= MAX_SOURCE_ID_LENGTH:
+        return source_id
+
+    digest = _digest(relative_path)
+    budget = MAX_SOURCE_ID_LENGTH - len(prefix) - len(digest) - 2
+    kept: list[str] = []
+    width = 0
+    for segment in reversed(segments):
+        if width + len(segment) > budget:
+            break
+        kept.insert(0, segment)
+        width += len(segment) + 1
+    return "_".join([prefix, *kept, digest])
+
+
+def assign_source_ids(entries: Sequence[tuple[str, str]]) -> list[str]:
+    """Ids for ``(source_type, relative_path)`` pairs, unique by construction.
+
+    Distinct paths can still sanitize to one id (``a-b/tools.py`` and
+    ``a_b/tools.py``). Both sides then take a digest of their own path
+    rather than one side keeping the plain form, so which file was walked
+    first never decides which one gets renamed.
+    """
+    ids = [source_id_for(source_type, path) for source_type, path in entries]
+    collided = {value for value, count in Counter(ids).items() if count > 1}
+    if not collided:
+        return ids
+    return [
+        f"{value}_{_digest(path)}" if value in collided else value
+        for value, (_source_type, path) in zip(ids, entries, strict=True)
+    ]
+
+
+def _path_segments(relative_path: str) -> list[str]:
+    pure = PurePosixPath(relative_path)
+    parts = [*pure.parts[:-1], pure.stem] if pure.parts else []
+    return [segment for segment in (_slug(part) for part in parts) if segment]
+
+
+def _slug(value: str) -> str:
+    return _NON_ID_CHARS.sub("_", value.lower()).strip("_")
+
+
+def _digest(relative_path: str) -> str:
+    return hashlib.sha256(relative_path.encode("utf-8")).hexdigest()[:_DIGEST_LENGTH]

--- a/src/agents_shipgate/cli/discovery/template.py
+++ b/src/agents_shipgate/cli/discovery/template.py
@@ -10,8 +10,11 @@ config block populated from glob discovery. OpenAPI/MCP suggested sources
 are emitted as ``tool_sources`` entries.
 
 The ``--minimal`` mode in ``main.py`` bypasses this module and uses
-``artifacts.render_manifest_template`` directly to preserve byte-exact
-backwards-compatibility with v0.5.x.
+``artifacts.render_manifest_template`` directly to preserve
+backwards-compatibility with the v0.5.x template. Both renderers derive
+``tool_sources[].id`` from the same helper (``source_ids.py``) — the one
+place where v0.16 changed the legacy output, because a basename-only id
+made both of them render manifests the schema rejects (#307).
 """
 
 from __future__ import annotations
@@ -24,6 +27,7 @@ from agents_shipgate.cli.discovery.artifacts import (
     discover_n8n_artifacts,
     discover_openai_api_artifacts,
 )
+from agents_shipgate.cli.discovery.source_ids import assign_source_ids
 from agents_shipgate.schemas.detect import DetectResult
 
 # Frameworks that register one tool_sources entry per candidate file.
@@ -35,7 +39,7 @@ def render_auto_manifest(workspace: Path, detect_result: DetectResult) -> str:
 
     Falls back to a CHANGE_ME-heavy template when no framework was
     detected (mirroring today's static-init behavior; ``--minimal`` is
-    the dedicated path for byte-exact pre-v0.6 output).
+    the dedicated path for the pre-v0.6 template).
     """
     workspace = workspace.resolve()
     project_name = _project_name(workspace, detect_result)
@@ -149,7 +153,7 @@ def _tool_sources_block(
     suppress duplicate config blocks downstream)."""
     lines: list[str] = []
     used: set[str] = set()
-    entries: list[tuple[str, str, str, str | None]] = []  # (type, id, path, mode)
+    entries: list[tuple[str, str, str | None]] = []  # (type, path, mode)
     seen_paths: set[str] = set()
 
     for framework in detect_result.frameworks:
@@ -159,8 +163,7 @@ def _tool_sources_block(
             if candidate in seen_paths:
                 continue
             seen_paths.add(candidate)
-            entry_id = _source_id_for(framework.type, candidate)
-            entries.append((framework.type, entry_id, candidate, None))
+            entries.append((framework.type, candidate, None))
             used.add(framework.type)
 
     for source in detect_result.suggested_sources:
@@ -168,22 +171,25 @@ def _tool_sources_block(
         if path in seen_paths:
             continue
         seen_paths.add(path)
-        entry_id = _source_id_for(source["type"], path)
-        entries.append((source["type"], entry_id, path, None))
+        entries.append((source["type"], path, None))
 
     for candidate in detect_result.codex_plugin_candidates:
         path = candidate.path
         if path in seen_paths:
             continue
         seen_paths.add(path)
-        entry_id = _source_id_for("codex_plugin", path)
-        entries.append(("codex_plugin", entry_id, path, candidate.mode))
+        entries.append(("codex_plugin", path, candidate.mode))
 
     if not entries:
         return [], used
 
+    # Ids are assigned for the block as a whole: paths are deduplicated
+    # above, but two distinct paths must not end up sharing an id — the
+    # manifest schema rejects the whole render when they do (#307).
+    entry_ids = assign_source_ids([(entry[0], entry[1]) for entry in entries])
+
     lines.append("tool_sources:")
-    for framework_type, entry_id, path, mode in entries:
+    for (framework_type, path, mode), entry_id in zip(entries, entry_ids, strict=True):
         lines.append(f"  - id: {entry_id}")
         lines.append(f"    type: {framework_type}")
         lines.append(f"    path: {path}")
@@ -212,21 +218,6 @@ def _excluded_sources_hint(excluded: list[dict[str, str]]) -> list[str]:
         "to tool_sources."
     )
     return lines
-
-
-def _source_id_for(framework_type: str, path: str) -> str:
-    path_obj = Path(path)
-    stem = (path_obj.stem or path_obj.name or "root").lower().replace("-", "_").replace(".", "_")
-    prefix = {
-        "langchain": "lc",
-        "crewai": "crewai",
-        "google_adk": "adk",
-        "openai_agents_sdk": "openai_sdk",
-        "mcp": "mcp",
-        "openapi": "openapi",
-        "codex_plugin": "codex_plugin",
-    }.get(framework_type, framework_type)
-    return f"{prefix}_{stem}"
 
 
 def _anthropic_block(workspace: Path, detect_result: DetectResult) -> list[str]:

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -193,7 +193,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/discovery/artifacts.py",
         surface="attr_call:subprocess.run",
-        line=494,
+        line=483,
         snippet=(
             "subprocess.run(['git', '--no-replace-objects', '-C', "
             "str(workspace), 'rev-parse', '--show-toplevel'], check=False, "
@@ -209,7 +209,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/discovery/artifacts.py",
         surface="attr_call:subprocess.Popen",
-        line=576,
+        line=565,
         snippet=(
             "subprocess.Popen(['git', '--no-replace-objects', '-C', "
             "str(workspace), *args], env=env, stdout=subprocess.PIPE, "

--- a/tests/test_init_auto.py
+++ b/tests/test_init_auto.py
@@ -4,7 +4,8 @@ The auto-default produces a *valid* shipgate.yaml that scans cleanly
 against the real loaders, replacing v0.5's CHANGE_ME-heavy template for
 workspaces that already look like agent projects.
 
-``--minimal`` preserves byte-exact compatibility with the v0.5 output.
+``--minimal`` preserves the v0.5 output, except for the ``tool_sources``
+ids it shares with the auto renderer (see the issue #307 section below).
 """
 
 from __future__ import annotations
@@ -19,6 +20,11 @@ from agents_shipgate.cli.discovery import (
     detect_workspace,
     render_auto_manifest,
     render_manifest_template,
+)
+from agents_shipgate.cli.discovery.source_ids import (
+    MAX_SOURCE_ID_LENGTH,
+    assign_source_ids,
+    source_id_for,
 )
 from agents_shipgate.cli.main import app
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
@@ -345,3 +351,160 @@ def test_minimal_template_excludes_mcpservers_config(tmp_path: Path) -> None:
     template = render_manifest_template(workspace.resolve())
     assert "tools/payments-mcp.json" in template
     assert "providers/cursor/plugin/mcp.json" not in template
+
+
+# --- Repeated basenames must not collide into one id (issue #307) ---
+# Found on usestrix/strix, a real OpenAI Agents SDK project: one `tool.py`
+# per tool package (`strix/tools/finish/tool.py`, `.../respond/tool.py`, …)
+# plus several `*/tools.py` modules. Ids derived from the basename alone
+# produced `openai_sdk_tool` three times, and the schema rejects a manifest
+# whose `tool_sources[].id` values repeat — so auto-init wrote nothing at
+# all on a conventional Python layout.
+
+_FUNCTION_TOOL_MODULE = """from agents import function_tool
+
+
+@function_tool
+def do_thing(target: str) -> str:
+    \"\"\"Do the thing.\"\"\"
+    return target
+"""
+
+
+def _openai_sdk_workspace(root: Path, relative_paths: list[str]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "strixlike"\ndependencies = ["openai-agents"]\n',
+        encoding="utf-8",
+    )
+    for relative in relative_paths:
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_FUNCTION_TOOL_MODULE, encoding="utf-8")
+    return root
+
+
+_REPEATED_BASENAMES = [
+    "strix/tools/finish/tool.py",
+    "strix/tools/load_skill/tool.py",
+    "strix/tools/respond/tool.py",
+    "strix/agents/tools.py",
+    "strix/runtime/tools.py",
+]
+
+
+def test_auto_init_repeated_basenames_emit_unique_source_ids(tmp_path: Path) -> None:
+    workspace = _openai_sdk_workspace(tmp_path / "strixlike", _REPEATED_BASENAMES)
+    detect = detect_workspace(workspace)
+    manifest = _validates(render_auto_manifest(workspace, detect))
+
+    declared = {s.path for s in manifest.tool_sources}
+    assert declared == set(_REPEATED_BASENAMES)
+    ids = [s.id for s in manifest.tool_sources]
+    assert len(set(ids)) == len(ids)
+    # Derived from the whole relative path, so the id still names its file.
+    by_path = {s.path: s.id for s in manifest.tool_sources}
+    assert by_path["strix/tools/finish/tool.py"] == "openai_sdk_strix_tools_finish_tool"
+    assert by_path["strix/agents/tools.py"] == "openai_sdk_strix_agents_tools"
+
+
+def test_cold_start_init_then_scan_with_repeated_basenames(tmp_path: Path) -> None:
+    """The documented cold-start flow — `init --write` → `scan` — must
+    survive a repo that ships one `tool.py` per tool package. Before the
+    fix, `init` exited 4 with `internal_error` and wrote no manifest."""
+    import json as _json
+
+    workspace = _openai_sdk_workspace(tmp_path / "strixlike", _REPEATED_BASENAMES)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app, ["init", "--workspace", str(workspace), "--write", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = _json.loads(result.output)
+    assert payload["created"] is True
+
+    scan_result = runner.invoke(
+        app, ["scan", "--config", str(workspace / "shipgate.yaml")]
+    )
+    assert scan_result.exit_code == 0, scan_result.output
+    assert "Config error" not in scan_result.output
+
+
+def test_auto_init_source_ids_are_stable_when_a_sibling_appears(tmp_path: Path) -> None:
+    """An id must depend only on the file it names. A positional suffix
+    (`_2`, `_3`) would renumber existing entries when an unrelated file is
+    added earlier in the walk, churning anything keyed on the id."""
+    before_ws = _openai_sdk_workspace(
+        tmp_path / "before", ["pkg/beta/tool.py", "pkg/gamma/tool.py"]
+    )
+    after_ws = _openai_sdk_workspace(
+        tmp_path / "after",
+        ["pkg/alpha/tool.py", "pkg/beta/tool.py", "pkg/gamma/tool.py"],
+    )
+
+    def ids_by_path(workspace: Path) -> dict[str, str]:
+        manifest = _validates(
+            render_auto_manifest(workspace, detect_workspace(workspace))
+        )
+        return {s.path: s.id for s in manifest.tool_sources}
+
+    before = ids_by_path(before_ws)
+    after = ids_by_path(after_ws)
+    assert before == {path: after[path] for path in before}
+
+
+def test_minimal_template_repeated_basenames_emit_unique_source_ids(
+    tmp_path: Path,
+) -> None:
+    """`--minimal` is the documented recovery path, and it had the same
+    basename-only id rule — with no validation gate, so it wrote the
+    invalid manifest and `scan` failed on it with a config error."""
+    workspace = tmp_path / "services"
+    spec = (
+        "openapi: 3.1.0\ninfo:\n  title: T\n  version: '1'\npaths:\n"
+        "  /thing:\n    get:\n      operationId: get_thing\n"
+        "      responses:\n        '200':\n          description: ok\n"
+    )
+    for service in ("billing", "support"):
+        target = workspace / service / "openapi.yaml"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(spec, encoding="utf-8")
+
+    manifest = _validates(render_manifest_template(workspace.resolve()))
+    ids = [s.id for s in manifest.tool_sources]
+    assert sorted(ids) == ["openapi_billing_openapi", "openapi_support_openapi"]
+
+
+def test_source_id_helper_disambiguates_and_bounds_length() -> None:
+    """Unit-level invariants the two renderers rely on."""
+    # Two paths can sanitize to the same id; both sides then take a digest
+    # of their own path, so walk order never decides which one is renamed.
+    collided = assign_source_ids(
+        [("openapi", "a-b/spec.yaml"), ("openapi", "a_b/spec.yaml")]
+    )
+    assert len(set(collided)) == 2
+    assert all(value.startswith("openapi_a_b_spec_") for value in collided)
+    # Assignment is a pure function of the entries, not of the call.
+    assert collided == assign_source_ids(
+        [("openapi", "a-b/spec.yaml"), ("openapi", "a_b/spec.yaml")]
+    )
+
+    # Deep monorepo paths stay readable: most specific segments, then a
+    # digest of the full path so truncation cannot merge two files.
+    deep = source_id_for(
+        "openai_agents_sdk",
+        "packages/services/payments/src/agents/tools/refunds/tools.py",
+    )
+    assert len(deep) <= MAX_SOURCE_ID_LENGTH
+    assert deep.startswith("openai_sdk_")
+    assert "refunds_tools" in deep
+    assert deep != source_id_for(
+        "openai_agents_sdk",
+        "packages/services/billing/src/agents/tools/refunds/tools.py",
+    )
+
+    # Unknown source types (third-party adapters) keep their own name.
+    assert source_id_for("my_custom_source", "specs/api.yaml") == (
+        "my_custom_source_specs_api"
+    )

--- a/tests/test_init_auto.py
+++ b/tests/test_init_auto.py
@@ -432,9 +432,10 @@ def test_cold_start_init_then_scan_with_repeated_basenames(tmp_path: Path) -> No
 
 
 def test_auto_init_source_ids_are_stable_when_a_sibling_appears(tmp_path: Path) -> None:
-    """An id must depend only on the file it names. A positional suffix
-    (`_2`, `_3`) would renumber existing entries when an unrelated file is
-    added earlier in the walk, churning anything keyed on the id."""
+    """Ids carry no positional component: a file added earlier in the walk
+    must not renumber the entries after it, the way a `_2`/`_3` suffix
+    would. (The one case that does shift an existing id — a path that
+    sanitizes to the same string — is pinned below.)"""
     before_ws = _openai_sdk_workspace(
         tmp_path / "before", ["pkg/beta/tool.py", "pkg/gamma/tool.py"]
     )
@@ -476,19 +477,83 @@ def test_minimal_template_repeated_basenames_emit_unique_source_ids(
     assert sorted(ids) == ["openapi_billing_openapi", "openapi_support_openapi"]
 
 
-def test_source_id_helper_disambiguates_and_bounds_length() -> None:
-    """Unit-level invariants the two renderers rely on."""
-    # Two paths can sanitize to the same id; both sides then take a digest
-    # of their own path, so walk order never decides which one is renamed.
-    collided = assign_source_ids(
-        [("openapi", "a-b/spec.yaml"), ("openapi", "a_b/spec.yaml")]
-    )
+def test_source_id_helper_disambiguates_identically_sanitized_paths() -> None:
+    # Sanitizing is lossy: `a-b/` and `a_b/` fold to the same string. Every
+    # member of the group takes a digest of its own path, so walk order
+    # never decides which one is renamed.
+    entries = [("openapi", "a-b/spec.yaml"), ("openapi", "a_b/spec.yaml")]
+    collided = assign_source_ids(entries)
     assert len(set(collided)) == 2
     assert all(value.startswith("openapi_a_b_spec_") for value in collided)
     # Assignment is a pure function of the entries, not of the call.
-    assert collided == assign_source_ids(
+    assert collided == assign_source_ids(entries)
+    # Reordering the same set renames the same files, not different ones.
+    assert dict(zip([p for _t, p in entries], collided, strict=True)) == dict(
+        zip(
+            [p for _t, p in reversed(entries)],
+            assign_source_ids(list(reversed(entries))),
+            strict=True,
+        )
+    )
+
+    # Unknown source types (third-party adapters) keep their own name.
+    assert source_id_for("my_custom_source", "specs/api.yaml") == (
+        "my_custom_source_specs_api"
+    )
+
+
+def test_source_ids_shift_only_within_the_group_that_sanitizes_alike(
+    tmp_path: Path,
+) -> None:
+    """The narrowed stability guarantee, pinned in both directions.
+
+    An id is a pure function of its own path *unless* another declared
+    path sanitizes to the same string; then both members take a digest, so
+    the one that was already there changes too. Making that file-local
+    would mean a digest on every id, including the readable common ones.
+    """
+    alone = assign_source_ids([("openapi", "a-b/spec.yaml")])
+    assert alone == ["openapi_a_b_spec"]
+
+    with_twin = assign_source_ids(
         [("openapi", "a-b/spec.yaml"), ("openapi", "a_b/spec.yaml")]
     )
+    assert with_twin[0] != alone[0]
+    assert with_twin[0].startswith("openapi_a_b_spec_")
+
+    # An unrelated third source is untouched by that group's rename.
+    with_bystander = assign_source_ids(
+        [
+            ("openapi", "a-b/spec.yaml"),
+            ("openapi", "a_b/spec.yaml"),
+            ("openapi", "billing/openapi.yaml"),
+        ]
+    )
+    assert with_bystander[:2] == with_twin
+    assert with_bystander[2] == "openapi_billing_openapi"
+
+
+def test_source_id_length_bound_holds_after_disambiguation() -> None:
+    """The cap is enforced on the value that ships, not on the value before
+    the collision digest is appended: two near-limit paths that sanitize
+    alike used to render 67-character ids."""
+    near_limit = ["a" * 20 + "/" + "b" * 20 + f"/spec{sep}one.yaml" for sep in "-_"]
+    plain = [source_id_for("openapi", path) for path in near_limit]
+    assert len(plain[0]) == 58 and plain[0] == plain[1]  # fits, and collides
+
+    resolved = assign_source_ids([("openapi", path) for path in near_limit])
+    assert len(set(resolved)) == 2
+    assert all(len(value) <= MAX_SOURCE_ID_LENGTH for value in resolved)
+
+    # A source-type prefix long enough to crowd out the digest is truncated
+    # too, so the bound holds for third-party adapter names of any length.
+    long_type = "my_" + "very_" * 15 + "custom_source"
+    assert len(source_id_for(long_type, "specs/api.yaml")) <= MAX_SOURCE_ID_LENGTH
+    long_prefix_collision = assign_source_ids(
+        [(long_type, "a-b/spec.yaml"), (long_type, "a_b/spec.yaml")]
+    )
+    assert len(set(long_prefix_collision)) == 2
+    assert all(len(v) <= MAX_SOURCE_ID_LENGTH for v in long_prefix_collision)
 
     # Deep monorepo paths stay readable: most specific segments, then a
     # digest of the full path so truncation cannot merge two files.
@@ -504,7 +569,22 @@ def test_source_id_helper_disambiguates_and_bounds_length() -> None:
         "packages/services/billing/src/agents/tools/refunds/tools.py",
     )
 
-    # Unknown source types (third-party adapters) keep their own name.
-    assert source_id_for("my_custom_source", "specs/api.yaml") == (
-        "my_custom_source_specs_api"
-    )
+
+def test_source_ids_stay_unique_when_a_plain_id_matches_a_digest_form() -> None:
+    """Contrived but constructible: a file named after the digest another
+    entry will be given. `--minimal` has no validation gate behind it, so
+    the assignment must not hand a duplicate to the render."""
+    from agents_shipgate.cli.discovery.source_ids import _digest
+
+    twin_digest = _digest("a-b/spec.yaml")
+    entries = [
+        ("openapi", "a-b/spec.yaml"),
+        ("openapi", "a_b/spec.yaml"),
+        ("openapi", f"a_b/spec_{twin_digest}.yaml"),
+    ]
+    # The third file's plain id is exactly what the first one is renamed to.
+    assert source_id_for(*entries[2]) == f"openapi_a_b_spec_{twin_digest}"
+
+    resolved = assign_source_ids(entries)
+    assert len(set(resolved)) == 3
+    assert all(len(value) <= MAX_SOURCE_ID_LENGTH for value in resolved)

--- a/tests/test_init_auto.py
+++ b/tests/test_init_auto.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -20,9 +21,11 @@ from agents_shipgate.cli.discovery import (
     detect_workspace,
     render_auto_manifest,
     render_manifest_template,
+    source_ids,
 )
 from agents_shipgate.cli.discovery.source_ids import (
     MAX_SOURCE_ID_LENGTH,
+    _digest,
     assign_source_ids,
     source_id_for,
 )
@@ -502,15 +505,16 @@ def test_source_id_helper_disambiguates_identically_sanitized_paths() -> None:
     )
 
 
-def test_source_ids_shift_only_within_the_group_that_sanitizes_alike(
+def test_source_ids_shift_only_for_entries_whose_ids_collide(
     tmp_path: Path,
 ) -> None:
     """The narrowed stability guarantee, pinned in both directions.
 
-    An id is a pure function of its own path *unless* another declared
-    path sanitizes to the same string; then both members take a digest, so
-    the one that was already there changes too. Making that file-local
-    would mean a digest on every id, including the readable common ones.
+    An id is a pure function of its own path *unless it collides* with
+    another entry's id; then both members take a digest, so the one that
+    was already there changes too. Making that file-local would mean a
+    digest on every id, including the readable common ones. Nothing
+    outside the collision is re-keyed.
     """
     alone = assign_source_ids([("openapi", "a-b/spec.yaml")])
     assert alone == ["openapi_a_b_spec"]
@@ -573,18 +577,68 @@ def test_source_id_length_bound_holds_after_disambiguation() -> None:
 def test_source_ids_stay_unique_when_a_plain_id_matches_a_digest_form() -> None:
     """Contrived but constructible: a file named after the digest another
     entry will be given. `--minimal` has no validation gate behind it, so
-    the assignment must not hand a duplicate to the render."""
-    from agents_shipgate.cli.discovery.source_ids import _digest
-
-    twin_digest = _digest("a-b/spec.yaml")
+    the assignment must not hand a duplicate to the render — and it must
+    settle that conflict without re-keying anything else."""
+    twin_digest = _digest("a-b/spec.yaml", 8)
     entries = [
         ("openapi", "a-b/spec.yaml"),
         ("openapi", "a_b/spec.yaml"),
         ("openapi", f"a_b/spec_{twin_digest}.yaml"),
+        ("openapi", "billing/openapi.yaml"),
     ]
     # The third file's plain id is exactly what the first one is renamed to.
     assert source_id_for(*entries[2]) == f"openapi_a_b_spec_{twin_digest}"
 
     resolved = assign_source_ids(entries)
+    assert len(set(resolved)) == 4
+    assert all(len(value) <= MAX_SOURCE_ID_LENGTH for value in resolved)
+    # Only the two entries that actually tied move to the wider digest: the
+    # third member of the sanitized class keeps its 8-hex id, and the
+    # bystander keeps the id its own path produced.
+    assert resolved[1] == f"openapi_a_b_spec_{_digest('a_b/spec.yaml', 8)}"
+    assert resolved[3] == "openapi_billing_openapi"
+
+
+# The pair below shares an 8-hex SHA-256 prefix *and* one sanitized class,
+# so the first disambiguation round hands both entries the same id. Found by
+# enumerating the 2**17 `-`/`_` spellings of one path and looking for a
+# repeated digest — seconds of work, which is why a digest prefix cannot be
+# treated as a unique key.
+_DIGEST_PREFIX_TWINS = (
+    "a_b_c-d_e-f-g_h_i-j_k_l_m-n-o-p_q_r/spec.yaml",
+    "a-b_c_d-e_f_g_h-i-j-k_l-m_n_o-p_q-r/spec.yaml",
+)
+
+
+def test_source_ids_survive_a_real_digest_prefix_collision() -> None:
+    first, second = _DIGEST_PREFIX_TWINS
+    assert source_id_for("openapi", first) == source_id_for("openapi", second)
+    assert _digest(first, 8) == _digest(second, 8)
+
+    resolved = assign_source_ids([("openapi", first), ("openapi", second)])
+    assert len(set(resolved)) == 2
+    assert all(len(value) <= MAX_SOURCE_ID_LENGTH for value in resolved)
+    # Settled by widening, not by numbering: still a digest of each path.
+    assert resolved[0].endswith(_digest(first, 16))
+    assert resolved[1].endswith(_digest(second, 16))
+
+
+def test_source_ids_number_tied_paths_when_every_digest_width_collides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uniqueness must not rest on an assumption about the hash. With the
+    digest forced to collide at every width, the tied paths are numbered in
+    sorted-path order — a property of the set, not of the walk."""
+    monkeypatch.setattr(source_ids, "_digest", lambda path, width: "f" * width)
+    entries = [
+        ("openapi", "a-b/spec.yaml"),
+        ("openapi", "a_b/spec.yaml"),
+        ("openapi", "a.b/spec.yaml"),
+    ]
+
+    resolved = assign_source_ids(entries)
     assert len(set(resolved)) == 3
     assert all(len(value) <= MAX_SOURCE_ID_LENGTH for value in resolved)
+    # "a-b" < "a.b" < "a_b" by path, so that is the numbering order.
+    assert [resolved[0][-2:], resolved[2][-2:], resolved[1][-2:]] == ["_0", "_1", "_2"]
+    assert assign_source_ids(list(reversed(entries))) == list(reversed(resolved))


### PR DESCRIPTION
Fixes #307.

## What was wrong

`tool_sources[].id` was built from the source type plus `Path(path).stem`, while both `init` renderers deduplicate entries by *full path*. A repository with one `tool.py` per tool package — the conventional Python layout, and exactly what `usestrix/strix` ships — produced three distinct entries all carrying `openai_sdk_tool`, and the manifest schema (correctly) rejects a manifest whose ids repeat.

The failure was total on the primary adoption path: `init --write` exited 4 with `internal_error`, wrote no manifest, and routed to `--minimal`, which throws away the detection work for a `CHANGE_ME` template.

**Second instance, found while fixing the first:** `--minimal` had the same basename-only rule *with no validation gate in front of it*. Two services that each ship `openapi.yaml` got an invalid manifest **written to disk** (exit 0), and the documented next step failed on it:

```
$ agents-shipgate init --workspace . --minimal --write
Wrote .../shipgate.yaml                                    # exit 0

$ agents-shipgate scan --config shipgate.yaml
Config error: Invalid shipgate.yaml:
- <root>: Value error, tool_sources[].id values must be unique
```

…and that error's `next_action` says *"Fix the manifest in place — do not re-run init"*, so the recovery path dead-ends in a manual edit.

## The fix

One helper, `cli/discovery/source_ids.py`, shared by the auto renderer (`template.py`) and the legacy `--minimal` renderer (`artifacts.py`) — the two copies of the rule were the two copies of the bug.

Ids are derived from the **whole workspace-relative path**:

```yaml
tool_sources:
  - id: openai_sdk_strix_tools_finish_tool
    type: openai_agents_sdk
    path: strix/tools/finish/tool.py
  - id: openai_sdk_strix_tools_respond_tool
    type: openai_agents_sdk
    path: strix/tools/respond/tool.py
```

Per the sanitized-relative-path preference in #307's triage comment, over a collision suffix: ids carry no positional component, so a file appearing earlier in the walk can never renumber the entries after it. Details:

- **Residual collisions** (`a-b/tools.py` vs `a_b/tools.py`, or paths whose segments are all non-ASCII) — *every* member of the group takes a digest of its own path rather than one side keeping the plain form, so walk order never decides which file gets renamed.
- **Stability, stated exactly** — an id is a pure function of its own path *unless another declared path sanitizes to the same string*; that group is the one case where adding a file changes an id that already existed. Making it file-local would mean a digest on every id, including the readable common ones. Bounded by `init` refusing to overwrite an existing manifest, so ids are assigned once per adoption. Pinned in both directions by tests.
- **Length** — a deep monorepo path keeps its most specific segments plus a digest of the full path, and the 64-char bound is enforced on the value that ships, disambiguated ids included.
- The auto path's post-render validation gate is unchanged and remains the backstop. Where `--minimal` has no such gate, the assignment itself is unique by construction.

## Verification

Reproduced before/after on the repository from the report (`usestrix/strix`, shallow clone):

| | `init --write --json` | manifest | `scan` |
|---|---|---|---|
| `527a0349` (v0.16.0b7) | exit 4, `internal_error` | not written | — |
| this branch | exit 0 | 23 sources, **23 unique ids**, longest id 47 chars | exit 0 |

Tests added to `tests/test_init_auto.py`: the #307 repro (multiple `tool.py` + `tools.py` in one detected framework), the full `init --write` → `scan` cold-start flow on that layout, an id-stability test that fails if ids ever become position-dependent, the `--minimal` repro, and unit invariants for the helper (collision digest, determinism, length bound, unknown source types).

`python -m pytest` and `python -m ruff check .` are green. `shipgate check` → `allow` / no violations; `shipgate verify` → `complete` / `passed`.

## Compatibility

- **`--minimal` ids for nested sources change** (`api/openapi.yaml`: `openapi_api_openapi` instead of `openapi_openapi`). Unavoidable — the colliding case had no valid id to preserve — and root-level sources are unchanged. STABILITY.md lists the `init` template under "what MAY change"; the test docstring claiming byte-exact v0.5 output is updated to name this one exception.
- **No existing `shipgate.yaml` is touched.** `init` refuses to overwrite one, so nothing keyed on an already-written id churns.
- No new CLI, schema, or report surface; one new internal module and two deleted duplicate helpers.
- `tests/test_adapter_static_only.py` moves two allowlist line numbers because the edited region of `artifacts.py` shifted. The `subprocess` call sites themselves are unchanged.

## Deliberately not changed

`--minimal` still has no manifest-validation gate. It is the fallback the auto gate routes *to*; making it exit 4 as well would leave a failing workspace with nowhere to go. This fix removes its known invalid-output mode instead; the test now pins that its render validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

