### PR TITLE
fix(identity): bind every declared adapter input to input_set_id (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,15 @@
   plan built with no snapshot at all; that table is derived from the manifest
   models rather than hand-kept, so a new artifact list — or a whole new framework
   block — is covered without editing it.
+  Capture also has to supply the *bytes*, not just the path list. Recording what
+  was read and then reopening those files to hash them takes the two halves of
+  the plan from two different instants: a file rewritten in between is attested
+  at its new content while `tool_sources` still lists what the old content
+  pointed at, so the receipt describes bytes the scan never evaluated. Plan
+  construction now runs under the finalized snapshot on both paths, and the
+  changed files are bound into it as well — `_blobs` skips a path the snapshot
+  contains but never read, so a changed file no adapter opens would otherwise
+  have dropped out of `changed_files`.
   A committed-tree run therefore has two snapshots alive, and each external
   input must belong to exactly one of them: the worktree snapshot binds the
   baseline, policy packs, and comparison report *before* the archived scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,13 @@
   explicit `--baseline`, `--diff-from`, and policy packs, with the comparison
   report bound as an external input on a committed-tree preparation because it
   is never mapped into the evaluated tree.
+  The manifest itself is now read once, through the snapshot, and parsed from
+  those bytes. `load_manifest_with_positions` otherwise reads it twice — a
+  direct `Path.read_text` for the model, then the snapshot for positions — so a
+  rewrite between the two let the adapters follow one manifest while the plan's
+  config blob attested to another: a receipt could name an entrypoint the scan
+  never opened. The worktree path always passed its captured text for this
+  reason; the committed-tree path and `verification prepare` passed none.
   A committed-tree run therefore has two snapshots alive, and each external
   input must belong to exactly one of them: the worktree snapshot binds the
   baseline, policy packs, and comparison report *before* the archived scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,46 @@
   its supporting scan in a temporary directory, preserving both the current
   report and forensic verifier evidence.
 
+- **`input_set_id` now covers every input an adapter is configured to read.**
+  ([#299](https://github.com/ThreeMoonsLab/agents-shipgate/issues/299))
+  `input_set_id` is the identity `verification-plan.json`,
+  `verification-unit-result.json`, `verify-run.json`, the terminal receipt, and
+  attestations all rest on, and its whole claim is that two runs sharing it read
+  the same bytes. Two producers broke that claim. The manifest-derived branch of
+  `build_verification_plan` walked only `tool_sources`, so
+  `openai_api.prompt_files` — and every other framework block that names paths:
+  `anthropic`, `google_adk`, `langchain`, `crewai`, `n8n`, `codex_plugins`,
+  `validation.evidence`, `checks.policy_packs`, `agent.sdk.entrypoint` — never
+  became a plan blob. Rewriting a prompt to say refunds need no approval left
+  `input_set_id` byte-identical. Worse, the *observed* branch was inert on the
+  committed-tree path: `verify --base X --head Y` evaluates an archived copy of
+  the head tree, while the static-input snapshot that records adapter reads is
+  bound to the worktree, so it captured nothing and the run emitted
+  `tool_sources: []`. On the CI path — where the receipt is the artifact anyone
+  downstream actually trusts — *no* declared input reached the request identity,
+  not even the MCP exports and OpenAPI specs the earlier fallback would have
+  caught. The two modes now agree: a committed-tree run enumerates the
+  manifest's declared inputs against the tree it actually scanned, and both
+  branches share one exclusion set so an input already hashed as a changed file
+  is not hashed twice. `verify` against a worktree is unchanged — read-boundary
+  capture already covered it, which is why the regression tests drive
+  `verification prepare` and the committed-tree path instead.
+  The declared-path table is derived from the manifest models rather than
+  hand-kept, so a new artifact list on an existing block, or a whole new
+  framework block, is covered without editing the enumeration. No schema
+  changes: `plan.inputs.tool_sources` gains entries, not fields. Existing
+  `input_set_id` and `request_id` values do move for manifests that declare
+  framework inputs or that were verified with `--head` — which is the point, and
+  means a receipt minted before this change cannot be compared by ID against one
+  minted after. One new way to fail: a declared input that resolves outside the
+  verification input root cannot be hashed portably, so it is now rejected
+  rather than dropped. `resolve_input_path` already rejected the same
+  declaration the moment an adapter read it, so this only reaches manifests
+  naming an out-of-root path nothing loads yet — most plausibly an
+  `agent.sdk.entrypoint` with no `openai_agents_sdk` tool source. It routes as
+  an input error (exit 3) with the path named. `verification prepare` routes
+  input errors at all now, instead of printing a traceback.
+
 - **`SHIP-VERIFY-POLICY-WEAKENED` can now actually see a weakened CI gate.**
   The `effective_policy` snapshot was built from the manifest *after* CLI
   overrides were folded into it, so it described the invocation rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,10 +151,14 @@
   Two behavior changes worth knowing. `verification prepare` reads inputs now,
   so it fails on a manifest whose inputs cannot be loaded; that is the same
   condition under which `verify` fails, and exactly when a prepared plan could
-  not honestly claim an input set. It also routes its errors (exit 2/3, with the
-  agent-mode `next_action`/`next_actions` envelope) instead of printing a
-  traceback. And the declared-path fallback rejects a path resolving outside the
-  verification input root, since it cannot be hashed portably.
+  not honestly claim an input set. It also routes its errors instead of printing
+  a traceback, through the shared diagnostic catalog rather than a local guess:
+  an absent manifest gets the setup route (`config_error`, exit 2, the same
+  answer `scan` gives), an unparseable one gets the edit route, and an input
+  that moved mid-run gets `input_parse_error`, exit 3 — the distinction matters
+  because agents branch on it. And the declared-path fallback rejects a path
+  resolving outside the verification input root, since it cannot be hashed
+  portably.
   No schema changes: `plan.inputs.tool_sources` gains entries, not fields.
   Existing `input_set_id` and `request_id` values do move — which is the point,
   and means a receipt minted before this change cannot be compared by ID against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,12 +87,12 @@
   its supporting scan in a temporary directory, preserving both the current
   report and forensic verifier evidence.
 
-- **`input_set_id` now covers every input an adapter is configured to read.**
+- **`input_set_id` now covers every input the adapters actually read.**
   ([#299](https://github.com/ThreeMoonsLab/agents-shipgate/issues/299))
   `input_set_id` is the identity `verification-plan.json`,
   `verification-unit-result.json`, `verify-run.json`, the terminal receipt, and
   attestations all rest on, and its whole claim is that two runs sharing it read
-  the same bytes. Two producers broke that claim. The manifest-derived branch of
+  the same bytes. Three things broke that claim. The manifest-derived branch of
   `build_verification_plan` walked only `tool_sources`, so
   `openai_api.prompt_files` — and every other framework block that names paths:
   `anthropic`, `google_adk`, `langchain`, `crewai`, `n8n`, `codex_plugins`,
@@ -103,29 +103,40 @@
   the head tree, while the static-input snapshot that records adapter reads is
   bound to the worktree, so it captured nothing and the run emitted
   `tool_sources: []`. On the CI path — where the receipt is the artifact anyone
-  downstream actually trusts — *no* declared input reached the request identity,
-  not even the MCP exports and OpenAPI specs the earlier fallback would have
-  caught. The two modes now agree: a committed-tree run enumerates the
-  manifest's declared inputs against the tree it actually scanned, and both
-  branches share one exclusion set so an input already hashed as a changed file
-  is not hashed twice. `verify` against a worktree is unchanged — read-boundary
-  capture already covered it, which is why the regression tests drive
-  `verification prepare` and the committed-tree path instead.
-  The declared-path table is derived from the manifest models rather than
-  hand-kept, so a new artifact list on an existing block, or a whole new
-  framework block, is covered without editing the enumeration. No schema
-  changes: `plan.inputs.tool_sources` gains entries, not fields. Existing
-  `input_set_id` and `request_id` values do move for manifests that declare
-  framework inputs or that were verified with `--head` — which is the point, and
-  means a receipt minted before this change cannot be compared by ID against one
-  minted after. One new way to fail: a declared input that resolves outside the
-  verification input root cannot be hashed portably, so it is now rejected
-  rather than dropped. `resolve_input_path` already rejected the same
-  declaration the moment an adapter read it, so this only reaches manifests
-  naming an out-of-root path nothing loads yet — most plausibly an
-  `agent.sdk.entrypoint` with no `openai_agents_sdk` tool source. It routes as
-  an input error (exit 3) with the path named. `verification prepare` routes
-  input errors at all now, instead of printing a traceback.
+  downstream actually trusts — *no* input reached the request identity at all.
+  And enumerating the manifest, however completely, can never reach an input the
+  manifest does not name: a Google ADK `McpToolset` inventory or an OpenAPI spec
+  constructed inside `agent.py` is discovered while parsing, not declared. Two
+  trees whose MCP inventories differed by a trailing newline produced the same
+  prepared `input_set_id`.
+  Identity is therefore taken at the read boundary, not from declarations. Each
+  producer snapshots the tree it evaluates and records what the adapters open: a
+  committed-tree run is now snapshotted against the archived tree it scans
+  (previously impossible — the snapshot watched the worktree), and
+  `verification prepare` loads sources to record their reads. Committed-tree and
+  worktree runs of the same tree now bind the same set, asserted as an invariant
+  in the suite. Enumerating declared paths survives only as the fallback for a
+  plan built with no snapshot at all; that table is derived from the manifest
+  models rather than hand-kept, so a new artifact list — or a whole new framework
+  block — is covered without editing it.
+  A committed-tree run therefore has two snapshots alive, and each external
+  input must belong to exactly one of them: the worktree snapshot binds the
+  baseline, policy packs, and comparison report *before* the archived scan
+  starts, so its tamper check still covers them — and covers a wider window than
+  before, since it now begins before the scan rather than at the scan's first
+  read. Letting both snapshots watch the same external directory instead makes
+  the second re-validation fail on a change the first legitimately allowed.
+  Two behavior changes worth knowing. `verification prepare` reads inputs now,
+  so it fails on a manifest whose inputs cannot be loaded; that is the same
+  condition under which `verify` fails, and exactly when a prepared plan could
+  not honestly claim an input set. It also routes its errors (exit 2/3, with the
+  agent-mode `next_action`/`next_actions` envelope) instead of printing a
+  traceback. And the declared-path fallback rejects a path resolving outside the
+  verification input root, since it cannot be hashed portably.
+  No schema changes: `plan.inputs.tool_sources` gains entries, not fields.
+  Existing `input_set_id` and `request_id` values do move — which is the point,
+  and means a receipt minted before this change cannot be compared by ID against
+  one minted after.
 
 - **`SHIP-VERIFY-POLICY-WEAKENED` can now actually see a weakened CI gate.**
   The `effective_policy` snapshot was built from the manifest *after* CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,10 +124,16 @@
   the plan from two different instants: a file rewritten in between is attested
   at its new content while `tool_sources` still lists what the old content
   pointed at, so the receipt describes bytes the scan never evaluated. Plan
-  construction now runs under the finalized snapshot on both paths, and the
-  changed files are bound into it as well — `_blobs` skips a path the snapshot
-  contains but never read, so a changed file no adapter opens would otherwise
-  have dropped out of `changed_files`.
+  construction now runs under the finalized snapshot on both paths. That makes
+  binding an obligation rather than an optimization: under an active snapshot
+  both `_blobs` and `_optional_blob` read a path that is *contained but never
+  read* as absent, so an input nobody bound does not merely go unhashed — it
+  disappears from the plan. Every input the plan hashes is therefore bound
+  before the snapshot is sealed: the adapters' own reads, the changed files (a
+  README no adapter opens would otherwise vanish from `changed_files`), and the
+  explicit `--baseline`, `--diff-from`, and policy packs, with the comparison
+  report bound as an external input on a committed-tree preparation because it
+  is never mapped into the evaluated tree.
   A committed-tree run therefore has two snapshots alive, and each external
   input must belong to exactly one of them: the worktree snapshot binds the
   baseline, policy packs, and comparison report *before* the archived scan

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -37,17 +37,27 @@ binds:
   set, plugin distribution set, and policy catalog; and
 - the normalized task list.
 
-"Every input an adapter is configured to read" is `plan.inputs.tool_sources`,
-and it covers more than the `tool_sources` manifest block: `prompt_files`, the
-framework blocks (`openai_api`, `anthropic`, `google_adk`, `langchain`,
-`crewai`, `n8n`, `codex_plugins`), `validation.evidence`,
-`checks.policy_packs`, and `agent.sdk.entrypoint` are all adapter inputs and
-all become blobs. A worktree run records them at the read boundary, so a path
-an adapter discovers is bound even when the manifest does not name it directly.
-A committed-tree run and an unevaluated `verification prepare` plan enumerate
-what the manifest declares instead, resolved against the tree being evaluated.
-Report output directories, `organization.audit.registry` (existence-tested,
-never read), and `baseline.audit_log` are deliberately not inputs.
+"Every input an adapter reads" is `plan.inputs.tool_sources`, and it covers
+more than the `tool_sources` manifest block. `prompt_files`, the framework
+blocks (`openai_api`, `anthropic`, `google_adk`, `langchain`, `crewai`, `n8n`,
+`codex_plugins`), `validation.evidence`, `checks.policy_packs`, and
+`agent.sdk.entrypoint` are all adapter inputs — and so is anything reached
+*through* one of them, such as a Google ADK `McpToolset` inventory or an
+OpenAPI spec named only from Python. Those transitive inputs are invisible to
+the manifest, so identity is taken at the read boundary rather than from
+declarations: each producer snapshots the tree it evaluates and records what
+the adapters open. A worktree run snapshots the worktree; a committed-tree run
+snapshots the archived tree it scans; `verification prepare` loads sources —
+statically, deciding nothing — for the same reason. Report output directories,
+`organization.audit.registry` (existence-tested, never read), and
+`baseline.audit_log` are deliberately not inputs.
+
+Because `prepare` reads inputs, it fails on a manifest whose inputs cannot be
+loaded. That is the same condition under which `verify` fails, and it is
+exactly when a prepared plan could not honestly claim an input set. Enumerating
+the manifest's declared paths remains only as a fallback for a plan built with
+no snapshot at all, and that fallback rejects a declared path resolving outside
+the input root, since it cannot be hashed portably.
 
 Committed snapshots are materialized from Git objects with `git ls-tree` and
 `git cat-file`. They do not use `git archive`, so `.gitattributes`

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -29,13 +29,25 @@ binds:
 
 - resolved base, head, tree, merge-base, and source/evaluated commit facts;
 - an exact committed tree or a hashed working-tree overlay;
-- the manifest, tool sources, policy packs, baseline, comparison report,
-  changed-file content, diff content, evaluation date, and behavior-affecting
-  options;
+- the manifest, every input an adapter is configured to read, policy packs,
+  baseline, comparison report, changed-file content, diff content, evaluation
+  date, and behavior-affecting options;
 - the Agents Shipgate version and installed package-content digest,
   Python/runtime requirements, installed dependency RECORD closure, adapter
   set, plugin distribution set, and policy catalog; and
 - the normalized task list.
+
+"Every input an adapter is configured to read" is `plan.inputs.tool_sources`,
+and it covers more than the `tool_sources` manifest block: `prompt_files`, the
+framework blocks (`openai_api`, `anthropic`, `google_adk`, `langchain`,
+`crewai`, `n8n`, `codex_plugins`), `validation.evidence`,
+`checks.policy_packs`, and `agent.sdk.entrypoint` are all adapter inputs and
+all become blobs. A worktree run records them at the read boundary, so a path
+an adapter discovers is bound even when the manifest does not name it directly.
+A committed-tree run and an unevaluated `verification prepare` plan enumerate
+what the manifest declares instead, resolved against the tree being evaluated.
+Report output directories, `organization.audit.registry` (existence-tested,
+never read), and `baseline.audit_log` are deliberately not inputs.
 
 Committed snapshots are materialized from Git objects with `git ls-tree` and
 `git cat-file`. They do not use `git archive`, so `.gitattributes`

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -52,6 +52,11 @@ statically, deciding nothing — for the same reason. Report output directories,
 `organization.audit.registry` (existence-tested, never read), and
 `baseline.audit_log` are deliberately not inputs.
 
+The snapshot supplies the hashed bytes as well as the path list. Plan blobs are
+never re-read from disk after capture, so a plan cannot pair a path list taken
+at one instant with content taken at another, and a receipt cannot attest to
+bytes the scan did not evaluate.
+
 Because `prepare` reads inputs, it fails on a manifest whose inputs cannot be
 loaded. That is the same condition under which `verify` fails, and it is
 exactly when a prepared plan could not honestly claim an input set. Enumerating

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -11,7 +11,15 @@ from typing import Any
 
 import typer
 
-from agents_shipgate.cli.agent_mode import emit_agent_mode_error_action
+from agents_shipgate.cli._helpers import (
+    _diagnose_config_error,
+    _echo_next_action_hint,
+)
+from agents_shipgate.cli.agent_mode import (
+    emit_agent_mode_error,
+    emit_agent_mode_error_action,
+)
+from agents_shipgate.cli.diagnostics import top_next_actions
 from agents_shipgate.cli.verify.git import (
     archive_tree,
     commit_date,
@@ -26,6 +34,7 @@ from agents_shipgate.cli.verify.git import (
     validate_source_head_identity,
     working_tree_context,
 )
+from agents_shipgate.config.loader import load_yaml_file
 from agents_shipgate.core.agent_handoff import build_agent_handoff
 from agents_shipgate.core.errors import ConfigError, InputParseError
 from agents_shipgate.core.static_inputs import (
@@ -143,16 +152,25 @@ def prepare(
         raise typer.Exit(3) from exc
     except ConfigError as exc:
         typer.echo(f"Config error: {exc}", err=True)
-        emit_agent_mode_error_action(
+        # Route through the shared diagnostic catalog rather than a local
+        # guess, so a missing manifest gets the setup route, an unparseable one
+        # gets the edit route, and an unresolved adapter gets its own — exactly
+        # as `scan` and `doctor` already answer.
+        actions = top_next_actions(
+            _diagnose_config_error(
+                config=str(config),
+                workspace=workspace,
+                exc=exc,
+                plugins_enabled=False if no_plugins else None,
+            )
+        )
+        _echo_next_action_hint(actions)
+        emit_agent_mode_error(
             "config_error",
-            message=exc,
+            message=str(exc),
             exit_code=2,
-            action=NextAction(
-                kind="edit",
-                path=str(config_relative),
-                why=f"Loader rejected {config_relative.as_posix()}: {exc}",
-                expects="agents-shipgate doctor -c <path> --json runs without raising ConfigError.",
-            ),
+            next_action=actions[0].to_legacy_string(),
+            next_actions=[action.model_dump(mode="json") for action in actions],
         )
         raise typer.Exit(2) from exc
     diff_path = out.with_name("verification-input.diff")
@@ -318,6 +336,14 @@ def _captured_inputs(
     from agents_shipgate.cli.scan.inputs import _load_inputs
     from agents_shipgate.cli.scan.prepare import _prepare_scan
 
+    if not config_path.exists():
+        # A manifest that is not there is a configuration problem with its own
+        # published route, not an input that moved mid-run. Resolve it before
+        # the capture below, which would otherwise recast the
+        # FileNotFoundError as "inputs changed while they were being read" and
+        # send an agent to the wrong recovery. Delegating to the loader keeps
+        # the message and its `init` hint in one place.
+        load_yaml_file(config_path)
     resolved_root = input_root.resolve()
     # A plan input outside the evaluated root — the comparison report on a
     # committed-tree preparation — has to be declared external or the snapshot

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -59,6 +61,9 @@ from agents_shipgate.schemas.verify_run import (
 )
 
 verification_app = typer.Typer(no_args_is_help=True)
+
+#: Matches the verifier's worktree changed-file ceiling.
+_MAX_CHANGED_FILE_BYTES = 64 * 1024 * 1024
 
 
 @verification_app.command("prepare")
@@ -190,70 +195,77 @@ def _build_plan(
         "plugins_enabled": not no_plugins,
     }
     if head is None:
-        return build_verification_plan(
-            git_root=root,
-            input_root=root,
+        with _captured_inputs(
             config_path=root / config_relative,
-            config_logical_path=config_relative.as_posix(),
-            base_ref=base,
-            head_ref=head_ref,
-            archived_head=False,
-            source_head_commit_sha=None,
-            **git_identity,
-            changed_files=changed,
-            diff_text=diff_text,
-            baseline_path=baseline_path,
-            diff_from_path=diff_from_path,
+            input_root=root,
             policy_pack_paths=policy_paths,
-            evaluation_date=resolved_date,
-            options=options,
             plugins_enabled=False if no_plugins else None,
-            captured_input_paths=_captured_input_paths(
-                config_path=root / config_relative,
+            changed_files=changed,
+        ) as captured:
+            return build_verification_plan(
+                git_root=root,
                 input_root=root,
+                config_path=root / config_relative,
+                config_logical_path=config_relative.as_posix(),
+                base_ref=base,
+                head_ref=head_ref,
+                archived_head=False,
+                source_head_commit_sha=None,
+                **git_identity,
+                changed_files=changed,
+                diff_text=diff_text,
+                baseline_path=baseline_path,
+                diff_from_path=diff_from_path,
                 policy_pack_paths=policy_paths,
+                evaluation_date=resolved_date,
+                options=options,
                 plugins_enabled=False if no_plugins else None,
-            ),
-        )
+                captured_input_paths=captured,
+            )
     source_identity = resolve_source_head_identity(root, head_ref=head_ref)
     with tempfile.TemporaryDirectory(prefix="agents-shipgate-plan-") as tmp:
         snapshot = Path(tmp) / "snapshot"
         archive_tree(root, head_ref, snapshot)
-        return build_verification_plan(
-            git_root=root,
-            input_root=snapshot,
+        mapped_policy_paths = [_map(snapshot, root, path) for path in policy_paths]
+        with _captured_inputs(
             config_path=snapshot / config_relative,
-            config_logical_path=config_relative.as_posix(),
-            base_ref=base,
-            head_ref=head_ref,
-            archived_head=True,
-            source_head_commit_sha=source_identity.source_head_commit_sha,
-            **git_identity,
-            changed_files=changed,
-            diff_text=diff_text,
-            baseline_path=_map(snapshot, root, baseline_path),
-            diff_from_path=diff_from_path,
-            policy_pack_paths=[_map(snapshot, root, path) for path in policy_paths],
-            evaluation_date=resolved_date,
-            options=options,
-            captured_input_paths=_captured_input_paths(
-                config_path=snapshot / config_relative,
-                input_root=snapshot,
-                policy_pack_paths=[_map(snapshot, root, path) for path in policy_paths],
-                plugins_enabled=False if no_plugins else None,
-            ),
+            input_root=snapshot,
+            policy_pack_paths=mapped_policy_paths,
             plugins_enabled=False if no_plugins else None,
-        )
+            changed_files=changed,
+        ) as captured:
+            return build_verification_plan(
+                git_root=root,
+                input_root=snapshot,
+                config_path=snapshot / config_relative,
+                config_logical_path=config_relative.as_posix(),
+                base_ref=base,
+                head_ref=head_ref,
+                archived_head=True,
+                source_head_commit_sha=source_identity.source_head_commit_sha,
+                **git_identity,
+                changed_files=changed,
+                diff_text=diff_text,
+                baseline_path=_map(snapshot, root, baseline_path),
+                diff_from_path=diff_from_path,
+                policy_pack_paths=mapped_policy_paths,
+                evaluation_date=resolved_date,
+                options=options,
+                captured_input_paths=captured,
+                plugins_enabled=False if no_plugins else None,
+            )
 
 
-def _captured_input_paths(
+@contextlib.contextmanager
+def _captured_inputs(
     *,
     config_path: Path,
     input_root: Path,
     policy_pack_paths: list[Path],
     plugins_enabled: bool | None,
-) -> list[Path]:
-    """Record which files the adapters actually open for this manifest.
+    changed_files: list[str],
+) -> Iterator[list[Path]]:
+    """Yield the paths the adapters opened, with their bytes still bound.
 
     Enumerating the manifest reaches only what it names. An input discovered
     while parsing something the manifest names — a Google ADK ``McpToolset``
@@ -262,6 +274,12 @@ def _captured_input_paths(
     byte-identical across two trees whose adapters read different bytes.
     Only the read boundary sees those, and it is the same boundary ``verify``
     binds its receipt to.
+
+    The snapshot stays active for the caller's plan construction. Handing back
+    a path list and letting the builder reopen the files would take the paths
+    and their hashes from two different instants: a file rewritten in between
+    would be attested at its new content while the path list still describes
+    what the old content pointed at.
 
     ``prepare`` still evaluates no policy: source loading is static, local,
     network-free, and decision-free, and the scan phases after it make no
@@ -277,34 +295,43 @@ def _captured_input_paths(
     snapshot = StaticInputSnapshot(resolved_root)
     token = activate_static_input_snapshot(snapshot)
     try:
-        resolved = _prepare_scan(
-            config_path=config_path,
-            ci_mode=None,
-            fail_on=None,
-            output_dir=None,
-            formats=None,
-            packet_enabled=None,
-            packet_formats=None,
-            baseline_mode="new-findings",
-        )
-        _load_inputs(
-            manifest=resolved.manifest,
-            base_dir=resolved.base_dir,
-            config_path=config_path,
-            policy_pack_paths=policy_pack_paths,
-            verbose=False,
-            plugins_enabled=plugins_enabled,
-        )
-        snapshot.finish()
-    except (OSError, ValueError) as exc:
-        raise InputParseError(
-            f"Verification inputs changed while they were being read: {exc}"
-        ) from exc
+        try:
+            resolved = _prepare_scan(
+                config_path=config_path,
+                ci_mode=None,
+                fail_on=None,
+                output_dir=None,
+                formats=None,
+                packet_enabled=None,
+                packet_formats=None,
+                baseline_mode="new-findings",
+            )
+            _load_inputs(
+                manifest=resolved.manifest,
+                base_dir=resolved.base_dir,
+                config_path=config_path,
+                policy_pack_paths=policy_pack_paths,
+                verbose=False,
+                plugins_enabled=plugins_enabled,
+            )
+            # Bind changed files too: plan construction runs under this
+            # snapshot, and ``_blobs`` drops a path it contains but never read,
+            # so a changed file no adapter opens would vanish from
+            # ``changed_files``.
+            for relative in changed_files:
+                candidate = resolved_root / relative
+                if candidate.is_file() and not candidate.is_symlink():
+                    snapshot.read_bytes(candidate, max_bytes=_MAX_CHANGED_FILE_BYTES)
+            snapshot.finish()
+        except (OSError, ValueError) as exc:
+            raise InputParseError(
+                f"Verification inputs changed while they were being read: {exc}"
+            ) from exc
+        # Blob paths are logical and relative to the input root, so a read
+        # outside it cannot become one.
+        yield [path for path in snapshot.paths() if resolved_root in path.parents]
     finally:
         reset_static_input_snapshot(token)
-    # Blob paths are logical and relative to the input root, so a read outside
-    # it cannot become one.
-    return [path for path in snapshot.paths() if resolved_root in path.parents]
 
 
 @verification_app.command("worker")

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import typer
 
+from agents_shipgate.cli.agent_mode import emit_agent_mode_error_action
 from agents_shipgate.cli.verify.git import (
     archive_tree,
     commit_date,
@@ -25,6 +26,11 @@ from agents_shipgate.cli.verify.git import (
 )
 from agents_shipgate.core.agent_handoff import build_agent_handoff
 from agents_shipgate.core.errors import ConfigError, InputParseError
+from agents_shipgate.core.static_inputs import (
+    StaticInputSnapshot,
+    activate_static_input_snapshot,
+    reset_static_input_snapshot,
+)
 from agents_shipgate.core.verification_identity import (
     build_executor,
     build_terminal_receipt,
@@ -37,6 +43,7 @@ from agents_shipgate.core.verification_identity import (
 )
 from agents_shipgate.packet.json_packet import load_packet_json, write_packet_json
 from agents_shipgate.report.json_report import report_json_payload
+from agents_shipgate.schemas.diagnostics import NextAction
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.verification_identity import (
     VerificationPlan,
@@ -89,9 +96,9 @@ def prepare(
     diff_from_path = _under(root, diff_from) if diff_from is not None else None
     git_identity = _git_identity(root, base, head_ref)
 
-    # A manifest that declares an input the plan cannot bind is the caller's to
-    # fix, so route it as an input failure instead of surfacing a traceback out
-    # of the identity builder.
+    # A manifest whose inputs cannot be read, or that declares one the plan
+    # cannot bind, is the caller's to fix — route it like every other input
+    # failure instead of surfacing a traceback out of the identity builder.
     try:
         plan = _build_plan(
             root=root,
@@ -112,7 +119,36 @@ def prepare(
         )
     except InputParseError as exc:
         typer.echo(f"Input parsing error: {exc}", err=True)
+        emit_agent_mode_error_action(
+            "input_parse_error",
+            message=exc,
+            exit_code=3,
+            action=NextAction(
+                kind="review",
+                why=(
+                    "Inspect the file referenced in the error; ensure it exists, "
+                    "is valid, and resolves under the manifest directory."
+                ),
+                expects=(
+                    "Referenced file is present, parseable, and inside the manifest directory."
+                ),
+            ),
+        )
         raise typer.Exit(3) from exc
+    except ConfigError as exc:
+        typer.echo(f"Config error: {exc}", err=True)
+        emit_agent_mode_error_action(
+            "config_error",
+            message=exc,
+            exit_code=2,
+            action=NextAction(
+                kind="edit",
+                path=str(config_relative),
+                why=f"Loader rejected {config_relative.as_posix()}: {exc}",
+                expects="agents-shipgate doctor -c <path> --json runs without raising ConfigError.",
+            ),
+        )
+        raise typer.Exit(2) from exc
     diff_path = out.with_name("verification-input.diff")
     diff_path.parent.mkdir(parents=True, exist_ok=True)
     diff_path.write_text(diff_text, encoding="utf-8")
@@ -172,6 +208,12 @@ def _build_plan(
             evaluation_date=resolved_date,
             options=options,
             plugins_enabled=False if no_plugins else None,
+            captured_input_paths=_captured_input_paths(
+                config_path=root / config_relative,
+                input_root=root,
+                policy_pack_paths=policy_paths,
+                plugins_enabled=False if no_plugins else None,
+            ),
         )
     source_identity = resolve_source_head_identity(root, head_ref=head_ref)
     with tempfile.TemporaryDirectory(prefix="agents-shipgate-plan-") as tmp:
@@ -194,8 +236,75 @@ def _build_plan(
             policy_pack_paths=[_map(snapshot, root, path) for path in policy_paths],
             evaluation_date=resolved_date,
             options=options,
+            captured_input_paths=_captured_input_paths(
+                config_path=snapshot / config_relative,
+                input_root=snapshot,
+                policy_pack_paths=[_map(snapshot, root, path) for path in policy_paths],
+                plugins_enabled=False if no_plugins else None,
+            ),
             plugins_enabled=False if no_plugins else None,
         )
+
+
+def _captured_input_paths(
+    *,
+    config_path: Path,
+    input_root: Path,
+    policy_pack_paths: list[Path],
+    plugins_enabled: bool | None,
+) -> list[Path]:
+    """Record which files the adapters actually open for this manifest.
+
+    Enumerating the manifest reaches only what it names. An input discovered
+    while parsing something the manifest names — a Google ADK ``McpToolset``
+    inventory, an OpenAPI spec referenced from Python, a sub-agent config —
+    is invisible to that walk, so a plan built from declarations alone can be
+    byte-identical across two trees whose adapters read different bytes.
+    Only the read boundary sees those, and it is the same boundary ``verify``
+    binds its receipt to.
+
+    ``prepare`` still evaluates no policy: source loading is static, local,
+    network-free, and decision-free, and the scan phases after it make no
+    further declared-input reads. It does mean ``prepare`` now fails on a
+    manifest whose inputs cannot be loaded — which is exactly when it cannot
+    honestly claim an input set, and when ``verify`` would fail too.
+    """
+
+    from agents_shipgate.cli.scan.inputs import _load_inputs
+    from agents_shipgate.cli.scan.prepare import _prepare_scan
+
+    resolved_root = input_root.resolve()
+    snapshot = StaticInputSnapshot(resolved_root)
+    token = activate_static_input_snapshot(snapshot)
+    try:
+        resolved = _prepare_scan(
+            config_path=config_path,
+            ci_mode=None,
+            fail_on=None,
+            output_dir=None,
+            formats=None,
+            packet_enabled=None,
+            packet_formats=None,
+            baseline_mode="new-findings",
+        )
+        _load_inputs(
+            manifest=resolved.manifest,
+            base_dir=resolved.base_dir,
+            config_path=config_path,
+            policy_pack_paths=policy_pack_paths,
+            verbose=False,
+            plugins_enabled=plugins_enabled,
+        )
+        snapshot.finish()
+    except (OSError, ValueError) as exc:
+        raise InputParseError(
+            f"Verification inputs changed while they were being read: {exc}"
+        ) from exc
+    finally:
+        reset_static_input_snapshot(token)
+    # Blob paths are logical and relative to the input root, so a read outside
+    # it cannot become one.
+    return [path for path in snapshot.paths() if resolved_root in path.parents]
 
 
 @verification_app.command("worker")

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -156,10 +156,17 @@ def prepare(
         # guess, so a missing manifest gets the setup route, an unparseable one
         # gets the edit route, and an unresolved adapter gets its own — exactly
         # as `scan` and `doctor` already answer.
+        #
+        # Diagnose the exact manifest this invocation asked for. Passing a
+        # workspace instead makes the catalog discover every `shipgate.yaml`
+        # beneath it and describe the first one that happens to parse, so a
+        # monorepo — or any `--config` naming a file that is not there — would
+        # be told to edit an unrelated, perfectly valid manifest. `prepare`
+        # always resolves one exact path, so there is nothing to discover.
         actions = top_next_actions(
             _diagnose_config_error(
-                config=str(config),
-                workspace=workspace,
+                config=str(root / config_relative),
+                workspace=None,
                 exc=exc,
                 plugins_enabled=False if no_plugins else None,
             )

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -31,6 +31,7 @@ from agents_shipgate.core.errors import ConfigError, InputParseError
 from agents_shipgate.core.static_inputs import (
     StaticInputSnapshot,
     activate_static_input_snapshot,
+    read_static_input_text,
     reset_static_input_snapshot,
 )
 from agents_shipgate.core.verification_identity import (
@@ -332,6 +333,11 @@ def _captured_inputs(
     token = activate_static_input_snapshot(snapshot)
     try:
         try:
+            # Read the manifest once, through the snapshot, and parse from those
+            # exact bytes. `load_manifest_with_positions` otherwise reads it
+            # twice — a direct `Path.read_text` for the model, then the snapshot
+            # for positions — so a rewrite between the two would let the
+            # adapters follow one manifest while the plan hashes the other.
             resolved = _prepare_scan(
                 config_path=config_path,
                 ci_mode=None,
@@ -341,6 +347,10 @@ def _captured_inputs(
                 packet_enabled=None,
                 packet_formats=None,
                 baseline_mode="new-findings",
+                manifest_text=read_static_input_text(
+                    config_path,
+                    max_bytes=_MAX_CHANGED_FILE_BYTES,
+                ),
             )
             _load_inputs(
                 manifest=resolved.manifest,

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -201,6 +201,11 @@ def _build_plan(
             policy_pack_paths=policy_paths,
             plugins_enabled=False if no_plugins else None,
             changed_files=changed,
+            plan_inputs=[
+                path
+                for path in (baseline_path, diff_from_path, *policy_paths)
+                if path is not None
+            ],
         ) as captured:
             return build_verification_plan(
                 git_root=root,
@@ -226,13 +231,26 @@ def _build_plan(
     with tempfile.TemporaryDirectory(prefix="agents-shipgate-plan-") as tmp:
         snapshot = Path(tmp) / "snapshot"
         archive_tree(root, head_ref, snapshot)
+        # Resolve once the tree exists. The snapshot matches paths lexically, and
+        # on macOS the temporary directory is reached through /var while every
+        # path derived below resolves to /private/var — leaving them in two
+        # spellings makes `contains()` false for inputs that are plainly inside.
+        snapshot = snapshot.resolve()
         mapped_policy_paths = [_map(snapshot, root, path) for path in policy_paths]
+        mapped_baseline_path = _map(snapshot, root, baseline_path)
         with _captured_inputs(
             config_path=snapshot / config_relative,
             input_root=snapshot,
             policy_pack_paths=mapped_policy_paths,
             plugins_enabled=False if no_plugins else None,
             changed_files=changed,
+            # The comparison report is never mapped into the tree, so it stays
+            # outside the evaluated root and must be bound as an external input.
+            plan_inputs=[
+                path
+                for path in (mapped_baseline_path, diff_from_path, *mapped_policy_paths)
+                if path is not None
+            ],
         ) as captured:
             return build_verification_plan(
                 git_root=root,
@@ -246,7 +264,7 @@ def _build_plan(
                 **git_identity,
                 changed_files=changed,
                 diff_text=diff_text,
-                baseline_path=_map(snapshot, root, baseline_path),
+                baseline_path=mapped_baseline_path,
                 diff_from_path=diff_from_path,
                 policy_pack_paths=mapped_policy_paths,
                 evaluation_date=resolved_date,
@@ -264,6 +282,7 @@ def _captured_inputs(
     policy_pack_paths: list[Path],
     plugins_enabled: bool | None,
     changed_files: list[str],
+    plan_inputs: list[Path],
 ) -> Iterator[list[Path]]:
     """Yield the paths the adapters opened, with their bytes still bound.
 
@@ -281,6 +300,13 @@ def _captured_inputs(
     would be attested at its new content while the path list still describes
     what the old content pointed at.
 
+    That makes binding an obligation rather than an optimization. Under an
+    active snapshot both ``_blobs`` and ``_optional_blob`` read a path that is
+    *contained but never read* as absent, so every input the plan will hash has
+    to be bound here — ``plan_inputs`` (the baseline, comparison report, and
+    policy packs) and the changed files as well as whatever the adapters open.
+    Miss one and it does not merely go unbound: it disappears from the plan.
+
     ``prepare`` still evaluates no policy: source loading is static, local,
     network-free, and decision-free, and the scan phases after it make no
     further declared-input reads. It does mean ``prepare`` now fails on a
@@ -292,7 +318,17 @@ def _captured_inputs(
     from agents_shipgate.cli.scan.prepare import _prepare_scan
 
     resolved_root = input_root.resolve()
-    snapshot = StaticInputSnapshot(resolved_root)
+    # A plan input outside the evaluated root — the comparison report on a
+    # committed-tree preparation — has to be declared external or the snapshot
+    # refuses to read it at all.
+    snapshot = StaticInputSnapshot(
+        resolved_root,
+        external_paths=[
+            path
+            for path in plan_inputs
+            if resolved_root not in path.resolve().parents
+        ],
+    )
     token = activate_static_input_snapshot(snapshot)
     try:
         try:
@@ -314,13 +350,16 @@ def _captured_inputs(
                 verbose=False,
                 plugins_enabled=plugins_enabled,
             )
-            # Bind changed files too: plan construction runs under this
-            # snapshot, and ``_blobs`` drops a path it contains but never read,
-            # so a changed file no adapter opens would vanish from
-            # ``changed_files``.
-            for relative in changed_files:
-                candidate = resolved_root / relative
-                if candidate.is_file() and not candidate.is_symlink():
+            for candidate in (
+                *plan_inputs,
+                *(resolved_root / relative for relative in changed_files),
+            ):
+                if (
+                    candidate.is_file()
+                    and not candidate.is_symlink()
+                    and snapshot.contains(candidate)
+                    and not snapshot.has(candidate)
+                ):
                     snapshot.read_bytes(candidate, max_bytes=_MAX_CHANGED_FILE_BYTES)
             snapshot.finish()
         except (OSError, ValueError) as exc:

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -89,8 +89,72 @@ def prepare(
     diff_from_path = _under(root, diff_from) if diff_from is not None else None
     git_identity = _git_identity(root, base, head_ref)
 
+    # A manifest that declares an input the plan cannot bind is the caller's to
+    # fix, so route it as an input failure instead of surfacing a traceback out
+    # of the identity builder.
+    try:
+        plan = _build_plan(
+            root=root,
+            head=head,
+            head_ref=head_ref,
+            base=base,
+            config_relative=config_relative,
+            baseline_path=baseline_path,
+            diff_from_path=diff_from_path,
+            policy_paths=policy_paths,
+            changed=changed,
+            diff_text=diff_text,
+            resolved_date=resolved_date,
+            git_identity=git_identity,
+            ci_mode=ci_mode,
+            no_plugins=no_plugins,
+            no_heuristics=no_heuristics,
+        )
+    except InputParseError as exc:
+        typer.echo(f"Input parsing error: {exc}", err=True)
+        raise typer.Exit(3) from exc
+    diff_path = out.with_name("verification-input.diff")
+    diff_path.parent.mkdir(parents=True, exist_ok=True)
+    diff_path.write_text(diff_text, encoding="utf-8")
+    _write_model(out, plan)
+    typer.echo(
+        json.dumps(
+            {
+                "request_id": plan.request_id,
+                "plan": str(out),
+                "diff": str(diff_path),
+            }
+        )
+    )
+
+
+def _build_plan(
+    *,
+    root: Path,
+    head: str | None,
+    head_ref: str,
+    base: str | None,
+    config_relative: Path,
+    baseline_path: Path | None,
+    diff_from_path: Path | None,
+    policy_paths: list[Path],
+    changed: list[str],
+    diff_text: str,
+    resolved_date: str,
+    git_identity: dict[str, str | None],
+    ci_mode: str,
+    no_plugins: bool,
+    no_heuristics: bool,
+) -> VerificationPlan:
+    """Build the worktree or committed-tree plan for ``prepare``."""
+
+    options = {
+        "ci_mode": ci_mode,
+        "no_heuristics": no_heuristics,
+        "plugins_enabled": not no_plugins,
+    }
     if head is None:
-        plan = build_verification_plan(
+        return build_verification_plan(
             git_root=root,
             input_root=root,
             config_path=root / config_relative,
@@ -106,57 +170,32 @@ def prepare(
             diff_from_path=diff_from_path,
             policy_pack_paths=policy_paths,
             evaluation_date=resolved_date,
-            options={
-                "ci_mode": ci_mode,
-                "no_heuristics": no_heuristics,
-                "plugins_enabled": not no_plugins,
-            },
+            options=options,
             plugins_enabled=False if no_plugins else None,
         )
-    else:
-        source_identity = resolve_source_head_identity(
-            root,
+    source_identity = resolve_source_head_identity(root, head_ref=head_ref)
+    with tempfile.TemporaryDirectory(prefix="agents-shipgate-plan-") as tmp:
+        snapshot = Path(tmp) / "snapshot"
+        archive_tree(root, head_ref, snapshot)
+        return build_verification_plan(
+            git_root=root,
+            input_root=snapshot,
+            config_path=snapshot / config_relative,
+            config_logical_path=config_relative.as_posix(),
+            base_ref=base,
             head_ref=head_ref,
+            archived_head=True,
+            source_head_commit_sha=source_identity.source_head_commit_sha,
+            **git_identity,
+            changed_files=changed,
+            diff_text=diff_text,
+            baseline_path=_map(snapshot, root, baseline_path),
+            diff_from_path=diff_from_path,
+            policy_pack_paths=[_map(snapshot, root, path) for path in policy_paths],
+            evaluation_date=resolved_date,
+            options=options,
+            plugins_enabled=False if no_plugins else None,
         )
-        with tempfile.TemporaryDirectory(prefix="agents-shipgate-plan-") as tmp:
-            snapshot = Path(tmp) / "snapshot"
-            archive_tree(root, head_ref, snapshot)
-            plan = build_verification_plan(
-                git_root=root,
-                input_root=snapshot,
-                config_path=snapshot / config_relative,
-                config_logical_path=config_relative.as_posix(),
-                base_ref=base,
-                head_ref=head_ref,
-                archived_head=True,
-                source_head_commit_sha=source_identity.source_head_commit_sha,
-                **git_identity,
-                changed_files=changed,
-                diff_text=diff_text,
-                baseline_path=_map(snapshot, root, baseline_path),
-                diff_from_path=diff_from_path,
-                policy_pack_paths=[_map(snapshot, root, path) for path in policy_paths],
-                evaluation_date=resolved_date,
-                options={
-                    "ci_mode": ci_mode,
-                    "no_heuristics": no_heuristics,
-                    "plugins_enabled": not no_plugins,
-                },
-                plugins_enabled=False if no_plugins else None,
-            )
-    diff_path = out.with_name("verification-input.diff")
-    diff_path.parent.mkdir(parents=True, exist_ok=True)
-    diff_path.write_text(diff_text, encoding="utf-8")
-    _write_model(out, plan)
-    typer.echo(
-        json.dumps(
-            {
-                "request_id": plan.request_id,
-                "plan": str(out),
-                "diff": str(diff_path),
-            }
-        )
-    )
 
 
 @verification_app.command("worker")

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -2462,13 +2462,21 @@ def _write_artifacts(
         Path(os.path.abspath(os.path.normpath(os.fspath(path))))
         for path in original_paths
     }
+    # The static-input snapshot is bound to the worktree. A committed-tree run
+    # evaluates an archived copy outside that root, so the snapshot observes
+    # none of the adapter reads and offering its (empty) path set as the
+    # captured input set would silently drop every declared tool source and
+    # framework input from ``input_set_id``. Hand plan construction ``None``
+    # there so it enumerates the manifest's declared inputs against the tree it
+    # actually scanned (issue #299).
+    archived_head = resolved_input_root != git_root.resolve()
     captured_input_paths = (
         [
             path
             for path in active_snapshot.paths()
             if path not in original_static_inputs
         ]
-        if active_snapshot is not None
+        if active_snapshot is not None and not archived_head
         else None
     )
     external_input_root = verifier_path.parent
@@ -2505,7 +2513,6 @@ def _write_artifacts(
     resolved_date = evaluation_date or commit_date(git_root, verifier.head_ref)
     base_commit = commit_sha(git_root, verifier.base_ref) if verifier.base_ref else None
     head_commit = commit_sha(git_root, verifier.head_ref)
-    archived_head = resolved_input_root != git_root.resolve()
     resolved_options = dict(verification_options or {})
     evaluated_hint = resolved_options.pop("evaluated_head_commit_sha", None)
     github_actions = resolved_options.pop("github_actions", False)

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -665,6 +665,7 @@ def run_verify(
     head_tree: str | None = None
     head_snapshot: StaticInputSnapshot | None = None
     head_snapshot_token: Token[StaticInputSnapshot | None] | None = None
+    head_manifest_text: str | None = None
     head_capability_lock: CapabilityLockFileV1 | None = None
     capability_lock_diff: CapabilityLockDiffV1 | None = None
 
@@ -744,6 +745,11 @@ def run_verify(
             head_tmp = tempfile.TemporaryDirectory(prefix="agents-shipgate-verify-head-")
             head_tree_dir = Path(head_tmp.name) / "head"
             archive_tree(git_root, head, head_tree_dir)
+            # Resolve once the tree exists. The snapshot matches paths lexically,
+            # and on macOS the temporary directory is reached through /var while
+            # every adapter resolves its base directory to /private/var — two
+            # spellings make `contains()` false for paths plainly inside it.
+            head_tree_dir = head_tree_dir.resolve()
             head_input_root = head_tree_dir
             head_tree = tree_sha(git_root, head)
             head_config_path = head_tree_dir / config_relative
@@ -773,14 +779,28 @@ def run_verify(
             # actually being evaluated, so an input discovered while parsing an
             # entrypoint — an ADK McpToolset inventory, an OpenAPI spec named
             # only from Python — reaches `input_set_id` here exactly as it
-            # already does for a worktree run. Resolve the root: on macOS the
-            # temporary directory is reached through /var, and every adapter
-            # resolves its base directory, so an unresolved root would make
-            # `contains()` false for every path under it.
+            # already does for a worktree run.
             head_snapshot = StaticInputSnapshot(
-                head_tree_dir.resolve(),
+                head_tree_dir,
                 excluded_paths=[out_dir],
             )
+            # Read the manifest once, here, and hand those exact bytes to the
+            # scan. `load_manifest_with_positions` otherwise parses it twice —
+            # first through a direct `Path.read_text`, only then through the
+            # snapshot for positions — so a rewrite between the two would let
+            # the scan follow one manifest while the plan hashes the other.
+            # The worktree path has always passed its captured text for this
+            # reason; the archived path passed None.
+            try:
+                head_manifest_text = head_snapshot.read_bytes(
+                    head_config_path,
+                    max_bytes=MAX_WORKTREE_CHANGED_FILE_BYTES,
+                ).decode("utf-8")
+            except (OSError, ValueError, UnicodeDecodeError) as exc:
+                raise ConfigError(
+                    f"Head manifest {config_relative.as_posix()} could not be "
+                    f"captured for verification: {exc}"
+                ) from exc
             # Externally supplied inputs keep their worktree location even for a
             # committed-tree run — `_map_optional_tree_path` only rewrites paths
             # under the repository — so the scan below reads them from outside
@@ -803,7 +823,7 @@ def run_verify(
             # worktree preload above.
             _bind_changed_files(
                 head_snapshot,
-                root=head_tree_dir.resolve(),
+                root=head_tree_dir,
                 relative_paths=changed_files,
             )
         with use_evaluation_date(date.fromisoformat(verification_date)):
@@ -838,7 +858,9 @@ def run_verify(
                         manifest_introduced=manifest_introduced,
                     ),
                     capability_lock_callback=capture_capability_lock,
-                    manifest_text=worktree_manifest_text if not archive_head else None,
+                    manifest_text=(
+                        head_manifest_text if archive_head else worktree_manifest_text
+                    ),
                 )
             finally:
                 # Deactivated for the rest of the run so the worktree snapshot

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -692,32 +692,11 @@ def run_verify(
             config_path,
             worktree_manifest_text.encode("utf-8"),
         )
-        for relative in changed_files:
-            candidate = Path(
-                os.path.abspath(
-                    os.path.normpath(os.fspath(git_root / relative))
-                )
-            )
-            try:
-                metadata = candidate.lstat()
-            except FileNotFoundError:
-                continue
-            except OSError as exc:
-                raise ConfigError(
-                    f"Changed worktree input {relative!r} could not be inspected: {exc}"
-                ) from exc
-            if not stat.S_ISREG(metadata.st_mode):
-                continue
-            try:
-                static_snapshot.read_bytes(
-                    candidate,
-                    max_bytes=MAX_WORKTREE_CHANGED_FILE_BYTES,
-                )
-            except (OSError, ValueError) as exc:
-                raise ConfigError(
-                    f"Changed worktree input {relative!r} could not be captured "
-                    f"for verification: {exc}"
-                ) from exc
+        _bind_changed_files(
+            static_snapshot,
+            root=git_root,
+            relative_paths=changed_files,
+        )
     static_snapshot_token = activate_static_input_snapshot(static_snapshot)
 
     try:
@@ -817,6 +796,16 @@ def run_verify(
                     and not static_snapshot.has(path)
                 ):
                     static_snapshot.read_bytes(path, max_bytes=64 * 1024 * 1024)
+            # Bind the changed files too. Plan construction runs under this
+            # snapshot, and ``_blobs`` drops a path it contains but never read —
+            # so a changed file the adapters do not open (a README, an unrelated
+            # module) would silently vanish from ``changed_files``. Mirrors the
+            # worktree preload above.
+            _bind_changed_files(
+                head_snapshot,
+                root=head_tree_dir.resolve(),
+                relative_paths=changed_files,
+            )
         with use_evaluation_date(date.fromisoformat(verification_date)):
             head_snapshot_token = (
                 activate_static_input_snapshot(head_snapshot)
@@ -852,9 +841,10 @@ def run_verify(
                     manifest_text=worktree_manifest_text if not archive_head else None,
                 )
             finally:
-                # Plan construction hashes the archived files directly, so the
-                # snapshot is not left active past the scan; it is the record of
-                # which paths were read, not the reader for the receipt.
+                # Deactivated for the rest of the run so the worktree snapshot
+                # is restored for the externally supplied inputs it owns. It is
+                # re-activated for plan construction, which must hash the bytes
+                # captured here rather than reopen the files.
                 if head_snapshot_token is not None:
                     reset_static_input_snapshot(head_snapshot_token)
         head_exit_code = _apply_strict_plugins(
@@ -1276,6 +1266,40 @@ def _safe_mtime(path: Path) -> float:
         return path.stat().st_mtime
     except OSError:
         return 0.0
+
+
+def _bind_changed_files(
+    snapshot: StaticInputSnapshot,
+    *,
+    root: Path,
+    relative_paths: list[str],
+) -> None:
+    """Bind every changed file's bytes to ``snapshot`` before it is sealed.
+
+    Plan construction runs under the snapshot, and ``_blobs`` skips a path the
+    snapshot contains but never read. Without this a changed file no adapter
+    opens would drop out of ``changed_files`` entirely.
+    """
+
+    for relative in relative_paths:
+        candidate = Path(os.path.abspath(os.path.normpath(os.fspath(root / relative))))
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ConfigError(
+                f"Changed worktree input {relative!r} could not be inspected: {exc}"
+            ) from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            continue
+        try:
+            snapshot.read_bytes(candidate, max_bytes=MAX_WORKTREE_CHANGED_FILE_BYTES)
+        except (OSError, ValueError) as exc:
+            raise ConfigError(
+                f"Changed worktree input {relative!r} could not be captured "
+                f"for verification: {exc}"
+            ) from exc
 
 
 def _map_policy_packs(
@@ -2596,44 +2620,60 @@ def _write_artifacts(
                 "source_head_relation": source_identity.relation,
             }
         )
-    plan = build_verification_plan(
-        git_root=git_root,
-        input_root=resolved_input_root,
-        config_path=config_path,
-        config_logical_path=logical_config,
-        base_ref=verifier.base_ref,
-        head_ref=verifier.head_ref,
-        archived_head=archived_head,
-        repository_id=repository_identity(git_root),
-        base_commit_sha=base_commit,
-        base_tree_sha=(
-            tree_sha(git_root, verifier.base_ref) if verifier.base_ref and base_commit else None
-        ),
-        source_head_commit_sha=source_head_commit,
-        head_commit_sha=head_commit,
-        head_tree_sha=(tree_sha(git_root, verifier.head_ref) if head_commit else None),
-        merge_base_sha=(
-            merge_base_sha(git_root, verifier.base_ref, verifier.head_ref)
-            if verifier.base_ref and base_commit
-            else None
-        ),
-        changed_files=verifier.changed_files,
-        diff_text=diff_text,
-        baseline_path=portable_baseline_path,
-        diff_from_path=portable_diff_from_path,
-        policy_pack_paths=portable_policy_pack_paths,
-        evaluation_date=resolved_date,
-        options={
-            "ci_mode": verifier.mode,
-            "fail_on": sorted(fail_on or []),
-            "no_heuristics": no_heuristics,
-            "plugins_enabled": plugins_enabled is not False,
-            **resolved_options,
-        },
-        plugins_enabled=plugins_enabled,
-        external_input_root=external_input_root,
-        captured_input_paths=captured_input_paths,
+    # Hash the bytes the adapters read, not whatever is on disk now. Without
+    # this the plan's path list and its blob hashes come from two different
+    # instants, so a file rewritten after the scan is attested at its new
+    # content while ``tool_sources`` still lists what the old content pointed
+    # at — a receipt for bytes the report never evaluated.
+    plan_snapshot_token = (
+        activate_static_input_snapshot(evaluated_snapshot)
+        if evaluated_snapshot is not None and evaluated_snapshot is not active_snapshot
+        else None
     )
+    try:
+        plan = build_verification_plan(
+            git_root=git_root,
+            input_root=resolved_input_root,
+            config_path=config_path,
+            config_logical_path=logical_config,
+            base_ref=verifier.base_ref,
+            head_ref=verifier.head_ref,
+            archived_head=archived_head,
+            repository_id=repository_identity(git_root),
+            base_commit_sha=base_commit,
+            base_tree_sha=(
+                tree_sha(git_root, verifier.base_ref)
+                if verifier.base_ref and base_commit
+                else None
+            ),
+            source_head_commit_sha=source_head_commit,
+            head_commit_sha=head_commit,
+            head_tree_sha=(tree_sha(git_root, verifier.head_ref) if head_commit else None),
+            merge_base_sha=(
+                merge_base_sha(git_root, verifier.base_ref, verifier.head_ref)
+                if verifier.base_ref and base_commit
+                else None
+            ),
+            changed_files=verifier.changed_files,
+            diff_text=diff_text,
+            baseline_path=portable_baseline_path,
+            diff_from_path=portable_diff_from_path,
+            policy_pack_paths=portable_policy_pack_paths,
+            evaluation_date=resolved_date,
+            options={
+                "ci_mode": verifier.mode,
+                "fail_on": sorted(fail_on or []),
+                "no_heuristics": no_heuristics,
+                "plugins_enabled": plugins_enabled is not False,
+                **resolved_options,
+            },
+            plugins_enabled=plugins_enabled,
+            external_input_root=external_input_root,
+            captured_input_paths=captured_input_paths,
+        )
+    finally:
+        if plan_snapshot_token is not None:
+            reset_static_input_snapshot(plan_snapshot_token)
     plan_path = verifier_path.with_name("verification-plan.json")
     diff_input_path = verifier_path.with_name("verification-input.diff")
     diff_input_path.write_text(diff_text, encoding="utf-8")

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -10,6 +10,7 @@ import shutil
 import stat
 import tempfile
 from collections import Counter
+from contextvars import Token
 from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -662,6 +663,8 @@ def run_verify(
     head_baseline_path = baseline_path
     head_policy_pack_paths = policy_pack_paths
     head_tree: str | None = None
+    head_snapshot: StaticInputSnapshot | None = None
+    head_snapshot_token: Token[StaticInputSnapshot | None] | None = None
     head_capability_lock: CapabilityLockFileV1 | None = None
     capability_lock_diff: CapabilityLockDiffV1 | None = None
 
@@ -785,34 +788,75 @@ def run_verify(
                 tree_dir=head_tree_dir,
                 path=baseline_path,
             )
-        with use_evaluation_date(date.fromisoformat(verification_date)):
-            report, head_exit_code = run_scan(
-                config_path=head_config_path,
-                output_dir=out_dir,
-                formats=HEAD_FORMATS,
-                ci_mode=ci_mode,
-                fail_on=fail_on,
-                baseline_path=head_baseline_path,
-                diff_from_path=base_report,
-                baseline_mode=baseline_mode,
-                policy_pack_paths=head_policy_pack_paths,
-                plugins_enabled=plugins_enabled,
-                verbose=verbose,
-                suggest_patches=suggest_patches,
-                packet_enabled=True,
-                packet_formats=HEAD_PACKET_FORMATS,
-                no_heuristics=no_heuristics,
-                verification_context=VerificationContext(
-                    changed_files=changed_files,
-                    diff_text=diff_text,
-                    diff_text_available=bool(diff_text),
-                    trigger_result=trigger,
-                    configured_manifest_path=config_relative.as_posix(),
-                    manifest_introduced=manifest_introduced,
-                ),
-                capability_lock_callback=capture_capability_lock,
-                manifest_text=worktree_manifest_text if not archive_head else None,
+            # The outer snapshot is bound to the worktree and cannot observe a
+            # read under the archived tree, so a committed-tree scan would
+            # otherwise record no adapter reads at all. Capture against the tree
+            # actually being evaluated, so an input discovered while parsing an
+            # entrypoint — an ADK McpToolset inventory, an OpenAPI spec named
+            # only from Python — reaches `input_set_id` here exactly as it
+            # already does for a worktree run. Resolve the root: on macOS the
+            # temporary directory is reached through /var, and every adapter
+            # resolves its base directory, so an unresolved root would make
+            # `contains()` false for every path under it.
+            head_snapshot = StaticInputSnapshot(
+                head_tree_dir.resolve(),
+                excluded_paths=[out_dir],
             )
+            # Externally supplied inputs keep their worktree location even for a
+            # committed-tree run — `_map_optional_tree_path` only rewrites paths
+            # under the repository — so the scan below reads them from outside
+            # the tree this snapshot watches. Bind their bytes to the worktree
+            # snapshot now, before the scan can observe them, so exactly one
+            # snapshot owns each external input for the whole run: two watchers
+            # would both have to re-validate the same directory, and the second
+            # would fail on any change the first legitimately allowed.
+            for path in external_snapshot_paths:
+                if (
+                    path.is_file()
+                    and static_snapshot.contains(path)
+                    and not static_snapshot.has(path)
+                ):
+                    static_snapshot.read_bytes(path, max_bytes=64 * 1024 * 1024)
+        with use_evaluation_date(date.fromisoformat(verification_date)):
+            head_snapshot_token = (
+                activate_static_input_snapshot(head_snapshot)
+                if head_snapshot is not None
+                else None
+            )
+            try:
+                report, head_exit_code = run_scan(
+                    config_path=head_config_path,
+                    output_dir=out_dir,
+                    formats=HEAD_FORMATS,
+                    ci_mode=ci_mode,
+                    fail_on=fail_on,
+                    baseline_path=head_baseline_path,
+                    diff_from_path=base_report,
+                    baseline_mode=baseline_mode,
+                    policy_pack_paths=head_policy_pack_paths,
+                    plugins_enabled=plugins_enabled,
+                    verbose=verbose,
+                    suggest_patches=suggest_patches,
+                    packet_enabled=True,
+                    packet_formats=HEAD_PACKET_FORMATS,
+                    no_heuristics=no_heuristics,
+                    verification_context=VerificationContext(
+                        changed_files=changed_files,
+                        diff_text=diff_text,
+                        diff_text_available=bool(diff_text),
+                        trigger_result=trigger,
+                        configured_manifest_path=config_relative.as_posix(),
+                        manifest_introduced=manifest_introduced,
+                    ),
+                    capability_lock_callback=capture_capability_lock,
+                    manifest_text=worktree_manifest_text if not archive_head else None,
+                )
+            finally:
+                # Plan construction hashes the archived files directly, so the
+                # snapshot is not left active past the scan; it is the record of
+                # which paths were read, not the reader for the receipt.
+                if head_snapshot_token is not None:
+                    reset_static_input_snapshot(head_snapshot_token)
         head_exit_code = _apply_strict_plugins(
             report, head_exit_code, strict_plugins=strict_plugins
         )
@@ -897,6 +941,7 @@ def run_verify(
                     pr_comment_style=pr_comment_style,
                     capability_lock_diff=capability_lock_diff,
                     input_root=head_input_root,
+                    input_snapshot=head_snapshot,
                     diff_text=diff_text,
                     diff_from_path=base_report,
                     authorization_path=authorization,
@@ -2375,6 +2420,7 @@ def _write_artifacts(
     pr_comment_style: str,
     capability_lock_diff: CapabilityLockDiffV1 | None = None,
     input_root: Path | None = None,
+    input_snapshot: StaticInputSnapshot | None = None,
     diff_text: str = "",
     diff_from_path: Path | None = None,
     authorization_path: Path | None = None,
@@ -2441,42 +2487,51 @@ def _write_artifacts(
         *([baseline_path] if baseline_path is not None else []),
         *([diff_from_path] if diff_from_path is not None else []),
     ]
-    if active_snapshot is not None:
+    def _finalize(snapshot: StaticInputSnapshot | None) -> None:
+        """Seal one snapshot, rejecting any input that moved under it."""
+
+        if snapshot is None:
+            return
         try:
             # Base-report enrichment can be generated after the snapshot was
             # activated. Capture it now, before finalizing directory identity,
             # so plan construction and the receipt consume exactly these bytes.
             for path in original_paths:
-                if (
-                    path.is_file()
-                    and active_snapshot.contains(path)
-                    and not active_snapshot.has(path)
-                ):
-                    active_snapshot.read_bytes(path, max_bytes=64 * 1024 * 1024)
-            active_snapshot.finish()
+                if path.is_file() and snapshot.contains(path) and not snapshot.has(path):
+                    snapshot.read_bytes(path, max_bytes=64 * 1024 * 1024)
+            snapshot.finish()
         except (OSError, ValueError) as exc:
             raise InputParseError(
                 f"Verification inputs changed while they were being evaluated: {exc}"
             ) from exc
+
+    _finalize(active_snapshot)
     original_static_inputs = {
         Path(os.path.abspath(os.path.normpath(os.fspath(path))))
         for path in original_paths
     }
-    # The static-input snapshot is bound to the worktree. A committed-tree run
-    # evaluates an archived copy outside that root, so the snapshot observes
-    # none of the adapter reads and offering its (empty) path set as the
-    # captured input set would silently drop every declared tool source and
-    # framework input from ``input_set_id``. Hand plan construction ``None``
-    # there so it enumerates the manifest's declared inputs against the tree it
-    # actually scanned (issue #299).
+    # Identity must rest on what the adapters actually read, which is the only
+    # account that reaches an input discovered while parsing an entrypoint
+    # rather than named in the manifest. Two snapshots observe two roots: the
+    # outer one is bound to the worktree, and a committed-tree run is observed
+    # by ``input_snapshot``, bound to the archived tree it scanned. Pick the one
+    # that watched the evaluated root; fall back to the manifest's declared
+    # inputs only when neither did (issue #299).
     archived_head = resolved_input_root != git_root.resolve()
+    evaluated_snapshot = input_snapshot if archived_head else active_snapshot
+    if evaluated_snapshot is not active_snapshot:
+        _finalize(evaluated_snapshot)
     captured_input_paths = (
         [
             path
-            for path in active_snapshot.paths()
+            for path in evaluated_snapshot.paths()
+            # Blob paths are logical and relative to the evaluated input root,
+            # so a read outside it cannot become one. In practice this only
+            # drops the externally supplied inputs already bound by name.
             if path not in original_static_inputs
+            and (resolved_input_root in path.parents)
         ]
-        if active_snapshot is not None and not archived_head
+        if evaluated_snapshot is not None
         else None
     )
     external_input_root = verifier_path.parent

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -20,8 +20,12 @@ from packaging.requirements import Requirement
 
 from agents_shipgate import __version__
 from agents_shipgate.checks.registry import _plugins_enabled, check_catalog
+from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.static_inputs import active_static_input_snapshot
 from agents_shipgate.inputs.protocol import REGISTRY
+from agents_shipgate.schemas.manifest.declared_paths import (
+    declared_manifest_input_paths,
+)
 from agents_shipgate.schemas.verification_identity import (
     VerificationArtifactManifest,
     VerificationArtifactRef,
@@ -224,33 +228,38 @@ def build_verification_plan(
         size_bytes=len(diff_bytes),
         source="generated",
     )
-    if captured_input_paths is None:
-        tool_sources = _manifest_tool_source_blobs(
-            config_path=config_path,
-            input_root=input_root,
-            source="git_blob" if archived_head else "worktree",
-        )
-    else:
-        excluded_paths = {
-            Path(os.path.abspath(os.path.normpath(os.fspath(path))))
-            for path in [
-                config_path,
-                *policy_pack_paths,
-                *([baseline_path] if baseline_path is not None else []),
-                *([diff_from_path] if diff_from_path is not None else []),
-                *(git_root / path for path in changed_files),
-            ]
-        }
-        tool_sources = _blobs(
-            [
-                path
-                for path in captured_input_paths
-                if Path(os.path.abspath(os.path.normpath(os.fspath(path))))
-                not in excluded_paths
-            ],
-            root=input_root,
-            source="worktree",
-        )
+    # Changed files are hashed under the root the scan actually read: the
+    # archived tree for a committed snapshot, the worktree otherwise.
+    changed_root = input_root if archived_head else git_root
+    excluded_paths = {
+        _lexical_path(path)
+        for path in [
+            config_path,
+            *policy_pack_paths,
+            *([baseline_path] if baseline_path is not None else []),
+            *([diff_from_path] if diff_from_path is not None else []),
+            *(changed_root / path for path in changed_files),
+        ]
+    }
+    # Prefer what the adapters actually read. Fall back to what the manifest
+    # declares they will read when no read boundary was observed — an unevaluated
+    # plan, or a committed-tree scan the worktree snapshot cannot see. Both
+    # branches must reach every adapter input: a path that lands in neither can
+    # change bytes while ``input_set_id`` stays byte-identical.
+    candidate_input_paths = (
+        _manifest_declared_input_paths(config_path=config_path, input_root=input_root)
+        if captured_input_paths is None
+        else list(captured_input_paths)
+    )
+    tool_sources = _blobs(
+        [
+            path
+            for path in candidate_input_paths
+            if _lexical_path(path) not in excluded_paths
+        ],
+        root=input_root,
+        source="git_blob" if archived_head else "worktree",
+    )
     bundle_root = external_input_root or input_root
     policy_blobs = _blobs(
         policy_pack_paths,
@@ -852,9 +861,15 @@ def validate_plan_inputs(
         raise ValueError("plan diff input size does not match")
 
 
-def _manifest_tool_source_blobs(
-    *, config_path: Path, input_root: Path, source: str
-) -> list[VerificationBlob]:
+def _manifest_declared_input_paths(*, config_path: Path, input_root: Path) -> list[Path]:
+    """Expand every adapter input path the manifest declares, under ``input_root``.
+
+    Covers the framework blocks as well as ``tool_sources`` — ``prompt_files``
+    and the rest of the declared artifact paths are adapter inputs exactly like
+    an MCP export is, and omitting them let a prompt edit leave ``input_set_id``
+    unchanged (issue #299).
+    """
+
     snapshot = active_static_input_snapshot()
     config_text = (
         snapshot.read_bytes(
@@ -864,15 +879,26 @@ def _manifest_tool_source_blobs(
         if snapshot is not None and snapshot.contains(config_path)
         else config_path.read_text(encoding="utf-8")
     )
-    raw = yaml.safe_load(config_text) or {}
-    rows = raw.get("tool_sources") if isinstance(raw, dict) else []
+    try:
+        raw = yaml.safe_load(config_text)
+    except yaml.YAMLError:
+        # An unparseable manifest cannot declare inputs. It fails visibly in
+        # the loader; identity construction must not raise a second, worse
+        # error over the same bytes, which are already hashed as the config blob.
+        return []
+    resolved_root = input_root.resolve()
     paths: list[Path] = []
-    for row in rows or []:
-        if not isinstance(row, dict) or not isinstance(row.get("path"), str):
-            continue
-        candidate = (config_path.parent / row["path"]).resolve()
-        if input_root.resolve() not in candidate.parents and candidate != input_root.resolve():
-            raise ValueError(f"tool source escapes verification input root: {row['path']}")
+    for declared in declared_manifest_input_paths(raw):
+        candidate = (config_path.parent / declared).resolve()
+        if candidate != resolved_root and resolved_root not in candidate.parents:
+            # Fail closed rather than drop it: an input outside the root cannot
+            # be hashed portably, and silently skipping it is the hole this
+            # enumeration exists to close. Routed as an input error because the
+            # manifest is what has to change — `resolve_input_path` rejects the
+            # same declaration the moment an adapter actually reads it.
+            raise InputParseError(
+                f"Declared input resolves outside the verification input root: {declared}"
+            )
         if snapshot is not None and snapshot.contains(candidate):
             if snapshot.has(candidate):
                 paths.append(candidate)
@@ -880,7 +906,11 @@ def _manifest_tool_source_blobs(
                 paths.extend(snapshot.paths_under(candidate))
         else:
             paths.extend(_expand_path(candidate))
-    return _blobs(paths, root=input_root, source=source)
+    return paths
+
+
+def _lexical_path(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.normpath(os.fspath(path))))
 
 
 def _expand_path(path: Path) -> list[Path]:
@@ -896,9 +926,7 @@ def _blobs(paths: list[Path], *, root: Path, source: str) -> list[VerificationBl
     snapshot = active_static_input_snapshot()
     candidates: set[Path] = set()
     for candidate in paths:
-        lexical = Path(
-            os.path.abspath(os.path.normpath(os.fspath(candidate)))
-        )
+        lexical = _lexical_path(candidate)
         if snapshot is not None and snapshot.contains(lexical):
             if snapshot.has(lexical):
                 candidates.add(lexical)

--- a/src/agents_shipgate/schemas/manifest/__init__.py
+++ b/src/agents_shipgate/schemas/manifest/__init__.py
@@ -13,6 +13,11 @@ If you are adding a new manifest section:
 3. Re-export the new models below (under the alphabetised section block).
 4. Regenerate ``docs/manifest-v0.1.json`` via
    ``python scripts/generate_schemas.py``.
+5. If the section names a file an adapter reads, type the field as
+   ``ArtifactPathConfig`` and ``declared_paths`` picks it up automatically.
+   A plain ``str`` path field does not derive — register it in
+   ``declared_paths._UNTYPED_PATH_FIELDS`` or it will never reach
+   ``input_set_id`` (see issue #299).
 
 Schema layering (enforced by ``tests/test_schema_boundaries.py``):
 modules in this package may import from ``schemas.common`` and from

--- a/src/agents_shipgate/schemas/manifest/declared_paths.py
+++ b/src/agents_shipgate/schemas/manifest/declared_paths.py
@@ -1,0 +1,156 @@
+"""Enumerate every filesystem path a manifest declares an adapter will read.
+
+``verification_identity`` needs this when it cannot observe the adapter read
+boundary directly — a plan prepared without evaluating policy
+(``verification prepare``), or a committed-tree ``verify`` whose scan reads an
+archived snapshot rather than the worktree the static-input snapshot is bound
+to. In those modes the declared list *is* the input set: a path that never
+becomes a plan blob can change bytes without moving ``input_set_id``, which is
+exactly the claim ``verification-plan.json``, ``verify-run.json``, the terminal
+receipt, and attestations exist to make.
+
+The enumeration runs on the raw mapping produced by ``yaml.safe_load`` rather
+than on ``AgentsShipgateManifest``, because request identity must still be
+constructible for a manifest that fails validation. It therefore has to
+recognize declared paths structurally. Two rules do that:
+
+1. a ``path:`` key anywhere inside a path-bearing block — the shape every
+   ``ArtifactPathConfig`` field accepts; and
+2. any key named after a field whose type carries an ``ArtifactPathConfig``,
+   because ``_parse_artifact_entries`` also accepts a bare string in place of
+   that object (``tools: [tools/openai.json]``).
+
+The field names for rule 2 are read off the manifest models at import time, so
+a new artifact list on an existing block — or a whole new framework block — is
+covered without editing this module. Only the handful of path fields that are
+*not* typed as ``ArtifactPathConfig`` need naming, in ``_UNTYPED_PATH_FIELDS``.
+
+Scope is deliberately "paths an adapter opens", which is the same boundary the
+observed branch captures. Three declared paths are therefore left out:
+
+- ``output.directory`` is where reports are written, not an input;
+- ``organization.audit.registry`` is existence-tested and never read, so
+  hashing its bytes would churn identity on edits that cannot change a
+  decision; and
+- ``baseline.audit_log`` is an append-only side log resolved against the
+  baseline file, not an adapter input.
+"""
+
+from __future__ import annotations
+
+from typing import Any, get_args
+
+from agents_shipgate.schemas.manifest._artifacts import ArtifactPathConfig
+from agents_shipgate.schemas.manifest.root import AgentsShipgateManifest
+
+#: Declared paths whose field type is a plain string rather than an
+#: ``ArtifactPathConfig``, keyed by the top-level block they live under. An
+#: empty set registers a block for the ``path:`` rule alone —
+#: ``tool_sources[].path`` is a bare ``str`` field, not an artifact object.
+_UNTYPED_PATH_FIELDS: dict[str, frozenset[str]] = {
+    # agent.sdk.entrypoint is the OpenAI Agents SDK entrypoint used when a
+    # tool_sources entry of that type omits its own path.
+    "agent": frozenset({"entrypoint"}),
+    # prompt_files accepts {path: ...} but collapses to list[str] on load, so
+    # it is not ArtifactPathConfig-typed and cannot be derived below.
+    "anthropic": frozenset({"prompt_files"}),
+    "openai_api": frozenset({"prompt_files"}),
+    "tool_sources": frozenset(),
+}
+
+
+def _carries_artifact_path(annotation: Any) -> bool:
+    if isinstance(annotation, type):
+        return issubclass(annotation, ArtifactPathConfig)
+    return any(_carries_artifact_path(arg) for arg in get_args(annotation))
+
+
+def _nested_models(annotation: Any) -> list[type]:
+    if isinstance(annotation, type):
+        return [annotation] if hasattr(annotation, "model_fields") else []
+    return [model for arg in get_args(annotation) for model in _nested_models(arg)]
+
+
+def _artifact_field_names(model: type, seen: set[type]) -> set[str]:
+    """Every YAML key under ``model`` whose value declares an artifact path."""
+
+    if model in seen:
+        return set()
+    seen.add(model)
+    names: set[str] = set()
+    for name, field in model.model_fields.items():
+        if _carries_artifact_path(field.annotation):
+            # populate_by_name means both spellings load; openai_api's
+            # api_model_config is aliased to `model_config` in YAML.
+            names.add(name)
+            if field.alias:
+                names.add(field.alias)
+            continue
+        for nested in _nested_models(field.annotation):
+            names |= _artifact_field_names(nested, seen)
+    return names
+
+
+def _derive_blocks() -> dict[str, frozenset[str]]:
+    blocks = {block: set(names) for block, names in _UNTYPED_PATH_FIELDS.items()}
+    for block, field in AgentsShipgateManifest.model_fields.items():
+        names: set[str] = set()
+        if _carries_artifact_path(field.annotation):
+            names.add(block)
+        for nested in _nested_models(field.annotation):
+            if not issubclass(nested, ArtifactPathConfig):
+                names |= _artifact_field_names(nested, set())
+        if names:
+            blocks.setdefault(block, set()).update(names)
+    return {block: frozenset(names) for block, names in sorted(blocks.items())}
+
+
+#: Manifest blocks that declare adapter inputs, mapped to the keys inside them
+#: that may carry a bare path string. Derived from the manifest models; see the
+#: module docstring.
+DECLARED_INPUT_PATH_BLOCKS: dict[str, frozenset[str]] = _derive_blocks()
+
+
+def declared_manifest_input_paths(raw: Any) -> list[str]:
+    """Return every declared input path in ``raw``, in stable sorted order.
+
+    ``raw`` is a ``yaml.safe_load`` result and may be any shape; anything that
+    is not a mapping yields an empty list. Paths are returned exactly as
+    declared — resolution and containment are the caller's boundary.
+    """
+
+    if not isinstance(raw, dict):
+        return []
+    found: list[str] = []
+    for block, path_keys in DECLARED_INPUT_PATH_BLOCKS.items():
+        _walk(raw.get(block), path_keys=path_keys, found=found)
+    return sorted(set(found))
+
+
+def _walk(node: Any, *, path_keys: frozenset[str], found: list[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "path" or key in path_keys:
+                _collect(value, found)
+            else:
+                _walk(value, path_keys=path_keys, found=found)
+    elif isinstance(node, list):
+        for item in node:
+            _walk(item, path_keys=path_keys, found=found)
+
+
+def _collect(value: Any, found: list[str]) -> None:
+    """Collect the declared path(s) in a bare string / {path: ...} / list."""
+
+    if isinstance(value, str):
+        found.append(value)
+    elif isinstance(value, dict):
+        candidate = value.get("path")
+        if isinstance(candidate, str):
+            found.append(candidate)
+    elif isinstance(value, list):
+        for item in value:
+            _collect(item, found)
+
+
+__all__ = ["DECLARED_INPUT_PATH_BLOCKS", "declared_manifest_input_paths"]

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -449,6 +449,64 @@ def test_committed_tree_verify_hashes_the_captured_bytes_not_a_later_rewrite(
     assert "note.txt" in {item["path"] for item in plan["inputs"]["changed_files"]}
 
 
+@pytest.mark.parametrize("committed", [False, True], ids=["worktree", "committed_tree"])
+def test_prepare_binds_the_explicit_baseline_and_comparison_report(
+    tmp_path: Path,
+    committed: bool,
+) -> None:
+    """Explicit ``--baseline`` / ``--diff-from`` are inputs like any other.
+
+    Running plan construction under the snapshot made this a trap: both
+    ``_blobs`` and ``_optional_blob`` read a path that is contained but never
+    read as *absent*, so an input nobody bound does not merely go unhashed — it
+    vanishes from the plan. Two preparations of one tree with different
+    baselines and comparison reports shared an ``input_set_id``.
+    """
+
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    for name, body in (
+        ("baseline-a.json", '{"source_report_run_id": "A", "findings": []}\n'),
+        ("baseline-b.json", '{"source_report_run_id": "B", "findings": []}\n'),
+        ("comparison-a.json", '{"comparison": "A"}\n'),
+        ("comparison-b.json", '{"comparison": "B"}\n'),
+    ):
+        (repo / name).write_text(body, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "add baselines and comparison reports")
+
+    plans = []
+    for variant in ("a", "b"):
+        # The output must land outside the repo, or the first run's artifacts
+        # become untracked changed files and move identity on their own.
+        out = tmp_path / f"out-{variant}" / "verification-plan.json"
+        result = runner.invoke(
+            app,
+            [
+                "verification",
+                "prepare",
+                "--workspace",
+                str(repo),
+                *(["--base", "HEAD", "--head", "HEAD"] if committed else []),
+                "--baseline",
+                f"baseline-{variant}.json",
+                "--diff-from",
+                f"comparison-{variant}.json",
+                "--out",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        plans.append(json.loads(out.read_text(encoding="utf-8")))
+
+    for plan, variant in zip(plans, ("a", "b"), strict=True):
+        assert plan["inputs"]["baseline"] is not None
+        assert plan["inputs"]["baseline"]["path"] == f"baseline-{variant}.json"
+        assert plan["inputs"]["diff_from"] is not None
+        assert plan["inputs"]["diff_from"]["path"] == f"comparison-{variant}.json"
+
+    assert plans[0]["inputs"]["input_set_id"] != plans[1]["inputs"]["input_set_id"]
+
+
 def test_prepare_input_error_carries_the_agent_mode_envelope(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -36,7 +36,11 @@ from typer.testing import CliRunner
 
 from agents_shipgate.cli.main import app
 from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.core.verification_identity import build_verification_plan
+from agents_shipgate.core.static_inputs import StaticInputSnapshot
+from agents_shipgate.core.verification_identity import (
+    build_verification_plan,
+    sha256_bytes,
+)
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
     ArtifactPathConfig,
@@ -348,6 +352,101 @@ def test_committed_tree_verify_agrees_with_the_worktree_on_the_input_set(
 
     assert "inventories/mcp-tools.json" in bound["committed"]
     assert bound["committed"] == bound["worktree"]
+
+
+def test_prepare_hashes_the_captured_bytes_not_a_later_rewrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paths and hashes must come from one instant, not two.
+
+    Capturing the read set and then reopening the files to hash them leaves a
+    window: a rewrite in between is attested at its new content while
+    ``tool_sources`` still lists what the old content pointed at, so the receipt
+    describes bytes the scan never evaluated.
+    """
+
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    agent = repo / "agent.py"
+    captured = agent.read_bytes()
+    real_finish = StaticInputSnapshot.finish
+    rewritten = False
+
+    def finish_then_rewrite(snapshot: StaticInputSnapshot) -> None:
+        nonlocal rewritten
+        real_finish(snapshot)
+        if not rewritten and snapshot.has(agent):
+            rewritten = True
+            agent.write_bytes(captured + b'\nEXTRA = "written after capture"\n')
+
+    monkeypatch.setattr(StaticInputSnapshot, "finish", finish_then_rewrite)
+    plan = _prepared_plan(repo, "out")
+
+    assert rewritten, "the rewrite never fired; the test proves nothing"
+    blob = next(
+        item for item in plan["inputs"]["tool_sources"] if item["path"] == "agent.py"
+    )
+    assert blob["sha256"] == sha256_bytes(captured)
+    assert blob["sha256"] != sha256_bytes(agent.read_bytes())
+
+
+def test_committed_tree_verify_hashes_the_captured_bytes_not_a_later_rewrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same window on the archived tree, where the receipt is actually minted."""
+
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    _git(repo, "branch", "base", "HEAD")
+    (repo / "note.txt").write_text("unrelated\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "unrelated change")
+    captured = (repo / "agent.py").read_bytes()
+    real_finish = StaticInputSnapshot.finish
+    rewritten: Path | None = None
+
+    def finish_then_rewrite(snapshot: StaticInputSnapshot) -> None:
+        nonlocal rewritten
+        real_finish(snapshot)
+        if rewritten is not None:
+            return
+        for path in snapshot.paths():
+            # Only the archived tree's copy; the worktree snapshot is finalized
+            # first and must not be the one we tamper with.
+            if path.name == "agent.py" and repo not in path.parents:
+                rewritten = path
+                path.write_bytes(captured + b'\nEXTRA = "written after capture"\n')
+                return
+
+    monkeypatch.setattr(StaticInputSnapshot, "finish", finish_then_rewrite)
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(repo),
+            "--base",
+            "base",
+            "--head",
+            "HEAD",
+            "--out",
+            str(repo / "reports" / "verifier.json"),
+        ],
+    )
+    assert result.exit_code in {0, 1}, result.output
+    assert rewritten is not None, "the rewrite never fired; the test proves nothing"
+
+    plan = json.loads(
+        (repo / "reports" / "verifier.json" / "verification-plan.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    blob = next(
+        item for item in plan["inputs"]["tool_sources"] if item["path"] == "agent.py"
+    )
+    assert blob["sha256"] == sha256_bytes(captured)
+    # The changed file no adapter opens still has to survive the capture path.
+    assert "note.txt" in {item["path"] for item in plan["inputs"]["changed_files"]}
 
 
 def test_prepare_input_error_carries_the_agent_mode_envelope(

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -685,6 +685,56 @@ def test_prepare_keeps_the_missing_manifest_setup_route(
     assert "--preview" in first["command"]
 
 
+def test_prepare_diagnoses_the_requested_config_not_a_discovered_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing ``--config`` must not route the caller at someone else's manifest.
+
+    Handing the diagnostic catalog a workspace makes it discover every
+    ``shipgate.yaml`` beneath it and describe the first one that parses. In a
+    monorepo — or any tree with a nested fixture manifest — that told the caller
+    to *edit* an unrelated, perfectly valid file while the message named the one
+    that was actually absent.
+    """
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    nested = repo / "packages" / "other"
+    nested.mkdir(parents=True)
+    (nested / "shipgate.yaml").write_text(
+        (repo / "shipgate.yaml").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "add a second, valid manifest")
+
+    result = runner.invoke(
+        app,
+        [
+            "verification",
+            "prepare",
+            "--workspace",
+            str(repo),
+            "--config",
+            "absent-manifest.yaml",
+            "--out",
+            str(tmp_path / "out" / "verification-plan.json"),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(
+        [line for line in result.output.splitlines() if line.startswith("{")][-1]
+    )
+    assert payload["error"] == "config_error"
+    assert "absent-manifest.yaml" in payload["message"]
+    # The requested manifest is absent, so the answer is setup — never "edit"
+    # some other file that happens to exist.
+    serialized = json.dumps(payload["next_actions"])
+    assert "packages/other/shipgate.yaml" not in serialized
+    assert payload["next_actions"][0]["kind"] == "command"
+
+
 def test_prepare_routes_an_unparseable_manifest_to_the_edit_action(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -507,6 +507,136 @@ def test_prepare_binds_the_explicit_baseline_and_comparison_report(
     assert plans[0]["inputs"]["input_set_id"] != plans[1]["inputs"]["input_set_id"]
 
 
+def _spy_on_the_parsed_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    replacement: str,
+) -> tuple[list[str], list[Path]]:
+    """Record each manifest parse, rewriting the parsed file after the first.
+
+    The rewrite targets the manifest the loader was actually handed — the
+    archived copy on a committed-tree run, not the worktree original, which the
+    scan there never opens. It lands between the first parse and anything that
+    reads the manifest again, which is exactly the window this guards.
+    """
+
+    from agents_shipgate.cli.scan import prepare as scan_prepare
+
+    seen: list[str] = []
+    rewritten: list[Path] = []
+    real_from_path = scan_prepare.load_manifest_with_positions
+    real_from_text = scan_prepare.load_manifest_text_with_positions
+
+    def record(text: str, target: Path) -> None:
+        seen.append(text)
+        if len(seen) == 1 and target.is_file():
+            target.write_text(replacement, encoding="utf-8")
+            rewritten.append(target)
+
+    def spy_from_path(path: Path):  # type: ignore[no-untyped-def]
+        target = Path(path)
+        record(target.read_text(encoding="utf-8"), target)
+        return real_from_path(path)
+
+    def spy_from_text(text: str, *, source: Any = "shipgate.yaml"):  # type: ignore[no-untyped-def]
+        record(text, Path(source))
+        return real_from_text(text, source=source)
+
+    monkeypatch.setattr(scan_prepare, "load_manifest_with_positions", spy_from_path)
+    monkeypatch.setattr(scan_prepare, "load_manifest_text_with_positions", spy_from_text)
+    return seen, rewritten
+
+
+def _adk_manifest_naming(entrypoint: str) -> str:
+    return (
+        'version: "0.1"\n\n'
+        "project:\n  name: google-adk-support-agent\n\n"
+        "agent:\n  name: adk-support-agent\n"
+        "  declared_purpose:\n    - handle support lookup\n\n"
+        "environment:\n  target: production_like\n\n"
+        "tool_sources:\n"
+        "  - id: adk_support\n    type: google_adk\n"
+        f"    path: {entrypoint}\n"
+    )
+
+
+@pytest.mark.parametrize("committed", [False, True], ids=["prepare", "committed_verify"])
+def test_the_scan_and_the_plan_agree_on_one_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    committed: bool,
+) -> None:
+    """The manifest must be parsed once, from the bytes the plan hashes.
+
+    ``load_manifest_with_positions`` reads it twice — a direct ``Path.read_text``
+    for the model, then the snapshot for positions. A rewrite in between lets
+    the adapters follow one manifest while the plan's config blob attests to
+    another, so a receipt could name an entrypoint the scan never opened.
+
+    Two outcomes are correct once the manifest is read through the snapshot:
+    refusing the run because the bytes moved, or emitting a plan that agrees
+    with the manifest the scan followed. Only the third is a defect — succeeding
+    with a plan that disagrees — so that is what this asserts against. Both
+    outcomes occur here: ``prepare`` fails closed, committed-tree ``verify``
+    emits a consistent plan.
+    """
+
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    (repo / "agent-two.py").write_bytes((repo / "agent.py").read_bytes())
+    manifest = repo / "shipgate.yaml"
+    manifest.write_text(_adk_manifest_naming("agent.py"), encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "single-entrypoint manifest")
+
+    seen, rewritten = _spy_on_the_parsed_manifest(
+        monkeypatch,
+        replacement=_adk_manifest_naming("agent-two.py"),
+    )
+
+    if committed:
+        plan_path = repo / "reports" / "verifier.json" / "verification-plan.json"
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                "--workspace",
+                str(repo),
+                # No base comparison: the base tree is scanned first and would
+                # otherwise absorb the one rewrite before the head scan parses.
+                "--no-base",
+                "--head",
+                "HEAD",
+                "--out",
+                str(repo / "reports" / "verifier.json"),
+            ],
+        )
+    else:
+        plan_path = tmp_path / "out" / "verification-plan.json"
+        result = runner.invoke(
+            app,
+            ["verification", "prepare", "--workspace", str(repo), "--out", str(plan_path)],
+        )
+
+    assert seen, "no manifest parse was observed; the test proves nothing"
+    # Compare against the replacement text, not the file: an archived tree is a
+    # temporary directory that is already gone by now.
+    assert rewritten, "the rewrite never landed; the test proves nothing"
+    assert seen[0] != _adk_manifest_naming("agent-two.py")
+
+    if not plan_path.is_file():
+        # Refused the run rather than attesting to a manifest that moved.
+        assert result.exit_code != 0, result.output
+        return
+
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    # The plan attests to the manifest the scan actually followed...
+    assert plan["inputs"]["config"]["sha256"] == sha256_bytes(seen[0].encode("utf-8"))
+    # ...and to the entrypoint that manifest named.
+    bound = {blob["path"] for blob in plan["inputs"]["tool_sources"]}
+    assert "agent.py" in bound
+    assert "agent-two.py" not in bound
+
+
 def test_prepare_input_error_carries_the_agent_mode_envelope(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -6,14 +6,19 @@ and attestations all rest on. If a path an adapter is configured to read never
 becomes a plan blob, two runs that read different bytes claim the same input
 set — a reproducibility hole, not just a caching one.
 
-Two producers had that hole:
+Three producers had that hole:
 
 - the manifest-derived branch of ``build_verification_plan`` walked only
   ``tool_sources``, so ``openai_api.prompt_files`` and every other framework
-  block stayed out of the plan; and
+  block stayed out of the plan;
 - ``verify --base X --head Y`` evaluates an archived tree while the
   static-input snapshot is bound to the worktree, so it observed no adapter
-  reads at all and emitted ``tool_sources: []``.
+  reads at all and emitted ``tool_sources: []``; and
+- neither of those reaches an input the manifest never names — a Google ADK
+  ``McpToolset`` inventory, an OpenAPI spec referenced from Python. Only the
+  read boundary sees those, so both remaining producers now observe it: the
+  committed-tree scan is snapshotted against the archived tree, and ``prepare``
+  loads sources (statically, deciding nothing) to record what they open.
 
 The ``verify`` worktree path was already covered by read-boundary capture, so
 these tests deliberately drive the other entry points.
@@ -30,6 +35,7 @@ import pytest
 from typer.testing import CliRunner
 
 from agents_shipgate.cli.main import app
+from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.verification_identity import build_verification_plan
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
@@ -223,15 +229,15 @@ def test_committed_tree_identity_moves_for_an_input_outside_the_diff(
     assert plans[0].inputs.input_set_id != plans[1].inputs.input_set_id
 
 
-def test_a_declared_input_outside_the_root_fails_closed_and_routes(
+def test_a_declared_input_outside_the_root_fails_the_fallback_closed(
     tmp_path: Path,
 ) -> None:
-    """An input that cannot be hashed portably must not be silently dropped.
+    """The declared fallback cannot hash an out-of-root path, so it refuses.
 
-    ``agent.sdk.entrypoint`` is only resolved when an ``openai_agents_sdk`` tool
-    source omits its own path, so a manifest without one reaches plan
-    construction with a declaration the scan never checked. Routed as an input
-    error (exit 3) — the manifest is what has to change, not the engine.
+    Only the fallback is affected. When the read boundary was observed, a
+    declaration nothing opens is simply not an input — which is why
+    ``prepare`` (below) accepts the same manifest rather than rejecting a path
+    no adapter would ever read.
     """
 
     repo = _sample_repo(tmp_path, "simple_openai_api_agent")
@@ -245,8 +251,116 @@ def test_a_declared_input_outside_the_root_fails_closed_and_routes(
         ),
         encoding="utf-8",
     )
+
+    with pytest.raises(InputParseError, match="outside the verification input root"):
+        build_verification_plan(
+            git_root=repo,
+            input_root=repo,
+            config_path=repo / "shipgate.yaml",
+            config_logical_path="shipgate.yaml",
+            base_ref=None,
+            head_ref="HEAD",
+            archived_head=False,
+            repository_id="https://example.test/org/repo.git",
+            base_commit_sha=None,
+            base_tree_sha=None,
+            head_commit_sha="c" * 40,
+            head_tree_sha="d" * 40,
+            merge_base_sha=None,
+            changed_files=[],
+            diff_text="",
+            baseline_path=None,
+            diff_from_path=None,
+            policy_pack_paths=[],
+            evaluation_date="2026-08-06",
+            options={"ci_mode": "advisory"},
+            plugins_enabled=False,
+            captured_input_paths=None,
+        )
+
+
+def test_prepare_binds_a_transitively_referenced_input(tmp_path: Path) -> None:
+    """An input the manifest never names still has to move ``input_set_id``.
+
+    ``agent.py`` constructs ``McpToolset(inventory_path="inventories/mcp-tools.json")``.
+    Nothing in ``shipgate.yaml`` mentions that file, so enumerating declarations
+    cannot reach it — only the read boundary can. Prepared plans bound
+    `agent.py`, the eval set, and the function inventory but not this one, so
+    two trees whose MCP inventories differed shared an ``input_set_id``.
+    """
+
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    before = _prepared_plan(repo, "before")
+    bound = {blob["path"] for blob in before["inputs"]["tool_sources"]}
+
+    assert "inventories/mcp-tools.json" in bound
+    # Reached only through the OpenAPI toolset built inside agent.py.
+    assert "specs/support.openapi.yaml" in bound
+
+    inventory = repo / "inventories" / "mcp-tools.json"
+    inventory.write_text(inventory.read_text(encoding="utf-8") + "\n", encoding="utf-8")
     _git(repo, "add", "-A")
-    _git(repo, "commit", "-q", "-m", "declare an out-of-root entrypoint")
+    _git(repo, "commit", "-q", "-m", "touch the transitive inventory")
+    after = _prepared_plan(repo, "after")
+
+    assert after["inputs"]["input_set_id"] != before["inputs"]["input_set_id"]
+
+
+def test_committed_tree_verify_agrees_with_the_worktree_on_the_input_set(
+    tmp_path: Path,
+) -> None:
+    """Both modes observe the same read boundary, so both bind the same set.
+
+    This is the invariant the two fixes exist to establish: a committed-tree run
+    is snapshotted against the archived tree it scans, so an input discovered
+    while parsing an entrypoint reaches the receipt on the CI path exactly as it
+    already did for a worktree run.
+    """
+
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    _git(repo, "branch", "base", "HEAD")
+    (repo / "note.txt").write_text("unrelated\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "unrelated change")
+
+    bound: dict[str, set[str]] = {}
+    for name, extra in (("worktree", []), ("committed", ["--head", "HEAD"])):
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                "--workspace",
+                str(repo),
+                "--base",
+                "base",
+                *extra,
+                "--out",
+                str(repo / name / "verifier.json"),
+            ],
+        )
+        assert result.exit_code in {0, 1}, result.output
+        plan = json.loads(
+            (repo / name / "verifier.json" / "verification-plan.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        bound[name] = {blob["path"] for blob in plan["inputs"]["tool_sources"]}
+
+    assert "inventories/mcp-tools.json" in bound["committed"]
+    assert bound["committed"] == bound["worktree"]
+
+
+def test_prepare_input_error_carries_the_agent_mode_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``docs/errors.json`` requires both ``next_action`` and ``next_actions``."""
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    repo = _sample_repo(tmp_path, "simple_openai_api_agent")
+    (repo / "prompts" / "support_refund.md").unlink()
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "drop a declared prompt file")
 
     result = runner.invoke(
         app,
@@ -260,9 +374,15 @@ def test_a_declared_input_outside_the_root_fails_closed_and_routes(
         ],
     )
 
-    assert result.exit_code == 3, result.output
-    assert "outside the verification input root" in result.output
-    assert not (repo / "out" / "verification-plan.json").exists()
+    assert result.exit_code in {2, 3}, result.output
+    payload = json.loads(
+        [line for line in result.output.splitlines() if line.startswith("{")][-1]
+    )
+    assert payload["error"] in {"config_error", "input_parse_error"}
+    assert payload["exit_code"] == result.exit_code
+    assert payload["next_action"]
+    assert payload["next_actions"]
+    assert payload["next_actions"][0]["kind"] in {"edit", "review"}
 
 
 def test_an_unparseable_manifest_still_yields_a_plan(tmp_path: Path) -> None:

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -637,6 +637,87 @@ def test_the_scan_and_the_plan_agree_on_one_manifest(
     assert "agent-two.py" not in bound
 
 
+def test_prepare_keeps_the_missing_manifest_setup_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A manifest that is absent is a setup problem, not an input that moved.
+
+    Reading the manifest through the snapshot puts its ``FileNotFoundError``
+    inside the capture block, where a broad ``except (OSError, ValueError)``
+    recast it as ``input_parse_error``/exit 3 with generic review advice —
+    stranding an agent that branches on the published contract. The absent case
+    is resolved before capture, and the route comes from the shared diagnostic
+    catalog so it matches what ``scan`` answers.
+    """
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "tests@example.com")
+    _git(repo, "config", "user.name", "Shipgate Tests")
+    (repo / "a.txt").write_text("hi\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "no manifest here")
+
+    result = runner.invoke(
+        app,
+        [
+            "verification",
+            "prepare",
+            "--workspace",
+            str(repo),
+            "--out",
+            str(tmp_path / "out" / "verification-plan.json"),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(
+        [line for line in result.output.splitlines() if line.startswith("{")][-1]
+    )
+    assert payload["error"] == "config_error"
+    assert payload["exit_code"] == 2
+    assert "Run `agents-shipgate init" in payload["message"]
+    first = payload["next_actions"][0]
+    assert first["kind"] == "command"
+    assert "--preview" in first["command"]
+
+
+def test_prepare_routes_an_unparseable_manifest_to_the_edit_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared catalog still separates 'absent' from 'present but rejected'."""
+
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    repo = _sample_repo(tmp_path, "google_adk_agent")
+    (repo / "shipgate.yaml").write_text('version: "0.1"\nproject: [oops\n', encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "break the manifest")
+
+    result = runner.invoke(
+        app,
+        [
+            "verification",
+            "prepare",
+            "--workspace",
+            str(repo),
+            "--out",
+            str(tmp_path / "out" / "verification-plan.json"),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(
+        [line for line in result.output.splitlines() if line.startswith("{")][-1]
+    )
+    assert payload["error"] == "config_error"
+    assert payload["next_actions"][0]["kind"] == "edit"
+    assert payload["next_actions"][0]["path"].endswith("shipgate.yaml")
+
+
 def test_prepare_input_error_carries_the_agent_mode_envelope(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -1,0 +1,438 @@
+"""Issue #299: every declared adapter input must reach ``input_set_id``.
+
+``input_set_id`` is the identity ``verification-plan.json``,
+``verification-unit-result.json``, ``verify-run.json``, the terminal receipt,
+and attestations all rest on. If a path an adapter is configured to read never
+becomes a plan blob, two runs that read different bytes claim the same input
+set — a reproducibility hole, not just a caching one.
+
+Two producers had that hole:
+
+- the manifest-derived branch of ``build_verification_plan`` walked only
+  ``tool_sources``, so ``openai_api.prompt_files`` and every other framework
+  block stayed out of the plan; and
+- ``verify --base X --head Y`` evaluates an archived tree while the
+  static-input snapshot is bound to the worktree, so it observed no adapter
+  reads at all and emitted ``tool_sources: []``.
+
+The ``verify`` worktree path was already covered by read-boundary capture, so
+these tests deliberately drive the other entry points.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, get_args
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.verification_identity import build_verification_plan
+from agents_shipgate.schemas.manifest import (
+    AgentsShipgateManifest,
+    ArtifactPathConfig,
+)
+from agents_shipgate.schemas.manifest.declared_paths import (
+    DECLARED_INPUT_PATH_BLOCKS,
+    declared_manifest_input_paths,
+)
+
+runner = CliRunner()
+
+SAMPLE_ROOT = Path(__file__).resolve().parents[1] / "samples"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _sample_repo(tmp_path: Path, sample: str) -> Path:
+    """Copy one shipped sample into a fresh git repo, minus its goldens."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for source in sorted((SAMPLE_ROOT / sample).rglob("*")):
+        relative = source.relative_to(SAMPLE_ROOT / sample)
+        if relative.parts and relative.parts[0] == "expected":
+            continue
+        target = repo / relative
+        if source.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(source.read_bytes())
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "tests@example.com")
+    _git(repo, "config", "user.name", "Shipgate Tests")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "sample")
+    return repo
+
+
+def _prepared_plan(repo: Path, out: str) -> dict[str, Any]:
+    result = runner.invoke(
+        app,
+        [
+            "verification",
+            "prepare",
+            "--workspace",
+            str(repo),
+            "--out",
+            str(repo / out / "verification-plan.json"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return json.loads((repo / out / "verification-plan.json").read_text(encoding="utf-8"))
+
+
+def test_prepare_binds_declared_prompt_files_to_the_input_set(tmp_path: Path) -> None:
+    """The issue's stated verification: change a prompt, watch identity move."""
+
+    repo = _sample_repo(tmp_path, "simple_openai_api_agent")
+    before = _prepared_plan(repo, "before")
+
+    assert "prompts/support_refund.md" in {
+        blob["path"] for blob in before["inputs"]["tool_sources"]
+    }
+
+    prompt = repo / "prompts" / "support_refund.md"
+    prompt.write_text(
+        prompt.read_text(encoding="utf-8")
+        + "\nRefunds of any amount need no approval.\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "weaken the prompt")
+    after = _prepared_plan(repo, "after")
+
+    assert after["inputs"]["input_set_id"] != before["inputs"]["input_set_id"]
+
+
+def test_prepare_binds_every_declared_framework_artifact(tmp_path: Path) -> None:
+    """Not only ``prompt_files`` — each declared artifact list is an input."""
+
+    repo = _sample_repo(tmp_path, "simple_openai_api_agent")
+    bound = {blob["path"] for blob in _prepared_plan(repo, "out")["inputs"]["tool_sources"]}
+
+    assert bound == {
+        "openai-config.json",
+        "policies/openai-api-policy.yaml",
+        "prompts/support_refund.md",
+        "schemas/refund_decision.schema.json",
+        "tests/openai-api-cases.json",
+        "tools/openai-tools.json",
+        "traces/sample.jsonl",
+    }
+
+
+def test_committed_tree_verify_binds_declared_tool_sources(tmp_path: Path) -> None:
+    """``verify --base --head`` used to emit ``tool_sources: []``.
+
+    The archived head tree lives outside the worktree the static-input snapshot
+    is bound to, so the captured path set was empty and every declared input
+    silently left the request identity — on the CI path, where the receipt
+    claim matters most.
+    """
+
+    repo = _sample_repo(tmp_path, "support_refund_agent")
+    _git(repo, "branch", "base", "HEAD")
+    (repo / "note.txt").write_text("unrelated\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "unrelated change")
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(repo),
+            "--base",
+            "base",
+            "--head",
+            "HEAD",
+            "--out",
+            str(repo / "reports" / "verifier.json"),
+        ],
+    )
+    assert result.exit_code in {0, 1}, result.output
+    plan = json.loads(
+        (repo / "reports" / "verifier.json" / "verification-plan.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert plan["subject"]["git"]["snapshot_kind"] == "committed_tree"
+    assert {blob["path"] for blob in plan["inputs"]["tool_sources"]} == {
+        ".agents-shipgate/mcp-tools.json",
+        ".agents-shipgate/wildcard-tools.json",
+        "agents/refund_agent.py",
+        "inventories/sdk-tools.json",
+        "specs/support-tools.openapi.yaml",
+    }
+    assert all(blob["source"] == "git_blob" for blob in plan["inputs"]["tool_sources"])
+
+
+def test_committed_tree_identity_moves_for_an_input_outside_the_diff(
+    tmp_path: Path,
+) -> None:
+    """An input the diff never mentions still has to move ``input_set_id``.
+
+    A prompt file carried unchanged across the compared range is invisible to
+    ``changed_files``, so the declared-input enumeration is the only thing that
+    can distinguish two trees whose prompts differ.
+    """
+
+    repo = _sample_repo(tmp_path, "simple_openai_api_agent")
+    plans = []
+    for text in ("original guidance\n", "weakened guidance\n"):
+        (repo / "prompts" / "support_refund.md").write_text(text, encoding="utf-8")
+        plans.append(
+            build_verification_plan(
+                git_root=repo,
+                input_root=repo,
+                config_path=repo / "shipgate.yaml",
+                config_logical_path="shipgate.yaml",
+                base_ref="base",
+                head_ref="HEAD",
+                archived_head=True,
+                repository_id="https://example.test/org/repo.git",
+                base_commit_sha="a" * 40,
+                base_tree_sha="b" * 40,
+                head_commit_sha="c" * 40,
+                head_tree_sha="d" * 40,
+                merge_base_sha="a" * 40,
+                changed_files=[],
+                diff_text="",
+                baseline_path=None,
+                diff_from_path=None,
+                policy_pack_paths=[],
+                evaluation_date="2026-08-06",
+                options={"ci_mode": "advisory"},
+                plugins_enabled=False,
+            )
+        )
+
+    assert plans[0].inputs.input_set_id != plans[1].inputs.input_set_id
+
+
+def test_a_declared_input_outside_the_root_fails_closed_and_routes(
+    tmp_path: Path,
+) -> None:
+    """An input that cannot be hashed portably must not be silently dropped.
+
+    ``agent.sdk.entrypoint`` is only resolved when an ``openai_agents_sdk`` tool
+    source omits its own path, so a manifest without one reaches plan
+    construction with a declaration the scan never checked. Routed as an input
+    error (exit 3) — the manifest is what has to change, not the engine.
+    """
+
+    repo = _sample_repo(tmp_path, "simple_openai_api_agent")
+    (tmp_path / "outside_agent.py").write_text("print('x')\n", encoding="utf-8")
+    manifest = repo / "shipgate.yaml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace(
+            "agent:\n  name: api-refund-assistant",
+            "agent:\n  name: api-refund-assistant\n"
+            "  sdk:\n    type: openai_agents\n    entrypoint: ../outside_agent.py",
+        ),
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "declare an out-of-root entrypoint")
+
+    result = runner.invoke(
+        app,
+        [
+            "verification",
+            "prepare",
+            "--workspace",
+            str(repo),
+            "--out",
+            str(repo / "out" / "verification-plan.json"),
+        ],
+    )
+
+    assert result.exit_code == 3, result.output
+    assert "outside the verification input root" in result.output
+    assert not (repo / "out" / "verification-plan.json").exists()
+
+
+def test_an_unparseable_manifest_still_yields_a_plan(tmp_path: Path) -> None:
+    """The enumeration must not turn a routed config error into a traceback.
+
+    A committed-tree run reads the manifest a second time to enumerate declared
+    inputs. When it does not parse, the loader has already said so with an
+    actionable error; identity construction falls back to the config blob,
+    which is the only thing that was read.
+    """
+
+    repo = _sample_repo(tmp_path, "support_refund_agent")
+    _git(repo, "branch", "base", "HEAD")
+    (repo / "shipgate.yaml").write_text(
+        'version: "0.1"\nproject: [unclosed\n', encoding="utf-8"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "break the manifest")
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(repo),
+            "--base",
+            "base",
+            "--head",
+            "HEAD",
+            "--out",
+            str(repo / "reports" / "verifier.json"),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    plan_path = repo / "reports" / "verifier.json" / "verification-plan.json"
+    assert plan_path.is_file()
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan["inputs"]["tool_sources"] == []
+    assert plan["inputs"]["config"]["path"] == "shipgate.yaml"
+
+
+def test_declared_paths_cover_every_documented_shape() -> None:
+    """Bare strings, ``{path: ...}`` objects, scalars, and nested blocks."""
+
+    raw = {
+        "agent": {"sdk": {"entrypoint": "agents/root.py"}},
+        "tool_sources": [{"id": "mcp", "type": "mcp", "path": "mcp/tools.json"}],
+        "openai_api": {
+            "prompt_files": ["prompts/a.md", {"path": "prompts/b.md"}],
+            "model_config": "openai-config.json",
+            "function_schemas": [{"path": "schemas/fn.json", "name": "fn"}],
+            "tools": ["tools/openai.json"],
+        },
+        "anthropic": {"prompt_files": ["prompts/c.md"]},
+        "n8n": {"workflows": [{"path": "flows/", "optional": True}]},
+        "codex_plugins": {
+            "mcp_tool_inventories": [
+                {"plugin": "p", "server": "s", "path": "codex/inv.json"}
+            ]
+        },
+        "validation": {
+            "mode": "human_in_the_loop",
+            "evidence": {"approval_traces": [{"path": "evidence/approvals.jsonl"}]},
+        },
+        "checks": {
+            "policy_packs": [{"path": "policies/org.yaml", "id": "org"}],
+            "ignore": [{"check_id": "SHIP-X", "reason": "documented"}],
+        },
+        # Outputs and never-read declarations stay out; see declared_paths.py.
+        "output": {"directory": "agents-shipgate-reports"},
+        "organization": {"audit": {"registry": "org/registry.json"}},
+        "baseline": {"audit_log": "baseline-audit.jsonl"},
+    }
+
+    assert declared_manifest_input_paths(raw) == [
+        "agents/root.py",
+        "codex/inv.json",
+        "evidence/approvals.jsonl",
+        "flows/",
+        "mcp/tools.json",
+        "openai-config.json",
+        "policies/org.yaml",
+        "prompts/a.md",
+        "prompts/b.md",
+        "prompts/c.md",
+        "schemas/fn.json",
+        "tools/openai.json",
+    ]
+
+
+@pytest.mark.parametrize("raw", [None, [], "shipgate", 7, {}])
+def test_declared_paths_tolerate_a_manifest_that_does_not_validate(raw: Any) -> None:
+    """Request identity must still be constructible for a broken manifest."""
+
+    assert declared_manifest_input_paths(raw) == []
+
+
+def test_every_artifact_path_field_is_reachable_from_the_derived_key_set() -> None:
+    """The derivation, not a hand-kept list, is what keeps this complete.
+
+    ``DECLARED_INPUT_PATH_BLOCKS`` is read off the manifest models so a new
+    artifact list — or a whole new framework block — is covered without editing
+    ``declared_paths``. This asserts the reflection still reaches every
+    ``ArtifactPathConfig``-typed field, which is what would break if the schema
+    grew a wrapper type the walk does not unpack.
+    """
+
+    def visit(model: type, block: str, seen: set[type]) -> list[tuple[str, str]]:
+        if model in seen:
+            return []
+        seen.add(model)
+        fields: list[tuple[str, str]] = []
+        for name, field in model.model_fields.items():
+            annotation = field.annotation
+            carries = any(
+                isinstance(arg, type) and issubclass(arg, ArtifactPathConfig)
+                for arg in (annotation, *get_args(annotation))
+            )
+            if carries:
+                fields.append((block, name))
+                continue
+            for arg in (annotation, *get_args(annotation)):
+                if (
+                    isinstance(arg, type)
+                    and hasattr(arg, "model_fields")
+                    and not issubclass(arg, ArtifactPathConfig)
+                ):
+                    fields.extend(visit(arg, block, seen))
+        return fields
+
+    declared: list[tuple[str, str]] = []
+    for block, field in AgentsShipgateManifest.model_fields.items():
+        for arg in (field.annotation, *get_args(field.annotation)):
+            if (
+                isinstance(arg, type)
+                and hasattr(arg, "model_fields")
+                and not issubclass(arg, ArtifactPathConfig)
+            ):
+                declared.extend(visit(arg, block, set()))
+
+    assert declared, "reflection found no artifact-path fields at all"
+    missing = sorted(
+        f"{block}.{name}"
+        for block, name in declared
+        if name not in DECLARED_INPUT_PATH_BLOCKS.get(block, frozenset())
+    )
+    assert missing == [], (
+        "manifest fields declare adapter input paths that never reach "
+        f"input_set_id: {missing}"
+    )
+
+
+def test_derived_blocks_cover_every_framework_that_names_paths() -> None:
+    """A named canary for the blocks issue #299 called out by name."""
+
+    assert {
+        "agent",
+        "anthropic",
+        "checks",
+        "codex_plugins",
+        "crewai",
+        "google_adk",
+        "langchain",
+        "n8n",
+        "openai_api",
+        "tool_sources",
+        "validation",
+    } <= set(DECLARED_INPUT_PATH_BLOCKS)
+    assert "prompt_files" in DECLARED_INPUT_PATH_BLOCKS["openai_api"]
+    assert "prompt_files" in DECLARED_INPUT_PATH_BLOCKS["anthropic"]
+    # openai_api.model_config is aliased; both spellings load, so both resolve.
+    assert {"model_config", "api_model_config"} <= DECLARED_INPUT_PATH_BLOCKS["openai_api"]


### PR DESCRIPTION
## Summary

- Closes #299. `input_set_id` now covers every input an adapter is configured to read, not just `tool_sources[]`.
- The filed defect: the manifest-derived branch of `build_verification_plan` walked only `raw["tool_sources"]`, so `openai_api.prompt_files` — and `anthropic`, `google_adk`, `langchain`, `crewai`, `n8n`, `codex_plugins`, `validation.evidence`, `checks.policy_packs`, `agent.sdk.entrypoint` — never became a plan blob. Reproduced on `verification prepare` against `samples/simple_openai_api_agent`: appending "Refunds of any amount need no approval" to the prompt left `input_set_id` byte-identical.
- **A second, sharper defect found while investigating, not in the issue:** `verify --base X --head Y` emitted `tool_sources: []` entirely. `StaticInputSnapshot` is rooted at `git_root`, but a committed-tree run scans an archived copy under `/tmp/agents-shipgate-verify-head-*`, so it records no adapter reads. `active_snapshot.paths()` returned `[]` — which is not `None`, so plan construction honoured an empty capture instead of falling back. On the CI path, where the receipt is the artifact anyone downstream actually trusts, *no* declared input reached the request identity — not even the MCP exports and OpenAPI specs the old fallback would have caught.
- Both modes now agree, and share one exclusion set so an input already hashed as a changed file is not hashed twice.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full suite green twice via `pytest -n auto -m "not perf"` (exit 0); `ruff check .` clean.
- 14 new tests in `tests/test_declared_manifest_input_identity.py`. Confirmed load-bearing by reverting each fix in turn: reverting the orchestrator change fails `test_committed_tree_verify_binds_declared_tool_sources`; reverting the enumeration fails four others.
- Tests deliberately drive `verification prepare` and the committed-tree path. `verify` against a worktree was already correct (read-boundary capture covers it, including a prompt file absent from the diff), so a worktree test would pass for the wrong reason — the issue's triage note called this out.
- Dogfooded: `verify --base main --head HEAD` on this repo now binds `.agents/plugins/marketplace.json` where it previously bound nothing; receipt `input_set_id` matches the plan; decision `passed`.
- Error paths exercised by hand: unparseable manifest on a committed-tree run still routes `config_error`/exit 2 and still writes a plan carrying the config blob; an out-of-root declared path routes `input_parse_error`/exit 3.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — n/a, no check IDs touched
- [x] Report/schema changes are additive or documented in `STABILITY.md` — no schema change; `plan.inputs.tool_sources` gains entries, not fields

## Notes for the reviewer

**Why the path table is derived, not hand-kept.** `schemas/manifest/declared_paths.py` walks raw `yaml.safe_load` output (identity must stay constructible for a manifest that fails validation) and recognizes paths by two rules: a `path:` key anywhere in a path-bearing block, plus any key named after a field whose type carries `ArtifactPathConfig`. That second rule is load-bearing — `_parse_artifact_entries` also accepts a bare string (`tools: [tools/openai.json]`), which a `path:`-only walk misses. The key set is read off the pydantic models at import time, so a new artifact list, or a whole new framework block, is covered with no edit here. Only non-`ArtifactPathConfig` string paths need naming by hand (`_UNTYPED_PATH_FIELDS`): `agent.sdk.entrypoint`, both `prompt_files`, and `tool_sources` (registered for the `path:` rule alone).

**Deliberately not inputs**, to stay symmetric with what read-boundary capture sees: `output.directory` (an output), `organization.audit.registry` (existence-tested, never read), `baseline.audit_log` (resolved against the baseline file, not an adapter input).

**Two things worth a second opinion:**

1. **One new way to fail, on purpose.** A declared path outside the input root cannot be hashed portably, so it is now rejected rather than dropped. Realistically only reachable via `agent.sdk.entrypoint` with no `openai_agents_sdk` tool source, since `resolve_input_path` rejects the rest at scan time. Fail-closed felt right — a silently unbound declared input is the class this issue is about — but it will hard-fail a manifest that verifies today. My first attempt raised `ValueError`, which surfaced as `internal_error`/exit 4 ("file an issue"); that is the wrong routing for something the user must fix in their manifest, hence `InputParseError`.
2. **`input_set_id` and `request_id` values move** for any manifest declaring framework inputs, and for every `--head` run. Receipts minted before and after this change cannot be compared by ID. Sample `expected/report.json` goldens are unaffected (they carry `input_set_id: null` — `scan` builds no plan).

**Generalizable bug class**, worth remembering beyond this PR: when a code path selects between "observed" and "declared" on `x is None`, an observer that is *inert* rather than absent silently wins with an empty result. Check that the observer could have seen anything at all, not just that it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
