### PR TITLE
fix(artifacts): prevent stale verifier evidence after scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@
   published report schema's `required` set; `report_schema_version` stays at
   `0.34`.
 
+- **Standalone scans now retire the complete verifier route as one lifecycle
+  set.** A later `scan` removes `verifier.json`, `agent-handoff.json`, the PR
+  comment and run projection, and every verification identity input and output
+  before publishing a replacement report, so stale control actions cannot
+  survive beside a newer release decision. Cleanup failures now return the
+  exact artifact path and recovery action in agent mode. `baseline save` keeps
+  its supporting scan in a temporary directory, preserving both the current
+  report and forensic verifier evidence.
+
 - **`SHIP-VERIFY-POLICY-WEAKENED` can now actually see a weakened CI gate.**
   The `effective_policy` snapshot was built from the manifest *after* CLI
   overrides were folded into it, so it described the invocation rather than

--- a/README.md
+++ b/README.md
@@ -634,18 +634,21 @@ and pre-commit equivalents.
 
 ## What it produces
 
-When a PR changes what your agent can do, the verify loop writes these
-artifacts — in read order:
-
 The read path is command-scoped. After standalone `scan`, read
 `report.json.release_decision.decision`; `scan` does not produce a valid
 verifier handoff or receipt. After `verify`, validate
 `verification-receipt.json` and then read `agent-handoff.json`. If both
 commands use the same output directory, a later standalone scan removes the
-prior handoff, plan, unit result, artifact manifest, receipt, and copied human
+prior verifier substrate, handoff, PR comment, run projection, plan, diff,
+base-report copy, unit result, artifact manifest, receipt, and copied human
 authorization before writing its report. `verify` writes a fresh
 content-addressed set after its internal scan completes. This prevents an old
-verifier route from being mistaken for the current scan result.
+verifier route from being mistaken for the current scan result. Supporting
+commands such as `baseline save` run their internal scans in isolated temporary
+directories and do not replace either command's report set.
+
+When a PR changes what your agent can do, the verify loop writes these
+artifacts — in read order:
 
 - **`agents-shipgate-reports/verification-receipt.json`** — the **first artifact a coding agent validates**: a terminal content-addressed closure over the exact request (including `verification-input.diff`), worker result, decision, and artifact set. It is written last; use `agents-shipgate verification reproduce` to validate every referenced hash.
 - **`agents-shipgate-reports/agent-handoff.json`** — the compact `shipgate.agent_handoff/v6` object. Lead with `control.state`, then `gate.merge_verdict`; it projects the same request, decision, and authorization evaluation and does not introduce a second verdict.

--- a/README.md
+++ b/README.md
@@ -637,6 +637,16 @@ and pre-commit equivalents.
 When a PR changes what your agent can do, the verify loop writes these
 artifacts — in read order:
 
+The read path is command-scoped. After standalone `scan`, read
+`report.json.release_decision.decision`; `scan` does not produce a valid
+verifier handoff or receipt. After `verify`, validate
+`verification-receipt.json` and then read `agent-handoff.json`. If both
+commands use the same output directory, a later standalone scan removes the
+prior handoff, plan, unit result, artifact manifest, receipt, and copied human
+authorization before writing its report. `verify` writes a fresh
+content-addressed set after its internal scan completes. This prevents an old
+verifier route from being mistaken for the current scan result.
+
 - **`agents-shipgate-reports/verification-receipt.json`** — the **first artifact a coding agent validates**: a terminal content-addressed closure over the exact request (including `verification-input.diff`), worker result, decision, and artifact set. It is written last; use `agents-shipgate verification reproduce` to validate every referenced hash.
 - **`agents-shipgate-reports/agent-handoff.json`** — the compact `shipgate.agent_handoff/v6` object. Lead with `control.state`, then `gate.merge_verdict`; it projects the same request, decision, and authorization evaluation and does not introduce a second verdict.
 - **`agents-shipgate-reports/verifier.json`** — the **authoritative PR/control evidence substrate** (`verifier_schema_version: "0.6"`). A coding agent switches on `control.state`, then reads `authorization`, `merge_verdict` (`mergeable | human_review_required | insufficient_evidence | blocked | unknown`), `can_merge_without_human`, `control.next_action`, and `fix_task` when producing reviewer evidence for an agent-capability PR. Only an accepted signed authorization evaluation may expose an exact reviewed command; the release verdict remains unchanged. Local control comes from `shipgate check --format agent-boundary-json` and `shipgate.agent_boundary_result/v1`. See [`docs/agent-contract-current.md`](docs/agent-contract-current.md) for the field contract.

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -128,6 +128,28 @@ one decision engine.
 `merge_verdict` is a deterministic projection of `release_decision.decision`, so
 the two can never disagree.
 
+### Command-scoped artifact lifecycle
+
+Choose the read path from the command that just completed, not merely from
+filenames already present in the output directory:
+
+- After standalone `scan`, `report.json.release_decision.decision` is
+  authoritative. `scan` writes report, advisory scaffold, and configured
+  packet formats; it does not produce a verifier handoff or terminal receipt.
+- After `verify`, validate `verification-receipt.json`, then read
+  `agent-handoff.json` and the supporting verifier artifacts in the order
+  above. The receipt and handoff retain the content-addressed identity of that
+  exact verify run.
+
+When standalone `scan` replaces a report set in the same output directory, it
+removes any prior `agent-handoff.json`, `verification-plan.json`,
+`verification-unit-result.json`, `verification-artifacts.json`,
+`verification-receipt.json`, and `human-authorization.json` before writing the
+new report. Their absence is intentional: an older verifier route or receipt
+must never appear to authorize or describe the newer scan. `verify` calls the
+same scan pipeline internally and writes a fresh, mutually consistent verifier
+artifact set afterward.
+
 ## Primary vs supporting surfaces
 
 Primary gates are intentionally narrow. CI gates on

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -142,13 +142,17 @@ filenames already present in the output directory:
   exact verify run.
 
 When standalone `scan` replaces a report set in the same output directory, it
-removes any prior `agent-handoff.json`, `verification-plan.json`,
-`verification-unit-result.json`, `verification-artifacts.json`,
-`verification-receipt.json`, and `human-authorization.json` before writing the
-new report. Their absence is intentional: an older verifier route or receipt
-must never appear to authorize or describe the newer scan. `verify` calls the
-same scan pipeline internally and writes a fresh, mutually consistent verifier
-artifact set afterward.
+removes the complete prior verifier route and its identity support:
+`verifier.json`, `agent-handoff.json`, `pr-comment.md`, `verify-run.json`,
+`verification-plan.json`, `verification-input.diff`,
+`verification-base-report.json`, `verification-unit-result.json`,
+`verification-artifacts.json`, `verification-receipt.json`, and
+`human-authorization.json`. Their absence is intentional: an older controller
+substrate, route, or receipt must never appear to authorize or describe the
+newer scan. `verify` calls the same scan pipeline internally and writes a fresh,
+mutually consistent verifier artifact set afterward. Supporting commands that
+only need an in-memory report, including `baseline save`, scan into an isolated
+temporary directory so they preserve the current report and verifier evidence.
 
 ## Primary vs supporting surfaces
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1152,6 +1152,28 @@ one decision engine.
 `merge_verdict` is a deterministic projection of `release_decision.decision`, so
 the two can never disagree.
 
+### Command-scoped artifact lifecycle
+
+Choose the read path from the command that just completed, not merely from
+filenames already present in the output directory:
+
+- After standalone `scan`, `report.json.release_decision.decision` is
+  authoritative. `scan` writes report, advisory scaffold, and configured
+  packet formats; it does not produce a verifier handoff or terminal receipt.
+- After `verify`, validate `verification-receipt.json`, then read
+  `agent-handoff.json` and the supporting verifier artifacts in the order
+  above. The receipt and handoff retain the content-addressed identity of that
+  exact verify run.
+
+When standalone `scan` replaces a report set in the same output directory, it
+removes any prior `agent-handoff.json`, `verification-plan.json`,
+`verification-unit-result.json`, `verification-artifacts.json`,
+`verification-receipt.json`, and `human-authorization.json` before writing the
+new report. Their absence is intentional: an older verifier route or receipt
+must never appear to authorize or describe the newer scan. `verify` calls the
+same scan pipeline internally and writes a fresh, mutually consistent verifier
+artifact set afterward.
+
 ## Primary vs supporting surfaces
 
 Primary gates are intentionally narrow. CI gates on

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1166,13 +1166,17 @@ filenames already present in the output directory:
   exact verify run.
 
 When standalone `scan` replaces a report set in the same output directory, it
-removes any prior `agent-handoff.json`, `verification-plan.json`,
-`verification-unit-result.json`, `verification-artifacts.json`,
-`verification-receipt.json`, and `human-authorization.json` before writing the
-new report. Their absence is intentional: an older verifier route or receipt
-must never appear to authorize or describe the newer scan. `verify` calls the
-same scan pipeline internally and writes a fresh, mutually consistent verifier
-artifact set afterward.
+removes the complete prior verifier route and its identity support:
+`verifier.json`, `agent-handoff.json`, `pr-comment.md`, `verify-run.json`,
+`verification-plan.json`, `verification-input.diff`,
+`verification-base-report.json`, `verification-unit-result.json`,
+`verification-artifacts.json`, `verification-receipt.json`, and
+`human-authorization.json`. Their absence is intentional: an older controller
+substrate, route, or receipt must never appear to authorize or describe the
+newer scan. `verify` calls the same scan pipeline internally and writes a fresh,
+mutually consistent verifier artifact set afterward. Supporting commands that
+only need an in-memory report, including `baseline save`, scan into an isolated
+temporary directory so they preserve the current report and verifier evidence.
 
 ## Primary vs supporting surfaces
 

--- a/src/agents_shipgate/cli/_artifact_lifecycle.py
+++ b/src/agents_shipgate/cli/_artifact_lifecycle.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents_shipgate.core.errors import AgentsShipgateError
+
+# These files carry an actionable verifier route or the content-addressed
+# identity that supports it.  They must move as one lifecycle set: retaining
+# even one beside a report from a later standalone scan can make the older
+# verification run look current.
+VERIFIER_ROUTE_ARTIFACT_NAMES = (
+    "agent-handoff.json",
+    "verification-plan.json",
+    "verification-unit-result.json",
+    "verification-artifacts.json",
+    "verification-receipt.json",
+    "human-authorization.json",
+)
+
+
+def clear_verifier_route_artifacts(out_dir: Path) -> None:
+    """Remove stale verifier route/identity artifacts from ``out_dir``.
+
+    Fail closed when a present artifact cannot be removed.  Writing a new
+    report while an older handoff or receipt remains would present
+    contradictory runs as one current artifact set.
+    """
+
+    for name in VERIFIER_ROUTE_ARTIFACT_NAMES:
+        path = out_dir / name
+        if not (path.is_file() or path.is_symlink()):
+            continue
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            # Another lifecycle cleanup won the race; the invariant already
+            # holds, so the caller can continue.
+            continue
+        except OSError as exc:
+            raise AgentsShipgateError(
+                f"Could not remove stale verifier artifact {path}: {exc}"
+            ) from exc

--- a/src/agents_shipgate/cli/_artifact_lifecycle.py
+++ b/src/agents_shipgate/cli/_artifact_lifecycle.py
@@ -9,13 +9,26 @@ from agents_shipgate.core.errors import AgentsShipgateError
 # even one beside a report from a later standalone scan can make the older
 # verification run look current.
 VERIFIER_ROUTE_ARTIFACT_NAMES = (
+    "verifier.json",
     "agent-handoff.json",
+    "pr-comment.md",
+    "verify-run.json",
     "verification-plan.json",
+    "verification-input.diff",
+    "verification-base-report.json",
     "verification-unit-result.json",
     "verification-artifacts.json",
     "verification-receipt.json",
     "human-authorization.json",
 )
+
+
+class ArtifactLifecycleError(AgentsShipgateError):
+    """A stale verifier artifact could not be removed safely."""
+
+    def __init__(self, path: Path, cause: OSError) -> None:
+        self.path = path
+        super().__init__(f"Could not remove stale verifier artifact {path}: {cause}")
 
 
 def clear_verifier_route_artifacts(out_dir: Path) -> None:
@@ -37,6 +50,4 @@ def clear_verifier_route_artifacts(out_dir: Path) -> None:
             # holds, so the caller can continue.
             continue
         except OSError as exc:
-            raise AgentsShipgateError(
-                f"Could not remove stale verifier artifact {path}: {exc}"
-            ) from exc
+            raise ArtifactLifecycleError(path, exc) from exc

--- a/src/agents_shipgate/cli/_register_baseline.py
+++ b/src/agents_shipgate/cli/_register_baseline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import tempfile
 from datetime import UTC, date, datetime
 from pathlib import Path
 
@@ -102,23 +103,30 @@ def register(app: typer.Typer) -> None:
             raise typer.Exit(2)
         try:
             configure_logging(verbose=verbose)
-            report, _ = run_scan(
-                config_path=config,
-                formats=["json"],
-                ci_mode="advisory",
-                verbose=verbose,
-            )
-            manifest = load_manifest(config)
-            audit_log = _resolve_audit_log_path(manifest, out)
-            baseline = write_baseline(
-                report,
-                out,
-                audit_log_path=audit_log,
-                owner=owner,
-                reason=reason,
-                expires=expires_date,
-                apply_to_existing=apply_to_existing,
-            )
+            # Baseline creation only consumes the in-memory report. Keep this
+            # supporting scan out of the manifest's normal reports directory:
+            # it must not supersede a verifier receipt or replace report.json.
+            with tempfile.TemporaryDirectory(
+                prefix="agents-shipgate-baseline-save-"
+            ) as scan_output:
+                report, _ = run_scan(
+                    config_path=config,
+                    output_dir=Path(scan_output),
+                    formats=["json"],
+                    ci_mode="advisory",
+                    verbose=verbose,
+                )
+                manifest = load_manifest(config)
+                audit_log = _resolve_audit_log_path(manifest, out)
+                baseline = write_baseline(
+                    report,
+                    out,
+                    audit_log_path=audit_log,
+                    owner=owner,
+                    reason=reason,
+                    expires=expires_date,
+                    apply_to_existing=apply_to_existing,
+                )
         except ConfigError as exc:
             typer.echo(f"Config error: {exc}", err=True)
             raise typer.Exit(2) from exc

--- a/src/agents_shipgate/cli/_register_scan.py
+++ b/src/agents_shipgate/cli/_register_scan.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import typer
 
+from agents_shipgate.cli._artifact_lifecycle import ArtifactLifecycleError
 from agents_shipgate.cli._helpers import (
     _apply_strict_plugins,
     _diagnose_config_error,
@@ -495,6 +496,32 @@ def register(app: typer.Typer) -> None:
                 next_actions=[a.model_dump(mode="json") for a in actions],
             )
             raise typer.Exit(3) from exc
+        except ArtifactLifecycleError as exc:
+            typer.echo(f"Agents Shipgate error: {exc}", err=True)
+            guidance = (
+                f"Remove {exc.path} and re-run scan; Agents Shipgate will not "
+                "write a replacement report while a stale verifier artifact "
+                "survives."
+            )
+            actions = [
+                NextAction(
+                    kind="edit",
+                    path=str(exc.path),
+                    why=guidance,
+                    expects=(
+                        "The stale verifier artifact is absent, then scan writes "
+                        "one current report set."
+                    ),
+                )
+            ]
+            _echo_next_action_hint(actions)
+            _emit_agent_mode_error(
+                "other_error",
+                message=str(exc),
+                next_action=guidance,
+                next_actions=[action.model_dump(mode="json") for action in actions],
+            )
+            raise typer.Exit(4) from exc
         except AgentsShipgateError as exc:
             typer.echo(f"Agents Shipgate error: {exc}", err=True)
             guidance = (

--- a/src/agents_shipgate/cli/scan/writing.py
+++ b/src/agents_shipgate/cli/scan/writing.py
@@ -8,6 +8,7 @@ from agents_shipgate.ci.release_decision import (
     SUGGESTED_DECLARATIONS_FILENAME,
     SUGGESTED_INVENTORY_FILENAME,
 )
+from agents_shipgate.cli._artifact_lifecycle import clear_verifier_route_artifacts
 from agents_shipgate.core.domain import Tool
 from agents_shipgate.core.privacy import sanitize_packet
 from agents_shipgate.packet.builder import build_packet
@@ -37,6 +38,10 @@ def _write_outputs(
     never serializes raw manifest content into the packet).
     """
     public_report = ReadinessReport.model_validate(public_report_payload)
+    # A standalone scan supersedes the report set in this directory.  Verify
+    # also calls run_scan internally, but writes its fresh route/identity
+    # artifacts only after this phase completes.
+    clear_verifier_route_artifacts(plan.out_dir)
     _write_reports(
         public_report,
         plan.generated_paths,

--- a/src/agents_shipgate/cli/verify/command.py
+++ b/src/agents_shipgate/cli/verify/command.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import typer
 
+from agents_shipgate.cli._artifact_lifecycle import ArtifactLifecycleError
 from agents_shipgate.cli._helpers import (
     _diagnose_config_error,
     _echo_next_action_hint,
@@ -201,9 +202,7 @@ def verify(
             raise ConfigError("--ci-mode must be advisory or strict")
         for label, value in (("--base", base), ("--head", head)):
             if value is not None and (
-                not value
-                or value.startswith("-")
-                or any(char in value for char in "\0\r\n")
+                not value or value.startswith("-") or any(char in value for char in "\0\r\n")
             ):
                 raise ConfigError(
                     f"{label} must be non-empty, must not begin with '-', "
@@ -331,6 +330,31 @@ def verify(
             ],
         )
         raise typer.Exit(3) from exc
+    except ArtifactLifecycleError as exc:
+        typer.echo(f"Agents Shipgate error: {exc}", err=True)
+        guidance = (
+            f"Remove {exc.path} and re-run verify; Agents Shipgate will not "
+            "write a replacement verifier route while a stale verifier "
+            "artifact survives."
+        )
+        emit_agent_mode_error(
+            "other_error",
+            message=str(exc),
+            exit_code=4,
+            next_action=guidance,
+            next_actions=[
+                NextAction(
+                    kind="edit",
+                    path=str(exc.path),
+                    why=guidance,
+                    expects=(
+                        "The stale verifier artifact is absent, then verify "
+                        "writes one content-addressed artifact set."
+                    ),
+                ).model_dump(mode="json")
+            ],
+        )
+        raise typer.Exit(4) from exc
     except AgentsShipgateError as exc:
         typer.echo(f"Agents Shipgate error: {exc}", err=True)
         guidance = (

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -17,6 +17,7 @@ from typing import Any
 from agents_shipgate import __version__
 from agents_shipgate.checks.verify import PROTECTED_FILE_EDITS
 from agents_shipgate.ci.release_decision import SUGGESTED_DECLARATIONS_FILENAME
+from agents_shipgate.cli._artifact_lifecycle import clear_verifier_route_artifacts
 from agents_shipgate.cli._helpers import _apply_strict_plugins
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.core.agent_control import derive_agent_control
@@ -224,7 +225,7 @@ def run_verify(
         ],
     )
     out_dir.mkdir(parents=True, exist_ok=True)
-    _clear_trusted_handoff(out_dir)
+    clear_verifier_route_artifacts(out_dir)
     verifier_path = out_dir / "verifier.json"
     verify_run_path = out_dir / "verify-run.json"
     pr_comment_path = out_dir / "pr-comment.md"
@@ -1974,23 +1975,6 @@ def _remove_scan_artifacts(out_dir: Path) -> None:
                 path.unlink()
 
 
-def _clear_trusted_handoff(out_dir: Path) -> None:
-    """Remove every prior terminal/projection artifact before a new run."""
-
-    for name in (
-        "agent-handoff.json",
-        "verification-plan.json",
-        "verification-unit-result.json",
-        "verification-artifacts.json",
-        "verification-receipt.json",
-        "human-authorization.json",
-    ):
-        path = out_dir / name
-        if path.is_file() or path.is_symlink():
-            with contextlib.suppress(OSError):
-                path.unlink()
-
-
 def _apply_authorization_overlay(
     verifier: VerifierArtifact,
     evaluation: AuthorizationEvaluationV1,
@@ -3116,7 +3100,7 @@ def run_preview(
         inputs=[("config", config_path)],
     )
     out_dir.mkdir(parents=True, exist_ok=True)
-    _clear_trusted_handoff(out_dir)
+    clear_verifier_route_artifacts(out_dir)
     verifier_path = out_dir / "verifier.json"
     verify_run_path = out_dir / "verify-run.json"
     agent_handoff_path = out_dir / "agent-handoff.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from typer.testing import CliRunner
 
 from agents_shipgate import __version__
 from agents_shipgate.checks import registry
+from agents_shipgate.cli._artifact_lifecycle import VERIFIER_ROUTE_ARTIFACT_NAMES
 from agents_shipgate.cli._helpers import _safe_output_name
 from agents_shipgate.cli.main import app
 from agents_shipgate.cli.scan import run_scan
@@ -1033,6 +1034,44 @@ def test_cli_baseline_save_and_scan(tmp_path):
     # mode must still fail even when every fingerprint is baseline-matched.
     assert scan.exit_code == 20
     assert "Baseline delta: matched=" in scan.output
+
+
+def test_cli_baseline_save_preserves_verification_evidence_and_report(tmp_path):
+    sample = tmp_path / "support_refund_agent"
+    shutil.copytree(
+        "samples/support_refund_agent",
+        sample,
+        ignore=shutil.ignore_patterns("agents-shipgate-reports"),
+    )
+    reports = sample / "agents-shipgate-reports"
+    reports.mkdir()
+    preserved = {
+        "report.json": b'{"current": "verification report"}\n',
+        **{
+            name: f"current verification artifact: {name}\n".encode()
+            for name in VERIFIER_ROUTE_ARTIFACT_NAMES
+        },
+    }
+    for name, contents in preserved.items():
+        (reports / name).write_bytes(contents)
+
+    baseline_path = sample / ".agents-shipgate" / "baseline.json"
+    result = runner.invoke(
+        app,
+        [
+            "baseline",
+            "save",
+            "--config",
+            str(sample / "shipgate.yaml"),
+            "--out",
+            str(baseline_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert baseline_path.is_file()
+    for name, contents in preserved.items():
+        assert (reports / name).read_bytes() == contents, name
 
 
 def test_cli_scan_missing_baseline_exits_three(tmp_path):

--- a/tests/test_init_auto.py
+++ b/tests/test_init_auto.py
@@ -451,9 +451,13 @@ def test_preview_then_init_scan_removes_preview_handoff(tmp_path: Path) -> None:
     assert preview.exit_code == 0, preview.output
     reports = workspace / "agents-shipgate-reports"
     handoff_path = reports / "agent-handoff.json"
+    verifier_path = reports / "verifier.json"
+    pr_comment_path = reports / "pr-comment.md"
     preview_handoff = json.loads(handoff_path.read_text(encoding="utf-8"))
     assert preview_handoff["operation"] == "verify_preview"
     assert preview_handoff["control"]["state"] == "agent_action_required"
+    assert verifier_path.is_file()
+    assert pr_comment_path.is_file()
 
     initialized = runner.invoke(
         app,
@@ -474,6 +478,8 @@ def test_preview_then_init_scan_removes_preview_handoff(tmp_path: Path) -> None:
     report = json.loads((reports / "report.json").read_text(encoding="utf-8"))
     assert report["release_decision"]["decision"] == "insufficient_evidence"
     assert not handoff_path.exists()
+    assert not verifier_path.exists()
+    assert not pr_comment_path.exists()
 
 
 def test_auto_init_source_ids_are_stable_when_a_sibling_appears(tmp_path: Path) -> None:

--- a/tests/test_init_auto.py
+++ b/tests/test_init_auto.py
@@ -10,6 +10,7 @@ ids it shares with the auto renderer (see the issue #307 section below).
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -432,6 +433,47 @@ def test_cold_start_init_then_scan_with_repeated_basenames(tmp_path: Path) -> No
     )
     assert scan_result.exit_code == 0, scan_result.output
     assert "Config error" not in scan_result.output
+
+
+def test_preview_then_init_scan_removes_preview_handoff(tmp_path: Path) -> None:
+    """A later scan must not expose the preview route as current evidence."""
+
+    workspace = _openai_sdk_workspace(
+        tmp_path / "preview-then-scan",
+        ["agent/tools.py"],
+    )
+    runner = CliRunner()
+
+    preview = runner.invoke(
+        app,
+        ["verify", "--workspace", str(workspace), "--preview", "--json"],
+    )
+    assert preview.exit_code == 0, preview.output
+    reports = workspace / "agents-shipgate-reports"
+    handoff_path = reports / "agent-handoff.json"
+    preview_handoff = json.loads(handoff_path.read_text(encoding="utf-8"))
+    assert preview_handoff["operation"] == "verify_preview"
+    assert preview_handoff["control"]["state"] == "agent_action_required"
+
+    initialized = runner.invoke(
+        app,
+        ["init", "--workspace", str(workspace), "--write", "--json"],
+    )
+    assert initialized.exit_code == 0, initialized.output
+
+    scanned = runner.invoke(
+        app,
+        [
+            "scan",
+            "--config",
+            str(workspace / "shipgate.yaml"),
+            "--suggest-patches",
+        ],
+    )
+    assert scanned.exit_code == 0, scanned.output
+    report = json.loads((reports / "report.json").read_text(encoding="utf-8"))
+    assert report["release_decision"]["decision"] == "insufficient_evidence"
+    assert not handoff_path.exists()
 
 
 def test_auto_init_source_ids_are_stable_when_a_sibling_appears(tmp_path: Path) -> None:

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,8 +1,12 @@
 import json
 from pathlib import Path
 
+import pytest
+
+from agents_shipgate.cli._artifact_lifecycle import VERIFIER_ROUTE_ARTIFACT_NAMES
 from agents_shipgate.cli.scan import run_scan
 from agents_shipgate.core.baseline import write_baseline
+from agents_shipgate.core.errors import AgentsShipgateError
 
 SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 GOOGLE_ADK_SAMPLE = Path("samples/google_adk_agent/shipgate.yaml")
@@ -26,6 +30,56 @@ def test_sample_scan_generates_reports(tmp_path):
     assert (tmp_path / "report.md").exists()
     assert (tmp_path / "report.json").exists()
     assert "summary" in (tmp_path / "report.json").read_text(encoding="utf-8")
+
+
+def test_scan_removes_stale_verifier_route_artifacts(tmp_path: Path) -> None:
+    for name in VERIFIER_ROUTE_ARTIFACT_NAMES:
+        (tmp_path / name).write_text('{"stale": true}\n', encoding="utf-8")
+
+    run_scan(
+        config_path=SAMPLE,
+        output_dir=tmp_path,
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=False,
+    )
+
+    assert (tmp_path / "report.json").is_file()
+    assert not [
+        name for name in VERIFIER_ROUTE_ARTIFACT_NAMES if (tmp_path / name).exists()
+    ]
+
+
+def test_scan_does_not_replace_report_when_stale_route_cannot_be_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stale_handoff = tmp_path / "agent-handoff.json"
+    stale_handoff.write_text('{"stale": true}\n', encoding="utf-8")
+    report_path = tmp_path / "report.json"
+    prior_report = '{"prior": true}\n'
+    report_path.write_text(prior_report, encoding="utf-8")
+    real_unlink = Path.unlink
+
+    def deny_stale_handoff_unlink(
+        path: Path, missing_ok: bool = False
+    ) -> None:
+        if path == stale_handoff:
+            raise PermissionError("test denied stale handoff cleanup")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", deny_stale_handoff_unlink)
+
+    with pytest.raises(AgentsShipgateError, match="Could not remove stale verifier artifact"):
+        run_scan(
+            config_path=SAMPLE,
+            output_dir=tmp_path,
+            formats=["json"],
+            ci_mode="advisory",
+            packet_enabled=False,
+        )
+
+    assert stale_handoff.is_file()
+    assert report_path.read_text(encoding="utf-8") == prior_report
 
 
 def test_openai_agents_sdk_directory_fixture_scans_static_tools(tmp_path):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -2,11 +2,15 @@ import json
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
-from agents_shipgate.cli._artifact_lifecycle import VERIFIER_ROUTE_ARTIFACT_NAMES
+from agents_shipgate.cli._artifact_lifecycle import (
+    VERIFIER_ROUTE_ARTIFACT_NAMES,
+    ArtifactLifecycleError,
+)
+from agents_shipgate.cli.main import app
 from agents_shipgate.cli.scan import run_scan
 from agents_shipgate.core.baseline import write_baseline
-from agents_shipgate.core.errors import AgentsShipgateError
 
 SAMPLE = Path("samples/support_refund_agent/shipgate.yaml")
 GOOGLE_ADK_SAMPLE = Path("samples/google_adk_agent/shipgate.yaml")
@@ -33,6 +37,19 @@ def test_sample_scan_generates_reports(tmp_path):
 
 
 def test_scan_removes_stale_verifier_route_artifacts(tmp_path: Path) -> None:
+    assert set(VERIFIER_ROUTE_ARTIFACT_NAMES) == {
+        "verifier.json",
+        "agent-handoff.json",
+        "pr-comment.md",
+        "verify-run.json",
+        "verification-plan.json",
+        "verification-input.diff",
+        "verification-base-report.json",
+        "verification-unit-result.json",
+        "verification-artifacts.json",
+        "verification-receipt.json",
+        "human-authorization.json",
+    }
     for name in VERIFIER_ROUTE_ARTIFACT_NAMES:
         (tmp_path / name).write_text('{"stale": true}\n', encoding="utf-8")
 
@@ -69,7 +86,9 @@ def test_scan_does_not_replace_report_when_stale_route_cannot_be_removed(
 
     monkeypatch.setattr(Path, "unlink", deny_stale_handoff_unlink)
 
-    with pytest.raises(AgentsShipgateError, match="Could not remove stale verifier artifact"):
+    with pytest.raises(
+        ArtifactLifecycleError, match="Could not remove stale verifier artifact"
+    ):
         run_scan(
             config_path=SAMPLE,
             output_dir=tmp_path,
@@ -80,6 +99,43 @@ def test_scan_does_not_replace_report_when_stale_route_cannot_be_removed(
 
     assert stale_handoff.is_file()
     assert report_path.read_text(encoding="utf-8") == prior_report
+
+
+def test_scan_cleanup_failure_agent_mode_names_exact_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stale_verifier = tmp_path / "verifier.json"
+    stale_verifier.write_text('{"stale": true}\n', encoding="utf-8")
+    real_unlink = Path.unlink
+
+    def deny_stale_verifier_unlink(
+        path: Path, missing_ok: bool = False
+    ) -> None:
+        if path == stale_verifier:
+            raise PermissionError("test denied stale verifier cleanup")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", deny_stale_verifier_unlink)
+    result = CliRunner().invoke(
+        app,
+        [
+            "scan",
+            "--config",
+            str(SAMPLE),
+            "--out",
+            str(tmp_path),
+            "--format",
+            "json",
+        ],
+        env={"AGENTS_SHIPGATE_AGENT_MODE": "1"},
+    )
+
+    assert result.exit_code == 4, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    expected_prefix = f"Remove {stale_verifier} and re-run scan"
+    assert payload["next_action"].startswith(expected_prefix)
+    assert payload["next_actions"][0]["kind"] == "edit"
+    assert payload["next_actions"][0]["path"] == str(stale_verifier)
 
 
 def test_openai_agents_sdk_directory_fixture_scans_static_tools(tmp_path):
@@ -1383,7 +1439,7 @@ def test_default_scan_does_not_import_user_code(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
     (project / "agent.py").write_text(
-        """
+        '''
 from pathlib import Path
 Path("imported.txt").write_text("executed")
 
@@ -1394,7 +1450,7 @@ def function_tool(fn):
 def harmless(name: str) -> str:
     \"\"\"Return a harmless greeting.\"\"\"
     return name
-""",
+''',
         encoding="utf-8",
     )
     (project / "shipgate.yaml").write_text(
@@ -1549,7 +1605,7 @@ agent = create_agent(model=None, tools=[lookup_case])
     )
     config = project / "shipgate.yaml"
     config.write_text(
-        '''
+        """
 version: "0.1"
 project:
   name: unreviewed-langchain
@@ -1562,7 +1618,7 @@ tool_sources:
   - id: langchain
     type: langchain
     path: agent.py
-''',
+""",
         encoding="utf-8",
     )
     return config

--- a/tests/test_verify_orchestrator.py
+++ b/tests/test_verify_orchestrator.py
@@ -116,7 +116,18 @@ tool_sources:
     assert exit_code == 0
     assert events == ["scan_cleanup", "verify_write"]
     reports = repo / "agents-shipgate-reports"
-    assert (reports / "agent-handoff.json").is_file()
+    for name in (
+        "verifier.json",
+        "agent-handoff.json",
+        "pr-comment.md",
+        "verify-run.json",
+        "verification-plan.json",
+        "verification-input.diff",
+        "verification-unit-result.json",
+        "verification-artifacts.json",
+        "verification-receipt.json",
+    ):
+        assert (reports / name).is_file(), name
     receipt = VerificationReceipt.model_validate(
         json.loads((reports / "verification-receipt.json").read_text(encoding="utf-8"))
     )

--- a/tests/test_verify_orchestrator.py
+++ b/tests/test_verify_orchestrator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from agents_shipgate.cli.scan import writing as scan_writing
 from agents_shipgate.cli.verification import assemble, worker
 from agents_shipgate.cli.verify import orchestrator as verify_orchestrator
 from agents_shipgate.cli.verify.git import commit_date
@@ -39,6 +40,87 @@ def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> None:
         capture_output=True,
         env=command_env,
     )
+
+
+def test_verify_writes_identity_after_internal_scan_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin verify's clear -> scan -> fresh identity-artifact ordering."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: lifecycle-test
+agent:
+  name: lifecycle-agent
+  declared_purpose:
+    - test artifact lifecycle
+environment:
+  target: local
+tool_sources:
+  - id: tools
+    type: mcp
+    path: tools.json
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (repo / "tools.json").write_text('{"tools": []}\n', encoding="utf-8")
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.test")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "fixture")
+
+    events: list[str] = []
+    real_clear = scan_writing.clear_verifier_route_artifacts
+    real_write = verify_orchestrator._write_artifacts
+
+    def track_scan_cleanup(out_dir: Path) -> None:
+        events.append("scan_cleanup")
+        real_clear(out_dir)
+
+    def track_verify_write(*args, **kwargs) -> None:
+        events.append("verify_write")
+        real_write(*args, **kwargs)
+
+    monkeypatch.setattr(
+        scan_writing,
+        "clear_verifier_route_artifacts",
+        track_scan_cleanup,
+    )
+    monkeypatch.setattr(verify_orchestrator, "_write_artifacts", track_verify_write)
+
+    _, _, exit_code = run_verify(
+        workspace=repo,
+        config=Path("shipgate.yaml"),
+        base=None,
+        head="HEAD",
+        archive_head=True,
+        out=repo / "agents-shipgate-reports",
+        ci_mode="advisory",
+        fail_on=None,
+        baseline=None,
+        baseline_mode="new-findings",
+        diff_from=None,
+        policy_packs=None,
+        plugins_enabled=False,
+        strict_plugins=False,
+        suggest_patches=False,
+        no_heuristics=False,
+        verbose=False,
+    )
+
+    assert exit_code == 0
+    assert events == ["scan_cleanup", "verify_write"]
+    reports = repo / "agents-shipgate-reports"
+    assert (reports / "agent-handoff.json").is_file()
+    receipt = VerificationReceipt.model_validate(
+        json.loads((reports / "verification-receipt.json").read_text(encoding="utf-8"))
+    )
+    assert receipt.request_id
 
 
 def test_verify_backdated_commit_cannot_extend_expired_override(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- treat the complete verifier control/identity surface as one lifecycle set when a standalone scan replaces a report
- remove stale `verifier.json`, handoff, PR comment, run projection, verification inputs, identity artifacts, receipt, and copied authorization before publishing the new report
- fail closed before replacing `report.json` when any stale verifier artifact cannot be removed, with an exact-path structured recovery action
- run `baseline save`'s supporting scan in an isolated temporary directory so it cannot clobber the current report or forensic verifier evidence
- document command-scoped artifact authority, add the CHANGELOG entry, and regenerate `llms-full.txt`

## Root cause

The original lifecycle set removed the terminal receipt and handoff but retained route-bearing surfaces such as `verifier.json`, `verify-run.json`, and `pr-comment.md`. That could leave a fresh standalone `report.json` beside an older actionable verifier route while deleting the receipt that made the mismatch detectable.

Separately, `baseline save` invoked `run_scan` without an explicit output directory. Its internal scan therefore used the manifest's normal reports directory, replacing `report.json` and triggering verifier cleanup even though the command only needed the in-memory report.

## Impact

A standalone scan now retires all 11 verifier route/identity artifacts before publishing a replacement report. No stale control substrate or downstream feedback route survives beside a newer release decision. If cleanup is denied, the existing report remains untouched and agent mode names the exact file to remove.

`baseline save` now writes only the requested baseline/audit outputs; an existing verification receipt, handoff, verifier substrate, run projection, PR comment, inputs, and report remain byte-identical.

## Validation

- focused regressions for scan cleanup, fail-closed recovery, preview → init → scan, baseline preservation, and verify rewrite ordering: passed
- full affected modules (`test_scan.py`, `test_init_auto.py`, `test_cli.py`, `test_verify_orchestrator.py`, `test_baseline_integrity.py`): 167 passed
- full repository suite: all non-packaging tests passed; the packaging fixture's isolated dependency install was blocked by the network sandbox, then all 8 packaging tests passed with package-index access
- Ruff checks for all modified Python files: passed
- `git diff --check`: passed
- Agents Shipgate committed-ref verify: `control.state=complete`, `merge_verdict=mergeable`, release decision `passed`, 0 blockers, 0 review items
- terminal verification receipt reproduced successfully

Closes #317