### PR TITLE
fix(inputs): refuse an absent input instead of reporting it as a malformed one (#389, #387, #384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## Unreleased
 
+- **An input that is not there is no longer reported as an input with the
+  wrong shape, and no command creates the workspace it was asked to inspect.**
+  Three reports, one class. `verify --preview` given a `--workspace` that did
+  not exist created the entire four-level path, wrote a full artifact set into
+  it, and exited 0 — so a typo produced a confident result about a workspace
+  that was never there, and in CI both signals a caller can gate on read
+  healthy. The leftover directory then blocked the `git clone` the reporter had
+  skipped, turning one missed step into a second, unrelated failure
+  ([#389](https://github.com/ThreeMoonsLab/agents-shipgate/issues/389)).
+
+  An absent `--workspace` is now an invocation error — `config_error`, exit 2,
+  decided before any directory is resolved or created — on **every** command
+  that takes the option, `--preview` included. Preview's documented "always
+  exits 0" is a promise about workspaces it evaluated; there is nothing here to
+  evaluate. The sweep that enforces this is generated from the live command
+  table, so a new `--workspace` command cannot quietly reopen the hole. It also
+  closes four defects found while closing the first: `init --write`,
+  `audit --host`, and `verification prepare`/`worker` raised bare
+  `FileNotFoundError` tracebacks, `install-hooks --write` wrote hooks into the
+  mistyped tree, and `mcp audit` answered `decision: allow` about a directory
+  that did not exist.
+
+  `doctor` reported an **absent** manifest as a malformed one — "Config file
+  must contain a YAML object" — for a file that had never been created. The
+  routing knew the difference all along, so the control envelope contradicted
+  itself: `control.reason` said *fix the file* while `control.next_action` said
+  *bootstrap from scratch*, and an agent reasoning from the reason edited a file
+  that was not there. Absent, empty, and present-but-not-a-mapping now produce
+  three distinct messages, classified where the read failed rather than after
+  the bytes have been flattened to `b""`
+  ([#384](https://github.com/ThreeMoonsLab/agents-shipgate/issues/384)). The
+  same conversion in the diff-input path — "Workspace is not inside a git
+  checkout" for a path that did not exist — is gone with it.
+
+- **A manifest type mismatch is an edit, not a bug report.** A YAML mapping
+  where a list belongs — `google_adk.tool_inventories:` with keys under it, the
+  prescribed remedy for the first gap most ADK adopters hit — was reported as
+  `internal_error` with "this is a bug — please file an issue", naming no field,
+  no file, and no line. Pydantic converts `ValueError` and `AssertionError`
+  raised inside a validator into a `ValidationError`, but lets `TypeError`
+  propagate past the config-loading boundary
+  ([#387](https://github.com/ThreeMoonsLab/agents-shipgate/issues/387)).
+
+  Every validator in the manifest schema now raises `ValueError`, so the same
+  mistake produces `config_error` (exit 2) naming the manifest path and routing
+  to `edit`, exactly as a bad key inside a correctly shaped list already did.
+  Messages also name the shape that was written — "must be a list of artifact
+  paths, but is a mapping" — and a build-time sweep fails if `raise TypeError`
+  reappears anywhere under `schemas/`, which closes the class rather than the
+  instance.
+
 - **A Google ADK sub-agent's tools are part of the analyzed surface, and a tool
   the gate did not look at can no longer go unmentioned.** On the canonical ADK
   multi-agent shape — a coordinator with `sub_agents=[salesforce_agent,

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -13,6 +13,72 @@ for reproducible CI.
 
 ---
 
+<a id="migration-note-unreleased-absent-input"></a>
+
+## Migration Note: unreleased — an absent input is refused, not misreported
+
+No version moves: `contract_version`, `report_schema_version`,
+`minimum_control_contract_version`, and every published schema document are
+unchanged. No new error kind and no new exit code — the refusals below all use
+the existing `config_error` / exit `2` slot published in
+[`docs/errors.json`](docs/errors.json).
+
+**`--workspace` must name an existing directory, on every command that takes
+it.** A path that does not exist is an invocation error, decided before any
+output directory is resolved and before anything is written. This changes
+observable behavior in three ways, all of them narrowing a case that
+previously "succeeded":
+
+- `verify --preview` no longer exits 0 for a `--workspace` that does not
+  exist. Its documented "always exits 0" holds for every workspace it
+  *evaluates*; an absent path is not one, and preview previously created the
+  entire path and wrote its artifact set into it before answering
+  ([#389](https://github.com/ThreeMoonsLab/agents-shipgate/issues/389)).
+- `detect`, `check`, `trigger`, `mcp audit`, and `install-hooks` previously
+  exited 0 with a payload describing a workspace that was not there; they now
+  exit 2 with `config_error`.
+- `init --write`, `audit --host`, and `verification prepare`/`worker`
+  previously raised an unhandled `FileNotFoundError` (exit 1); they now exit 2
+  with `config_error`.
+
+A caller that passes an existing `--workspace` — every documented invocation —
+is unaffected. Commands whose `--workspace` is optional still accept its
+absence, which means "discover instead", not "a workspace that is missing".
+
+**Three manifest states, three messages.** An absent manifest, an empty one,
+and a present-but-not-a-mapping one previously produced one identical
+`Config file must contain a YAML object: <path>` string while routing to two
+different actions, so `control.reason` and `control.next_action` could
+disagree about whether the file existed
+([#384](https://github.com/ThreeMoonsLab/agents-shipgate/issues/384)). The
+messages are now:
+
+| State | Message | `next_action.kind` |
+|---|---|---|
+| absent | `Config file not found: <path> in <cwd>.` (plus the `init --write` hint for `shipgate.yaml`) | `verify` |
+| empty | `Config file is empty: <path>.` | `edit` |
+| not a mapping | `Config file must contain a YAML object: <path>` | `edit` |
+
+Routing is unchanged — it always distinguished the cases. `ConfigError` and
+exit `2` are unchanged for all three. Consumers that pattern-matched on the
+`must contain a YAML object` text to detect a *missing* manifest must switch
+to the diagnostic id (`SHIP-DIAG-MISSING-MANIFEST`) or to
+`control.next_action`, which is what the recovery hint in `docs/errors.json`
+already directs.
+
+**A manifest type mismatch is a `config_error`, not an `internal_error`.**
+`raise TypeError` inside a Pydantic validator propagates past the
+config-loading boundary; the manifest schema now raises `ValueError`
+throughout, so a YAML mapping where a list belongs produces
+`Invalid shipgate.yaml:` with the offending field path and an `edit` route,
+the same as any other manifest validation failure
+([#387](https://github.com/ThreeMoonsLab/agents-shipgate/issues/387)). Error
+text for these fields changed shape (it now names what was written, e.g.
+"must be a list of artifact paths, but is a mapping"); the field path prefix
+is the stable part.
+
+---
+
 <a id="migration-note-unreleased-doctor-environment"></a>
 
 ## Migration Note: unreleased — `doctor --json` reports the environment that answered

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -532,7 +532,11 @@ skips a head-only scan; `verifier.json.merge_verdict` is `unknown` and the
 command exits 2.
 
 `agents-shipgate verify --preview --json` is a lightweight relevance check — no
-scan, no manifest required, exits 0. It emits a `verifier.json` with
+scan, no manifest required, exits 0 for every workspace it evaluates. A
+`--workspace` that does not exist is not a workspace it evaluates: it is
+refused as an invocation error (`config_error`, exit 2) before any directory
+is created, on preview and on every other command that takes the option. It
+emits a `verifier.json` with
 `mode: "preview"`, `execution: "not_run"`,
 `applicability: "not_evaluated"`, and
 `control.state: "agent_action_required"`. `control.next_action` carries the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,6 +14,33 @@ Then inspect the sources before running checks:
 agents-shipgate doctor --config shipgate.yaml
 ```
 
+## `--workspace does not exist: <path>`
+
+Every command that takes `--workspace` refuses a path that is not there, with
+`config_error` and exit 2, before it creates anything. Two causes, both common
+on a first run:
+
+- **The clone has not happened yet.** Preview is the first command in the
+  adoption path, so it is easy to run one step early. Clone first, then point
+  `--workspace` at the checkout.
+- **The relative path resolved against a different directory.** The message
+  names the directory it resolved against for exactly this case.
+
+`--workspace is not a directory: <path>` is a different mistake: the path
+exists but is a file. Point the option at the checkout root, not at a file
+inside it (`shipgate.yaml` goes to `--config`).
+
+## Absent, empty, and malformed manifests read differently
+
+| Manifest state | Message | Recovery |
+| --- | --- | --- |
+| Not on disk | `Config file not found: <path> in <cwd>.` | `init --workspace . --write` — the `next_action` bootstraps rather than edits. |
+| Present but empty | `Config file is empty: <path>.` | Edit the file in place; do not re-run `init`, which refuses to overwrite. |
+| Present, valid YAML, not a mapping | `Config file must contain a YAML object: <path>` | Edit the file in place. |
+
+If you see "must contain a YAML object" for a file you never created, that is a
+bug — the three states are asserted to stay distinguishable.
+
 ## First Real Repo Decision Tree
 
 Use this before reading the full manifest schema.

--- a/docs/use-cases/ai-generated-agent-prs.md
+++ b/docs/use-cases/ai-generated-agent-prs.md
@@ -107,7 +107,10 @@ agents-shipgate verify --base origin/main --head HEAD --json
 - `verify --preview --json` is a lightweight relevance check — no scan, no
   manifest required, exits 0. It emits `mode: "preview"` and `control.next_action`
   with an exact init command for unconfigured repos or an exact verify command
-  for configured repos. Use it as the first touch on any repo or PR.
+  for configured repos. Use it as the first touch on any repo or PR. If
+  `--workspace` names a directory that does not exist, preview refuses with
+  `config_error` (exit 2) and creates nothing — run it after the clone, not
+  before.
 - `init --write --json` writes only `shipgate.yaml`. CI and agent-instruction
   trust roots remain separate, explicitly reviewed setup steps.
 - `verify --base origin/main --head HEAD --json` runs the authoritative head

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1798,7 +1798,11 @@ skips a head-only scan; `verifier.json.merge_verdict` is `unknown` and the
 command exits 2.
 
 `agents-shipgate verify --preview --json` is a lightweight relevance check — no
-scan, no manifest required, exits 0. It emits a `verifier.json` with
+scan, no manifest required, exits 0 for every workspace it evaluates. A
+`--workspace` that does not exist is not a workspace it evaluates: it is
+refused as an invocation error (`config_error`, exit 2) before any directory
+is created, on preview and on every other command that takes the option. It
+emits a `verifier.json` with
 `mode: "preview"`, `execution: "not_run"`,
 `applicability: "not_evaluated"`, and
 `control.state: "agent_action_required"`. `control.next_action` carries the

--- a/src/agents_shipgate/cli/_helpers.py
+++ b/src/agents_shipgate/cli/_helpers.py
@@ -636,3 +636,4 @@ def _action_surface_has_signal(summary) -> bool:
             summary.blocking_findings,
         )
     )
+

--- a/src/agents_shipgate/cli/_register_doctor.py
+++ b/src/agents_shipgate/cli/_register_doctor.py
@@ -23,6 +23,8 @@ from agents_shipgate.cli.setup_control import (
     setup_control_envelope,
     setup_input_id,
 )
+from agents_shipgate.cli.workspace_guard import require_workspace
+from agents_shipgate.config.loader import manifest_read_error
 from agents_shipgate.core.errors import ConfigError, InputParseError
 from agents_shipgate.core.logging import configure_logging
 from agents_shipgate.environment import environment_report
@@ -179,6 +181,7 @@ def register(app: typer.Typer) -> None:
         verbose: bool = typer.Option(False, "--verbose", help="Enable debug logs."),
     ) -> None:
         """Validate manifests and enumerate declared sources without running checks."""
+        require_workspace(workspace)
         # Which Python is running which build of Shipgate, and what disagrees.
         # Read once for the whole run: it describes the process, not a manifest,
         # so per-manifest answers would be the same answer repeated.
@@ -238,14 +241,26 @@ def register(app: typer.Typer) -> None:
         # let an edit land in between: doctor emitted manifest A's diagnostic
         # while `control.input_id` hashed manifest B.
         snapshots: dict[Path, bytes] = {}
+        # A failed read still binds to ``b""`` so the failure envelope hashes
+        # the same bytes the diagnosis was taken from — but *why* the read
+        # failed is only knowable here, and `b""` is indistinguishable from an
+        # empty file by the time it reaches the YAML shape check. Classifying
+        # at the read is what keeps `control.reason` ("this file is not
+        # there") and `control.next_action` (bootstrap it) telling one story
+        # instead of two (#384).
+        read_failures: dict[Path, ConfigError] = {}
         for path in paths:
             try:
                 snapshots[path] = path.read_bytes()
-            except OSError:
+            except OSError as exc:
                 snapshots[path] = b""
+                read_failures[path] = manifest_read_error(path, exc)
         try:
             for path in paths:
                 try:
+                    read_failure = read_failures.get(path)
+                    if read_failure is not None:
+                        raise read_failure
                     payloads.append(
                         inspect_sources(
                             config_path=path,

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -38,6 +38,7 @@ from agents_shipgate.cli.setup_control import (
     setup_control_envelope,
     setup_input_id,
 )
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.errors import DiscoveryError
 from agents_shipgate.invocation import render_command
 from agents_shipgate.schemas.agent_control import AgentActionKind
@@ -731,6 +732,7 @@ def register(app: typer.Typer) -> None:
         emit a near-complete manifest. Use --minimal to fall back to the
         pre-v0.6 CHANGE_ME-heavy template.
         """
+        require_workspace(workspace)
         workspace_resolved = workspace.resolve()
         target = workspace / "shipgate.yaml"
 

--- a/src/agents_shipgate/cli/_register_scan.py
+++ b/src/agents_shipgate/cli/_register_scan.py
@@ -21,6 +21,7 @@ from agents_shipgate.cli._helpers import (
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error as _emit_agent_mode_error
 from agents_shipgate.cli.diagnostics import top_next_actions
 from agents_shipgate.cli.scan.orchestrator import run_scan
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_controls import git_root_for
 from agents_shipgate.core.current_control import CurrentControlPublishError
 from agents_shipgate.core.errors import AgentsShipgateError, ConfigError, InputParseError
@@ -327,6 +328,7 @@ def register(app: typer.Typer) -> None:
         verbose: bool = typer.Option(False, "--verbose", help="Show debug extraction details."),
     ) -> None:
         """Run the deterministic merge gate for AI-generated agent capability changes."""
+        require_workspace(workspace)
         # Parse CLI options first, in their own try block. ConfigError raised
         # here is about flag values, not the manifest — emitting a manifest
         # diagnostic ("edit shipgate.yaml") would route the agent to the

--- a/src/agents_shipgate/cli/agent_interface.py
+++ b/src/agents_shipgate/cli/agent_interface.py
@@ -8,6 +8,7 @@ import typer
 
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error
 from agents_shipgate.cli.current_workspace import live_workspace
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_control_envelope import (
     AgentControlRouteUnavailable,
     envelope_from_pointer,
@@ -160,6 +161,7 @@ def control(
     already published.  ``--format pointer`` returns the underlying artifact
     unchanged.
     """
+    require_workspace(workspace)
 
     if format_ not in {"control", "pointer"}:
         guidance = "Re-run with --format control or --format pointer."

--- a/src/agents_shipgate/cli/authorization.py
+++ b/src/agents_shipgate/cli/authorization.py
@@ -19,6 +19,7 @@ from agents_shipgate.cli.verify.git import (
     ensure_git_workspace,
     resolve_git_push_endpoint,
 )
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.authorization_execution import (
     authorization_execute_command,
     authorization_workspace_root,
@@ -209,6 +210,7 @@ def execute_authorization(
     ),
 ) -> None:
     """Revalidate and execute one receipt-bound signed operation."""
+    require_workspace(workspace)
 
     try:
         root = artifacts_root.resolve()

--- a/src/agents_shipgate/cli/bootstrap.py
+++ b/src/agents_shipgate/cli/bootstrap.py
@@ -36,6 +36,7 @@ from typing import Any
 import typer
 
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error
+from agents_shipgate.cli.workspace_guard import require_workspace
 
 _ENV_VAR = "AGENTS_SHIPGATE_AGENT_MODE"
 
@@ -509,6 +510,7 @@ def bootstrap(
     keep using the GitHub Action — bootstrap is the one-shot
     convenience layer for first-time setup.
     """
+    require_workspace(workspace)
     result = bootstrap_run(
         workspace=workspace,
         confidence=confidence,

--- a/src/agents_shipgate/cli/check.py
+++ b/src/agents_shipgate/cli/check.py
@@ -19,6 +19,7 @@ from agents_shipgate.cli.agent_result import (
     git_boundary_change_set,
 )
 from agents_shipgate.cli.verify.git import commit_sha
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_control import derive_agent_control
 from agents_shipgate.core.agent_control_envelope import (
     envelope_from_agent_result,
@@ -224,6 +225,7 @@ def check(
     ),
 ) -> None:
     """Run the agent-native local boundary check."""
+    require_workspace(workspace)
 
     # The actor lands in the result and in the audit id, so an undetected
     # harness mislabels every row it writes. An explicit flag always wins.

--- a/src/agents_shipgate/cli/detect.py
+++ b/src/agents_shipgate/cli/detect.py
@@ -24,6 +24,7 @@ from agents_shipgate.cli.setup_control import (
     setup_control_envelope,
     setup_input_id,
 )
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.errors import DiscoveryError
 from agents_shipgate.invocation import render_command
 from agents_shipgate.schemas.agent_control import AgentActionKind
@@ -54,6 +55,7 @@ def detect(
     ),
 ) -> None:
     """Classify a workspace: which agent framework(s), if any."""
+    require_workspace(workspace)
     workspace_resolved = workspace.resolve()
     try:
         result = detect_workspace(

--- a/src/agents_shipgate/cli/host_audit.py
+++ b/src/agents_shipgate/cli/host_audit.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import typer
 
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error_action
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.host_grants import (
     DEFAULT_BASELINE_FILE,
     HOST_GRANTS_INVENTORY_SCHEMA_VERSION,
@@ -192,6 +193,7 @@ def audit(
     ),
 ) -> None:
     """Zero-config, read-only audits. Currently supports --host."""
+    require_workspace(workspace)
 
     if not host:
         command = (

--- a/src/agents_shipgate/cli/install_hooks.py
+++ b/src/agents_shipgate/cli/install_hooks.py
@@ -11,6 +11,7 @@ from typing import Any
 import typer
 
 from agents_shipgate.checks.verify import TRUST_ROOT_SURFACES
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.trust_roots import inspect_lexical_path_identity
 
@@ -95,6 +96,7 @@ def install_hooks(
     ),
 ) -> None:
     """Install advisory local hooks for supported coding-agent runtimes."""
+    require_workspace(workspace)
 
     try:
         result = render_or_install_hooks(

--- a/src/agents_shipgate/cli/mcp.py
+++ b/src/agents_shipgate/cli/mcp.py
@@ -11,6 +11,7 @@ import typer
 import yaml
 
 from agents_shipgate.cli.agent_result import agent_result_json_payload
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_control import derive_agent_control
 from agents_shipgate.core.capabilities import build_capability_facts
 from agents_shipgate.core.capability_delta import diff_capability_fact_sets
@@ -236,6 +237,7 @@ def mcp_audit(
         help="Output format: json or agent-json.",
     ),
 ) -> None:
+    require_workspace(workspace)
     del config
     if format_ not in {"json", "agent-json"}:
         typer.echo("--format must be 'json' or 'agent-json'.", err=True)

--- a/src/agents_shipgate/cli/org.py
+++ b/src/agents_shipgate/cli/org.py
@@ -11,6 +11,7 @@ import typer
 from agents_shipgate import __version__
 from agents_shipgate.cli.attest import build_attestation_payload
 from agents_shipgate.cli.registry import _row_from_attestation
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.host_grants import (
@@ -71,6 +72,7 @@ def org_status(
     json_output: bool = typer.Option(False, "--json", help="Emit JSON."),
 ) -> None:
     """Evaluate opt-in org governance gates without changing release verdicts."""
+    require_workspace(workspace)
 
     try:
         as_of_date = date.fromisoformat(as_of) if as_of else datetime.now(UTC).date()
@@ -125,6 +127,7 @@ def org_policy_packs(
     json_output: bool = typer.Option(False, "--json", help="Emit JSON."),
 ) -> None:
     """Report local organization policy-pack pin status."""
+    require_workspace(workspace)
 
     root = workspace.resolve()
     config_path = config if config.is_absolute() else root / config
@@ -191,6 +194,7 @@ def org_bundle(
     json_output: bool = typer.Option(False, "--json", help="Print JSON to stdout."),
 ) -> None:
     """Build a compact organization evidence bundle from local artifacts."""
+    require_workspace(workspace)
 
     try:
         as_of_date = date.fromisoformat(as_of) if as_of else datetime.now(UTC).date()

--- a/src/agents_shipgate/cli/preflight.py
+++ b/src/agents_shipgate/cli/preflight.py
@@ -13,6 +13,7 @@ import typer
 from pydantic import ValidationError
 
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.bounded_io import (
     MAX_EXPLICIT_DIFF_BYTES,
     MAX_EXPLICIT_JSON_BYTES,
@@ -287,6 +288,7 @@ def preflight(
     verbose: bool = typer.Option(False, "--verbose", help="Show debug details."),
 ) -> None:
     """Run the proactive static preflight contract for coding agents."""
+    require_workspace(workspace)
 
     # A plan combined with the per-flag inputs is a request-shape conflict:
     # replaying it verbatim can never satisfy its own ``expects``. Offer a

--- a/src/agents_shipgate/cli/scan/inspect.py
+++ b/src/agents_shipgate/cli/scan/inspect.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from agents_shipgate.config.loader import load_manifest_text
+from agents_shipgate.config.loader import load_manifest_text, manifest_read_error
 from agents_shipgate.core.artifact_models import (
     AnthropicArtifacts,
     CodexPluginArtifacts,
@@ -81,8 +81,11 @@ def inspect_sources(
     if manifest_bytes is None:
         try:
             manifest_bytes = config_path.read_bytes()
-        except OSError:
-            manifest_bytes = b""
+        except OSError as exc:
+            # Absent is not empty. Letting the read failure fall through as
+            # ``b""`` made a manifest that was never created report as one
+            # with the wrong shape (#384); the errno is only in hand here.
+            raise manifest_read_error(config_path, exc) from exc
     manifest = load_manifest_text(decode_manifest(manifest_bytes, config_path), source=config_path)
     base_dir = config_path.resolve().parent
     unresolved_sources = _resolve_source_paths(manifest, base_dir, config_path)

--- a/src/agents_shipgate/cli/trigger.py
+++ b/src/agents_shipgate/cli/trigger.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import typer
 
 from agents_shipgate.cli.discovery.scope import manifest_opt_in
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.bounded_io import (
     MAX_EXPLICIT_DIFF_BYTES,
     MAX_EXPLICIT_JSON_BYTES,
@@ -116,6 +117,7 @@ def trigger(
     ),
 ) -> None:
     """Decide whether Shipgate should run on a diff (run/skip verdict)."""
+    require_workspace(workspace)
     triggers = load_triggers()
 
     if list_rules:

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -36,6 +36,7 @@ from agents_shipgate.cli.verify.git import (
     working_tree_context,
     working_tree_paths,
 )
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.config.loader import load_yaml_file
 from agents_shipgate.core.agent_handoff import build_agent_handoff
 from agents_shipgate.core.current_control import (
@@ -102,6 +103,7 @@ def prepare(
     out: Path = typer.Option(Path("agents-shipgate-reports/verification-plan.json"), "--out"),
 ) -> None:
     """Prepare one portable, content-addressed plan without evaluating policy."""
+    require_workspace(workspace)
 
     root = ensure_git_workspace(workspace.resolve())
     if head is not None and base is None:
@@ -473,6 +475,7 @@ def worker(
     ),
 ) -> None:
     """Validate one task's immutable inputs and emit decision-free worker IR."""
+    require_workspace(workspace)
 
     plan = VerificationPlan.model_validate(_load_json(plan_path))
     resolved_diff = diff_path or plan_path.with_name(plan.inputs.diff.path)

--- a/src/agents_shipgate/cli/verify/command.py
+++ b/src/agents_shipgate/cli/verify/command.py
@@ -17,6 +17,7 @@ from agents_shipgate.cli.agent_mode import emit_agent_mode_error, is_agent_mode
 from agents_shipgate.cli.current_workspace import live_workspace
 from agents_shipgate.cli.diagnostics import top_next_actions
 from agents_shipgate.cli.discovery.gitignore_block import REPORTS_DIR_NAME
+from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_control_envelope import (
     control_headline_lines,
     denied_control_envelope,
@@ -117,7 +118,9 @@ def verify(
             "Lightweight relevance check: evaluate triggers and report "
             "whether Shipgate is relevant + what to run next, WITHOUT "
             "running a scan, requiring a manifest, or writing any files "
-            "beyond the verifier artifacts. Always exits 0."
+            "beyond the verifier artifacts. Exits 0 for every workspace it "
+            "evaluates; a --workspace that does not exist is refused as an "
+            "invocation error (exit 2) before anything is created."
         ),
     ),
     out: Path | None = typer.Option(
@@ -213,6 +216,11 @@ def verify(
     verbose: bool = typer.Option(False, "--verbose", help="Show debug details."),
 ) -> None:
     """Run the canonical ongoing-PR verifier around the existing scan engine."""
+
+    # Ahead of every other check, including flag parsing: a workspace that is
+    # not there has no output directory to resolve, and preview used to create
+    # the whole mistyped path before saying so (#389).
+    require_workspace(workspace)
 
     # Flag parsing gets its own try block, mirroring scan: a ConfigError
     # raised here is about flag values, not the manifest — emitting a

--- a/src/agents_shipgate/cli/verify/git.py
+++ b/src/agents_shipgate/cli/verify/git.py
@@ -17,6 +17,7 @@ import yaml
 from agents_shipgate.core.boundary_registry import is_agent_boundary_path
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.trust_roots import trust_root_class_for
+from agents_shipgate.core.workspace_input import workspace_input_error
 from agents_shipgate.schemas.human_authorization import canonical_https_git_endpoint
 
 _GIT_OBJECT_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
@@ -249,8 +250,19 @@ def ensure_git_workspace(workspace: Path) -> Path:
     ``verify`` is a PR-diff workflow, so git is required for base/head
     orchestration. The command remains local-only: all calls are fixed argv
     reads against the existing checkout.
+
+    A path that is not there is classified before git is consulted. Running
+    ``git rev-parse`` in a directory that does not exist fails the same way as
+    running it in one that is not a repository, and reporting both as "not
+    inside a git checkout" asserts the directory exists — which sent a
+    first-time user to diagnose their git installation when the real state was
+    a workspace they had not cloned yet (#389, and the second instance
+    recorded on #384).
     """
 
+    workspace_error = workspace_input_error(workspace)
+    if workspace_error is not None:
+        raise workspace_error
     result = _run_git(workspace, ["rev-parse", "--show-toplevel"], check=False)
     if result.returncode != 0:
         raise ConfigError(f"Workspace is not inside a git checkout: {workspace}")

--- a/src/agents_shipgate/cli/workspace_guard.py
+++ b/src/agents_shipgate/cli/workspace_guard.py
@@ -1,0 +1,70 @@
+"""The one place a command refuses an unusable ``--workspace``.
+
+Kept as a leaf module — typer plus
+:mod:`agents_shipgate.core.workspace_input` — so that every command can call
+it as its first statement without importing the scan machinery, and so the
+refusal is provably ahead of any output directory, manifest write, or git
+probe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from agents_shipgate.core.errors import ConfigError
+from agents_shipgate.core.workspace_input import require_workspace_directory
+
+__all__ = ["require_workspace"]
+
+
+def require_workspace(
+    workspace: Path | None, *, option: str = "--workspace"
+) -> Path | None:
+    """Return the resolved workspace, or refuse the invocation with exit 2.
+
+    Call this before anything else in a command body. ``verify --preview`` is
+    the reason for the placement: it resolved an output directory from a
+    ``--workspace`` that did not exist, created the entire four-deep path,
+    wrote a full artifact set into it, and exited 0 — so a typo produced a
+    confident result about a workspace that was never there, and in CI it
+    looked healthy on both signals a caller can gate on (#389).
+
+    An absent workspace is an invocation error, not an evaluation outcome, so
+    this exits 2 (``config_error``) on every command — ``--preview``
+    included. The preview's documented "always exits 0" is a promise about
+    workspaces it evaluated; there is nothing here to evaluate, and the exit
+    code is the signal the silent 0 was misleading.
+
+    ``None`` passes through: commands whose ``--workspace`` is optional use it
+    to mean "discover from the manifest instead", which is not a workspace
+    claim to check.
+    """
+
+    from agents_shipgate.cli._helpers import _echo_next_action_hint
+    from agents_shipgate.cli.agent_mode import emit_agent_mode_error_action
+    from agents_shipgate.schemas.diagnostics import NextAction
+
+    if workspace is None:
+        return None
+    try:
+        return require_workspace_directory(workspace, option=option)
+    except ConfigError as exc:
+        typer.echo(f"Config error: {exc}", err=True)
+        action = NextAction(
+            kind="review",
+            why=str(exc),
+            expects=(
+                f"Re-run with {option} pointing at an existing checkout "
+                "directory."
+            ),
+        )
+        _echo_next_action_hint([action])
+        emit_agent_mode_error_action(
+            "config_error",
+            message=str(exc),
+            exit_code=2,
+            action=action,
+        )
+        raise typer.Exit(2) from exc

--- a/src/agents_shipgate/config/loader.py
+++ b/src/agents_shipgate/config/loader.py
@@ -16,19 +16,80 @@ from agents_shipgate.inputs.common import (
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
 
 
+def config_not_found_error(path: Path) -> ConfigError:
+    """The one message for a manifest that is not on disk.
+
+    Absent, empty, and present-but-not-a-mapping are three different
+    workspace states with three different repairs, so they get three
+    different messages. Collapsing them told a first-time user that a file
+    they had never created was malformed (#384).
+    """
+
+    hint = ""
+    if path.name == "shipgate.yaml":
+        hint = " Run `agents-shipgate init --workspace . --write` to create one."
+    return ConfigError(f"Config file not found: {path} in {Path.cwd()}.{hint}")
+
+
+def manifest_read_error(path: Path, exc: OSError) -> ConfigError:
+    """Classify a failed manifest read where the errno is still in hand.
+
+    Readers that snapshot the manifest bytes collapse a failed read into
+    ``b""`` so that a later failure is reported against the same bytes the
+    identity hashed. That part is deliberate. But ``b""`` then parses as an
+    empty YAML document and reaches the shape check below, which reports an
+    absent file as a malformed one — and the control envelope that carries
+    that reason routes to ``verify``, so ``reason`` and ``next_action``
+    disagree about whether the file exists (#384). Classifying at the read
+    keeps the ``b""`` binding and gives the two fields one story.
+    """
+
+    if isinstance(exc, FileNotFoundError):
+        return config_not_found_error(path)
+    if isinstance(exc, NotADirectoryError):
+        # ENOTDIR: the file is absent, but "not found" would send the reader
+        # to create it — and creating it is exactly what cannot work while a
+        # regular file sits in the middle of the path.
+        return ConfigError(
+            f"Config file path runs through a file, not a directory: {path}"
+        )
+    if isinstance(exc, IsADirectoryError):
+        return ConfigError(f"Config path is a directory, not a manifest file: {path}")
+    detail = exc.strerror or str(exc)
+    return ConfigError(f"Config file could not be read: {path}: {detail}")
+
+
+def _empty_config_error(path: Path) -> ConfigError:
+    return ConfigError(
+        f"Config file is empty: {path}. A manifest needs at least "
+        "version, project, agent, and environment."
+    )
+
+
+def _parsed_manifest_mapping(
+    data: Any, text: str, config_path: Path
+) -> dict[str, Any]:
+    """Reject a parsed manifest that is not a mapping, saying which way."""
+
+    if isinstance(data, dict):
+        return data
+    if data is None and not text.strip():
+        raise _empty_config_error(config_path)
+    raise ConfigError(f"Config file must contain a YAML object: {config_path}")
+
+
 def load_yaml_file(path: Path) -> dict[str, Any]:
     if not path.exists():
-        hint = ""
-        if path.name == "shipgate.yaml":
-            hint = " Run `agents-shipgate init --workspace . --write` to create one."
-        raise ConfigError(f"Config file not found: {path} in {Path.cwd()}.{hint}")
+        raise config_not_found_error(path)
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise manifest_read_error(path, exc) from exc
+    try:
+        data = yaml.safe_load(text)
     except yaml.YAMLError as exc:
         raise ConfigError(f"Invalid YAML in {path}: {exc}") from exc
-    if not isinstance(data, dict):
-        raise ConfigError(f"Config file must contain a YAML object: {path}")
-    return data
+    return _parsed_manifest_mapping(data, text, path)
 
 
 def load_manifest(path: str | Path) -> AgentsShipgateManifest:
@@ -49,9 +110,9 @@ def load_manifest_text(
         data = yaml.safe_load(text)
     except yaml.YAMLError as exc:
         raise ConfigError(f"Invalid YAML in {config_path}: {exc}") from exc
-    if not isinstance(data, dict):
-        raise ConfigError(f"Config file must contain a YAML object: {config_path}")
-    return _validate_manifest_data(data, config_path)
+    return _validate_manifest_data(
+        _parsed_manifest_mapping(data, text, config_path), config_path
+    )
 
 
 def load_manifest_with_positions(

--- a/src/agents_shipgate/core/workspace_input.py
+++ b/src/agents_shipgate/core/workspace_input.py
@@ -1,0 +1,124 @@
+"""One classification of the ``--workspace`` argument, shared by every command.
+
+A workspace is an input Shipgate *reads*, and like every other input it has
+distinct failure states that mean distinct things to whoever has to fix it:
+the path is not there, the path is there but is a file, the path is there but
+cannot be read. Before this module each command discovered the difference on
+its own — or did not. ``verify --preview`` created a four-deep directory tree
+for a mistyped path and exited 0; ``init --write``, ``audit --host``, and the
+verification workers raised a bare ``FileNotFoundError`` traceback;
+``mcp audit`` answered ``decision: allow`` about a directory that did not
+exist; and every command routed through :func:`ensure_git_workspace` reported
+an absent path as "not inside a git checkout", which asserts the path exists
+and sends the reader to install git rather than to fix the typo (#389, and
+the second instance recorded on #384).
+
+The rule this module enforces: **an absent ``--workspace`` is an invocation
+error, decided before anything is created.** It is not a preview outcome, not
+a gate verdict, and not a shape complaint about a directory that was never
+there.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Literal
+
+from agents_shipgate.core.errors import ConfigError
+
+WorkspacePresence = Literal["present", "absent", "not_a_directory", "unreadable"]
+
+__all__ = [
+    "WorkspacePresence",
+    "classify_workspace",
+    "require_workspace_directory",
+    "workspace_input_error",
+]
+
+
+def classify_workspace(workspace: Path) -> WorkspacePresence:
+    """Report what the filesystem says about ``workspace``.
+
+    Uses ``os.stat`` rather than ``Path.exists()`` so that a permission or
+    I/O failure is reported as itself instead of silently reading as absent:
+    a directory you cannot traverse is a different repair from one that is
+    not there.
+    """
+
+    try:
+        stat_result = os.stat(workspace)
+    except FileNotFoundError:
+        return "absent"
+    except NotADirectoryError:
+        # A path component that is a file, e.g. ``repo/shipgate.yaml/src``.
+        return "not_a_directory"
+    except OSError:
+        return "unreadable"
+    if not stat.S_ISDIR(stat_result.st_mode):
+        return "not_a_directory"
+    return "present"
+
+
+def workspace_input_error(
+    workspace: Path, *, option: str = "--workspace"
+) -> ConfigError | None:
+    """The invocation error for an unusable ``workspace``, or ``None``.
+
+    Pure: it decides, it does not print, exit, or create anything. Callers
+    that already sit inside a ``ConfigError`` boundary raise the result;
+    the CLI guard turns it into the standard agent-mode error line.
+    """
+
+    presence = classify_workspace(workspace)
+    if presence == "present":
+        return None
+    display = _display_path(workspace)
+    if presence == "absent":
+        return ConfigError(
+            f"{option} does not exist: {display}. Point it at an existing "
+            "checkout — clone or create the directory first. Nothing was "
+            "written."
+        )
+    if presence == "not_a_directory":
+        return ConfigError(
+            f"{option} is not a directory: {display}. Point it at the "
+            "checkout root rather than at a file inside it."
+        )
+    return ConfigError(
+        f"{option} could not be read: {display}. Check the permissions on "
+        "the path and every directory above it."
+    )
+
+
+def require_workspace_directory(
+    workspace: Path, *, option: str = "--workspace"
+) -> Path:
+    """Return the resolved workspace, or raise the invocation error.
+
+    Resolution happens *after* the check so the message names the path the
+    caller typed rather than a normalized one they never wrote.
+    """
+
+    error = workspace_input_error(workspace, option=option)
+    if error is not None:
+        raise error
+    try:
+        return workspace.resolve()
+    except OSError:  # pragma: no cover - resolvable by construction above
+        return workspace
+
+
+def _display_path(workspace: Path) -> str:
+    """Absolutize for the message without requiring the path to exist.
+
+    ``Path.resolve()`` is fine on a missing path, but a caller who typed a
+    relative ``--workspace`` needs to see which directory it was relative
+    *to* — that is the whole content of the "ran the preview before the
+    clone" report.
+    """
+
+    if workspace.is_absolute():
+        return str(workspace)
+    return f"{workspace} (resolved to {Path(os.path.abspath(workspace))})"

--- a/src/agents_shipgate/schemas/manifest/_artifacts.py
+++ b/src/agents_shipgate/schemas/manifest/_artifacts.py
@@ -4,7 +4,10 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from agents_shipgate.schemas.manifest._common import STRICT_MODEL_CONFIG
+from agents_shipgate.schemas.manifest._common import (
+    STRICT_MODEL_CONFIG,
+    describe_yaml_shape,
+)
 
 
 class ArtifactPathConfig(BaseModel):
@@ -23,9 +26,12 @@ def _parse_artifact_entries(value: Any) -> list[ArtifactPathConfig]:
     if value is None:
         return []
     if not isinstance(value, list):
-        raise TypeError("artifact entries must be a list")
+        raise ValueError(
+            "must be a list of artifact paths, but is "
+            f"{describe_yaml_shape(value)}"
+        )
     entries: list[ArtifactPathConfig] = []
-    for item in value:
+    for index, item in enumerate(value):
         if isinstance(item, ArtifactPathConfig):
             entries.append(item)
         elif isinstance(item, str):
@@ -33,7 +39,10 @@ def _parse_artifact_entries(value: Any) -> list[ArtifactPathConfig]:
         elif isinstance(item, dict):
             entries.append(ArtifactPathConfig.model_validate(item))
         else:
-            raise TypeError("artifact entries must be strings or objects")
+            raise ValueError(
+                f"entry {index} must be a path string or an object with a "
+                f"path, but is {describe_yaml_shape(item)}"
+            )
     return entries
 
 
@@ -41,9 +50,12 @@ def _parse_named_artifact_entries(value: Any) -> list[NamedArtifactPathConfig]:
     if value is None:
         return []
     if not isinstance(value, list):
-        raise TypeError("artifact entries must be a list")
+        raise ValueError(
+            "must be a list of artifact paths, but is "
+            f"{describe_yaml_shape(value)}"
+        )
     entries: list[NamedArtifactPathConfig] = []
-    for item in value:
+    for index, item in enumerate(value):
         if isinstance(item, NamedArtifactPathConfig):
             entries.append(item)
         elif isinstance(item, str):
@@ -51,5 +63,8 @@ def _parse_named_artifact_entries(value: Any) -> list[NamedArtifactPathConfig]:
         elif isinstance(item, dict):
             entries.append(NamedArtifactPathConfig.model_validate(item))
         else:
-            raise TypeError("artifact entries must be strings or objects")
+            raise ValueError(
+                f"entry {index} must be a path string or an object with a "
+                f"path, but is {describe_yaml_shape(item)}"
+            )
     return entries

--- a/src/agents_shipgate/schemas/manifest/_common.py
+++ b/src/agents_shipgate/schemas/manifest/_common.py
@@ -1,3 +1,16 @@
+"""Shared pieces of the manifest schema.
+
+**Validators in this package raise ``ValueError``, never ``TypeError``.**
+Pydantic converts ``ValueError`` and ``AssertionError`` raised inside a
+validator into a ``ValidationError`` carrying the field's location, which
+the config loader renders as a ``config_error`` naming the manifest key. A
+``TypeError`` propagates instead: it escapes the config-loading boundary,
+lands in the generic internal-error handler, and tells someone who wrote a
+mapping where a list belongs that they hit a bug and should file an issue
+(#387). ``tests/test_config.py`` fails the build if a ``raise TypeError``
+reappears anywhere under ``schemas/``.
+"""
+
 from __future__ import annotations
 
 from pydantic import ConfigDict
@@ -7,3 +20,27 @@ from pydantic import ConfigDict
 # config loader translates those errors into ``ConfigError`` (exit 2)
 # with a close-match suggestion for the offending field name.
 STRICT_MODEL_CONFIG = ConfigDict(extra="forbid")
+
+
+def describe_yaml_shape(value: object) -> str:
+    """Name the YAML shape a manifest value arrived as.
+
+    Manifest type mismatches are edits, not defects, so the message has to
+    say what was written as well as what was expected. YAML names are used
+    rather than Python ones: someone reading the error is looking at
+    ``shipgate.yaml``, not at a traceback.
+    """
+
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "a boolean"
+    if isinstance(value, dict):
+        return "a mapping"
+    if isinstance(value, (list, tuple)):
+        return "a list"
+    if isinstance(value, str):
+        return "a string"
+    if isinstance(value, (int, float)):
+        return "a number"
+    return f"a {type(value).__name__}"

--- a/src/agents_shipgate/schemas/manifest/anthropic.py
+++ b/src/agents_shipgate/schemas/manifest/anthropic.py
@@ -8,6 +8,7 @@ from agents_shipgate.schemas.manifest._artifacts import (
     ArtifactPathConfig,
     _parse_artifact_entries,
 )
+from agents_shipgate.schemas.manifest._common import describe_yaml_shape
 
 
 class AnthropicConfig(BaseModel):
@@ -23,15 +24,21 @@ class AnthropicConfig(BaseModel):
         if value is None:
             return []
         if not isinstance(value, list):
-            raise TypeError("prompt_files must be a list")
+            raise ValueError(
+                "must be a list of prompt files, but is "
+                f"{describe_yaml_shape(value)}"
+            )
         files: list[str] = []
-        for item in value:
+        for index, item in enumerate(value):
             if isinstance(item, str):
                 files.append(item)
             elif isinstance(item, dict) and isinstance(item.get("path"), str):
                 files.append(item["path"])
             else:
-                raise TypeError("prompt_files entries must be strings or objects with path")
+                raise ValueError(
+                    f"entry {index} must be a path string or an object with "
+                    f"a path, but is {describe_yaml_shape(item)}"
+                )
         return files
 
     @field_validator("tools", "policy_rules", mode="before")

--- a/src/agents_shipgate/schemas/manifest/checks.py
+++ b/src/agents_shipgate/schemas/manifest/checks.py
@@ -6,7 +6,10 @@ from typing import Any, get_args
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from agents_shipgate.schemas.common import Severity
-from agents_shipgate.schemas.manifest._common import STRICT_MODEL_CONFIG
+from agents_shipgate.schemas.manifest._common import (
+    STRICT_MODEL_CONFIG,
+    describe_yaml_shape,
+)
 from agents_shipgate.schemas.manifest.policy_packs import (
     PolicyPackConfig,
     _parse_policy_pack_entries,
@@ -79,7 +82,10 @@ class ChecksConfig(BaseModel):
         if value is None:
             return {}
         if not isinstance(value, dict):
-            raise TypeError("checks.severity_overrides must be a mapping")
+            raise ValueError(
+                "must be a mapping of check_id to severity, but is "
+                f"{describe_yaml_shape(value)}"
+            )
         valid_severities = set(get_args(Severity))
         coerced: dict[str, SeverityOverrideEntry] = {}
         for check_id, raw in value.items():
@@ -100,9 +106,9 @@ class ChecksConfig(BaseModel):
             if isinstance(raw, dict):
                 coerced[check_id] = SeverityOverrideEntry.model_validate(raw)
                 continue
-            raise TypeError(
+            raise ValueError(
                 f"severity_overrides[{check_id!r}] must be a severity "
-                f"string or a mapping; got {type(raw).__name__}"
+                f"string or a mapping, but is {describe_yaml_shape(raw)}"
             )
         return coerced
 

--- a/src/agents_shipgate/schemas/manifest/codex_plugin.py
+++ b/src/agents_shipgate/schemas/manifest/codex_plugin.py
@@ -5,7 +5,10 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from agents_shipgate.schemas.manifest._artifacts import ArtifactPathConfig
-from agents_shipgate.schemas.manifest._common import STRICT_MODEL_CONFIG
+from agents_shipgate.schemas.manifest._common import (
+    STRICT_MODEL_CONFIG,
+    describe_yaml_shape,
+)
 
 
 class CodexPluginMcpInventoryConfig(ArtifactPathConfig):
@@ -21,15 +24,21 @@ def _parse_codex_plugin_inventory_entries(
     if value is None:
         return []
     if not isinstance(value, list):
-        raise TypeError("mcp_tool_inventories must be a list")
+        raise ValueError(
+            "must be a list of inventory objects, but is "
+            f"{describe_yaml_shape(value)}"
+        )
     entries: list[CodexPluginMcpInventoryConfig] = []
-    for item in value:
+    for index, item in enumerate(value):
         if isinstance(item, CodexPluginMcpInventoryConfig):
             entries.append(item)
         elif isinstance(item, dict):
             entries.append(CodexPluginMcpInventoryConfig.model_validate(item))
         else:
-            raise TypeError("mcp_tool_inventories entries must be objects")
+            raise ValueError(
+                f"entry {index} must be an object with plugin, server, and "
+                f"path, but is {describe_yaml_shape(item)}"
+            )
     return entries
 
 

--- a/src/agents_shipgate/schemas/manifest/openai_api.py
+++ b/src/agents_shipgate/schemas/manifest/openai_api.py
@@ -10,6 +10,7 @@ from agents_shipgate.schemas.manifest._artifacts import (
     _parse_artifact_entries,
     _parse_named_artifact_entries,
 )
+from agents_shipgate.schemas.manifest._common import describe_yaml_shape
 
 
 class OpenAIApiConfig(BaseModel):
@@ -30,15 +31,21 @@ class OpenAIApiConfig(BaseModel):
         if value is None:
             return []
         if not isinstance(value, list):
-            raise TypeError("prompt_files must be a list")
+            raise ValueError(
+                "must be a list of prompt files, but is "
+                f"{describe_yaml_shape(value)}"
+            )
         files: list[str] = []
-        for item in value:
+        for index, item in enumerate(value):
             if isinstance(item, str):
                 files.append(item)
             elif isinstance(item, dict) and isinstance(item.get("path"), str):
                 files.append(item["path"])
             else:
-                raise TypeError("prompt_files entries must be strings or objects with path")
+                raise ValueError(
+                    f"entry {index} must be a path string or an object with "
+                    f"a path, but is {describe_yaml_shape(item)}"
+                )
         return files
 
     @field_validator("tools", "test_cases", "trace_samples", "policy_rules", mode="before")
@@ -60,4 +67,7 @@ class OpenAIApiConfig(BaseModel):
             return ArtifactPathConfig(path=value)
         if isinstance(value, dict):
             return ArtifactPathConfig.model_validate(value)
-        raise TypeError("model_config must be a string path or object with path")
+        raise ValueError(
+            "must be a path string or an object with a path, but is "
+            f"{describe_yaml_shape(value)}"
+        )

--- a/src/agents_shipgate/schemas/manifest/policies.py
+++ b/src/agents_shipgate/schemas/manifest/policies.py
@@ -4,7 +4,10 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from agents_shipgate.schemas.manifest._common import STRICT_MODEL_CONFIG
+from agents_shipgate.schemas.manifest._common import (
+    STRICT_MODEL_CONFIG,
+    describe_yaml_shape,
+)
 
 
 class PolicyToolEntry(BaseModel):
@@ -22,9 +25,12 @@ def _parse_policy_entries(value: Any) -> list[PolicyToolEntry]:
     if value is None:
         return []
     if not isinstance(value, list):
-        raise TypeError("policy value must be a list")
+        raise ValueError(
+            "must be a list of tool entries, but is "
+            f"{describe_yaml_shape(value)}"
+        )
     entries: list[PolicyToolEntry] = []
-    for item in value:
+    for index, item in enumerate(value):
         if isinstance(item, PolicyToolEntry):
             entries.append(item)
         elif isinstance(item, str):
@@ -32,7 +38,10 @@ def _parse_policy_entries(value: Any) -> list[PolicyToolEntry]:
         elif isinstance(item, dict):
             entries.append(PolicyToolEntry.model_validate(item))
         else:
-            raise TypeError("policy entries must be strings or objects")
+            raise ValueError(
+                f"entry {index} must be a tool-name string or an object with "
+                f"a tool, but is {describe_yaml_shape(item)}"
+            )
     return entries
 
 

--- a/src/agents_shipgate/schemas/manifest/policy_packs.py
+++ b/src/agents_shipgate/schemas/manifest/policy_packs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from agents_shipgate.schemas.manifest._artifacts import ArtifactPathConfig
+from agents_shipgate.schemas.manifest._common import describe_yaml_shape
 
 
 class PolicyPackConfig(ArtifactPathConfig):
@@ -20,9 +21,12 @@ def _parse_policy_pack_entries(value: Any) -> list[PolicyPackConfig]:
     if value is None:
         return []
     if not isinstance(value, list):
-        raise TypeError("policy_packs must be a list")
+        raise ValueError(
+            "must be a list of policy packs, but is "
+            f"{describe_yaml_shape(value)}"
+        )
     entries: list[PolicyPackConfig] = []
-    for item in value:
+    for index, item in enumerate(value):
         if isinstance(item, PolicyPackConfig):
             entries.append(item)
         elif isinstance(item, str):
@@ -30,5 +34,8 @@ def _parse_policy_pack_entries(value: Any) -> list[PolicyPackConfig]:
         elif isinstance(item, dict):
             entries.append(PolicyPackConfig.model_validate(item))
         else:
-            raise TypeError("policy_packs entries must be strings or objects")
+            raise ValueError(
+                f"entry {index} must be a path string or an object with a "
+                f"path, but is {describe_yaml_shape(item)}"
+            )
     return entries

--- a/tests/test_absent_input_messages.py
+++ b/tests/test_absent_input_messages.py
@@ -1,0 +1,182 @@
+"""An absent input and a malformed input never share a message (#384).
+
+Shipgate reads six kinds of input: the manifest, the workspace, a tool source,
+a policy pack, a baseline, and a pair of diff refs. Each has a not-found
+branch and a shape-check branch, and two of them used to route *absent*
+through the shape check:
+
+- the manifest, where a failed read collapsed to ``b""`` and then parsed as an
+  empty YAML document, so a file that had never been created was reported as
+  "Config file must contain a YAML object";
+- the workspace, where ``git rev-parse`` fails identically in a directory that
+  is not a repository and one that is not there, so both were reported as
+  "Workspace is not inside a git checkout".
+
+Both cost real diagnosis time in one session, in unrelated subsystems, which
+is why this is a table over every input rather than two regression tests. The
+other four already told the states apart and are asserted here so a future
+refactor cannot quietly re-collapse them.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+
+runner = CliRunner()
+
+MANIFEST = """version: "0.1"
+project:
+  name: absent-input-probe
+agent:
+  name: probe-agent
+  declared_purpose:
+    - look things up
+environment:
+  target: local
+tool_sources:
+  - id: tools
+    type: mcp
+    path: tools.json
+"""
+
+TOOLS_JSON = (
+    '{"tools": [{"name": "lookup", "description": '
+    '"look an order up by its identifier for a support agent"}]}\n'
+)
+
+# Text that asserts the input exists and has the wrong shape. An absent input
+# must never produce any of it.
+SHAPE_CLAIMS = (
+    "must contain a YAML object",
+    "not inside a git checkout",
+    "Unable to parse",
+    "Invalid baseline file",
+)
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "shipgate.yaml").write_text(MANIFEST, encoding="utf-8")
+    (workspace / "tools.json").write_text(TOOLS_JSON, encoding="utf-8")
+    return workspace
+
+
+def _run(argv: list[str]) -> str:
+    return runner.invoke(app, argv).output
+
+
+def _manifest_cases(tmp_path: Path) -> tuple[str, str]:
+    workspace = _workspace(tmp_path)
+    malformed = workspace / "malformed.yaml"
+    malformed.write_text("- a\n- b\n", encoding="utf-8")
+    absent = _run(["doctor", "--config", str(workspace / "gone.yaml")])
+    return absent, _run(["doctor", "--config", str(malformed)])
+
+
+def _workspace_cases(tmp_path: Path) -> tuple[str, str]:
+    workspace = _workspace(tmp_path)
+    # "Exists but is not a git checkout" is the shape complaint here: the
+    # workspace fixture is a plain directory, never `git init`ed.
+    absent = _run(["verify", "--workspace", str(tmp_path / "gone")])
+    return absent, _run(["verify", "--workspace", str(workspace)])
+
+
+def _tool_source_cases(tmp_path: Path) -> tuple[str, str]:
+    workspace = _workspace(tmp_path)
+    absent_manifest = workspace / "absent-source.yaml"
+    absent_manifest.write_text(
+        MANIFEST.replace("path: tools.json", "path: gone.json"), encoding="utf-8"
+    )
+    (workspace / "broken.json").write_text("{ not json\n", encoding="utf-8")
+    malformed_manifest = workspace / "malformed-source.yaml"
+    malformed_manifest.write_text(
+        MANIFEST.replace("path: tools.json", "path: broken.json"), encoding="utf-8"
+    )
+    return (
+        _run(["scan", "--config", str(absent_manifest), "--format", "json"]),
+        _run(["scan", "--config", str(malformed_manifest), "--format", "json"]),
+    )
+
+
+def _policy_pack_cases(tmp_path: Path) -> tuple[str, str]:
+    workspace = _workspace(tmp_path)
+    (workspace / "broken-pack.yaml").write_text("- a\n- b\n", encoding="utf-8")
+
+    def manifest_with(pack: str, name: str) -> Path:
+        path = workspace / name
+        path.write_text(
+            MANIFEST + f"checks:\n  policy_packs:\n    - {pack}\n", encoding="utf-8"
+        )
+        return path
+
+    absent = manifest_with("gone-pack.yaml", "absent-pack.yaml")
+    malformed = manifest_with("broken-pack.yaml", "malformed-pack.yaml")
+    return (
+        _run(["scan", "--config", str(absent), "--format", "json"]),
+        _run(["scan", "--config", str(malformed), "--format", "json"]),
+    )
+
+
+def _baseline_cases(tmp_path: Path) -> tuple[str, str]:
+    workspace = _workspace(tmp_path)
+    manifest = workspace / "shipgate.yaml"
+    broken = workspace / "broken-baseline.json"
+    broken.write_text("not json", encoding="utf-8")
+    common = ["scan", "--config", str(manifest), "--format", "json", "--baseline"]
+    return (
+        _run([*common, str(workspace / "gone-baseline.json")]),
+        _run([*common, str(broken)]),
+    )
+
+
+def _diff_ref_cases(tmp_path: Path) -> tuple[str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for argv in (
+        ["init", "-q", "-b", "main"],
+        ["config", "user.email", "test@example.com"],
+        ["config", "user.name", "Test User"],
+    ):
+        subprocess.run(["git", *argv], cwd=repo, check=True)
+    (repo / "shipgate.yaml").write_text(MANIFEST, encoding="utf-8")
+    (repo / "tools.json").write_text(TOOLS_JSON, encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "one"], cwd=repo, check=True)
+
+    common = ["verify", "--preview", "--json", "--workspace", str(repo), "--head", "HEAD"]
+    # The "malformed" counterpart for a ref pair is a readable diff that
+    # matched nothing — the state an unreadable one must never be reported as.
+    return (
+        _run([*common, "--base", "no-such-ref"]),
+        _run([*common, "--base", "HEAD"]),
+    )
+
+
+INPUT_CASES = {
+    "manifest": (_manifest_cases, ("not found",)),
+    "workspace": (_workspace_cases, ("does not exist",)),
+    "tool_source": (_tool_source_cases, ("not found",)),
+    "policy_pack": (_policy_pack_cases, ("not found",)),
+    "baseline": (_baseline_cases, ("not found",)),
+    "diff_refs": (_diff_ref_cases, ("not available locally",)),
+}
+
+
+@pytest.mark.parametrize("name", sorted(INPUT_CASES))
+def test_absent_input_is_not_reported_as_a_malformed_one(
+    name: str, tmp_path: Path
+) -> None:
+    build, absent_markers = INPUT_CASES[name]
+    absent_output, malformed_output = build(tmp_path)
+
+    assert absent_output != malformed_output, name
+    assert any(marker in absent_output for marker in absent_markers), absent_output
+    for claim in SHAPE_CLAIMS:
+        assert claim not in absent_output, (name, claim, absent_output)

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -166,7 +166,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/bootstrap.py",
         surface="attr_call:subprocess.run",
-        line=72,
+        line=73,
         snippet=(
             "subprocess.run(argv, cwd=str(cwd), env=env, "
             "capture_output=True, text=True, check=False)"
@@ -257,7 +257,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.Popen",
-        line=1806,
+        line=1818,
         snippet=(
             "subprocess.Popen(cmd, env=env, stderr=subprocess.PIPE, "
             "stdin=subprocess.PIPE if input is not None else "
@@ -276,7 +276,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.run",
-        line=2050,
+        line=2062,
         snippet=(
             "subprocess.run(cmd, capture_output=capture_output, check=check, "
             "env=env, input=input, stderr=stderr, stdin=stdin, stdout=stdout, "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,3 +172,205 @@ def test_yaml_unsafe_constructor_is_rejected(tmp_path):
         load_manifest(manifest_path)
 
     assert not marker.exists()
+
+
+# --- manifest type mismatches are edits, not crashes (#387) -----------------
+
+MINIMAL_MANIFEST = """version: "0.1"
+project:
+  name: repro
+agent:
+  name: repro-agent
+environment: dev
+"""
+
+
+def _write_manifest(tmp_path: Path, extra: str) -> Path:
+    manifest_path = tmp_path / "shipgate.yaml"
+    manifest_path.write_text(MINIMAL_MANIFEST + extra, encoding="utf-8")
+    return manifest_path
+
+
+# Every ``mode="before"`` validator that coerces a manifest value, given the
+# wrong YAML shape. The expected substring is the manifest path the reader
+# has to go edit; `pytest.raises` proves the exception class is the one the
+# config-loading boundary catches.
+WRONG_SHAPE_MANIFESTS: list[tuple[str, str, str]] = [
+    (
+        "google_adk mapping for a list",
+        "google_adk:\n  tool_inventories:\n    adk_agent: tool-inventory.json\n",
+        "google_adk.tool_inventories",
+    ),
+    (
+        "google_adk scalar entry",
+        "google_adk:\n  python_entrypoints:\n    - 3\n",
+        "google_adk.python_entrypoints",
+    ),
+    (
+        "anthropic prompt_files mapping",
+        "anthropic:\n  prompt_files:\n    a: b\n",
+        "anthropic.prompt_files",
+    ),
+    (
+        "openai_api model_config list",
+        "openai_api:\n  model_config:\n    - a\n",
+        "openai_api.model_config",
+    ),
+    (
+        "openai_api function_schemas mapping",
+        "openai_api:\n  function_schemas:\n    a: b\n",
+        "openai_api.function_schemas",
+    ),
+    (
+        "codex_plugins mcp_tool_inventories mapping",
+        "codex_plugins:\n  mcp_tool_inventories:\n    a: b\n",
+        "codex_plugins.mcp_tool_inventories",
+    ),
+    (
+        "policies mapping for a list",
+        "policies:\n  require_approval_for_tools:\n    refund: yes\n",
+        "policies.require_approval_for_tools",
+    ),
+    (
+        "policy_packs mapping",
+        "checks:\n  policy_packs:\n    a: b\n",
+        "checks.policy_packs",
+    ),
+    (
+        "severity_overrides list",
+        "checks:\n  severity_overrides:\n    - SHIP-TOOL-DESC\n",
+        "checks.severity_overrides",
+    ),
+    (
+        "n8n workflows mapping",
+        "n8n:\n  workflows:\n    a: b\n",
+        "n8n.workflows",
+    ),
+    (
+        "crewai python_entrypoints mapping",
+        "crewai:\n  python_entrypoints:\n    a: b\n",
+        "crewai.python_entrypoints",
+    ),
+    (
+        "langchain python_entrypoints mapping",
+        "langchain:\n  python_entrypoints:\n    a: b\n",
+        "langchain.python_entrypoints",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("extra", "expected_path"),
+    [(extra, path) for _, extra, path in WRONG_SHAPE_MANIFESTS],
+    ids=[name for name, _, _ in WRONG_SHAPE_MANIFESTS],
+)
+def test_manifest_type_mismatch_is_a_config_error_naming_the_field(
+    tmp_path, extra: str, expected_path: str
+) -> None:
+    """A mapping where a list belongs is a typo, and typos are ConfigError.
+
+    ``TypeError`` raised inside a Pydantic validator is *not* converted into
+    a ``ValidationError`` — it propagates past the config-loading boundary
+    into the generic internal-error handler, which told the user their own
+    manifest mistake was a Shipgate bug and asked them to file an issue
+    (#387).
+    """
+
+    manifest_path = _write_manifest(tmp_path, extra)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_manifest(manifest_path)
+
+    assert expected_path in str(excinfo.value)
+
+
+def test_manifest_type_mismatch_reports_the_shape_that_was_written(
+    tmp_path,
+) -> None:
+    manifest_path = _write_manifest(
+        tmp_path,
+        "google_adk:\n  tool_inventories:\n    adk_agent: tool-inventory.json\n",
+    )
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_manifest(manifest_path)
+
+    assert "but is a mapping" in str(excinfo.value)
+
+
+def test_no_schema_module_raises_typeerror() -> None:
+    """The class, not the instance.
+
+    Any ``raise TypeError`` reachable from a validator is a latent
+    "tell the user to file a bug" path. Banning the statement outright in
+    the schema package is cheaper to enforce than proving reachability, and
+    a schema module has no legitimate use for it: every rejection here is a
+    rejection of *manifest input*.
+    """
+
+    import ast
+
+    offenders: list[str] = []
+    for path in sorted(Path("src/agents_shipgate/schemas").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Raise) or node.exc is None:
+                continue
+            raised = node.exc
+            if isinstance(raised, ast.Call):
+                raised = raised.func
+            if isinstance(raised, ast.Name) and raised.id == "TypeError":
+                offenders.append(f"{path}:{node.lineno}")
+
+    assert offenders == [], (
+        "raise ValueError instead — Pydantic converts ValueError into a "
+        f"ValidationError, and TypeError escapes as an internal error: {offenders}"
+    )
+
+
+# --- absent, empty, and malformed are three states (#384) -------------------
+
+
+def test_absent_empty_and_non_mapping_manifests_have_distinct_messages(
+    tmp_path,
+) -> None:
+    """One message for three states sent readers to fix a file that was
+    never there — and the control envelope built on it disagreed with its
+    own ``next_action`` about whether the workspace had a manifest at all.
+    """
+
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("", encoding="utf-8")
+    a_list = tmp_path / "list.yaml"
+    a_list.write_text("- a\n- b\n", encoding="utf-8")
+
+    messages = {}
+    for label, path in (
+        ("absent", tmp_path / "absent-dir" / "shipgate.yaml"),
+        ("empty", empty),
+        ("list", a_list),
+    ):
+        with pytest.raises(ConfigError) as excinfo:
+            load_manifest(path)
+        messages[label] = str(excinfo.value)
+
+    assert len(set(messages.values())) == 3, messages
+    assert "not found" in messages["absent"]
+    assert "must contain a YAML object" not in messages["absent"]
+    assert "is empty" in messages["empty"]
+    assert "must contain a YAML object" in messages["list"]
+
+
+def test_absent_manifest_read_through_a_snapshot_still_reports_not_found(
+    tmp_path,
+) -> None:
+    """``doctor``/``scan`` read the manifest as bytes and collapse a failed
+    read into ``b""`` so the failure hashes the same input the diagnosis
+    came from. That is deliberate — but ``b""`` parses as an empty document,
+    so the absent case reached the YAML shape check (#384).
+    """
+
+    from agents_shipgate.cli.scan.inspect import inspect_sources
+
+    with pytest.raises(ConfigError, match="Config file not found"):
+        inspect_sources(config_path=tmp_path / "absent" / "shipgate.yaml")

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1898,3 +1898,39 @@ agent_bindings:
         "base reference" in warning and "Duplicate action_surface action_id" in warning
         for warning in report.source_warnings
     ), f"Expected a base-side collision warning; got: {report.source_warnings}"
+
+
+def test_scan_reports_a_manifest_type_mismatch_as_a_config_error(tmp_path):
+    """The reproduction from #387, on the command it was reported against.
+
+    A mapping where ``google_adk.tool_inventories`` expects a list raised
+    ``TypeError`` inside a Pydantic validator. Pydantic converts
+    ``ValueError`` and ``AssertionError`` into a ``ValidationError`` but lets
+    ``TypeError`` propagate, so the manifest typo escaped the config-loading
+    boundary and surfaced as ``internal_error`` with "this is a bug — please
+    file an issue".
+    """
+
+    manifest = tmp_path / "shipgate.yaml"
+    manifest.write_text(
+        'version: "0.1"\n'
+        "project:\n  name: repro\n"
+        "agent:\n  name: repro-agent\n"
+        "environment: dev\n"
+        "google_adk:\n  tool_inventories:\n    adk_agent: tool-inventory.json\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["scan", "--config", str(manifest), "--format", "json"],
+        env={"AGENTS_SHIPGATE_AGENT_MODE": "1"},
+    )
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["error"] == "config_error"
+    assert "google_adk.tool_inventories" in payload["message"]
+    assert "file an issue" not in json.dumps(payload)
+    assert payload["next_actions"][0]["kind"] == "edit"
+    assert payload["next_actions"][0]["path"] == str(manifest)

--- a/tests/test_setup_control.py
+++ b/tests/test_setup_control.py
@@ -1866,3 +1866,114 @@ def test_a_dry_run_that_wrote_the_workflow_does_not_claim_it_wrote_nothing(tmp_p
         runner.invoke(app, ["init", "--workspace", str(plain), "--json"]).stdout
     )
     assert bare["control"]["next_action"]["why"].startswith("The manifest was not written.")
+
+
+# --- the envelope's two fields must describe one workspace (#384) ------------
+
+
+def _doctor_error_payload(
+    argv: list[str], monkeypatch: pytest.MonkeyPatch
+) -> dict:
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    result = runner.invoke(app, argv)
+    lines = [
+        line for line in result.output.splitlines() if line.startswith('{"error"')
+    ]
+    assert len(lines) == 1, result.output
+    return json.loads(lines[0])
+
+
+def test_an_absent_manifest_is_not_reported_as_a_malformed_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``control.reason`` and ``control.next_action`` told two stories.
+
+    ``reason`` said "Config file must contain a YAML object", which asserts
+    the file exists and has the wrong shape, so an agent reasoning from it
+    edits a file that is not there. ``next_action.kind`` said ``verify`` —
+    bootstrap from scratch — which was the correct read of the same
+    workspace. The routing always knew; only the message did not.
+    """
+
+    absent = tmp_path / "absent-dir" / "shipgate.yaml"
+
+    payload = _doctor_error_payload(
+        ["doctor", "--config", str(absent), "--json"], monkeypatch
+    )
+    control = payload["control"]
+
+    assert "Config file not found" in control["reason"]
+    assert "must contain a YAML object" not in control["reason"]
+    # The routing is unchanged — it was right all along.
+    assert control["next_action"]["kind"] == "verify"
+    assert control["verify_required"] is True
+    # And the reason now agrees with it: bootstrap, do not edit.
+    assert "init --workspace . --write" in control["reason"]
+
+
+def test_absent_empty_and_non_mapping_manifests_route_and_read_differently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A negative control: a future refactor must not re-collapse the three.
+
+    All three used to emit one identical string while routing to two
+    different actions, which is exactly the state that is invisible without
+    an assertion on the strings themselves.
+    """
+
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("", encoding="utf-8")
+    a_list = tmp_path / "list.yaml"
+    a_list.write_text("- a\n- b\n", encoding="utf-8")
+
+    reasons = {}
+    kinds = {}
+    for label, path in (
+        ("absent", tmp_path / "absent-dir" / "shipgate.yaml"),
+        ("empty", empty),
+        ("list", a_list),
+    ):
+        payload = _doctor_error_payload(
+            ["doctor", "--config", str(path), "--json"], monkeypatch
+        )
+        reasons[label] = payload["control"]["reason"]
+        kinds[label] = payload["control"]["next_action"]["kind"]
+
+    assert len(set(reasons.values())) == 3, reasons
+    assert kinds == {"absent": "verify", "empty": "edit", "list": "edit"}
+
+
+# --- a manifest typo is an edit, never a bug report (#387) ------------------
+
+
+def test_a_manifest_type_mismatch_routes_to_the_editor_not_the_tracker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``TypeError`` inside a validator escaped as ``internal_error``.
+
+    ``google_adk.tool_inventories`` is the prescribed remedy for the first
+    gap most ADK adopters hit, so the mapping-instead-of-list mistake lands
+    on the adoption path — and it answered "this is a bug — please file an
+    issue" for the user's own typo.
+    """
+
+    manifest = tmp_path / "shipgate.yaml"
+    manifest.write_text(
+        'version: "0.1"\n'
+        "project:\n  name: repro\n"
+        "agent:\n  name: repro-agent\n"
+        "environment: dev\n"
+        "google_adk:\n  tool_inventories:\n    adk_agent: tool-inventory.json\n",
+        encoding="utf-8",
+    )
+
+    payload = _doctor_error_payload(
+        ["doctor", "--config", str(manifest), "--json"], monkeypatch
+    )
+
+    assert payload["error"] == "config_error"
+    assert payload["exit_code"] == 2
+    assert "google_adk.tool_inventories" in payload["message"]
+    assert "file an issue" not in json.dumps(payload)
+    assert payload["next_actions"][0]["kind"] == "edit"
+    assert payload["next_actions"][0]["path"] == str(manifest)

--- a/tests/test_workspace_input_guard.py
+++ b/tests/test_workspace_input_guard.py
@@ -1,0 +1,262 @@
+"""An absent ``--workspace`` is an invocation error on every command (#389).
+
+The reported defect was ``verify --preview``: given a ``--workspace`` that did
+not exist it created the whole four-level path, wrote a complete artifact set
+into it, and exited 0 — so a typo produced a confident-looking result about a
+workspace that was never there, and in CI it looked healthy on both signals a
+caller can gate on. The same class was live elsewhere: ``init --write``,
+``audit --host``, and the verification workers raised bare
+``FileNotFoundError`` tracebacks; ``install-hooks --write`` wrote hooks into
+the mistyped tree; ``mcp audit`` answered ``decision: allow``.
+
+The sweep below is the part that keeps the class closed. It enumerates every
+command that exposes ``--workspace`` from the live Typer app and fails if one
+is not covered here, so a new command cannot quietly reintroduce the hole.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer.main
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.cli.verify.git import ensure_git_workspace
+from agents_shipgate.core.errors import ConfigError
+from agents_shipgate.core.workspace_input import (
+    classify_workspace,
+    require_workspace_directory,
+    workspace_input_error,
+)
+
+runner = CliRunner()
+
+# One invocation per command that takes ``--workspace``. Extra flags exist
+# only to reach the command body; the guard must fire before any of them
+# matter, and before any of them writes.
+COMMAND_INVOCATIONS: dict[str, list[str]] = {
+    "detect": ["detect"],
+    "check": ["check", "--agent", "codex"],
+    "preflight": ["preflight", "--json"],
+    "bootstrap": ["bootstrap", "--json"],
+    "trigger": ["trigger", "--json"],
+    "verify": ["verify", "--json"],
+    "install-hooks": ["install-hooks", "--target", "claude-code", "--write"],
+    "audit": ["audit", "--host", "--json"],
+    "scan": ["scan", "--format", "json"],
+    "init": ["init", "--write"],
+    "doctor": ["doctor", "--json"],
+    "agent control": ["agent", "control"],
+    "mcp audit": ["mcp", "audit"],
+    "org status": ["org", "status"],
+    "org policy-packs": ["org", "policy-packs"],
+    "org bundle": ["org", "bundle"],
+    "verification prepare": ["verification", "prepare"],
+    "verification worker": ["verification", "worker", "--plan", "plan.json"],
+    "authorization execute": ["authorization", "execute"],
+}
+
+# ``verify --preview`` is not a separate command, but it is the invocation the
+# issue was filed against and the one with the documented "always exits 0"
+# promise, so it is swept alongside the commands.
+EXTRA_INVOCATIONS: dict[str, list[str]] = {
+    "verify --preview": ["verify", "--preview", "--json"],
+}
+
+
+def _commands_with_workspace_option() -> set[str]:
+    """Every command in the live app that exposes ``--workspace``."""
+
+    root = typer.main.get_command(app)
+    found: set[str] = set()
+
+    def walk(command: object, prefix: tuple[str, ...]) -> None:
+        subcommands = getattr(command, "commands", None)
+        if subcommands:
+            for name, sub in subcommands.items():
+                walk(sub, (*prefix, name))
+            return
+        options = [
+            opt
+            for param in getattr(command, "params", ())
+            for opt in getattr(param, "opts", ())
+        ]
+        if "--workspace" in options:
+            found.add(" ".join(prefix))
+
+    walk(root, ())
+    return found
+
+
+def test_every_workspace_command_is_swept() -> None:
+    """A new ``--workspace`` command must be added to the sweep.
+
+    Without this the sweep silently stops covering the surface it is meant
+    to protect: the next command to grow the option would reintroduce the
+    "creates the path it was told to inspect" defect unnoticed.
+    """
+
+    assert _commands_with_workspace_option() == set(COMMAND_INVOCATIONS)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    list(COMMAND_INVOCATIONS.values()) + list(EXTRA_INVOCATIONS.values()),
+    ids=list(COMMAND_INVOCATIONS) + list(EXTRA_INVOCATIONS),
+)
+def test_absent_workspace_is_refused_and_creates_nothing(
+    argv: list[str], tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    absent = root / "does-not-exist" / "nested" / "workspace"
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(app, [*argv, "--workspace", str(absent)])
+
+    assert result.exit_code == 2, result.output
+    assert "does not exist" in result.output
+    assert str(absent) in result.output
+    # The filesystem is the acceptance criterion the issue actually asks
+    # for: refusing after writing the artifacts is not refusing.
+    assert list(root.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "argv",
+    list(COMMAND_INVOCATIONS.values()) + list(EXTRA_INVOCATIONS.values()),
+    ids=list(COMMAND_INVOCATIONS) + list(EXTRA_INVOCATIONS),
+)
+def test_absent_workspace_emits_one_config_error_line(
+    argv: list[str], tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Agents route on the structured line, not on the prose."""
+
+    absent = tmp_path / "nope"
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(app, [*argv, "--workspace", str(absent)])
+
+    payloads = [
+        json.loads(line)
+        for line in result.output.splitlines()
+        if line.startswith('{"error"')
+    ]
+    assert len(payloads) == 1, result.output
+    payload = payloads[0]
+    assert payload["error"] == "config_error"
+    assert payload["exit_code"] == 2
+    assert "does not exist" in payload["message"]
+    assert payload["next_actions"][0]["kind"] == "review"
+
+
+def test_preview_no_longer_creates_the_workspace_it_was_given(tmp_path) -> None:
+    """The reported reproduction, asserted on the filesystem.
+
+    The original run created four directory levels plus an
+    ``agents-shipgate-reports`` tree with four artifacts in it, and the
+    leftover directory then blocked the ``git clone`` the user had skipped.
+    """
+
+    absent = tmp_path / "does-not-exist" / "nested" / "workspace"
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--preview",
+            "--json",
+            "--workspace",
+            str(absent),
+            "--base",
+            "main",
+            "--head",
+            "HEAD",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert not (tmp_path / "does-not-exist").exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_workspace_pointing_at_a_file_is_named_as_such(tmp_path) -> None:
+    manifest = tmp_path / "shipgate.yaml"
+    manifest.write_text("version: '0.1'\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["detect", "--workspace", str(manifest)])
+
+    assert result.exit_code == 2
+    assert "is not a directory" in result.output
+    # Distinct from the absent message: a file in the way and a path that
+    # was never created are different repairs.
+    assert "does not exist" not in result.output
+
+
+def test_relative_workspace_message_names_the_directory_it_resolved_against(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """"Ran the preview before the clone" is a cwd mistake as often as a typo."""
+
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["detect", "--workspace", "adk-samples"])
+
+    assert result.exit_code == 2
+    assert "adk-samples" in result.output
+    assert str(tmp_path.resolve()) in result.output
+
+
+# --- the classifier itself --------------------------------------------------
+
+
+def test_classify_workspace_states(tmp_path) -> None:
+    directory = tmp_path / "repo"
+    directory.mkdir()
+    regular_file = tmp_path / "file.txt"
+    regular_file.write_text("x", encoding="utf-8")
+
+    assert classify_workspace(directory) == "present"
+    assert classify_workspace(tmp_path / "absent") == "absent"
+    assert classify_workspace(regular_file) == "not_a_directory"
+    # A path whose *parent* component is a file, not a directory.
+    assert classify_workspace(regular_file / "child") == "not_a_directory"
+
+
+def test_workspace_input_error_is_none_for_a_real_directory(tmp_path) -> None:
+    assert workspace_input_error(tmp_path) is None
+    assert require_workspace_directory(tmp_path) == tmp_path.resolve()
+
+
+def test_workspace_input_error_option_label_is_carried(tmp_path) -> None:
+    error = workspace_input_error(tmp_path / "absent", option="--out")
+    assert error is not None
+    assert str(error).startswith("--out does not exist:")
+
+
+# --- the git reader, which reported absent as "not a git checkout" ----------
+
+
+def test_ensure_git_workspace_distinguishes_absent_from_not_a_repository(
+    tmp_path,
+) -> None:
+    """Two states, two messages (#384's second instance, filed via #389).
+
+    "Workspace is not inside a git checkout" asserts the directory exists
+    and lacks git, which sends the reader to diagnose git when the real
+    state is a directory they never created.
+    """
+
+    not_a_repository = tmp_path / "plain"
+    not_a_repository.mkdir()
+
+    with pytest.raises(ConfigError) as absent:
+        ensure_git_workspace(tmp_path / "absent")
+    with pytest.raises(ConfigError) as no_git:
+        ensure_git_workspace(not_a_repository)
+
+    assert "does not exist" in str(absent.value)
+    assert "not inside a git checkout" not in str(absent.value)
+    assert "not inside a git checkout" in str(no_git.value)


### PR DESCRIPTION
## Summary

- Three reports, one class: **an input that is not there was reported as an input with the wrong shape** — and in one case the command created the input it had been asked to inspect.
- Closes #389, closes #387, closes #384.

### #389 — an absent `--workspace` is an invocation error, decided before anything is created

`verify --preview` given a `--workspace` that did not exist created the entire four-level path, wrote a full artifact set into it, and **exited 0**. A typo produced a confident-looking result about a workspace that was never there; in CI both signals a caller can gate on — exit code and "did artifacts appear" — read healthy. The leftover directory then blocked the `git clone` the reporter had skipped.

New pure classifier `core/workspace_input.py` (`present` / `absent` / `not_a_directory` / `unreadable`) plus the CLI guard `cli/workspace_guard.py`, called as the **first statement** of all 19 commands that expose `--workspace`, and from `ensure_git_workspace` so the diff-input path stops reporting an absent path as "not inside a git checkout".

Probing the whole surface turned up four more live instances of the same class:

| Command | Before | After |
|---|---|---|
| `verify --preview` | created 4 dirs + 4 artifacts, exit 0 | exit 2, nothing created |
| `init --write`, `audit --host`, `verification prepare` / `worker` | bare `FileNotFoundError` traceback, exit 1 | exit 2, `config_error` |
| `install-hooks --write` | **wrote hooks** into the mistyped tree | exit 2, nothing created |
| `mcp audit` | `decision: allow` about a nonexistent directory | exit 2, `config_error` |
| `detect`, `check`, `trigger` | exit 0 with a payload describing nothing | exit 2, `config_error` |

**The open question in #389, answered:** the guard lands in argument validation, and preview exits 2. Its documented "always exits 0" is a promise about workspaces it *evaluates*; there is nothing here to evaluate, and the exit code is exactly the signal the silent 0 was misleading. Recorded as a STABILITY.md unreleased migration note — no contract or schema version moves, and the refusal reuses the existing `config_error` / exit 2 slot rather than adding an error kind.

### #384 — absent, empty, and malformed manifests read differently

Classified at the read boundary (`config/loader.py::manifest_read_error`), so the deliberate `OSError → b""` collapse still binds a failure to the bytes the identity hashed, while absent no longer reaches the YAML shape check. `control.reason` and `control.next_action` now tell one story instead of two:

| State | Message | `next_action.kind` |
|---|---|---|
| absent | `Config file not found: <path> in <cwd>. Run agents-shipgate init …` | `verify` |
| empty | `Config file is empty: <path>.` | `edit` |
| not a mapping | `Config file must contain a YAML object: <path>` | `edit` |

Routing is unchanged — it always distinguished the cases; only the message did not.

The cross-cutting check asked for in the issue comment is `tests/test_absent_input_messages.py`, a table over all six inputs Shipgate reads. Audit result: **only the manifest and the workspace conflated the states**. Tool source, policy pack, baseline, and diff refs already told them apart and are now pinned so they stay that way.

### #387 — a manifest type mismatch is an edit, not a bug report

Pydantic converts `ValueError` and `AssertionError` raised inside a validator into a `ValidationError`, but lets `TypeError` propagate past the config-loading boundary into the generic internal-error handler — so `google_adk.tool_inventories:` written as a mapping told the user their own typo was a Shipgate bug and asked them to file an issue. Every `raise TypeError` under `schemas/` is now `ValueError` (12 sites, 8 modules):

```
Config error: Invalid shipgate.yaml:
- google_adk.tool_inventories: Value error, must be a list of artifact paths, but is a mapping
```

`config_error`, exit 2, `next_action.kind: edit` against the manifest path. Messages also name the shape that *was* written.

### What keeps the class closed

Two sweeps, not two patches:

- `test_every_workspace_command_is_swept` enumerates `--workspace` commands from the **live Typer app** and fails when a new one is not in the coverage table.
- `test_no_schema_module_raises_typeerror` bans `raise TypeError` outright under `schemas/`.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full suite green (`pytest -n auto`, exit 0) and `ruff check .` clean.
- `./shipgate self-check --json` → `ready: true`, all fixtures `ok`.
- All three issue reproductions re-run verbatim against the built CLI; the `#389` one asserted on the filesystem (`find` returns nothing).
- All 19 `--workspace` commands probed by hand with an absent path: uniform exit 2, zero filesystem creation.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — n/a, no check IDs changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — no schema change; the behavior narrowing is documented in a new unreleased migration note

## Notes for the reviewer

- **The guard is side-effect only.** `require_workspace(workspace)` is deliberately not `workspace = require_workspace(workspace)`: `check` and the invocation policy (#322) render `--workspace .` relative to cwd, and resolving would rewrite the commands Shipgate emits.
- **Behavior narrowing to weigh.** Commands that previously exited 0 with a payload about a nonexistent workspace (`detect`, `check`, `trigger`, `mcp audit`, `install-hooks`) now exit 2. Every documented invocation passes an existing `--workspace` and is unaffected; commands whose `--workspace` is optional still accept its absence, which means "discover instead", not "a workspace that is missing".
- **Message-text change.** A consumer that pattern-matched `must contain a YAML object` to detect a *missing* manifest must switch to `SHIP-DIAG-MISSING-MANIFEST` or `control.next_action` — which is what `docs/errors.json` already directs. Same for the `#387` field messages: the field-path prefix is the stable part.
- **Incidental fix.** `tests/test_adapter_static_only.py` pins allowlisted `subprocess` call sites by line number; the new imports in `cli/bootstrap.py` and `cli/verify/git.py` shifted three of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
