### PR TITLE
test(authorization): stop the fixture grant from expiring mid-test

### DIFF
--- a/tests/test_authorization_verify_integration.py
+++ b/tests/test_authorization_verify_integration.py
@@ -53,6 +53,16 @@ DESTINATION_REF = "refs/heads/codex/human-authorization-state"
 LEASE_OID = "e" * 40
 REPOSITORY_ID = "example.test/acme/review-agent"
 PUSH_URL = "https://example.test/acme/review-agent.git"
+# Grants minted here are evaluated against real wall time: neither ``run_verify``
+# nor ``authorization execute`` passes an evaluation clock, and expiry is
+# deliberately strict (clock skew never extends authority). A fixture TTL sized
+# like a real host policy therefore raced the test itself under ``pytest -n
+# auto``, where the gap between minting a grant and the assertions that consume
+# it is bounded only by machine load. This TTL outlives any plausible run; the
+# strictness of expiry is covered by the "expired" case below and by the
+# clock-pinned tests in tests/test_human_authorization.py.
+FIXTURE_GRANT_TTL = timedelta(hours=12)
+FIXTURE_KEY_VALIDITY = FIXTURE_GRANT_TTL * 2
 runner = CliRunner()
 
 
@@ -249,8 +259,8 @@ def _trusted_key(
         public_key=_b64url(public_key),
         provider="github",
         principal="github:user:release-reviewer",
-        valid_from=now - timedelta(days=1),
-        valid_until=now + timedelta(days=1),
+        valid_from=now - FIXTURE_KEY_VALIDITY,
+        valid_until=now + FIXTURE_KEY_VALIDITY,
     )
 
 
@@ -295,7 +305,7 @@ def _write_host_policy(
     policy = build_human_authorization_trust_policy(
         repository_ids=[request.repository_id],
         keys=[key],
-        max_ttl_seconds=900,
+        max_ttl_seconds=int(FIXTURE_GRANT_TTL.total_seconds()) + 60,
         clock_skew_seconds=30,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -367,7 +377,7 @@ def test_signed_authorization_overlays_one_exact_command_and_binds_artifact(
         request,
         issued_at=now - timedelta(seconds=1),
         not_before=now - timedelta(seconds=1),
-        expires_at=now + timedelta(minutes=5),
+        expires_at=now + FIXTURE_GRANT_TTL,
     )
     grant_path = tmp_path / "host" / "authorization.json"
     _write_grant(grant_path, grant)
@@ -387,6 +397,8 @@ def test_signed_authorization_overlays_one_exact_command_and_binds_artifact(
     assert authorized_report is not None
     assert _static_gate(authorized) == _static_gate(initial)
     assert authorized_report.release_decision.decision == report.release_decision.decision
+    # Asserted before the status so a rejection reports why it was rejected.
+    assert authorized.authorization.reason_codes == []
     assert authorized.authorization.status == "accepted"
     assert authorized.authorization.authorization_id == grant.authorization_id
     out = repo / "agents-shipgate-reports"
@@ -733,7 +745,7 @@ def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
         )
     issued_at = now - timedelta(seconds=1)
     not_before = now - timedelta(seconds=1)
-    expires_at = now + timedelta(minutes=5)
+    expires_at = now + FIXTURE_GRANT_TTL
     if failure == "expired":
         issued_at = now - timedelta(minutes=10)
         not_before = issued_at
@@ -786,6 +798,10 @@ def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
         "missing_trust": {"trust_policy_unavailable"},
     }
     assert expected_reasons[failure] <= set(rejected.authorization.reason_codes)
+    # Every other case must be rejected for its own reason, never because the
+    # fixture grant aged out while the test ran.
+    if failure != "expired":
+        assert "authorization_expired" not in rejected.authorization.reason_codes
     # A rejected grant falls back to the ordinary review route: merge and
     # completion stay denied, and no authorized operation command is exposed.
     assert rejected.control.state == "review_publishable"


### PR DESCRIPTION
## Summary

- `tests/test_authorization_verify_integration.py::test_signed_authorization_overlays_one_exact_command_and_binds_artifact` failed once during a full `pytest -n auto` run with `assert authorized.authorization.status == 'rejected' == 'accepted'`, and passed both in isolation and on an immediate full re-run. A pristine-HEAD full run also passed, so it was not attributable to any change.
- The fixture minted a grant with `expires_at = now + 5 minutes`, but nothing on the `run_verify` / `authorization execute` path passes an evaluation clock. Expiry is checked against real wall time, and strictly — `evaluated_at >= statement.expires_at` at `src/agents_shipgate/core/human_authorization.py:389`, deliberately so, because clock skew must never extend authority. The gap between minting the grant and the assertions that consume it is bounded only by machine load, so the fixture's validity window was a race with the test runner rather than a property of the code under test.
- Fix: widen the fixture TTL to 12 hours, derive the trusted-key window and the policy's `max_ttl_seconds` from it, and assert `reason_codes` before the boolean status so a future rejection reports why.

**Production expiry is untouched.** Its strictness — including the boundary case where `evaluated_at == expires_at` rejects — stays covered by the clock-pinned tests in `tests/test_human_authorization.py`.

## Confirming the mechanism

The rejection `reason_codes` were not asserted, so the original failure output did not say why it rejected. Two checks pinned it down:

1. **The failure signature is unique to expiry.** Forcing the grant to expire (`expires_at = now + 1ms`) reproduces the observed failure exactly: every preceding assertion passes — `authorized_exit`, `authorized_report`, `_static_gate(authorized) == _static_gate(initial)`, and the `release_decision.decision` equality — and only the status assertion trips, with `reason_codes == ['authorization_expired']`. An expired grant falls back to the ordinary review route, which is identical on all the coarse gates the test checks first.
2. **Expiry is the only clock-sensitive rejection reachable here.** Every other input to the decision is content-addressed and stable across the two verify passes: `authorization_request_id` is a `content_id` over git SHAs plus `request_id`/`subject_id`/`decision_id`, and `decision_id` (`orchestrator.py:2858`) hashes only `request_id`, unit-result ids, and the decision fields — no clock input anywhere. If any of them drifted, the test would fail on every run, not once. Of the remaining time gates, the fixture had a full day of margin on key validity, `issued_at`/`not_before` sit in the past behind 30s of skew, and the TTL bound is static.

One caveat on magnitude, for the reviewer: instrumenting a full `-n auto` run stretched the mint-to-evaluate gap only to **2.5s** on the machine that saw the failure, so pure CPU contention would need a ~120x inflation to blow 5 minutes. On darwin the likelier amplifier is the process being frozen — a sleep/suspend moves wall time forward by minutes while burning no CPU. Either way the window is bounded by machine behaviour, not by the test, which is the thing being fixed.

## Why widen the TTL rather than pin the clock

Pinning would mean monkeypatching the private `_utc_now` in production code, and it would switch off the very gate this test walks through end to end. The widened fixture keeps the real clock path live with a window no run can exhaust. Verified that this does not disable the gate: shrinking `FIXTURE_GRANT_TTL` to 1ms still rejects with `authorization_expired`.

## Second grant site

The site at `:735` had the same 5-minute exposure and now uses the same constant, with the `"expired"` parametrized case keeping its negative TTL untouched. Its reason assertion is a subset check (`expected <= set(...)`), so a slow run would have silently added `authorization_expired` and let `tampered` pass for a half-wrong reason — added an explicit guard that the code appears nowhere but the `expired` case.

Swept the rest of the suite for the same class: no other test has a wall-clock deadline later evaluated against real time (the remaining `datetime.now` uses in `tests/harness/` are plain record timestamps).

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only
- [x] Test-only (no shipped behavior changes)

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full suite twice under `pytest -n auto`, exit 0 both times.
- All five authorization test files together (90 tests), green.
- Negative control: `FIXTURE_GRANT_TTL = 1ms` still fails with `['authorization_expired'] == []`, proving the widened fixture did not disable the expiry gate.
- `ruff check .` clean. Note `ruff format` is not enforced here (CI runs `ruff check` only) and this file was already non-format-clean at HEAD, so the formatter was not run — the diff is 6 hunks, all intentional.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — n/a, no check changes
- [x] Report/schema changes are additive or documented in `STABILITY.md` — n/a, no schema changes

No CHANGELOG entry: that section becomes the GitHub Release body, and nothing shipped changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)