### PR TITLE
fix(google-adk): represent a shared FunctionTool as one tool with N bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## Unreleased
 
+- **Google ADK repositories that share one tool between agents can be scanned
+  again.** Binding the same `FunctionTool` to a coordinator and its sub-agents
+  is the canonical ADK multi-agent shape — it is what `google/adk-samples`
+  demonstrates — and it aborted the scan with `Duplicate tool observation
+  identity` before any finding or `release_decision` existed. That is worse
+  than an abstention: `insufficient_evidence` at least routes a human, while a
+  hard input failure produces nothing to act on, so on real multi-agent ADK
+  repositories the supported adapter returned no gate at all. The extractor
+  emitted one `Tool` per *agent binding*, and catalog observation identity is
+  `(source_type, source_id, native_locator)` where the locator is the file plus
+  function name — so the second binding of one function collided with the
+  first. The fix is not to widen that identity with the agent name: one
+  function is one action, and minting a capability per binding would inflate
+  every count derived from the catalog and quietly change what "unique tools"
+  means. The function is now observed once, and the many-to-many binding
+  relation travels as framework-owned `AgentBindingObservation` records — the
+  same surface the OpenAI Agents SDK adapter already uses — so all three
+  bindings survive as first-class edges in the binding graph, in
+  root-reachability, and in each tool's `binding_assessment.claims[]`, each
+  claim pointing at its own `LlmAgent(...)` call site. Sharing a tool is still
+  distinguished from declaring one twice: the observation-identity guard is
+  untouched, and a source that genuinely repeats a declaration still fails
+  closed. A toolset assigned to a variable and shared between agents is
+  likewise loaded once rather than once per binding, and a function bound as
+  both `FunctionTool` and `LongRunningFunctionTool` keeps the stricter
+  long-running contract and raises a warning instead of letting binding order
+  decide. Two consequences worth knowing when upgrading: ADK Python tools no
+  longer carry the single-valued `adk_agent_name` annotation (bindings can no
+  longer be read off a tool, which was only ever able to name one of N
+  agents), so the first scan after upgrade may report a metadata-only
+  annotation-hash change for ADK tools — tool identities, fingerprints,
+  baselines, and decisions are unaffected; and `frameworks.google_adk` gains
+  `tool_binding_count` alongside `function_tool_count`, which now counts tool
+  *definitions*, so a function shared by three agents reads as one tool and
+  three bindings. `tool_binding_count` is additive and not yet listed in the
+  published report schema's `required` set; `report_schema_version` stays at
+  `0.34`.
+
 - **`SHIP-VERIFY-POLICY-WEAKENED` can now actually see a weakened CI gate.**
   The `effective_policy` snapshot was built from the manifest *after* CLI
   overrides were folded into it, so it described the invocation rather than

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1658,7 +1658,7 @@ These are not stable — assume they may grow but not shrink:
 
 - **Risk-tag taxonomy.** New tags may appear (e.g. `infrastructure_change`, `code_execution`). Existing tags' meanings will not change.
 - **`capability_facts[].capability` vocabulary.** Values are an open vocabulary seeded from risk tags plus review sentinels such as `wildcard_tool_surface` and `unknown`.
-- **Report `frameworks.{name}` blocks.** New framework summaries (e.g. `frameworks.langchain`) may appear.
+- **Report `frameworks.{name}` blocks.** New framework summaries (e.g. `frameworks.langchain`) may appear, and new count keys may be added to an existing summary (e.g. `frameworks.google_adk.tool_binding_count`). Tool counts such as `function_tool_count` count tool *definitions*: one tool bound to three agents is one tool and three bindings, and only the binding count moves with the wiring.
 - **Manifest fields.** New optional fields under existing sections.
 - **Check default severities.** May tighten over time. To pin a severity for your repo, use `checks.severity_overrides`.
 - **`release_decision.decision` enum values.** New states (e.g., `insufficient_evidence` added at `report_schema_version` 0.14) may be added. Consumers that switch on the enum MUST fall back to `review_required` for unrecognized values — that is the safe default. Existing values' meanings will not change. New states do not change CI exit codes (exit 20 still requires a `fail_on` match on actual findings).

--- a/docs/framework-adapter-checklist.md
+++ b/docs/framework-adapter-checklist.md
@@ -30,6 +30,20 @@ model calls, no MCP connections, and no network access.
 - Generate stable names and IDs so finding fingerprints and baselines are
   reproducible.
 
+## Agent Bindings
+
+- Emit one `Tool` per tool *definition*, never one per agent binding. Catalog
+  observation identity is `(source_type, source_id, native_locator)`, so a tool
+  object bound to several agents collides and aborts the scan; widening that
+  identity with the agent name is not the fix, because it models one underlying
+  action as several independent capabilities.
+- Publish agent wiring as `LoadedToolSource.binding_observations`
+  (`AgentBindingObservation`) rather than a per-tool annotation. A single-valued
+  annotation can only ever name one of N binding agents, and catalog-controlled
+  annotations must never become authority-bearing binding evidence.
+- Keep unique tool counts and binding counts separately reportable, so one tool
+  shared by three agents reads as one tool and three bindings.
+
 ## Confidence
 
 - Set high confidence for explicit inventories and direct static function/class

--- a/src/agents_shipgate/core/artifact_models.py
+++ b/src/agents_shipgate/core/artifact_models.py
@@ -208,8 +208,13 @@ class GoogleAdkArtifacts(BaseModel):
     trace_sample_files: list[str] = Field(default_factory=list)
     trace_samples: list[dict[str, Any]] = Field(default_factory=list)
     agents: list[dict[str, Any]] = Field(default_factory=list)
+    # One record per tool *definition*. A tool shared by several agents is
+    # one entry here, not one per binding.
     function_tools: list[dict[str, Any]] = Field(default_factory=list)
     long_running_tools: list[dict[str, Any]] = Field(default_factory=list)
+    # One record per agent -> tool binding edge, so a shared tool stays a
+    # single capability while every agent that can reach it stays visible.
+    tool_bindings: list[dict[str, Any]] = Field(default_factory=list)
     toolsets: list[GoogleAdkToolset] = Field(default_factory=list)
     callbacks: list[dict[str, Any]] = Field(default_factory=list)
     plugins: list[dict[str, Any]] = Field(default_factory=list)
@@ -226,6 +231,9 @@ class GoogleAdkArtifacts(BaseModel):
             "agent_count": len(self.agents),
             "function_tool_count": len(self.function_tools),
             "long_running_tool_count": len(self.long_running_tools),
+            # Distinct from ``function_tool_count``: one function shared by
+            # three agents is one tool and three bindings.
+            "tool_binding_count": len(self.tool_bindings),
             "toolset_count": len(self.toolsets),
             "dynamic_toolset_count": len(dynamic_toolsets),
             "callback_count": len(self.callbacks),

--- a/src/agents_shipgate/inputs/google_adk.py
+++ b/src/agents_shipgate/inputs/google_adk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
@@ -9,6 +10,7 @@ from agents_shipgate.core.artifact_models import (
     GoogleAdkToolset,
 )
 from agents_shipgate.core.domain import (
+    AgentBindingObservation,
     AuthInfo,
     LoadedToolSource,
     Tool,
@@ -417,6 +419,9 @@ def _tool_from_config_entry(
             "metadata_present": bool(args.get("description") or args.get("parameters")),
         }
     )
+    _record_tool_binding(
+        artifacts, agent_name=agent_name, tool_name=tool.name, source_ref=location
+    )
     return []
 
 
@@ -452,6 +457,9 @@ def _record_config_openapi_toolset(
     for tool in loaded.tools:
         tool.annotations["adk_toolset"] = "OpenAPIToolset"
         tool.annotations["adk_agent_name"] = agent_name
+        _record_tool_binding(
+            artifacts, agent_name=agent_name, tool_name=tool.name, source_ref=location
+        )
     return [loaded]
 
 
@@ -491,7 +499,57 @@ def _record_config_mcp_toolset(
     for tool in loaded.tools:
         tool.annotations["adk_toolset"] = "McpToolset"
         tool.annotations["adk_agent_name"] = agent_name
+        _record_tool_binding(
+            artifacts, agent_name=agent_name, tool_name=tool.name, source_ref=location
+        )
     return [loaded]
+
+
+@dataclass
+class _AdkAgentBinding:
+    """One agent's ordered tool bindings inside a single ADK Python module.
+
+    An ADK tool object may be bound to any number of agents (the canonical
+    multi-agent shape shares one ``FunctionTool`` between a coordinator and
+    its sub-agents). The underlying function is one capability, so it must
+    enter the catalog exactly once; the many-to-many agent relation is
+    carried here and published as ``AgentBindingObservation`` instead.
+    """
+
+    agent: str
+    source_pointer: str
+    tool_names: list[str] = field(default_factory=list)
+
+    def bind(self, tool_name: str) -> bool:
+        """Add one tool to this agent; return False if it was already bound."""
+
+        if tool_name in self.tool_names:
+            return False
+        self.tool_names.append(tool_name)
+        return True
+
+
+def _record_tool_binding(
+    artifacts: GoogleAdkArtifacts,
+    *,
+    agent_name: str,
+    tool_name: str,
+    source_ref: str,
+) -> None:
+    """Record one agent -> tool binding edge.
+
+    Bindings are counted separately from tool definitions so a shared tool
+    stays one entry in ``function_tools`` while every agent that can call it
+    remains visible to reviewers.
+    """
+
+    artifacts.tool_bindings.append(
+        {
+            "agent_name": agent_name,
+            "tool_name": tool_name,
+            "source_ref": source_ref,
+        }
+    )
 
 
 class _PythonAdkExtractor:
@@ -518,6 +576,14 @@ class _PythonAdkExtractor:
         }
         self.wrappers = self._wrapper_assignments()
         self.toolset_assignments = self._toolset_assignments()
+        # One canonical Tool per function definition, keyed by the def name.
+        # Every later binding of the same definition reuses this entry.
+        self.canonical_function_tools: dict[str, Tool] = {}
+        # Tool names produced by one toolset construction, keyed by the AST
+        # call node. A toolset assigned to a variable and shared between
+        # agents is loaded once, not once per agent.
+        self.toolset_tool_names: dict[int, list[str]] = {}
+        self.agent_bindings: dict[str, _AdkAgentBinding] = {}
 
     def extract(self) -> list[LoadedToolSource]:
         tools: list[Tool] = []
@@ -553,16 +619,51 @@ class _PythonAdkExtractor:
                         )
                     )
                 continue
+            binding = self._binding_for(agent_name, call)
             for item in tools_expr.elts:
-                loaded_sources.extend(self._extract_tool_expr(item, tools, agent_name))
+                loaded_sources.extend(
+                    self._extract_tool_expr(item, tools, agent_name, binding)
+                )
         return [
             LoadedToolSource(
                 source_id=self.source_id,
                 source_type="google_adk",
                 tools=tools,
                 warnings=[],
+                binding_observations=self._binding_observations(),
             ),
             *loaded_sources,
+        ]
+
+    def _binding_for(self, agent_name: str, call: ast.Call) -> _AdkAgentBinding:
+        binding = self.agent_bindings.get(agent_name)
+        if binding is None:
+            binding = _AdkAgentBinding(
+                agent=agent_name,
+                source_pointer=f"{self.source_ref}:{call.lineno}",
+            )
+            self.agent_bindings[agent_name] = binding
+        return binding
+
+    def _binding_observations(self) -> list[AgentBindingObservation]:
+        """Publish agent wiring as framework-owned binding observations.
+
+        Bindings deliberately do not travel on ``Tool.annotations``: the
+        catalog holds one observation per tool definition, so a per-tool
+        agent name could only ever name one of N binding agents. Handoffs
+        stay with the ``sub_agents`` artifact records that already own them.
+        """
+
+        return [
+            AgentBindingObservation(
+                agent=binding.agent,
+                source_id=self.source_id,
+                source=self.source_ref,
+                source_pointer=binding.source_pointer,
+                tool_names=list(binding.tool_names),
+            )
+            for binding in self.agent_bindings.values()
+            if binding.tool_names
         ]
 
     def _agent_calls(self) -> list[tuple[str | None, ast.Call]]:
@@ -616,19 +717,19 @@ class _PythonAdkExtractor:
         expr: ast.AST,
         tools: list[Tool],
         agent_name: str,
+        binding: _AdkAgentBinding,
     ) -> list[LoadedToolSource]:
         if isinstance(expr, ast.Name):
             if expr.id in self.wrappers:
-                self._append_wrapper_tool(expr.id, tools, agent_name)
+                self._append_wrapper_tool(expr.id, tools, agent_name, binding)
             elif expr.id in self.toolset_assignments:
-                call = self.toolset_assignments[expr.id]
-                call_name = _qualified_name(call.func, self.aliases)
-                if call_name in OPENAPI_TOOLSET_NAMES:
-                    return self._extract_openapi_toolset(call, agent_name)
-                if call_name in MCP_TOOLSET_NAMES:
-                    return self._extract_mcp_toolset(call, agent_name)
+                return self._extract_toolset_call(
+                    self.toolset_assignments[expr.id], agent_name, binding
+                )
             elif expr.id in self.functions:
-                tools.append(self._function_to_tool(self.functions[expr.id], agent_name, False))
+                self._bind_function_tool(
+                    self.functions[expr.id], tools, agent_name, binding, False
+                )
             else:
                 self.artifacts.warnings.append(
                     f"Google ADK agent {agent_name!r} references unresolved tool {expr.id!r}."
@@ -639,38 +740,128 @@ class _PythonAdkExtractor:
             if call_name in FUNCTION_TOOL_NAMES | LONG_RUNNING_TOOL_NAMES:
                 func_name = _call_func_name(expr)
                 if func_name and func_name in self.functions:
-                    tools.append(
-                        self._function_to_tool(
-                            self.functions[func_name],
-                            agent_name,
-                            call_name in LONG_RUNNING_TOOL_NAMES,
-                        )
+                    self._bind_function_tool(
+                        self.functions[func_name],
+                        tools,
+                        agent_name,
+                        binding,
+                        call_name in LONG_RUNNING_TOOL_NAMES,
                     )
                 return []
-            if call_name in OPENAPI_TOOLSET_NAMES:
-                return self._extract_openapi_toolset(expr, agent_name)
-            if call_name in MCP_TOOLSET_NAMES:
-                return self._extract_mcp_toolset(expr, agent_name)
+            if call_name in OPENAPI_TOOLSET_NAMES | MCP_TOOLSET_NAMES:
+                return self._extract_toolset_call(expr, agent_name, binding)
         self.artifacts.warnings.append(
             f"Google ADK agent {agent_name!r} has a tool expression that could not be statically resolved."
         )
         return []
 
-    def _append_wrapper_tool(self, wrapper_name: str, tools: list[Tool], agent_name: str) -> None:
+    def _append_wrapper_tool(
+        self,
+        wrapper_name: str,
+        tools: list[Tool],
+        agent_name: str,
+        binding: _AdkAgentBinding,
+    ) -> None:
         wrapper = self.wrappers[wrapper_name]
         func_name = wrapper.get("func_name")
         if isinstance(func_name, str) and func_name in self.functions:
-            tools.append(
-                self._function_to_tool(
-                    self.functions[func_name],
-                    agent_name,
-                    bool(wrapper.get("long_running")),
-                )
+            self._bind_function_tool(
+                self.functions[func_name],
+                tools,
+                agent_name,
+                binding,
+                bool(wrapper.get("long_running")),
             )
             return
         self.artifacts.warnings.append(
             f"Google ADK tool wrapper {wrapper_name!r} has no statically resolvable function."
         )
+
+    def _bind_function_tool(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        tools: list[Tool],
+        agent_name: str,
+        binding: _AdkAgentBinding,
+        long_running: bool,
+    ) -> None:
+        """Bind one function definition to one agent.
+
+        The first binding creates the canonical catalog observation; later
+        bindings of the same definition only add an edge. Emitting a tool per
+        binding would model one action as several independent capabilities
+        (and collide on tool observation identity).
+        """
+
+        tool = self.canonical_function_tools.get(node.name)
+        if tool is None:
+            tool = self._function_to_tool(node, agent_name, long_running)
+            self.canonical_function_tools[node.name] = tool
+            tools.append(tool)
+        elif long_running != (tool.annotations.get("long_running") is True):
+            # The same function wrapped as both FunctionTool and
+            # LongRunningFunctionTool is a contradictory declaration about one
+            # action. Keep the stricter contract and route it to review rather
+            # than letting binding order decide.
+            self.artifacts.warnings.append(
+                f"Google ADK function {node.name!r} is bound as both a long-running "
+                "and a standard function tool; review its operation contract."
+            )
+            if long_running:
+                tool.annotations["long_running"] = True
+                self.artifacts.long_running_tools.append(
+                    self._function_tool_payload(tool, agent_name)
+                )
+        if binding.bind(tool.name):
+            _record_tool_binding(
+                self.artifacts,
+                agent_name=agent_name,
+                tool_name=tool.name,
+                source_ref=tool.source_location or self.source_ref,
+            )
+
+    def _extract_toolset_call(
+        self,
+        call: ast.Call,
+        agent_name: str,
+        binding: _AdkAgentBinding,
+    ) -> list[LoadedToolSource]:
+        """Extract one toolset construction, at most once per call site.
+
+        A toolset bound to a variable and shared between agents is one tool
+        surface, so it is loaded once; every sharing agent gets an edge.
+        """
+
+        cached = self.toolset_tool_names.get(id(call))
+        if cached is not None:
+            self._bind_toolset_tools(cached, agent_name, binding)
+            return []
+        call_name = _qualified_name(call.func, self.aliases)
+        if call_name in OPENAPI_TOOLSET_NAMES:
+            loaded_sources = self._extract_openapi_toolset(call, agent_name)
+        else:
+            loaded_sources = self._extract_mcp_toolset(call, agent_name)
+        tool_names = [
+            tool.name for loaded in loaded_sources for tool in loaded.tools
+        ]
+        self.toolset_tool_names[id(call)] = tool_names
+        self._bind_toolset_tools(tool_names, agent_name, binding)
+        return loaded_sources
+
+    def _bind_toolset_tools(
+        self,
+        tool_names: list[str],
+        agent_name: str,
+        binding: _AdkAgentBinding,
+    ) -> None:
+        for tool_name in tool_names:
+            if binding.bind(tool_name):
+                _record_tool_binding(
+                    self.artifacts,
+                    agent_name=agent_name,
+                    tool_name=tool_name,
+                    source_ref=self.source_ref,
+                )
 
     def _function_to_tool(
         self,
@@ -704,7 +895,10 @@ class _PythonAdkExtractor:
             parameters=parameters,
             function_signature=signature,
             annotations={
-                "adk_agent_name": agent_name,
+                # No ``adk_agent_name`` here: this Tool is the canonical
+                # observation of one function definition, and the same
+                # definition may be bound to several agents. The binding
+                # relation travels as AgentBindingObservation instead.
                 "adk_agent_source_id": self.source_id,
                 "long_running": long_running,
             },
@@ -712,16 +906,25 @@ class _PythonAdkExtractor:
             extraction_confidence="medium",
             extraction={"method": "google_adk_python_ast", "confidence": "medium"},
         )
-        payload = {
+        payload = self._function_tool_payload(tool, agent_name)
+        self.artifacts.function_tools.append(payload)
+        if long_running:
+            self.artifacts.long_running_tools.append(payload)
+        return tool
+
+    def _function_tool_payload(self, tool: Tool, agent_name: str) -> dict[str, Any]:
+        """One record per function definition (not per agent binding).
+
+        ``agent_name`` is the first agent observed binding the definition;
+        the complete set of binding agents lives in ``tool_bindings``.
+        """
+
+        return {
             "name": tool.name,
             "source_ref": tool.source_location,
             "agent_name": agent_name,
             "metadata_present": bool(tool.description and tool.parameters),
         }
-        self.artifacts.function_tools.append(payload)
-        if long_running:
-            self.artifacts.long_running_tools.append(payload)
-        return tool
 
     def _extract_openapi_toolset(self, call: ast.Call, agent_name: str) -> list[LoadedToolSource]:
         spec_path = _extract_path_argument(call, self.aliases, OPENAPI_PATH_KEYS)
@@ -751,7 +954,9 @@ class _PythonAdkExtractor:
         )
         for tool in loaded.tools:
             tool.annotations["adk_toolset"] = "OpenAPIToolset"
-            tool.annotations["adk_agent_name"] = agent_name
+            # ``adk_agent_source_id`` keeps the binding resolver able to match
+            # these tools back to the ADK source; the binding agents
+            # themselves come from AgentBindingObservation.
             tool.annotations["adk_agent_source_id"] = self.source_id
         return [loaded]
 
@@ -787,7 +992,6 @@ class _PythonAdkExtractor:
         )
         for tool in loaded.tools:
             tool.annotations["adk_toolset"] = "McpToolset"
-            tool.annotations["adk_agent_name"] = agent_name
             tool.annotations["adk_agent_source_id"] = self.source_id
         return [loaded]
 

--- a/tests/test_google_adk.py
+++ b/tests/test_google_adk.py
@@ -1,10 +1,79 @@
 import json
 
+import pytest
+
 from agents_shipgate.checks.adk import _has_long_running_contract
 from agents_shipgate.cli.scan import inspect_sources, run_scan
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.inputs.google_adk import load_google_adk_artifacts
 from agents_shipgate.schemas.manifest import ToolSourceConfig
+
+# A shared mapping tool bound to a coordinator and two sub-agents: the
+# canonical Google ADK multi-agent shape (see google/adk-samples). The
+# module-level raise proves the extractor never imports the file.
+SHARED_TOOL_AGENT_SOURCE = '''
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool
+
+raise RuntimeError("this file must never be imported")
+
+
+def map_salesforce_account_to_sap_bp(account_id: str) -> dict:
+    """Map a Salesforce account to an SAP business partner."""
+    return {"business_partner": account_id}
+
+
+def map_salesforce_product_to_sap_material(product_id: str) -> dict:
+    """Map a Salesforce product to an SAP material."""
+    return {"material": product_id}
+
+
+tool_map_account = FunctionTool(func=map_salesforce_account_to_sap_bp)
+tool_map_product = FunctionTool(func=map_salesforce_product_to_sap_material)
+
+salesforce_agent = LlmAgent(
+    name="salesforce_agent",
+    instruction="Read Salesforce records.",
+    tools=[tool_map_account, tool_map_product],
+)
+
+sap_agent = LlmAgent(
+    name="sap_agent",
+    instruction="Read SAP records.",
+    tools=[tool_map_account, tool_map_product],
+)
+
+root_agent = LlmAgent(
+    name="smart_closer",
+    instruction="Coordinate Salesforce and SAP mapping.",
+    tools=[tool_map_account, tool_map_product],
+    sub_agents=[salesforce_agent, sap_agent],
+)
+'''
+
+SHARED_TOOL_MANIFEST = """
+version: "0.1"
+project:
+  name: adk-shared-function-tool
+agent:
+  name: smart_closer
+  declared_purpose:
+    - map salesforce records onto sap records
+environment:
+  target: local
+tool_sources:
+  - id: adk_smart_closer
+    type: google_adk
+    path: agent.py
+"""
+
+
+def _shared_tool_project(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(SHARED_TOOL_AGENT_SOURCE, encoding="utf-8")
+    (project / "shipgate.yaml").write_text(SHARED_TOOL_MANIFEST, encoding="utf-8")
+    return project
 
 
 def test_google_adk_python_static_extraction_without_importing_user_code(tmp_path):
@@ -128,6 +197,250 @@ policies:
     assert "SHIP-ADK-LONGRUNNING-CONTRACT-MISSING" in {
         finding.check_id for finding in report.findings
     }
+
+
+def test_google_adk_shared_function_tool_is_one_capability_with_three_bindings(tmp_path):
+    """Regression for #321.
+
+    Binding one ``FunctionTool`` to a coordinator and two sub-agents used to
+    emit one tool observation per binding; the second collided on
+    ``(source_type, source_id, native_locator)`` and aborted the scan with
+    ``InputParseError`` before any finding or release decision existed.
+
+    The function is one action, so it must enter the catalog exactly once
+    while every agent that can call it keeps a first-class binding edge.
+    """
+    project = _shared_tool_project(tmp_path)
+
+    report, exit_code = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    # A decision exists at all: the input no longer fails to parse.
+    assert exit_code == 0
+    assert report.release_decision is not None
+
+    # One canonical observation per function definition, not per binding.
+    catalog = {entry["name"]: entry for entry in report.tool_catalog}
+    assert set(catalog) == {
+        "map_salesforce_account_to_sap_bp",
+        "map_salesforce_product_to_sap_material",
+    }
+    for entry in catalog.values():
+        assert len(entry["observation_ids"]) == 1
+
+    # Every binding survives, and all three agents reach both tools.
+    graph = report.binding_surface_facts
+    agents = {agent.name: agent.agent_id for agent in graph.agents}
+    assert set(agents) == {"smart_closer", "salesforce_agent", "sap_agent"}
+    bound = {(edge.agent_id, edge.tool_id) for edge in graph.tool_edges}
+    assert bound == {
+        (agent_id, entry["tool_id"])
+        for agent_id in agents.values()
+        for entry in catalog.values()
+    }
+    assert graph.root_agent_id == agents["smart_closer"]
+    assert sorted(graph.reachable_tool_ids) == sorted(
+        entry["tool_id"] for entry in catalog.values()
+    )
+    assert graph.possible_tool_ids == []
+    assert graph.issues == []
+
+    # Reviewer evidence names every binding agent, not just the first one.
+    for entry in catalog.values():
+        claims = entry["binding_assessment"]["claims"]
+        assert {claim["value"].split("->")[0] for claim in claims} == set(agents.values())
+
+    # Unique tools and bindings stay separately countable.
+    surface = report.frameworks["google_adk"]
+    assert surface["agent_count"] == 3
+    assert surface["function_tool_count"] == 2
+    assert surface["tool_binding_count"] == 6
+    assert surface["warnings"] == []
+
+
+def test_google_adk_shared_toolset_variable_is_loaded_once(tmp_path):
+    """One toolset construction shared by two agents is one tool surface.
+
+    Re-loading it per binding would inflate the catalog with duplicate
+    observations of the same MCP inventory under different source ids.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "mcp.json").write_text(
+        json.dumps(
+            {
+                "tools": [
+                    {
+                        "name": "support.search",
+                        "description": "Search support records.",
+                        "annotations": {"readOnlyHint": True},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / "agent.py").write_text(
+        """
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool import McpToolset
+
+raise RuntimeError("this file must never be imported")
+
+shared_toolset = McpToolset(tool_filter=["support.search"], inventory_path="mcp.json")
+
+reader_agent = LlmAgent(name="reader_agent", tools=[shared_toolset])
+root_agent = LlmAgent(
+    name="root_agent",
+    tools=[shared_toolset],
+    sub_agents=[reader_agent],
+)
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: adk-shared-toolset
+agent:
+  name: root-agent
+  declared_purpose:
+    - search support records
+environment:
+  target: local
+tool_sources:
+  - id: adk_shared_toolset
+    type: google_adk
+    path: agent.py
+""",
+        encoding="utf-8",
+    )
+
+    report, exit_code = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    assert exit_code == 0
+    catalog = [entry for entry in report.tool_catalog if entry["name"] == "support.search"]
+    assert len(catalog) == 1
+    graph = report.binding_surface_facts
+    agents = {agent.name: agent.agent_id for agent in graph.agents}
+    assert {(edge.agent_id, edge.tool_id) for edge in graph.tool_edges} == {
+        (agents["root_agent"], catalog[0]["tool_id"]),
+        (agents["reader_agent"], catalog[0]["tool_id"]),
+    }
+    assert report.frameworks["google_adk"]["toolset_count"] == 1
+    assert report.frameworks["google_adk"]["tool_binding_count"] == 2
+
+
+def test_google_adk_conflicting_long_running_bindings_route_to_review(tmp_path):
+    """One function bound as both long-running and standard is contradictory.
+
+    Collapsing to one observation must not let binding order pick the
+    contract: keep the stricter one and surface the conflict.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        """
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool, LongRunningFunctionTool
+
+raise RuntimeError("this file must never be imported")
+
+
+def start_migration(tenant_id: str) -> dict:
+    \"\"\"Start a tenant migration.\"\"\"
+    return {"status": "pending"}
+
+
+fast = FunctionTool(func=start_migration)
+slow = LongRunningFunctionTool(func=start_migration)
+
+worker_agent = LlmAgent(name="worker_agent", tools=[fast])
+root_agent = LlmAgent(name="root_agent", tools=[slow], sub_agents=[worker_agent])
+""",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: adk-long-running-conflict
+agent:
+  name: root-agent
+  declared_purpose:
+    - migrate tenants
+environment:
+  target: local
+tool_sources:
+  - id: adk_conflict
+    type: google_adk
+    path: agent.py
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    surface = report.frameworks["google_adk"]
+    assert surface["function_tool_count"] == 1
+    assert surface["tool_binding_count"] == 2
+    assert any("long-running" in warning for warning in surface["warnings"])
+    assert "SHIP-ADK-LONGRUNNING-CONTRACT-MISSING" in {
+        finding.check_id for finding in report.findings
+    }
+
+
+def test_google_adk_true_duplicate_source_still_fails_closed(tmp_path):
+    """Sharing a tool is not the same as declaring one twice.
+
+    The observation-identity guard exists to reject a genuinely duplicated
+    declaration within one source; collapsing shared bindings must not
+    weaken it into "same locator is always fine".
+    """
+    project = _shared_tool_project(tmp_path)
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: adk-duplicate-entrypoint
+agent:
+  name: smart_closer
+  declared_purpose:
+    - map salesforce records onto sap records
+environment:
+  target: local
+google_adk:
+  python_entrypoints:
+    - agent.py
+    - agent.py
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InputParseError) as excinfo:
+        run_scan(
+            config_path=project / "shipgate.yaml",
+            output_dir=tmp_path / "reports",
+            formats=["json"],
+            ci_mode="advisory",
+        )
+
+    assert "Duplicate tool observation identity" in str(excinfo.value)
 
 
 def test_google_adk_agent_config_dynamic_toolset_findings(tmp_path):


### PR DESCRIPTION
## Summary

- Fixes #321. Binding one `FunctionTool` to a coordinator and its sub-agents — the canonical ADK multi-agent shape — aborted the scan with `Duplicate tool observation identity` before any finding or `release_decision` existed. Reproduced at `7e0bfdf5` with the issue's three-agent shape; the same manifest now scans to a decision.
- The Python extractor emitted one `Tool` per **agent binding**, and observation identity is `(source_type, source_id, native_locator)` where the locator is file + function name, so binding #2 collided with binding #1. Adding the agent name to that identity is rejected for the reason the issue gives: one function is one action, and a capability per binding inflates every catalog-derived count.
- The function is now observed **once**, and the many-to-many relation travels as framework-owned `AgentBindingObservation` records on `LoadedToolSource` — the surface the OpenAI Agents SDK adapter already uses, whose stated contract is that catalog-controlled metadata never becomes authority-bearing binding evidence. `adk_agent_name` is dropped from ADK Python tools (a single-valued annotation can only ever name one of N agents); `adk_agent_source_id` stays, because it is what lets toolset-loaded tools resolve back to the ADK source.
- Worth noting: name-based edge resolution requires **exactly one** match, so even without the parse abort the shared shape would have produced `unresolved_bound_tool` for every shared tool. Collapsing to one canonical observation fixes the binding graph too, not just the crash.
- Two sibling shapes fixed while in here: a toolset assigned to a variable and shared between agents is loaded once instead of once per agent (it was minting a duplicate observation of the same spec under a second source id), and a function bound as both `FunctionTool` and `LongRunningFunctionTool` keeps the stricter long-running contract plus a warning instead of letting binding order decide the operation contract.

### Acceptance criteria

| Criterion | Where |
|---|---|
| Shared `FunctionTool` across three agents scans without `InputParseError` | `test_google_adk_shared_function_tool_is_one_capability_with_three_bindings` |
| One canonical observation per function definition | same test — `len(observation_ids) == 1` per catalog entry |
| All three bindings available to root-reachability and reviewer evidence | same test — full agent x tool edge set, `reachable_tool_ids`, and `binding_assessment.claims[]` naming every binding agent |
| Unique tool counts and binding counts distinguishable | `frameworks.google_adk.function_tool_count` (definitions) vs. new `tool_binding_count` (edges): 2 vs. 6 |
| Offline regression fixture: two shared mapping tools, root + two sub-agents | `SHARED_TOOL_AGENT_SOURCE` in `tests/test_google_adk.py` |
| No agent code imported or executed | fixture raises at module level; `tests/test_adapter_static_only.py` + `tests/test_fixture_no_import.py` unchanged and green |

Per the review comment on the issue, true duplicates still fail closed: `test_google_adk_true_duplicate_source_still_fails_closed` declares the same entrypoint twice under one source id and asserts `Duplicate tool observation identity` still raises. The guard itself is untouched — the fix is upstream of it.

## Type

- [x] Input adapter change
- [x] Report, schema, or SARIF output

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full CI-equivalent suite green: `pytest -n auto -m "not perf" --ignore=tests/test_adapter_static_only.py` (exit 0), plus `tests/test_adapter_static_only.py`, `test_p0_safety_canaries.py`, `test_p0_binding_canaries.py`, `test_agent_boundary.py`, `ruff`, `compileall`, `generate_schemas.py --check`.
- Reproduced the issue verbatim first (three agents, two shared mapping tools) and confirmed the exact error, then confirmed the same manifest now exits 0 with 2 canonical tools, 6 bindings, 3 agent nodes, both sub-agent handoffs, `status: structural`, `pass_eligible: true`, and zero binding issues.
- A/B'd `samples/google_adk_agent` before/after: decisions, findings, tool ids, and the agent x tool edge set are identical. Two intended deltas — binding edges now cite the `LlmAgent(...)` call site (`agent.py:34`) instead of the tool's own inventory/spec file with a null pointer, and the `annotations` hash moves for ADK tools because `adk_agent_name` is gone. Identity, schema, policy, and risk hashes are unchanged, so fingerprints and baselines are unaffected; the first scan after upgrade may show a metadata-only tool-surface change.
- Verified a per-agent widening (a sub-agent gains an already-reachable tool) shows up in `binding_surface_facts.tool_edges` and moves `tool_binding_count` 4 -> 5.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — none added or changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — `frameworks.google_adk.tool_binding_count` is additive under the existing "framework blocks may grow" rule, and that rule now states that tool counts count definitions while bindings move with the wiring. `report_schema_version` stays `0.34`; the published `required` set is untouched (`additionalProperties: true`), so the new key can be promoted to required at the next bump.

## Follow-up (not in scope here)

`binding_surface_diff` carries only reachable-tool and handoff deltas, so "a second agent gained the refund tool" is visible in `binding_surface_facts` and in `tool_binding_count` but produces no diff row when the tool was already root-reachable. That per-edge delta is now representable for the first time; happy to file it as a separate issue rather than widen this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)