### PR TITLE
fix(google-adk): reach sub-agent tools and name every unreached one (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,17 @@
   agent name produced one phantom node per sub-agent, owning no tools, so the
   handoff landed on a node with nothing behind it and the real agent stayed
   unreachable. The two spellings are now reconciled from the module's own
-  assignments, which also collapses the duplicate nodes the graph used to
-  report. An element that cannot be named — built inline, imported from
-  elsewhere, or behind a non-literal `sub_agents` value — now fails closed as
-  partial evidence; naming two of three sub-agents previously reported the two
-  as the whole handoff set.
+  assignments, resolved innermost-out through the enclosing scopes so that two
+  factories reusing one local name cannot cross their sub-agents. This also
+  collapses the duplicate nodes the graph used to report.
+
+  An element that cannot be resolved to an agent definition — built inline,
+  imported from another module, behind a non-literal `sub_agents` value, or
+  rebound ambiguously within one scope — now fails closed as partial evidence
+  naming the spelling. It no longer becomes a node of its own: an empty tool
+  set on a node named after an import reads as proof the sub-agent has no
+  capability, which is the opposite of what is known about it. Naming two of
+  three sub-agents likewise no longer reports the two as the whole handoff set.
 
   `agent_bindings.declarations` was the documented remedy and could not work.
   Declaring an agent seeded a synthetic node for it, and for an agent the
@@ -35,10 +41,10 @@
   to root-reachable tools, so such a tool is never judged; before this it was
   not mentioned either, leaving the ratio `6/12 catalog tools reachable` as its
   only trace. This covers tools whose owning agent the scan identified — a hole
-  in the graph shipgate built. A catalog entry that no agent binds at all is a
-  different claim and is unchanged: catalog membership is deliberately not
-  evidence of capability, so declaring an OpenAPI spec or MCP server does not
-  become self-blocking.
+  in the graph Agents Shipgate built. A catalog entry that no agent binds at
+  all is a different claim and is unchanged: catalog membership is deliberately
+  not evidence of capability, so declaring an OpenAPI spec or MCP server does
+  not become self-blocking.
 
 - **One command runs Agents Shipgate from this checkout, and `doctor` now says
   which Shipgate answered.** Running the CLI from a source tree meant either a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## Unreleased
 
+- **A Google ADK sub-agent's tools are part of the analyzed surface, and a tool
+  the gate did not look at can no longer go unmentioned.** On the canonical ADK
+  multi-agent shape — a coordinator with `sub_agents=[salesforce_agent,
+  sap_agent]` — every tool the sub-agents owned fell out of the root-reachable
+  graph, and none of the 25 evidence gaps named one. On the reported repository
+  the excluded half was the half a release gate exists to judge: three financial
+  writes, including one that sets opportunities to `Closed Won` and one that
+  creates an SAP sales order
+  ([#385](https://github.com/ThreeMoonsLab/agents-shipgate/issues/385)).
+
+  ADK routes a handoff by the sub-agent's `name=`, but `sub_agents=[…]` spells
+  the Python variable the agent was assigned to. Reading the variable as an
+  agent name produced one phantom node per sub-agent, owning no tools, so the
+  handoff landed on a node with nothing behind it and the real agent stayed
+  unreachable. The two spellings are now reconciled from the module's own
+  assignments, which also collapses the duplicate nodes the graph used to
+  report. An element that cannot be named — built inline, imported from
+  elsewhere, or behind a non-literal `sub_agents` value — now fails closed as
+  partial evidence; naming two of three sub-agents previously reported the two
+  as the whole handoff set.
+
+  `agent_bindings.declarations` was the documented remedy and could not work.
+  Declaring an agent seeded a synthetic node for it, and for an agent the
+  scanner had already observed that second node made the name ambiguous, so the
+  resolver rejected names its own scan had emitted. Declarations now reuse the
+  observed node, and a genuinely ambiguous name says how many agents share it
+  and which sources they came from instead of reporting the name as unknown.
+
+  Finally, a tool bound to an agent the configured root cannot reach now gets an
+  evidence gap naming it. Everything downstream of the binding graph is narrowed
+  to root-reachable tools, so such a tool is never judged; before this it was
+  not mentioned either, leaving the ratio `6/12 catalog tools reachable` as its
+  only trace. This covers tools whose owning agent the scan identified — a hole
+  in the graph shipgate built. A catalog entry that no agent binds at all is a
+  different claim and is unchanged: catalog membership is deliberately not
+  evidence of capability, so declaring an OpenAPI spec or MCP server does not
+  become self-blocking.
+
 - **One command runs Agents Shipgate from this checkout, and `doctor` now says
   which Shipgate answered.** Running the CLI from a source tree meant either a
   bare `agents-shipgate`, which resolves through `PATH` and can silently execute

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -452,6 +452,17 @@ agent_bindings:
       reason: reviewed against the deployed agent wiring
 ```
 
+`root.object` and `declarations[].agent` are matched against the agent names
+the scan reports in `binding_surface_facts.agents[].name`, so read that list
+from `report.json` rather than guessing: for frameworks that name agents
+explicitly it is the framework's own name (a Google ADK `LlmAgent(name=…)`),
+not the Python variable the agent was assigned to. `agent: root` is the one
+reserved spelling and always means the configured root. A declaration may
+introduce an agent the extractors never observed — a decorator-only project
+has no agent object to observe — but a name that two observed agents share
+resolves to neither, and the resulting `unresolved_agent_binding` says which
+sources collided.
+
 Catalog membership, action declarations, permissions, and controls never imply
 binding. `complete` must be `true`; the declaration is exact and may not erase
 positive structural edges. Empty `tools` and `handoffs` prove a zero-capability

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -531,6 +531,9 @@ def _binding_coverage(
                 ),
             )
         )
+    for gap in _unreached_tool_gaps(report):
+        _increment(reason_counts, gap.kind)
+        gaps.append(gap)
     return (
         BindingCoverageDecision(
             total_catalog_tools=(
@@ -547,6 +550,92 @@ def _binding_coverage(
         ),
         gaps,
     )
+
+
+def _unreached_tool_gaps(report: ReadinessReport) -> list[EvidenceGap]:
+    """One row per tool an *identified* agent owns that the root cannot reach.
+
+    Everything downstream of the binding graph — findings, the action
+    surface, semantic coverage, ``tool_inventory`` — is narrowed to the
+    root-reachable tools (``cli/scan/tools_agent.py``). A tool that lands in
+    ``unbound_tool_ids`` is therefore never judged, and it used to go
+    unmentioned too: the entire write surface of a multi-agent app could
+    disappear behind the ratio ``6/12 catalog tools reachable`` while all 25
+    evidence gaps named only the six tools that were reached (#385). Being
+    told the gate did not look is materially different from being told
+    nothing.
+
+    The rows stop at tools carrying a structural edge, and that boundary is
+    deliberate. Such a tool is a hole in *our* graph: the scan proved some
+    agent in the repository owns it and then failed to connect that agent to
+    the root, so the evidence exists and is incomplete. A catalog entry with
+    no edge at all is the opposite claim — nothing in the repository says any
+    agent can call it — and catalog membership is deliberately not evidence
+    of capability (see ``samples/large_multi_framework_agent``, where 58 of
+    63 declared spec operations are correctly out of scope). Emitting a gap
+    for those would make declaring an OpenAPI spec or an MCP server
+    self-blocking. They stay honestly accounted for by
+    ``binding_coverage.unbound_tools`` and the ``unbound_tool_ids``
+    partition.
+    """
+
+    graph = report.binding_surface_facts
+    if not graph.unbound_tool_ids:
+        return []
+    agent_names = {agent.agent_id: agent.name for agent in graph.agents}
+    holders: dict[str, set[str]] = {}
+    for edge in graph.tool_edges:
+        holders.setdefault(edge.tool_id, set()).add(
+            agent_names.get(edge.agent_id, edge.agent_id)
+        )
+    catalog = {
+        str(row.get("tool_id")): row
+        for row in report.tool_catalog
+        if row.get("tool_id")
+    }
+    gaps: list[EvidenceGap] = []
+    for tool_id in graph.unbound_tool_ids:
+        owners = sorted(holders.get(tool_id, ()))
+        if not owners:
+            continue
+        row = catalog.get(tool_id, {})
+        name = str(row.get("name") or tool_id)
+        provider = row.get("provider")
+        gaps.append(
+            EvidenceGap(
+                kind="missing_binding_evidence",
+                subject=f"{name} [{provider}]" if provider else name,
+                source_type=str(row["source_type"]) if row.get("source_type") else None,
+                source_ref=str(row["source_ref"]) if row.get("source_ref") else None,
+                why=(
+                    f"{name} is bound to {', '.join(owners)}, which the configured "
+                    "root agent does not reach; it was excluded from the analyzed "
+                    "surface."
+                ),
+                next_action=EvidenceGapAction(
+                    kind="declare_agent_bindings",
+                    command=_SEMANTIC_RERUN_COMMAND,
+                    path="shipgate.yaml#agent_bindings.declarations",
+                    why=(
+                        "A tool outside the root-reachable graph is never judged, "
+                        "so the verdict must not be silent about it."
+                    ),
+                    expects=(
+                        "Wire the handoff that reaches this agent in source, or "
+                        "declare it under the reaching agent's handoffs, then "
+                        "rerun verification."
+                    ),
+                    accepted_values=[
+                        "agent",
+                        "complete:true",
+                        "tools",
+                        "handoffs",
+                        "reason",
+                    ],
+                ),
+            )
+        )
+    return gaps
 
 
 def _semantic_coverage(

--- a/src/agents_shipgate/core/agent_bindings.py
+++ b/src/agents_shipgate/core/agent_bindings.py
@@ -736,14 +736,36 @@ def _observations(
                 if source_name:
                     agents.append(_AgentObservation(target, _str(record.get("source_id")), _str(record.get("source_ref")), _str(record.get("source_ref")), True))
                     handoffs.append(_RawHandoffEdge(source_name, target, _str(record.get("source_id")), "subagent", _str(record.get("source_ref")) or "google_adk", _str(record.get("source_ref")), True))
-            # ``sub_agents_complete`` is present only on Python-entrypoint
-            # records; the extractor sets it False when the ``sub_agents``
-            # value was not a literal sequence *or* when any element could
-            # not be named. Comparing counts here rather than testing for an
-            # empty name list is what makes a partially-named list fail
-            # closed: naming two of three sub-agents used to report the two
-            # as the whole handoff set.
-            if "sub_agents_complete" in record and not record["sub_agents_complete"]:
+            # Only Python-entrypoint records carry ``sub_agent_count``; Agent
+            # Config records describe sub-agents by config path instead.
+            if "sub_agent_count" not in record:
+                continue
+            # A sub-agent the extractor could name but not match to an agent
+            # definition — imported from a module this scan does not read, or
+            # rebound ambiguously — is a branch of the capability surface
+            # nobody followed. Left unsaid, an imported sub-agent owning a
+            # delete tool produced a `structural` graph with `pass_eligible`
+            # and no trace of the tool anywhere (#385 review).
+            unresolved = _string_list(record.get("unresolved_sub_agents"))
+            if unresolved:
+                # Deliberately says "could not match", not "no such agent":
+                # the agent may well be in the report under its own name,
+                # reached through a source this entrypoint cannot resolve. The
+                # claim is about the spelling, and it must not read as a claim
+                # the agent does not exist.
+                partials.add(
+                    f"Google ADK agent {source_name!r} hands off to "
+                    f"{', '.join(sorted(unresolved))}, which this scan could not "
+                    "match to an agent definition; that sub-agent's tools were "
+                    "not analyzed."
+                )
+            # Comparing counts, rather than testing for an empty name list, is
+            # what makes a partially enumerated list fail closed: naming two of
+            # three sub-agents used to report the two as the whole handoff set.
+            declared_count = record.get("sub_agent_count")
+            if not isinstance(declared_count, int) or declared_count > len(
+                _string_list(record.get("sub_agents"))
+            ) + len(unresolved):
                 partials.add(f"Google ADK agent {source_name!r} has sub-agents that were not statically named.")
         for toolset in adk.toolsets:
             if toolset.dynamic or not toolset.resolved:

--- a/src/agents_shipgate/core/agent_bindings.py
+++ b/src/agents_shipgate/core/agent_bindings.py
@@ -104,14 +104,25 @@ def resolve_agent_binding_graph(
         invalid_annotations,
     ) = _observations(tools, artifacts, loaded_sources or [])
     declarations = manifest.agent_bindings.declarations
+    # A declaration may introduce an agent the extractors never saw — a
+    # decorator-only repository has no agent object to observe. It must NOT
+    # introduce a second node for one the extractors *did* see: the seeded
+    # node carries no ``source_id``, so it lands under a different dedupe key,
+    # and ``_resolve_agent`` then finds two nodes for the name and resolves
+    # neither. Declaring a structurally known agent used to be self-defeating
+    # for exactly that reason — the resolver rejected names its own scanner
+    # had emitted (#385).
+    observed_names = {observation.name for observation in agent_observations}
     for declaration in declarations:
-        if declaration.agent != "root":
+        for name in (
+            *([] if declaration.agent == "root" else [declaration.agent]),
+            *declaration.handoffs,
+        ):
+            if name in observed_names:
+                continue
+            observed_names.add(name)
             agent_observations.append(
-                _AgentObservation(declaration.agent, None, "shipgate.yaml", None, True)
-            )
-        for handoff in declaration.handoffs:
-            agent_observations.append(
-                _AgentObservation(handoff, None, "shipgate.yaml", None, True)
+                _AgentObservation(name, None, "shipgate.yaml", None, True)
             )
 
     agents = _dedupe_agents(agent_observations)
@@ -264,7 +275,11 @@ def resolve_agent_binding_graph(
             issues.append(
                 AgentBindingIssue(
                     kind="unresolved_agent_binding",
-                    message=f"Declaration references unresolved agent {declaration.agent!r}.",
+                    message=_unresolved_agent_message(
+                        "Declaration references agent",
+                        declaration.agent,
+                        by_agent_name,
+                    ),
                     source="shipgate.yaml",
                     source_pointer=f"{pointer}/agent",
                 )
@@ -319,7 +334,11 @@ def resolve_agent_binding_graph(
                 issues.append(
                     AgentBindingIssue(
                         kind="unresolved_agent_binding",
-                        message=f"Declaration references unresolved handoff {target_name!r}.",
+                        message=_unresolved_agent_message(
+                            "Declaration references handoff target",
+                            target_name,
+                            by_agent_name,
+                        ),
                         agent_id=agent.agent_id,
                         source="shipgate.yaml",
                         source_pointer=f"{pointer}/handoffs/{handoff_index}",
@@ -717,7 +736,14 @@ def _observations(
                 if source_name:
                     agents.append(_AgentObservation(target, _str(record.get("source_id")), _str(record.get("source_ref")), _str(record.get("source_ref")), True))
                     handoffs.append(_RawHandoffEdge(source_name, target, _str(record.get("source_id")), "subagent", _str(record.get("source_ref")) or "google_adk", _str(record.get("source_ref")), True))
-            if record.get("sub_agent_count") and not record.get("sub_agents"):
+            # ``sub_agents_complete`` is present only on Python-entrypoint
+            # records; the extractor sets it False when the ``sub_agents``
+            # value was not a literal sequence *or* when any element could
+            # not be named. Comparing counts here rather than testing for an
+            # empty name list is what makes a partially-named list fail
+            # closed: naming two of three sub-agents used to report the two
+            # as the whole handoff set.
+            if "sub_agents_complete" in record and not record["sub_agents_complete"]:
                 partials.add(f"Google ADK agent {source_name!r} has sub-agents that were not statically named.")
         for toolset in adk.toolsets:
             if toolset.dynamic or not toolset.resolved:
@@ -805,6 +831,30 @@ def _agents_by_name(agents: list[AgentBindingNode]) -> dict[str, list[AgentBindi
     for agent in agents:
         result[agent.name].append(agent)
     return result
+
+
+def _unresolved_agent_message(
+    subject: str,
+    name: str,
+    by_name: dict[str, list[AgentBindingNode]],
+) -> str:
+    """Say which of the two failures happened: unknown name, or ambiguous one.
+
+    They need opposite repairs. "Unresolved" alone sent a reader hunting for a
+    spelling mistake even when the name was spelled exactly as the scan
+    reported it and the real problem was two agents sharing it.
+    """
+
+    candidates = by_name.get(name, [])
+    if len(candidates) > 1:
+        sources = ", ".join(
+            sorted({agent.source_id or agent.source_ref or "unknown source" for agent in candidates})
+        )
+        return (
+            f"{subject} {name!r}, which names {len(candidates)} agents "
+            f"in the binding graph ({sources}); the name is ambiguous."
+        )
+    return f"{subject} {name!r}, which no agent in the binding graph matches."
 
 
 def _resolve_agent(name: str, source_id: str | None, by_name: dict[str, list[AgentBindingNode]]) -> AgentBindingNode | None:

--- a/src/agents_shipgate/inputs/google_adk.py
+++ b/src/agents_shipgate/inputs/google_adk.py
@@ -73,6 +73,16 @@ CALLBACK_KEYS = {
 OPENAPI_PATH_KEYS = {"spec_path", "path", "spec_file", "openapi_path", "openapi_spec"}
 MCP_INVENTORY_KEYS = {"inventory_path", "tool_inventory_path", "mcp_tools_path", "mcp_inventory"}
 EVAL_PATH_KEYS = {"eval_set", "eval_sets", "eval_file", "eval_files", "eval_path", "eval_paths"}
+# Python constructs that own a name binding. A ``variable = Agent(...)`` is
+# reachable only from its own scope outward, so resolving a ``sub_agents``
+# element has to respect them.
+_SCOPE_NODES = (
+    ast.Module,
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.Lambda,
+    ast.ClassDef,
+)
 
 
 def load_google_adk_artifacts(
@@ -589,17 +599,12 @@ class _PythonAdkExtractor:
         # reused: ``extract`` iterates it, and the sub-agent spelling map
         # below is built from it.
         self.agent_call_list = self._agent_calls()
-        # ADK routes a handoff to the sub-agent's ``name=``, but
-        # ``sub_agents=[salesforce_agent]`` spells the Python variable the
-        # agent was assigned to. Agent nodes are keyed by the name, so the
-        # two spellings must be reconciled here — otherwise the handoff
-        # lands on a phantom node that owns no tools and every tool the
-        # sub-agent holds drops out of the root-reachable surface (#385).
-        self.agent_names_by_variable = {
-            target_name: _kwarg_string(call, "name") or target_name
-            for target_name, call in self.agent_call_list
-            if target_name
+        self.parents = {
+            child: node
+            for node in ast.walk(tree)
+            for child in ast.iter_child_nodes(node)
         }
+        self.agent_names_by_variable = self._agent_names_by_variable()
 
     def extract(self) -> list[LoadedToolSource]:
         tools: list[Tool] = []
@@ -650,6 +655,64 @@ class _PythonAdkExtractor:
             ),
             *loaded_sources,
         ]
+
+    def _agent_names_by_variable(self) -> dict[tuple[ast.AST | None, str], str | None]:
+        """Map each ``variable = Agent(...)`` to the agent's declared ``name=``.
+
+        ADK routes a handoff to the sub-agent's ``name=``, but
+        ``sub_agents=[salesforce_agent]`` spells the Python variable the agent
+        was assigned to. Agent nodes are keyed by the name, so the two
+        spellings have to be reconciled or the handoff lands on a phantom node
+        owning no tools and the sub-agent's whole surface drops out of the
+        root-reachable graph (#385).
+
+        The key carries the enclosing scope because ``_agent_calls`` walks
+        nested functions too. Two factories that each build a local ``worker``
+        are one flat key apart, and collapsing them made a root reach the
+        *other* factory's agent — analyzing tools it cannot call and excluding
+        the ones it can, while still reporting ``pass_eligible``. Rebinding one
+        name to differently named agents inside a single scope is genuine
+        flow-sensitivity that AST position cannot settle, so it maps to
+        ``None`` and resolves to nothing rather than to a guess.
+        """
+
+        names: dict[tuple[ast.AST | None, str], str | None] = {}
+        for target_name, call in self.agent_call_list:
+            if not target_name:
+                continue
+            key = (self._scope_of(call), target_name)
+            agent_name = _kwarg_string(call, "name") or target_name
+            if key in names and names[key] != agent_name:
+                names[key] = None
+                continue
+            names[key] = agent_name
+        return names
+
+    def _scope_of(self, node: ast.AST) -> ast.AST | None:
+        """The nearest enclosing scope of ``node``, or None above the module."""
+
+        current = self.parents.get(node)
+        while current is not None and not isinstance(current, _SCOPE_NODES):
+            current = self.parents.get(current)
+        return current
+
+    def _sub_agent_name(self, variable: str, call: ast.Call) -> str | None:
+        """Resolve one ``sub_agents`` element to an agent defined in this module.
+
+        Walks scopes innermost-out from the referencing call, so a factory's
+        local agent wins over a module-level name and a sibling factory's
+        identical local name is never consulted. Returns None for anything
+        this module does not define as an agent — an imported name, an
+        ambiguous rebinding — which the caller reports as incomplete rather
+        than binding to a name it cannot stand behind.
+        """
+
+        scope: ast.AST | None = self._scope_of(call)
+        while scope is not None:
+            if (scope, variable) in self.agent_names_by_variable:
+                return self.agent_names_by_variable[(scope, variable)]
+            scope = self._scope_of(scope)
+        return None
 
     def _binding_for(self, agent_name: str, call: ast.Call) -> _AdkAgentBinding:
         binding = self.agent_bindings.get(agent_name)
@@ -1037,35 +1100,37 @@ class _PythonAdkExtractor:
                     else None
                 )
                 sub_agent_count = len(elements) if elements is not None else None
-                # Resolve each element to the agent's declared ``name=`` when
-                # this module assigns it; an element naming an agent defined
-                # elsewhere (or built inline) stays unresolved and is counted
-                # as such by the binding graph.
-                sub_agent_names = (
-                    [
-                        self.agent_names_by_variable.get(name, name)
-                        for item in elements
-                        if (name := _qualified_name(item, self.aliases)) is not None
-                    ]
-                    if elements is not None
-                    else []
-                )
+                # Three outcomes per element, kept apart because they mean
+                # different things to the binding graph. Resolved to an agent
+                # this module defines: a real handoff target. Named but
+                # matching no agent definition — an import, an ambiguous
+                # rebinding: recorded so the graph can say a branch of the
+                # capability surface was not followed, never bound to the
+                # spelling itself (that produced a phantom node whose empty
+                # tool set read as proof of no capability). Not nameable at
+                # all — an inline construction, a call: left to the count.
+                sub_agent_names: list[str] = []
+                unresolved_sub_agents: list[str] = []
+                for item in elements or []:
+                    variable = _qualified_name(item, self.aliases)
+                    if variable is None:
+                        continue
+                    resolved = self._sub_agent_name(variable, call)
+                    if resolved is None:
+                        unresolved_sub_agents.append(variable)
+                    else:
+                        sub_agent_names.append(resolved)
                 self.artifacts.sub_agents.append(
                     {
                         "agent_name": agent_name,
                         "source_id": self.source_id,
+                        # Present on every Python-entrypoint record and on no
+                        # Agent Config record; the binding graph reads it to
+                        # tell the two apart. None when ``sub_agents`` is not
+                        # a literal sequence.
                         "sub_agent_count": sub_agent_count,
                         "sub_agents": sub_agent_names,
-                        # False when ``sub_agents`` is not a literal sequence,
-                        # or when any element could not be named. The binding
-                        # graph turns that into a partial-evidence gap: a
-                        # handoff we cannot name is a branch of the capability
-                        # surface we did not follow, and it must say so rather
-                        # than report the named subset as the whole.
-                        "sub_agents_complete": (
-                            elements is not None
-                            and len(sub_agent_names) == len(elements)
-                        ),
+                        "unresolved_sub_agents": unresolved_sub_agents,
                         "source_ref": f"{self.source_ref}:{call.lineno}",
                     }
                 )

--- a/src/agents_shipgate/inputs/google_adk.py
+++ b/src/agents_shipgate/inputs/google_adk.py
@@ -585,12 +585,27 @@ class _PythonAdkExtractor:
         # agents is loaded once, not once per agent.
         self.toolset_tool_names: dict[int, list[str]] = {}
         self.agent_bindings: dict[str, _AdkAgentBinding] = {}
+        # Every ``Agent(...)`` assignment in this module, walked once and
+        # reused: ``extract`` iterates it, and the sub-agent spelling map
+        # below is built from it.
+        self.agent_call_list = self._agent_calls()
+        # ADK routes a handoff to the sub-agent's ``name=``, but
+        # ``sub_agents=[salesforce_agent]`` spells the Python variable the
+        # agent was assigned to. Agent nodes are keyed by the name, so the
+        # two spellings must be reconciled here — otherwise the handoff
+        # lands on a phantom node that owns no tools and every tool the
+        # sub-agent holds drops out of the root-reachable surface (#385).
+        self.agent_names_by_variable = {
+            target_name: _kwarg_string(call, "name") or target_name
+            for target_name, call in self.agent_call_list
+            if target_name
+        }
 
     def extract(self) -> list[LoadedToolSource]:
         tools: list[Tool] = []
         loaded_sources: list[LoadedToolSource] = []
         self._record_eval_references()
-        for target_name, call in self._agent_calls():
+        for target_name, call in self.agent_call_list:
             agent_name = _kwarg_string(call, "name") or target_name or "adk_agent"
             tools_expr = _kwarg(call, "tools")
             tool_count = len(tools_expr.elts) if isinstance(tools_expr, (ast.List, ast.Tuple)) else 0
@@ -1016,14 +1031,23 @@ class _PythonAdkExtractor:
                     }
                 )
             elif keyword.arg == "sub_agents":
-                sub_agent_count = len(keyword.value.elts) if isinstance(keyword.value, ast.List | ast.Tuple) else None
+                elements = (
+                    keyword.value.elts
+                    if isinstance(keyword.value, ast.List | ast.Tuple)
+                    else None
+                )
+                sub_agent_count = len(elements) if elements is not None else None
+                # Resolve each element to the agent's declared ``name=`` when
+                # this module assigns it; an element naming an agent defined
+                # elsewhere (or built inline) stays unresolved and is counted
+                # as such by the binding graph.
                 sub_agent_names = (
                     [
-                        name
-                        for item in keyword.value.elts
+                        self.agent_names_by_variable.get(name, name)
+                        for item in elements
                         if (name := _qualified_name(item, self.aliases)) is not None
                     ]
-                    if isinstance(keyword.value, ast.List | ast.Tuple)
+                    if elements is not None
                     else []
                 )
                 self.artifacts.sub_agents.append(
@@ -1032,6 +1056,16 @@ class _PythonAdkExtractor:
                         "source_id": self.source_id,
                         "sub_agent_count": sub_agent_count,
                         "sub_agents": sub_agent_names,
+                        # False when ``sub_agents`` is not a literal sequence,
+                        # or when any element could not be named. The binding
+                        # graph turns that into a partial-evidence gap: a
+                        # handoff we cannot name is a branch of the capability
+                        # surface we did not follow, and it must say so rather
+                        # than report the named subset as the whole.
+                        "sub_agents_complete": (
+                            elements is not None
+                            and len(sub_agent_names) == len(elements)
+                        ),
                         "source_ref": f"{self.source_ref}:{call.lineno}",
                     }
                 )

--- a/tests/test_google_adk.py
+++ b/tests/test_google_adk.py
@@ -681,3 +681,271 @@ def test_google_adk_long_running_contract_accepts_google_operation_shape():
             },
         }
     )
+
+
+# The google/adk-samples multi-agent shape, spelled the way real samples
+# spell it: the LlmAgent's ``name=`` differs from the Python variable, and
+# ``sub_agents`` names the variable. Reproduced from google/adk-samples#1745,
+# where every tool the sub-agents owned — including all three financial
+# writes — fell out of the analyzed surface with no evidence gap naming it.
+SUB_AGENT_NAME_MISMATCH_SOURCE = '''
+from google.adk.agents import LlmAgent
+
+raise RuntimeError("this file must never be imported")
+
+
+def get_salesforce_opportunities() -> list[dict]:
+    """List open Salesforce opportunities."""
+    return []
+
+
+def create_salesforce_quote(opportunity_id: str) -> str:
+    """Create a Salesforce quote."""
+    return "quote"
+
+
+def create_sap_sales_order(business_partner_id: str) -> str:
+    """Create an SAP sales order."""
+    return "order"
+
+
+def get_manager_email() -> str:
+    """Look up the approving manager."""
+    return "manager@example.com"
+
+
+salesforce_agent = LlmAgent(
+    name="SalesforceAgent",
+    instruction="Work Salesforce records.",
+    tools=[get_salesforce_opportunities, create_salesforce_quote],
+)
+
+sap_agent = LlmAgent(
+    name="SapAgent",
+    instruction="Work SAP records.",
+    tools=[create_sap_sales_order],
+)
+
+root_agent = LlmAgent(
+    name="SmartCloserAgent",
+    instruction="Coordinate Salesforce and SAP.",
+    tools=[get_manager_email],
+    sub_agents=[salesforce_agent, sap_agent],
+)
+'''
+
+SUB_AGENT_NAME_MISMATCH_MANIFEST = """
+version: "0.1"
+project:
+  name: adk-sub-agent-names
+agent:
+  name: SmartCloserAgent
+  declared_purpose:
+    - close deals across salesforce and sap
+environment:
+  target: local
+tool_sources:
+  - id: adk_agent
+    type: google_adk
+    path: agent.py
+agent_bindings:
+  root:
+    source_id: adk_agent
+    object: SmartCloserAgent
+"""
+
+
+def _sub_agent_name_mismatch_project(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(SUB_AGENT_NAME_MISMATCH_SOURCE, encoding="utf-8")
+    (project / "shipgate.yaml").write_text(
+        SUB_AGENT_NAME_MISMATCH_MANIFEST, encoding="utf-8"
+    )
+    return project
+
+
+def test_google_adk_sub_agents_resolve_variable_spellings_to_agent_names(tmp_path):
+    """``sub_agents=[salesforce_agent]`` must reach the agent named SalesforceAgent.
+
+    ADK routes a handoff by the agent's ``name=``; the list spells the Python
+    variable. Reading the variable as an agent name produced one phantom node
+    per sub-agent — holding no tools — so every sub-agent tool dropped out of
+    the root-reachable surface (#385).
+    """
+    project = _sub_agent_name_mismatch_project(tmp_path)
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    graph = report.binding_surface_facts
+    assert sorted(agent.name for agent in graph.agents) == [
+        "SalesforceAgent",
+        "SapAgent",
+        "SmartCloserAgent",
+    ]
+    names = {entry["tool_id"]: entry["name"] for entry in report.tool_catalog}
+    assert sorted(names[tool_id] for tool_id in graph.reachable_tool_ids) == [
+        "create_salesforce_quote",
+        "create_sap_sales_order",
+        "get_manager_email",
+        "get_salesforce_opportunities",
+    ]
+    assert graph.unbound_tool_ids == []
+
+
+def test_google_adk_unreachable_sub_agent_tools_are_never_silently_excluded(tmp_path):
+    """No catalog tool is both outside the analyzed surface and unnamed.
+
+    The root is pinned to the Salesforce sub-agent, so the coordinator's own
+    tool and the whole SAP surface are unreachable. Being told the gate did
+    not look is materially different from being told nothing, so every
+    unreached tool must appear in ``evidence_gaps`` by name.
+    """
+    project = _sub_agent_name_mismatch_project(tmp_path)
+    (project / "shipgate.yaml").write_text(
+        SUB_AGENT_NAME_MISMATCH_MANIFEST.replace(
+            "object: SmartCloserAgent", "object: SalesforceAgent"
+        ),
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    graph = report.binding_surface_facts
+    names = {entry["tool_id"]: entry["name"] for entry in report.tool_catalog}
+    unreached = {names[tool_id] for tool_id in graph.unbound_tool_ids}
+    assert unreached == {"create_sap_sales_order", "get_manager_email"}
+
+    decision = report.release_decision
+    assert decision is not None
+    gap_text = " ".join(
+        f"{gap.subject} {gap.why}" for gap in decision.evidence_coverage.evidence_gaps
+    )
+    for name in unreached:
+        assert name in gap_text
+    assert decision.decision == "insufficient_evidence"
+
+
+def test_google_adk_declaration_resolves_an_agent_the_scan_already_named(tmp_path):
+    """A declaration naming an observed agent must resolve, not collide with it.
+
+    Seeding a synthetic node for every declared agent gave a structurally
+    observed agent a second, source-id-less node; the resolver then saw two
+    candidates for the name and rejected both. Declaring an agent the scan
+    itself reported was self-defeating (#385).
+    """
+    project = _sub_agent_name_mismatch_project(tmp_path)
+    (project / "shipgate.yaml").write_text(
+        SUB_AGENT_NAME_MISMATCH_MANIFEST
+        + """  declarations:
+    - agent: SapAgent
+      complete: true
+      tools:
+        - tool: create_sap_sales_order
+      reason: Reviewed from the sap_agent LlmAgent tools list.
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    graph = report.binding_surface_facts
+    assert [agent.name for agent in graph.agents].count("SapAgent") == 1
+    assert not [issue for issue in graph.issues if issue.kind == "unresolved_agent_binding"]
+    declared = {
+        edge.tool_id
+        for edge in graph.tool_edges
+        if edge.provenance_kind == "static_declaration"
+    }
+    names = {entry["tool_id"]: entry["name"] for entry in report.tool_catalog}
+    assert {names[tool_id] for tool_id in declared} == {"create_sap_sales_order"}
+
+
+def test_google_adk_partially_named_sub_agents_fail_closed(tmp_path):
+    """Naming two of three sub-agents must not report the two as the whole set.
+
+    The un-nameable element is a branch of the capability surface that was
+    not followed; the graph has to say so instead of reporting the named
+    subset as complete.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        '''
+from google.adk.agents import LlmAgent
+
+raise RuntimeError("this file must never be imported")
+
+
+def read_case(case_id: str) -> dict:
+    """Read one support case."""
+    return {"case_id": case_id}
+
+
+def escalate(case_id: str) -> dict:
+    """Escalate one support case."""
+    return {"case_id": case_id}
+
+
+reader_agent = LlmAgent(name="ReaderAgent", tools=[read_case])
+root_agent = LlmAgent(
+    name="RootAgent",
+    tools=[escalate],
+    sub_agents=[reader_agent, build_partner_agent()],
+)
+''',
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: adk-partial-sub-agents
+agent:
+  name: RootAgent
+  declared_purpose:
+    - triage support cases
+environment:
+  target: local
+tool_sources:
+  - id: adk_agent
+    type: google_adk
+    path: agent.py
+agent_bindings:
+  root:
+    source_id: adk_agent
+    object: root_agent
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    graph = report.binding_surface_facts
+    assert graph.status == "partial"
+    assert graph.pass_eligible is False
+    assert any(
+        issue.kind == "partial_binding_evidence"
+        and "not statically named" in issue.message
+        for issue in graph.issues
+    )

--- a/tests/test_google_adk.py
+++ b/tests/test_google_adk.py
@@ -949,3 +949,251 @@ agent_bindings:
         and "not statically named" in issue.message
         for issue in graph.issues
     )
+
+
+def test_google_adk_imported_sub_agent_is_not_reported_as_a_proven_surface(tmp_path):
+    """A sub-agent this scan cannot see must not read as proof of no capability.
+
+    ``from sub import worker`` qualifies to a name, but no agent definition in
+    the scanned entrypoint matches it, and ``sub.py`` is not a declared source —
+    so ``delete_record`` never enters the catalog at all and the per-tool gap
+    cannot cover it. Counting the element as named let the graph report
+    ``structural`` / ``pass_eligible`` with an entire sub-agent invisible,
+    recreating the silent exclusion this change exists to close (#385 review).
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "sub.py").write_text(
+        '''
+from google.adk.agents import LlmAgent
+
+
+def delete_record(record_id: str) -> str:
+    """Delete a record permanently."""
+    return "deleted"
+
+
+worker = LlmAgent(name="WorkerAgent", tools=[delete_record])
+''',
+        encoding="utf-8",
+    )
+    (project / "root.py").write_text(
+        '''
+from google.adk.agents import LlmAgent
+
+from sub import worker
+
+raise RuntimeError("this file must never be imported")
+
+
+def read_status() -> str:
+    """Read the pipeline status."""
+    return "ok"
+
+
+root_agent = LlmAgent(name="RootAgent", tools=[read_status], sub_agents=[worker])
+''',
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: adk-imported-sub-agent
+agent:
+  name: RootAgent
+  declared_purpose:
+    - coordinate record work
+environment:
+  target: local
+tool_sources:
+  - id: adk_root
+    type: google_adk
+    path: root.py
+agent_bindings:
+  root:
+    source_id: adk_root
+    object: RootAgent
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    graph = report.binding_surface_facts
+    assert graph.status == "partial"
+    assert graph.pass_eligible is False
+    # No phantom node stands in for the agent: an empty tool set on a node
+    # named after an import reads as proof the sub-agent has no capability.
+    assert [agent.name for agent in graph.agents] == ["RootAgent"]
+    assert any(
+        issue.kind == "partial_binding_evidence"
+        and "sub.worker" in issue.message
+        and "not analyzed" in issue.message
+        for issue in graph.issues
+    )
+
+
+def test_google_adk_factory_locals_do_not_leak_between_scopes(tmp_path):
+    """Two factories reusing one local name must not cross their sub-agents.
+
+    ``_agent_calls`` walks nested functions, so a variable-to-agent map keyed
+    by the bare name collapses ``build_a``'s ``worker`` into ``build_b``'s.
+    That routed ``RootA`` to ``WorkerB`` — the gate then analyzed a tool the
+    root cannot call and excluded the one it can, while still reporting
+    ``pass_eligible`` (#385 review).
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        '''
+from google.adk.agents import LlmAgent
+
+raise RuntimeError("this file must never be imported")
+
+
+def read_a() -> str:
+    """Read the A ledger."""
+    return "a"
+
+
+def write_b(value: str) -> str:
+    """Write to the B ledger."""
+    return "b"
+
+
+def build_a():
+    worker = LlmAgent(name="WorkerA", tools=[read_a])
+    return LlmAgent(name="RootA", sub_agents=[worker])
+
+
+def build_b():
+    worker = LlmAgent(name="WorkerB", tools=[write_b])
+    return LlmAgent(name="RootB", sub_agents=[worker])
+
+
+root_agent = build_a()
+''',
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: adk-two-factories
+agent:
+  name: RootA
+  declared_purpose:
+    - work the A ledger
+environment:
+  target: local
+tool_sources:
+  - id: adk_agent
+    type: google_adk
+    path: agent.py
+agent_bindings:
+  root:
+    source_id: adk_agent
+    object: RootA
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    graph = report.binding_surface_facts
+    by_id = {agent.agent_id: agent.name for agent in graph.agents}
+    assert {
+        (by_id[edge.source_agent_id], by_id[edge.target_agent_id])
+        for edge in graph.handoff_edges
+    } == {("RootA", "WorkerA"), ("RootB", "WorkerB")}
+    names = {entry["tool_id"]: entry["name"] for entry in report.tool_catalog}
+    assert sorted(names[tool_id] for tool_id in graph.reachable_tool_ids) == ["read_a"]
+    # RootB's surface is out of scope for this root, and says so by name.
+    decision = report.release_decision
+    assert decision is not None
+    assert any(
+        gap.kind == "missing_binding_evidence" and "write_b" in gap.subject
+        for gap in decision.evidence_coverage.evidence_gaps
+    )
+
+
+def test_google_adk_ambiguous_agent_variable_resolves_to_nothing(tmp_path):
+    """One name rebound to two agents in one scope is not settled by position.
+
+    Straight-line AST order is not control flow, so picking either binding
+    would be a guess about which agent the handoff reaches. Fail closed.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        '''
+from google.adk.agents import LlmAgent
+
+raise RuntimeError("this file must never be imported")
+
+
+def read_a() -> str:
+    """Read the A ledger."""
+    return "a"
+
+
+def write_b(value: str) -> str:
+    """Write to the B ledger."""
+    return "b"
+
+
+worker = LlmAgent(name="WorkerA", tools=[read_a])
+root_agent = LlmAgent(name="RootAgent", sub_agents=[worker])
+worker = LlmAgent(name="WorkerB", tools=[write_b])
+''',
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project:
+  name: adk-ambiguous-agent-variable
+agent:
+  name: RootAgent
+  declared_purpose:
+    - work the ledgers
+environment:
+  target: local
+tool_sources:
+  - id: adk_agent
+    type: google_adk
+    path: agent.py
+agent_bindings:
+  root:
+    source_id: adk_agent
+    object: RootAgent
+""",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+
+    graph = report.binding_surface_facts
+    assert graph.status == "partial"
+    assert graph.pass_eligible is False
+    assert not graph.handoff_edges
+    assert any(
+        issue.kind == "partial_binding_evidence" and "worker" in issue.message
+        for issue in graph.issues
+    )


### PR DESCRIPTION
## Summary

Closes #385.

On the canonical Google ADK multi-agent shape — a coordinator with `sub_agents=[salesforce_agent, sap_agent]` — every tool the sub-agents owned fell out of the root-reachable graph, and none of the 25 evidence gaps named one. On [google/adk-samples#1745](https://github.com/google/adk-samples/pull/1745) the excluded half was the half a release gate exists to judge: three financial writes, including one that sets opportunities to `Closed Won` and one that creates an SAP sales order.

Three independent defects produced the one symptom. Each was reproduced against that PR before being fixed.

**1. `sub_agents` was read by the wrong name.** ADK routes a handoff by the sub-agent's `name=`, but `sub_agents=[…]` spells the Python variable the agent was assigned to. Reading the variable as an agent name produced one phantom node per sub-agent, owning no tools, so the handoff landed on a node with nothing behind it and the real agent stayed unreachable — this is also where the duplicate nodes the issue reported came from. The two spellings are now reconciled from the module's own `Agent(...)` assignments. An element that cannot be named — built inline, imported from elsewhere, or behind a non-literal `sub_agents` value — now fails closed as partial evidence; naming two of three sub-agents previously reported the two as the whole handoff set.

**2. `agent_bindings.declarations` invalidated its own remedy.** Declaring an agent seeded a synthetic node with no `source_id`. For an agent the scanner had *already observed*, that second node landed under a different dedupe key and made the name ambiguous, so `_resolve_agent` rejected names its own scan had emitted. Declarations now reuse the observed node, and a genuinely ambiguous name reports how many agents share it and which sources they came from instead of reading as a spelling mistake.

**3. Unreached tools were unmentioned.** A tool bound to an agent the configured root cannot reach now gets an evidence gap naming it. Everything downstream of the binding graph — findings, the action surface, semantic coverage, `tool_inventory` — is narrowed to root-reachable tools, so such a tool is never judged; before this it was not mentioned either, leaving the ratio `6/12 catalog tools reachable` as its only trace.

### Result on the reported repository

| | before | after |
|---|---|---|
| catalog tools reachable | 6/12 | **12/12** |
| agent nodes for 3 agents | 5 (7 with the issue's config) | **3** |
| `create_salesforce_quote` / `update_opportunity_status` / `create_sap_sales_order` | absent from findings and gaps | judged, findings emitted |

The issue's example declaration now resolves. It then reports `conflicting_binding_evidence` — a true positive, because `SalesforceAgent` really holds 6 tools, not the 1 the example declared.

## Type

- [x] Input adapter change
- [x] Report, schema, or SARIF output — new `evidence_gaps` rows only; no schema change (see below)
- [x] Documentation only — `docs/manifest-v0.1.md` gains the agent-name vocabulary for `agent_bindings`

## Reviewer notes

**The judgment call worth your review.** The new gap fires **only for a tool carrying a structural edge** to an agent the root cannot reach — a hole in the graph *we* built: the scan proved some agent owns the tool and then failed to connect that agent to the root. A catalog tool with **no** edge at all is deliberately left ungated, because catalog membership is not evidence of capability: `samples/large_multi_framework_agent` has **58 of 63** declared spec operations correctly out of scope, and gating them would make declaring an OpenAPI spec or MCP server self-blocking. Both existing samples with `unbound_tools > 0` turned out to be the no-edge kind — that is how the boundary was chosen rather than guessed, and the rationale is in the `_unreached_tool_gaps` docstring.

**No schema bump.** The new rows reuse the existing `missing_binding_evidence` kind, whose meaning ("the agent's tool bindings are unproven") already matches exactly. `EvidenceGap.kind` is a frozen `Literal`, so a new member would have forced a report-schema bump for no added meaning.

**Verified and deliberately left out of scope.** Both were reproduced; both now fail *closed* and are visible rather than silent, so neither blocks this fix:

- **Cross-module `sub_agents`.** `from subs.salesforce import salesforce_agent` resolves to a dotted name no per-file map holds, so the phantom node persists and the sub-agent's tool stays unbound — but it is now named in a gap (`create_salesforce_quote … is bound to SalesforceAgent, which the configured root agent does not reach`). Closing it needs cross-source variable→name matching, which is its own piece of work. This is the branch #385 explicitly allows: "`6/12` **plus** evidence gaps naming the unreached tools".
- **ADK Agent Config (YAML) binds nothing.** A `root.yaml` with `sub_agents[].config_path` reports **0/2 reachable** — including the root's own tool — because that path never sets `adk_agent_name`. It falls back to the graph-level `missing_binding_evidence`. Separately, config agent records carry no `source_id`, so a `root: {source_id: …}` selector can never match a YAML-config agent. Worth its own issue.

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full suite green, **no golden churn** — an earlier, broader version of the gap rule flipped `samples/large_multi_framework_agent` and the `support_refund_agent` packet golden; that is what surfaced the boundary above.
- `ruff check .` and `compileall -q src tests` clean.
- End-to-end against a real checkout of google/adk-samples#1745 for the before/after table, plus purpose-built multi-file and Agent-Config-YAML workspaces for the two out-of-scope findings.
- Four regression tests in `tests/test_google_adk.py`, including issue #385's acceptance criterion 4: a `sub_agents=[…]` fixture asserting no tool is both in-catalog and gap-free while unreachable.

## Release-readiness notes

- [x] No user-code import added to default scan paths — the fixtures keep the module-level `raise RuntimeError("this file must never be imported")` guard
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — n/a, no check IDs added or changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — no schema change; new rows reuse the existing `missing_binding_evidence` gap kind
