### PR TITLE
fix(google-adk): measure extraction confidence instead of assuming it (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,55 @@
   (script version `0.4.0`), pinned by the parity test — which now includes a
   workspace that actually truncates, since every sample fixture sits far under
   the cap.
+- **Google ADK extraction confidence is now measured on the module, not
+  hardcoded.** The Python AST path set `extraction_confidence="medium"` on
+  every tool it produced, and the only code that ever set `"high"` applied to
+  tools loaded from a `tool_inventory` artifact. Every gate tests `!= "high"`,
+  so no ADK repository could reach a pass from source however statically
+  analysable it was: `insufficient_evidence` was not a property of a
+  repository, it was the framework's default first-run verdict. Reproduced on
+  the most trivial case available — one file, twelve annotated module-level
+  functions, `12/12` catalog tools reachable, `0` unbound, `0` source warnings —
+  which still reported twelve `low_confidence_tool` gaps and abstained. A
+  condition that holds for every input carries no information: it could not
+  tell a toolkit factory from twelve plain functions, and the remedy it
+  prescribed was transcription — copy the twelve tools Shipgate had just
+  extracted correctly into `suggested-inventory.json`, adding no fact to the
+  system ([#393](https://github.com/ThreeMoonsLab/agents-shipgate/issues/393)).
+
+  A Google ADK Python entrypoint now reports `high` when the adapter can show
+  it read the whole surface, and `medium` with a named reason when it cannot.
+  The proof is scoped to the file: one unresolved construct anywhere holds
+  every tool the file produced, because a fully-resolved agent in a
+  half-resolved module can reach tools nobody enumerated. Module-scoped reasons
+  are `dynamic_tools_expression`, `unresolved_tool_reference`,
+  `unresolved_tool_expression`, `unresolved_tool_wrapper`, `dynamic_toolset`,
+  `conflicting_tool_contract`, `unresolved_sub_agent`, `mutable_tool_binding`
+  (anything reaching `agent.tools` after construction, including through an
+  alias or `setattr`), `dynamic_agent_kwargs` (`Agent(**config)`, which hides
+  `tools` entirely), and `shadowed_tool_definition` (the name-to-definition map
+  is flat and scope-blind, so `tools=[helper]` can resolve to a factory's inner
+  function, a method lifted out of a class body, one of two conditional
+  definitions, or a definition the module later rebinds — the tool is still
+  named, its signature is not proven). Per-function reasons are `decorated_tool_function`,
+  `variadic_parameters`, and `untyped_parameter` — the JSON-schema fallback
+  types an unannotated parameter `string`, and a guess may not ship as a
+  schema. The `low_confidence_tool` evidence gap now names the reasons instead
+  of repeating one sentence on every AST tool in every repository.
+
+  `_surface_is_complete` changed with it: an AST source type used to be
+  disqualified outright, which was the same constant one layer down and would
+  have kept `incomplete_surface` open on a proven surface. Membership now poses
+  the question and the adapter's own attestation answers it. Saying nothing
+  still reads as incomplete, so adapters not yet taught to answer —
+  LangChain, CrewAI, the OpenAI Agents SDK static path — keep their previous
+  verdict, an unclassified new warning demotes its module automatically, and
+  a wildcard exposure still outranks any completeness claim.
+
+  Net effect on the reported subject: a fully static ADK project with its
+  actions declared reaches `passed` instead of `insufficient_evidence`, and one
+  without them is asked for the effect and authority declarations a human
+  genuinely owes rather than for a transcription it cannot learn anything from.
 
 - **A tool inventory now completes the source that asked for it, instead of
   shadowing it.** `incomplete_surface` fires for every statically-extracted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,16 +168,33 @@
   `unresolved_tool_expression`, `unresolved_tool_wrapper`, `dynamic_toolset`,
   `conflicting_tool_contract`, `unresolved_sub_agent`, `mutable_tool_binding`
   (anything reaching `agent.tools` after construction, including through an
-  alias or `setattr`), `dynamic_agent_kwargs` (`Agent(**config)`, which hides
-  `tools` entirely), and `shadowed_tool_definition` (the name-to-definition map
-  is flat and scope-blind, so `tools=[helper]` can resolve to a factory's inner
-  function, a method lifted out of a class body, one of two conditional
-  definitions, or a definition the module later rebinds — the tool is still
-  named, its signature is not proven). Per-function reasons are `decorated_tool_function`,
-  `variadic_parameters`, and `untyped_parameter` — the JSON-schema fallback
-  types an unannotated parameter `string`, and a guess may not ship as a
-  schema. The `low_confidence_tool` evidence gap now names the reasons instead
-  of repeating one sentence on every AST tool in every repository.
+  alias, `setattr`, or `getattr(agent, "tools")`), `dynamic_agent_kwargs`
+  (`Agent(**config)`, which hides `tools` entirely), `unresolved_tool_wrapper`
+  (a recognised `FunctionTool`/`LongRunningFunctionTool` whose `func` this
+  module does not define — an import, an attribute, a lambda, or none at all),
+  and `shadowed_tool_definition` (the name-to-definition map is flat and
+  scope-blind, so `tools=[helper]` can resolve to a factory's inner function, a
+  method lifted out of a class body, one of two conditional definitions, or a
+  definition that a parameter, class, import, `except ... as`, `case ... as`,
+  `global`, or later assignment rebinds — the tool is still named, its
+  signature is not proven). Per-function reasons are `decorated_tool_function`,
+  `variadic_parameters`, `untyped_parameter`, and
+  `unrepresentable_annotation`. The last two are the same defect twice: the
+  JSON-schema fallback types an unannotated parameter `string`, and it types
+  `set[str]`, `int | None`, `tuple[...]`, a Pydantic model, and even
+  `typing.List[str]` `string` as well. A guess may not ship as a schema, so
+  faithfulness is now checked by asking the emitter what it would produce and
+  comparing it to what the annotation denotes — including the return
+  annotation, which feeds `output_schema` through the same fallback. The
+  `low_confidence_tool` evidence gap names the reasons instead of repeating one
+  sentence on every AST tool in every repository.
+
+  Module-scoped reasons reach every tool the file contributed, not just its
+  function tools. A module whose only tools come from a *resolved* OpenAPI or
+  MCP toolset still has a tool set the file could not prove — `Agent(**config)`
+  beside a resolved `McpToolset` is the case — so those tools are lowered too.
+  They are only ever lowered, never raised: this step cannot promote a tool the
+  adapter did not extract.
 
   `_surface_is_complete` changed with it: an AST source type used to be
   disqualified outright, which was the same constant one layer down and would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,12 +189,34 @@
   `low_confidence_tool` evidence gap names the reasons instead of repeating one
   sentence on every AST tool in every repository.
 
+  A recognised constructor is only ADK's while the name still refers to the
+  import: `from google.adk.tools import FunctionTool` followed by
+  `FunctionTool = replacement` used to have a foreign factory read with
+  Google's semantics (`shadowed_framework_symbol`), and a `from x import *`
+  can rebind anything the module defines (`star_import_shadowing`). Both are
+  refused rather than guessed at.
+
+  Two correctness fixes came out of the same review. Injected context
+  parameters are identified the way ADK identifies them — by type, with
+  `tool_context` as the name fallback — instead of by dropping every parameter
+  spelled `ctx` or `context`, which deleted ordinary model-visible inputs from
+  the emitted schema. And `List[...]`/`Dict[...]` now emit `array`/`object`
+  rather than `string`, so `from typing import List` is usable without holding
+  the tool at `medium` for what was an emitter gap.
+
   Module-scoped reasons reach every tool the file contributed, not just its
   function tools. A module whose only tools come from a *resolved* OpenAPI or
   MCP toolset still has a tool set the file could not prove — `Agent(**config)`
   beside a resolved `McpToolset` is the case — so those tools are lowered too.
   They are only ever lowered, never raised: this step cannot promote a tool the
-  adapter did not extract.
+  adapter did not extract. They also survive `tool_identity` merging: an
+  identity binding proves two observations describe the same operation, which
+  says nothing about whether the module one of them came from exposes further
+  tools, so a member's unproven tool *set* caps the canonical tool. Reasons
+  about a single tool's own interface still resolve in the primary's favour —
+  that is what a reviewed inventory is for — and the evidence gap for an
+  unproven set now names the construct to fix instead of asking for an
+  inventory or spec the repository has already supplied.
 
   `_surface_is_complete` changed with it: an AST source type used to be
   disqualified outright, which was the same constant one layer down and would

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,9 +37,14 @@ Useful fixtures:
 - [`baseline_workflow`](../samples/baseline_workflow/) — adoption path from existing findings to strict mode.
 - [`_anti_patterns`](../samples/_anti_patterns/) — intentionally invalid or unsafe shapes for testing errors and documentation.
 
-Framework AST extraction remains conservative: these positive fixtures use
-reviewed inventories because an AST-only binding graph does not qualify for an
-evidence-backed `passed` verdict on its own.
+Framework AST extraction remains conservative, and most of these positive
+fixtures use reviewed inventories for that reason. The Google ADK Python
+adapter is the exception: it establishes completeness on the parsed module
+rather than assuming it, so an entrypoint it fully resolved can reach an
+evidence-backed `passed` verdict from source alone once its actions are
+declared. Every other framework adapter still needs the inventory. See
+[Google ADK extraction confidence](upstream-integrations.md#google-adk-python--agent-config-yaml)
+for exactly what "fully resolved" requires.
 
 ## CI recipes
 

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -133,6 +133,13 @@ Every framework block (`google_adk`, `langchain`, `crewai`, `n8n`) accepts
 tools static extraction could not fully enumerate. Each entry takes a `path`
 and, optionally, `source_id`.
 
+An inventory is for a surface the adapter genuinely could not read, not a
+transcription of one it already read correctly. A Google ADK Python entrypoint
+the adapter fully resolved now reaches high extraction confidence from source
+alone and asks for no inventory; when it does ask, the `low_confidence_tool`
+evidence gap names the construct that blocked it. Other framework adapters
+still report AST-extracted tools as `medium` and need the inventory.
+
 **`source_id` names the tool source this file completes.** With it, every entry
 whose name the source already exposes is joined to that source's observation:
 the catalog stays the same size, the merged tool inherits the inventory's high

--- a/docs/upstream-integrations.md
+++ b/docs/upstream-integrations.md
@@ -142,9 +142,23 @@ ci:
 
 **Working fixture**: [`samples/google_adk_agent/`](../samples/google_adk_agent/).
 
+**Extraction confidence** is measured on the module, not assumed from the
+framework. A Python entrypoint whose tool surface the adapter fully resolved
+reaches `high` on its own, with no tool inventory: every `tools=` element
+resolves to a single module-level definition that nothing later rebinds, no
+toolset is dynamic, no `sub_agents` element is unresolvable, nothing reaches
+`agent.tools` after construction, no agent is built from `**kwargs`, and each
+bound function is undecorated with every parameter annotated and no
+`*args`/`**kwargs`. Anything else holds the
+whole file at `medium` and the `low_confidence_tool` evidence gap names the
+construct responsible (`dynamic_toolset`, `untyped_parameter`,
+`mutable_tool_binding`, …). Agent Config `tools:` entries are name references
+with no signature to read, so that path stays `low`.
+
 **Pitfalls**:
 - `OpenAPIToolset(...)` and `McpToolset(...)` need `tool_filter` declared; without it, the toolset counts as "unfiltered" and `SHIP-ADK-MCP-TOOLSET-UNFILTERED` fires high. Add the filter, then point `inventory_path` at a local tool inventory.
 - Production targets need `google_adk.eval_sets` declared; otherwise `SHIP-ADK-EVAL-COVERAGE-MISSING` fires. Add the block only after the eval file exists, or mark the artifact `optional: true` during bring-up.
+- An unannotated parameter is enough to hold a tool at `medium`: the JSON-schema fallback would type it `string`, which is a guess wearing a schema's clothes. ADK builds its own function declarations from those annotations, so adding them is worth doing regardless.
 
 ## MCP-only (no Python framework)
 

--- a/docs/upstream-integrations.md
+++ b/docs/upstream-integrations.md
@@ -159,13 +159,24 @@ reaches `high` on its own, with no tool inventory. That requires all of:
 - each bound function is undecorated, takes no `*args`/`**kwargs`, and annotates
   every parameter with a type the schema emitter represents faithfully.
 
-Anything else holds the whole file at `medium`, and the `low_confidence_tool`
+Anything else lowers the tool to `medium`, and the `low_confidence_tool`
 evidence gap names the construct responsible (`dynamic_toolset`,
-`untyped_parameter`, `mutable_tool_binding`, …). Module-scoped reasons reach
-tools contributed by a *resolved* OpenAPI or MCP toolset too, because the
-module could not prove its tool set either way; those tools are only ever
-lowered, never raised. Agent Config `tools:` entries are name references with
-no signature to read, so that path stays `low`.
+`untyped_parameter`, `mutable_tool_binding`, …). How far it reaches depends on
+what the reason is about:
+
+- The first four bullets are about **which tools exist**, so one of them holds
+  the whole file at `medium` — including tools contributed by a *resolved*
+  OpenAPI or MCP toolset in that file, and including the canonical tool after a
+  reviewed `tool_identity` binding merges the observation into another source.
+  No reviewed inventory can close these: an inventory describes tools, not
+  which tools an agent has. Fix the construct in the module.
+- The last bullet is about **one function's interface**, so it lowers only that
+  tool and leaves its siblings proven. A reviewed inventory *can* close these,
+  since the schema is exactly what it supplies.
+
+Propagation only ever lowers a tool, never raises one. Agent Config `tools:`
+entries are name references with no signature to read, so that path stays
+`low`.
 
 **Pitfalls**:
 - `OpenAPIToolset(...)` and `McpToolset(...)` need `tool_filter` declared; without it, the toolset counts as "unfiltered" and `SHIP-ADK-MCP-TOOLSET-UNFILTERED` fires high. Add the filter, then point `inventory_path` at a local tool inventory.

--- a/docs/upstream-integrations.md
+++ b/docs/upstream-integrations.md
@@ -144,16 +144,28 @@ ci:
 
 **Extraction confidence** is measured on the module, not assumed from the
 framework. A Python entrypoint whose tool surface the adapter fully resolved
-reaches `high` on its own, with no tool inventory: every `tools=` element
-resolves to a single module-level definition that nothing later rebinds, no
-toolset is dynamic, no `sub_agents` element is unresolvable, nothing reaches
-`agent.tools` after construction, no agent is built from `**kwargs`, and each
-bound function is undecorated with every parameter annotated and no
-`*args`/`**kwargs`. Anything else holds the
-whole file at `medium` and the `low_confidence_tool` evidence gap names the
-construct responsible (`dynamic_toolset`, `untyped_parameter`,
-`mutable_tool_binding`, …). Agent Config `tools:` entries are name references
-with no signature to read, so that path stays `low`.
+reaches `high` on its own, with no tool inventory. That requires all of:
+
+- every `tools=` element resolves to a definition **in this module**, including
+  the `func=` of every `FunctionTool` / `LongRunningFunctionTool`;
+- every name it resolves through is bound exactly once, at module scope — a
+  parameter, class, import, `except ... as`, `case ... as`, `global`, or later
+  assignment of the same name is enough to make the resolution a guess rather
+  than a proof;
+- no toolset is dynamic and no `sub_agents` element is unresolvable;
+- nothing reaches `agent.tools` after construction — including through an
+  alias, `setattr`, or `getattr(agent, "tools")` — and no agent is built from
+  `**kwargs`;
+- each bound function is undecorated, takes no `*args`/`**kwargs`, and annotates
+  every parameter with a type the schema emitter represents faithfully.
+
+Anything else holds the whole file at `medium`, and the `low_confidence_tool`
+evidence gap names the construct responsible (`dynamic_toolset`,
+`untyped_parameter`, `mutable_tool_binding`, …). Module-scoped reasons reach
+tools contributed by a *resolved* OpenAPI or MCP toolset too, because the
+module could not prove its tool set either way; those tools are only ever
+lowered, never raised. Agent Config `tools:` entries are name references with
+no signature to read, so that path stays `low`.
 
 **Pitfalls**:
 - `OpenAPIToolset(...)` and `McpToolset(...)` need `tool_filter` declared; without it, the toolset counts as "unfiltered" and `SHIP-ADK-MCP-TOOLSET-UNFILTERED` fires high. Add the filter, then point `inventory_path` at a local tool inventory.

--- a/samples/google_adk_agent/shipgate.yaml
+++ b/samples/google_adk_agent/shipgate.yaml
@@ -19,13 +19,18 @@ tool_sources:
 google_adk:
   eval_sets:
     - evals/support.eval.json
-  # Reviewed inventory resolves the otherwise AST-only function bindings.
-  # `source_id` names the source it completes: each entry matching a name
-  # `adk_support` already exposes is joined to that observation rather than
-  # added beside it, so the catalog keeps its size and the tools reach high
-  # extraction confidence. Written out tool by tool, this is the same thing as
-  # a `tool_identity.bindings` entry per name — see samples/simple_crewai_agent
+  # Reviewed inventory joined to the source it completes. `source_id` names
+  # that source: each entry matching a name `adk_support` already exposes is
+  # joined to that observation rather than added beside it, so the catalog
+  # keeps its size. Written out tool by tool, this is the same thing as a
+  # `tool_identity.bindings` entry per name — see samples/simple_crewai_agent
   # and samples/simple_langchain_agent for that longer form.
+  #
+  # Since #393 this file is no longer what earns high extraction confidence
+  # here: `agent.py` resolves completely, so its two function tools reach
+  # `high` from source alone. What the inventory still contributes is reviewed
+  # metadata — descriptions and schemas a human stands behind. Keep it as the
+  # worked `source_id` example; a fully static ADK entrypoint does not need one.
   tool_inventories:
     - path: inventories/function-tools.json
       source_id: adk_support

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -1115,7 +1115,30 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
     )
     for tool in low_confidence:
         manifest_key = inventory_manifest_key(tool.source_type)
-        if manifest_key is not None:
+        if tool.extraction.get("tool_set_proven") is False:
+            # An unproven tool *set* is not a missing artifact. Routing it by
+            # source type asked for an inventory or spec the repository had
+            # already supplied — the OpenAPI file is right there and complete;
+            # what is unresolved is the ADK module that decides which tools the
+            # agent gets (#400 review). Name that instead.
+            action = EvidenceGapAction(
+                kind="provide_source",
+                why=(
+                    "The tool surface this source belongs to could not be "
+                    "enumerated, so the set of tools is unknown even where an "
+                    "individual tool's schema is not."
+                ),
+                expects=(
+                    "Resolve the construct named in this row's reason in the "
+                    "source module — a dynamic tools expression, a toolset "
+                    "with no static inventory, an agent built from unpacked "
+                    "keyword arguments, or a tool list mutated after "
+                    "construction — then rerun the scan. A tool inventory "
+                    "cannot close this: it describes tools, not which tools "
+                    "an agent has."
+                ),
+            )
+        elif manifest_key is not None:
             action = EvidenceGapAction(
                 kind="declare_tool_inventory",
                 path=SUGGESTED_INVENTORY_FILENAME,

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -1081,6 +1081,25 @@ def inventory_manifest_key(source_type: str) -> str | None:
     return None
 
 
+def _surface_gap_note(tool: Tool) -> str:
+    """Name the constructs that held this tool below high confidence (#393).
+
+    "static extraction could not prove the full tool surface" was the same
+    sentence on every AST-extracted tool in every repository, so it told a
+    reader nothing about *their* code and nothing about what to change. An
+    adapter that measures completeness can say which construct is responsible;
+    one that does not is unchanged.
+    """
+
+    raw_gaps = tool.extraction.get("surface_gaps")
+    if not isinstance(raw_gaps, list):
+        return ""
+    reasons = sorted({value for value in raw_gaps if isinstance(value, str) and value})
+    if not reasons:
+        return ""
+    return f" Unresolved: {', '.join(reasons)}."
+
+
 def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceGap]:
     """v0.26: one actionable row per measurable evidence gap.
 
@@ -1128,6 +1147,7 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
                 why=(
                     f"extraction_confidence={tool.extraction_confidence}; "
                     "static extraction could not prove the full tool surface."
+                    f"{_surface_gap_note(tool)}"
                 ),
                 next_action=action,
             )

--- a/src/agents_shipgate/core/domain.py
+++ b/src/agents_shipgate/core/domain.py
@@ -276,6 +276,20 @@ class AuthInfo(BaseModel):
     invalid_annotations: list[str] = Field(default_factory=list)
 
 
+#: ``Tool.extraction["surface"]`` — an adapter's answer to "did you read the
+#: whole tool surface, or only report what you could see?".
+#:
+#: Only an adapter writes ``extraction``; no loader copies it out of a parsed
+#: input file, so unlike ``annotations`` this claim cannot be self-declared by
+#: an untrusted artifact. Absence of the key is *not* ``SURFACE_PARTIAL`` with
+#: extra steps — it means the adapter has no answer, which every consumer must
+#: treat as incomplete. Defined here so the producers (``inputs/*``) and the
+#: consumer (``core.semantic_assessment``) share one spelling rather than two
+#: string literals that have to agree (#393).
+SURFACE_ENUMERATED = "enumerated"
+SURFACE_PARTIAL = "partial"
+
+
 class ToolParameter(BaseModel):
     model_config = ConfigDict(extra="allow")
 

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from agents_shipgate.core.domain import (
+    SURFACE_ENUMERATED,
     AuthorityMode,
     AuthoritySemanticAssessment,
     BindingSemanticAssessment,
@@ -42,6 +43,12 @@ _MCP_SOURCE_TYPES = frozenset(
         "conductor_mcp_call",
     }
 )
+#: Source types whose tool surface is read out of source code rather than out
+#: of a published contract, so completeness has to be established rather than
+#: assumed. Membership alone is *not* a verdict: an adapter that proves it
+#: enumerated the surface says so on the tool (see
+#: :data:`agents_shipgate.core.domain.SURFACE_ENUMERATED`), and only a source
+#: type that says nothing is treated as incomplete.
 _AST_ONLY_SOURCE_TYPES = frozenset(
     {
         "sdk_function",
@@ -886,12 +893,31 @@ def _issue(
 
 
 def _surface_is_complete(tool: Tool) -> bool:
-    return not (
-        tool.source_type in _AST_ONLY_SOURCE_TYPES
-        or tool.annotations.get("wildcard_tools") is True
+    """Whether this tool's surface is known, not merely reported.
+
+    Until #393 an AST source type was disqualified outright. That made
+    ``incomplete_surface`` a constant for every repository built on a supported
+    Python framework — true of a toolkit factory and of twelve annotated
+    module-level functions alike — and a condition that holds for every input
+    distinguishes nothing. The only way out was a reviewed inventory
+    transcribing tools the adapter had already extracted correctly, which added
+    no fact to the system.
+
+    An AST adapter may now discharge the doubt by measuring it: it enumerates
+    the surface, or it names what it could not resolve. Saying nothing still
+    reads as incomplete, so adapters that have not been taught to answer keep
+    their previous verdict and a newly unresolvable construct fails closed.
+    """
+
+    if (
+        tool.annotations.get("wildcard_tools") is True
         or tool.annotations.get("mcp_wildcard_tools") is True
         or tool.annotations.get("mcp_unknown_schema") is True
-    )
+    ):
+        return False
+    if tool.source_type in _AST_ONLY_SOURCE_TYPES:
+        return tool.extraction.get("surface") == SURFACE_ENUMERATED
+    return True
 
 
 def _validated_hint_basis(

--- a/src/agents_shipgate/core/tool_identity.py
+++ b/src/agents_shipgate/core/tool_identity.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from agents_shipgate.core.domain import (
+    SURFACE_PARTIAL,
     LoadedToolSource,
     SemanticClaim,
     SemanticIssue,
@@ -772,7 +773,52 @@ def _merge_bound_observations(primary: Tool, members: list[Tool]) -> tuple[Tool,
         )
         merged.auth.invalid_annotations.extend(member.auth.invalid_annotations)
     issues.extend(_backfill_preserved_evidence(merged, primary, members))
+    _carry_unproven_tool_set(merged, members)
     return merged, issues
+
+
+def _carry_unproven_tool_set(merged: Tool, members: list[Tool]) -> None:
+    """Keep a member's *set*-level incompleteness on the canonical tool.
+
+    The merge starts from the primary and copies nothing about extraction
+    across, which is deliberate: promoting the primary's fidelity is what
+    naming a reviewed inventory is *for* (#386). That reasoning holds only for
+    claims about one tool's own interface, though. An identity assertion proves
+    two observations describe the same operation; it says nothing about whether
+    the module one of them came from exposes further tools nobody enumerated.
+
+    So an ADK observation carrying ``dynamic_agent_kwargs`` merged into a
+    high-confidence OpenAPI primary produced a high, pass-eligible canonical
+    tool and a `passed` verdict, with the module's gap nowhere in the report
+    (#400 review). Set-scoped reasons now survive the merge and cap the result;
+    interface-scoped ones still resolve in the primary's favour.
+    """
+
+    unproven = [
+        member
+        for member in members
+        if member.extraction.get("tool_set_proven") is False
+    ]
+    if not unproven:
+        return
+    carried: set[str] = set()
+    for member in unproven:
+        raw_gaps = member.extraction.get("surface_gaps")
+        if isinstance(raw_gaps, list):
+            carried.update(
+                value for value in raw_gaps if isinstance(value, str) and value
+            )
+    existing = merged.extraction.get("surface_gaps")
+    if isinstance(existing, list):
+        carried.update(
+            value for value in existing if isinstance(value, str) and value
+        )
+    merged.extraction["surface"] = SURFACE_PARTIAL
+    merged.extraction["surface_gaps"] = sorted(carried)
+    merged.extraction["tool_set_proven"] = False
+    if merged.extraction_confidence == "high":
+        merged.extraction["confidence"] = "medium"
+        merged.extraction_confidence = "medium"
 
 
 #: Tool fields a member may fill in when the primary has nothing there, and

--- a/src/agents_shipgate/inputs/google_adk.py
+++ b/src/agents_shipgate/inputs/google_adk.py
@@ -10,6 +10,8 @@ from agents_shipgate.core.artifact_models import (
     GoogleAdkToolset,
 )
 from agents_shipgate.core.domain import (
+    SURFACE_ENUMERATED,
+    SURFACE_PARTIAL,
     AgentBindingObservation,
     AuthInfo,
     LoadedToolSource,
@@ -84,6 +86,62 @@ _SCOPE_NODES = (
     ast.Lambda,
     ast.ClassDef,
 )
+#: ``Tool.extraction["surface"]`` — whether this adapter *proved* the tool
+#: surface it reports, rather than merely produced it.
+#:
+#: Before #393 the Python AST path hardcoded ``confidence="medium"``, so no ADK
+#: repository could reach ``high`` from source however statically analysable it
+#: was, and ``insufficient_evidence`` was the framework's default first-run
+#: verdict rather than a property of any repository. A condition that holds for
+#: every input carries no information: it could not tell a toolkit factory from
+#: twelve module-level functions, and the remedy it prescribed — transcribe the
+#: twelve tools Shipgate had just extracted correctly into an inventory — added
+#: no fact to the system.
+#:
+#: ``SURFACE_ENUMERATED`` is therefore a claim the extractor has to earn on the
+#: parsed module. Every construct that leaves any part of the surface
+#: unresolved records a reason code below and holds the whole module at
+#: ``medium``; absence of the attestation reads as incomplete everywhere
+#: downstream, so a new ambiguity nobody classified fails closed.
+
+#: Module-scoped reasons: one unresolved construct anywhere in the file means
+#: this file's tool surface was not proven, so it holds every tool the file
+#: produced. Scoping them per agent instead would let a fully-resolved agent in
+#: a half-resolved module claim a proof the module cannot support.
+SURFACE_GAP_DYNAMIC_TOOLS = "dynamic_tools_expression"
+SURFACE_GAP_UNRESOLVED_REFERENCE = "unresolved_tool_reference"
+SURFACE_GAP_UNRESOLVED_EXPRESSION = "unresolved_tool_expression"
+SURFACE_GAP_UNRESOLVED_WRAPPER = "unresolved_tool_wrapper"
+SURFACE_GAP_DYNAMIC_TOOLSET = "dynamic_toolset"
+SURFACE_GAP_CONFLICTING_CONTRACT = "conflicting_tool_contract"
+SURFACE_GAP_UNRESOLVED_SUB_AGENT = "unresolved_sub_agent"
+#: The module reaches an agent's ``tools`` attribute after construction, or
+#: builds an agent from unpacked keyword arguments. Reading the ``tools=``
+#: literal proves the surface only if that literal is the whole story;
+#: ``agent.tools.append(imported)`` and ``Agent(**config)`` both make it not be.
+SURFACE_GAP_MUTABLE_TOOL_BINDING = "mutable_tool_binding"
+SURFACE_GAP_DYNAMIC_AGENT_KWARGS = "dynamic_agent_kwargs"
+#: A ``tools=`` element resolved to a definition the name may not actually
+#: refer to. ``self.functions`` is a flat, scope-blind name map, so it happily
+#: answers with a function defined inside a factory, a method lifted out of a
+#: class body, one of two conditional definitions, or a definition whose name
+#: was later rebound. Naming the tool is still useful; claiming its signature
+#: was proven is not.
+SURFACE_GAP_SHADOWED_DEFINITION = "shadowed_tool_definition"
+#: Emitted only by the fail-closed backstop in
+#: ``_PythonAdkExtractor._resolve_extraction_evidence``:
+#: a warning this module raised through neither surface helper. It means a new
+#: ambiguity was added without deciding what it says about the surface, so the
+#: module declines to claim one.
+SURFACE_GAP_UNCLASSIFIED = "unclassified_extractor_warning"
+#: Per-tool reasons: the module may be fully enumerated while one function's
+#: own callable interface still is not.
+SURFACE_GAP_UNTYPED_PARAMETER = "untyped_parameter"
+SURFACE_GAP_VARIADIC_PARAMETERS = "variadic_parameters"
+SURFACE_GAP_DECORATED_FUNCTION = "decorated_tool_function"
+#: An Agent Config lists tool *names*; there is no signature to read, so this
+#: path never claims an enumerated surface.
+SURFACE_GAP_TOOL_REFERENCE_ONLY = "tool_reference_only"
 
 
 def load_google_adk_artifacts(
@@ -422,7 +480,12 @@ def _tool_from_config_entry(
         annotations={"adk_tool_reference": name, "agent_name": agent_name},
         auth=AuthInfo(source="google_adk_config"),
         extraction_confidence="low",
-        extraction={"method": "google_adk_agent_config", "confidence": "low"},
+        extraction={
+            "method": "google_adk_agent_config",
+            "confidence": "low",
+            "surface": SURFACE_PARTIAL,
+            "surface_gaps": [SURFACE_GAP_TOOL_REFERENCE_ONLY],
+        },
     )
     tools.append(tool)
     artifacts.function_tools.append(
@@ -588,6 +651,11 @@ class _PythonAdkExtractor:
             for node in ast.walk(tree)
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         }
+        # Names ``self.functions`` can answer for without being right. The map
+        # above is flat and scope-blind by design — it has to be, to name a
+        # tool at all — but the answer is only a *proof* of the signature when
+        # the name is defined once, at module scope, and never rebound.
+        self.unproven_function_names = _unproven_function_names(tree)
         self.wrappers = self._wrapper_assignments()
         self.toolset_assignments = self._toolset_assignments()
         # One canonical Tool per function definition, keyed by the def name.
@@ -598,6 +666,13 @@ class _PythonAdkExtractor:
         # agents is loaded once, not once per agent.
         self.toolset_tool_names: dict[int, list[str]] = {}
         self.agent_bindings: dict[str, _AdkAgentBinding] = {}
+        # Reasons this module's tool surface was not proven complete (#393).
+        # Empty at the end of ``extract`` is what earns ``SURFACE_ENUMERATED``.
+        self.surface_gaps: list[str] = []
+        # Warnings this module raised through ``_surface_warning`` or
+        # ``_note_warning``. Compared against the real growth of
+        # ``artifacts.warnings`` so an unclassified append fails closed.
+        self._accounted_warnings = 0
         # Every ``Agent(...)`` assignment in this module, walked once and
         # reused: ``extract`` iterates it, and the sub-agent spelling map
         # below is built from it.
@@ -612,9 +687,16 @@ class _PythonAdkExtractor:
     def extract(self) -> list[LoadedToolSource]:
         tools: list[Tool] = []
         loaded_sources: list[LoadedToolSource] = []
+        warnings_before = len(self.artifacts.warnings)
         self._record_eval_references()
+        self._record_mutable_tool_bindings()
         for target_name, call in self.agent_call_list:
             agent_name = _kwarg_string(call, "name") or target_name or "adk_agent"
+            if any(keyword.arg is None for keyword in call.keywords):
+                # ``Agent(**config)`` hides every keyword, ``tools`` included.
+                # Without ``tools=`` the agent silently records tool_count 0,
+                # which would otherwise read as a proven empty surface.
+                self._note_surface_gap(SURFACE_GAP_DYNAMIC_AGENT_KWARGS)
             tools_expr = _kwarg(call, "tools")
             tool_count = len(tools_expr.elts) if isinstance(tools_expr, (ast.List, ast.Tuple)) else 0
             self.artifacts.agents.append(
@@ -630,8 +712,9 @@ class _PythonAdkExtractor:
             self._record_agent_callbacks_plugins_subagents(call, agent_name)
             if not isinstance(tools_expr, (ast.List, ast.Tuple)):
                 if tools_expr is not None:
-                    self.artifacts.warnings.append(
-                        f"Google ADK agent {agent_name!r} uses a dynamic tools expression."
+                    self._surface_warning(
+                        f"Google ADK agent {agent_name!r} uses a dynamic tools expression.",
+                        SURFACE_GAP_DYNAMIC_TOOLS,
                     )
                     self.artifacts.toolsets.append(
                         GoogleAdkToolset(
@@ -648,6 +731,7 @@ class _PythonAdkExtractor:
                 loaded_sources.extend(
                     self._extract_tool_expr(item, tools, agent_name, binding)
                 )
+        self._resolve_extraction_evidence(warnings_before)
         return [
             LoadedToolSource(
                 source_id=self.source_id,
@@ -658,6 +742,102 @@ class _PythonAdkExtractor:
             ),
             *loaded_sources,
         ]
+
+    def _surface_warning(self, message: str, reason: str) -> None:
+        """Report a construct that leaves part of this module's surface unknown."""
+
+        self.artifacts.warnings.append(message)
+        self._accounted_warnings += 1
+        self._note_surface_gap(reason)
+
+    def _note_warning(self, message: str) -> None:
+        """Report a warning that says nothing about the tool surface.
+
+        Eval-artifact references are about test collateral, not about which
+        tools an agent can call, so they must not cost the module its
+        completeness claim. Everything else goes through ``_surface_warning``.
+        """
+
+        self.artifacts.warnings.append(message)
+        self._accounted_warnings += 1
+
+    def _note_surface_gap(self, reason: str) -> None:
+        if reason not in self.surface_gaps:
+            self.surface_gaps.append(reason)
+
+    def _record_mutable_tool_bindings(self) -> None:
+        """Notice any reach for an agent's ``tools`` after it is constructed.
+
+        The ``tools=`` literal is only a proof of the surface while nothing
+        else touches it. ``root_agent.tools.append(imported_tool)``,
+        ``root_agent.tools = [...]``, ``setattr(root_agent, "tools", ...)``,
+        and an alias bound with ``bucket = root_agent.tools`` all add tools the
+        walk above never sees, and every one of them was silently promoted to
+        ``high`` before this guard.
+
+        Any ``.tools`` access at all counts, not only the mutating spellings:
+        a read can be aliased and a subscript store hides behind a load. The
+        cost of over-reporting is one module that stays at ``medium``, which is
+        where it already was; the cost of under-reporting is a proven-surface
+        claim over tools nobody enumerated. Dotted module paths such as
+        ``google.adk.tools.FunctionTool`` are excluded by their imported root —
+        those are packages, not agents.
+        """
+
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.Attribute) and node.attr == "tools":
+                if not self._is_imported_module_path(node.value):
+                    self._note_surface_gap(SURFACE_GAP_MUTABLE_TOOL_BINDING)
+                    return
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "setattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value == "tools"
+            ):
+                self._note_surface_gap(SURFACE_GAP_MUTABLE_TOOL_BINDING)
+                return
+
+    def _is_imported_module_path(self, node: ast.AST) -> bool:
+        """Whether ``node`` roots in a name this module imported."""
+
+        current = node
+        while isinstance(current, ast.Attribute):
+            current = current.value
+        return isinstance(current, ast.Name) and current.id in self.aliases
+
+    def _resolve_extraction_evidence(self, warnings_before: int) -> None:
+        """Settle each tool's extraction confidence on what this module proved.
+
+        Runs once, after the whole module is walked, because completeness is a
+        property of the file rather than of the agent that happened to be
+        visited first: a dynamic tools expression on the last agent invalidates
+        the proof for tools bound by the first.
+
+        The unaccounted-warning backstop is the load-bearing part. A future
+        ambiguity added with a plain ``artifacts.warnings.append`` would
+        otherwise leave ``surface_gaps`` empty and silently promote an
+        unresolved module to ``high`` — the fail-open shape a "safe" block-level
+        signal clearing a path-wide guard produces. Counting warnings makes the
+        default answer "not proven".
+        """
+
+        emitted = len(self.artifacts.warnings) - warnings_before
+        if emitted != self._accounted_warnings:
+            self._note_surface_gap(SURFACE_GAP_UNCLASSIFIED)
+        for tool in self.canonical_function_tools.values():
+            raw_gaps = tool.extraction.get("surface_gaps")
+            local_gaps = raw_gaps if isinstance(raw_gaps, list) else []
+            gaps = sorted({*self.surface_gaps, *local_gaps})
+            confidence = "medium" if gaps else "high"
+            tool.extraction["surface"] = (
+                SURFACE_PARTIAL if gaps else SURFACE_ENUMERATED
+            )
+            tool.extraction["surface_gaps"] = gaps
+            tool.extraction["confidence"] = confidence
+            tool.extraction_confidence = confidence
 
     def _agent_names_by_variable(self) -> dict[tuple[ast.AST | None, str], str | None]:
         """Map each ``variable = Agent(...)`` to the agent's declared ``name=``.
@@ -813,8 +993,9 @@ class _PythonAdkExtractor:
                     self.functions[expr.id], tools, agent_name, binding, False
                 )
             else:
-                self.artifacts.warnings.append(
-                    adk_unresolved_tool_warning(agent_name, expr.id)
+                self._surface_warning(
+                    adk_unresolved_tool_warning(agent_name, expr.id),
+                    SURFACE_GAP_UNRESOLVED_REFERENCE,
                 )
             return []
         if isinstance(expr, ast.Call):
@@ -832,8 +1013,9 @@ class _PythonAdkExtractor:
                 return []
             if call_name in OPENAPI_TOOLSET_NAMES | MCP_TOOLSET_NAMES:
                 return self._extract_toolset_call(expr, agent_name, binding)
-        self.artifacts.warnings.append(
-            f"Google ADK agent {agent_name!r} has a tool expression that could not be statically resolved."
+        self._surface_warning(
+            f"Google ADK agent {agent_name!r} has a tool expression that could not be statically resolved.",
+            SURFACE_GAP_UNRESOLVED_EXPRESSION,
         )
         return []
 
@@ -855,8 +1037,9 @@ class _PythonAdkExtractor:
                 bool(wrapper.get("long_running")),
             )
             return
-        self.artifacts.warnings.append(
-            f"Google ADK tool wrapper {wrapper_name!r} has no statically resolvable function."
+        self._surface_warning(
+            f"Google ADK tool wrapper {wrapper_name!r} has no statically resolvable function.",
+            SURFACE_GAP_UNRESOLVED_WRAPPER,
         )
 
     def _bind_function_tool(
@@ -875,6 +1058,8 @@ class _PythonAdkExtractor:
         (and collide on tool observation identity).
         """
 
+        if node.name in self.unproven_function_names:
+            self._note_surface_gap(SURFACE_GAP_SHADOWED_DEFINITION)
         tool = self.canonical_function_tools.get(node.name)
         if tool is None:
             tool = self._function_to_tool(node, agent_name, long_running)
@@ -885,9 +1070,10 @@ class _PythonAdkExtractor:
             # LongRunningFunctionTool is a contradictory declaration about one
             # action. Keep the stricter contract and route it to review rather
             # than letting binding order decide.
-            self.artifacts.warnings.append(
+            self._surface_warning(
                 f"Google ADK function {node.name!r} is bound as both a long-running "
-                "and a standard function tool; review its operation contract."
+                "and a standard function tool; review its operation contract.",
+                SURFACE_GAP_CONFLICTING_CONTRACT,
             )
             if long_running:
                 tool.annotations["long_running"] = True
@@ -985,8 +1171,15 @@ class _PythonAdkExtractor:
                 "long_running": long_running,
             },
             auth=AuthInfo(source="google_adk_static"),
+            # Provisional: ``_resolve_extraction_evidence`` settles both fields
+            # once the whole module has been walked. ``medium`` here so a tool
+            # is never high-confidence in flight.
             extraction_confidence="medium",
-            extraction={"method": "google_adk_python_ast", "confidence": "medium"},
+            extraction={
+                "method": "google_adk_python_ast",
+                "confidence": "medium",
+                "surface_gaps": _function_surface_gaps(node, parameters),
+            },
         )
         payload = self._function_tool_payload(tool, agent_name)
         self.artifacts.function_tools.append(payload)
@@ -1021,9 +1214,10 @@ class _PythonAdkExtractor:
         )
         self.artifacts.toolsets.append(toolset)
         if not spec_path:
-            self.artifacts.warnings.append(
+            self._surface_warning(
                 f"Google ADK OpenAPIToolset at {self.source_ref}:{call.lineno} "
-                "has no static local spec path."
+                "has no static local spec path.",
+                SURFACE_GAP_DYNAMIC_TOOLSET,
             )
             return []
         loaded = load_openapi_tools(
@@ -1059,9 +1253,10 @@ class _PythonAdkExtractor:
         )
         self.artifacts.toolsets.append(toolset)
         if not inventory_path:
-            self.artifacts.warnings.append(
+            self._surface_warning(
                 f"Google ADK McpToolset at {self.source_ref}:{call.lineno} "
-                "has no static MCP tool inventory path."
+                "has no static MCP tool inventory path.",
+                SURFACE_GAP_DYNAMIC_TOOLSET,
             )
             return []
         loaded = load_mcp_tools(
@@ -1121,6 +1316,14 @@ class _PythonAdkExtractor:
                     resolved = self._sub_agent_name(variable, call)
                     if resolved is None:
                         unresolved_sub_agents.append(variable)
+                        # A handoff target this module does not define owns
+                        # tools this module never saw, so the file cannot
+                        # claim it enumerated the surface reachable from
+                        # here. Deliberately no warning: #385 left an
+                        # unreached branch ungated, and adding one now would
+                        # move repositories between verdicts for a reason
+                        # this change is not about.
+                        self._note_surface_gap(SURFACE_GAP_UNRESOLVED_SUB_AGENT)
                     else:
                         sub_agent_names.append(resolved)
                 self.artifacts.sub_agents.append(
@@ -1160,12 +1363,12 @@ class _PythonAdkExtractor:
             try:
                 path = resolve_input_path(self.entrypoint_dir, value)
             except InputParseError:
-                self.artifacts.warnings.append(
+                self._note_warning(
                     f"Google ADK eval reference {value!r} resolves outside the entrypoint directory."
                 )
                 continue
             if not path.exists():
-                self.artifacts.warnings.append(
+                self._note_warning(
                     f"Google ADK eval reference {value!r} was detected but not found."
                 )
                 continue
@@ -1429,6 +1632,75 @@ def _parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ToolParame
             continue
         parameters.append(_parameter(arg, required=default is None))
     return parameters
+
+
+def _unproven_function_names(tree: ast.Module) -> set[str]:
+    """Names whose function definition the AST cannot stand behind.
+
+    ``tools=[helper]`` is resolved through a flat ``name -> FunctionDef`` map
+    built by walking the whole module, which is what lets the adapter name a
+    tool at all. It is not what lets it *prove* one: the same map answers with
+    a definition nested inside a factory (``helper = build()``), a method
+    lifted out of a class body, whichever of two conditional definitions the
+    walk saw last, or a definition whose name was later rebound to an import.
+    Each of those reports a signature the running agent will not use.
+
+    A name is proven only when exactly one definition of it exists, that
+    definition is a direct child of the module, and nothing else in the file
+    binds the name. Everything else is listed here and costs the module its
+    completeness claim — the tool is still reported, just not as proven.
+    """
+
+    definitions: dict[str, int] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            definitions[node.name] = definitions.get(node.name, 0) + 1
+    module_level = {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+    rebound: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store | ast.Del):
+            rebound.add(node.id)
+        elif isinstance(node, ast.Import | ast.ImportFrom):
+            for alias in node.names:
+                rebound.add(alias.asname or alias.name.split(".", 1)[0])
+    return {
+        name
+        for name, count in definitions.items()
+        if count > 1 or name not in module_level or name in rebound
+    }
+
+
+def _function_surface_gaps(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    parameters: list[ToolParameter],
+) -> list[str]:
+    """Reasons this one function's callable interface was not fully read.
+
+    Separate from the module-scoped reasons: a file can resolve every tool
+    expression it contains and still hold a function whose real signature the
+    AST does not give up.
+
+    * A decorator replaces the callable ADK introspects, so the definition's
+      parameters are not necessarily the tool's parameters.
+    * ``*args`` / ``**kwargs`` are dropped by :func:`_parameters` — the schema
+      would understate an open-ended surface rather than describe it.
+    * An unannotated parameter is typed ``string`` by
+      :func:`_json_schema_type`'s fallback. That is a guess presented as a
+      schema, which is exactly what a high-confidence extraction may not do.
+    """
+
+    gaps: list[str] = []
+    if node.decorator_list:
+        gaps.append(SURFACE_GAP_DECORATED_FUNCTION)
+    if node.args.vararg is not None or node.args.kwarg is not None:
+        gaps.append(SURFACE_GAP_VARIADIC_PARAMETERS)
+    if any(parameter.type is None for parameter in parameters):
+        gaps.append(SURFACE_GAP_UNTYPED_PARAMETER)
+    return sorted(gaps)
 
 
 def _parameter(arg: ast.arg, *, required: bool) -> ToolParameter:

--- a/src/agents_shipgate/inputs/google_adk.py
+++ b/src/agents_shipgate/inputs/google_adk.py
@@ -139,6 +139,10 @@ SURFACE_GAP_UNCLASSIFIED = "unclassified_extractor_warning"
 SURFACE_GAP_UNTYPED_PARAMETER = "untyped_parameter"
 SURFACE_GAP_VARIADIC_PARAMETERS = "variadic_parameters"
 SURFACE_GAP_DECORATED_FUNCTION = "decorated_tool_function"
+#: An annotation is present but the emitter cannot represent it, so the schema
+#: it ships is a guess with better manners than an absent annotation's. See
+#: :func:`_annotation_is_faithful`.
+SURFACE_GAP_UNREPRESENTABLE_ANNOTATION = "unrepresentable_annotation"
 #: An Agent Config lists tool *names*; there is no signature to read, so this
 #: path never claims an enumerated surface.
 SURFACE_GAP_TOOL_REFERENCE_ONLY = "tool_reference_only"
@@ -651,11 +655,11 @@ class _PythonAdkExtractor:
             for node in ast.walk(tree)
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         }
-        # Names ``self.functions`` can answer for without being right. The map
-        # above is flat and scope-blind by design — it has to be, to name a
-        # tool at all — but the answer is only a *proof* of the signature when
-        # the name is defined once, at module scope, and never rebound.
-        self.unproven_function_names = _unproven_function_names(tree)
+        # Every binding occurrence of every name in the module. The maps above
+        # are flat and scope-blind by design — they have to be, to name a tool
+        # at all — so this is what says whether their answer is also a *proof*.
+        # Read through ``_name_is_proven``.
+        self.name_bindings = _name_binding_occurrences(tree)
         self.wrappers = self._wrapper_assignments()
         self.toolset_assignments = self._toolset_assignments()
         # One canonical Tool per function definition, keyed by the def name.
@@ -731,7 +735,7 @@ class _PythonAdkExtractor:
                 loaded_sources.extend(
                     self._extract_tool_expr(item, tools, agent_name, binding)
                 )
-        self._resolve_extraction_evidence(warnings_before)
+        self._resolve_extraction_evidence(warnings_before, loaded_sources)
         return [
             LoadedToolSource(
                 source_id=self.source_id,
@@ -782,6 +786,11 @@ class _PythonAdkExtractor:
         claim over tools nobody enumerated. Dotted module paths such as
         ``google.adk.tools.FunctionTool`` are excluded by their imported root —
         those are packages, not agents.
+
+        Reflective access is checked separately because it carries the
+        attribute name as data: ``getattr(root_agent, "tools").append(...)``
+        contains no ``Attribute`` node named ``tools`` at all and walked
+        straight past the first check (PR #400 review).
         """
 
         for node in ast.walk(self.tree):
@@ -789,32 +798,78 @@ class _PythonAdkExtractor:
                 if not self._is_imported_module_path(node.value):
                     self._note_surface_gap(SURFACE_GAP_MUTABLE_TOOL_BINDING)
                     return
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id == "setattr"
-                and len(node.args) >= 2
-                and isinstance(node.args[1], ast.Constant)
-                and node.args[1].value == "tools"
-            ):
+            if _is_reflective_tools_access(node):
                 self._note_surface_gap(SURFACE_GAP_MUTABLE_TOOL_BINDING)
                 return
 
     def _is_imported_module_path(self, node: ast.AST) -> bool:
-        """Whether ``node`` roots in a name this module imported."""
+        """Whether ``node`` roots in a name that is *only* ever an import.
+
+        Membership in ``self.aliases`` is not enough. ``from x import agents``
+        followed by ``agents = LlmAgent(...)`` leaves the name in the alias map
+        while it now refers to an agent, so ``agents.tools.append(...)`` was
+        waved through as a package path (PR #400 review). A root that anything
+        else in the module rebinds is not a package.
+        """
 
         current = node
         while isinstance(current, ast.Attribute):
             current = current.value
-        return isinstance(current, ast.Name) and current.id in self.aliases
+        if not isinstance(current, ast.Name) or current.id not in self.aliases:
+            return False
+        bindings = self.name_bindings.get(current.id, [])
+        return len(bindings) == 1 and isinstance(bindings[0], ast.alias)
 
-    def _resolve_extraction_evidence(self, warnings_before: int) -> None:
+    def _name_is_proven(self, name: str) -> bool:
+        """Whether ``name`` unambiguously refers to what the flat maps say.
+
+        True only when the module binds the name exactly once, at module scope,
+        through a statement that is a direct child of the module body. A second
+        binding of any kind — a parameter, a class, an import, a later
+        assignment, a ``global`` declaration — means the resolution is a guess
+        about which one was in effect, and a guess is not a proof.
+        """
+
+        bindings = self.name_bindings.get(name, [])
+        if len(bindings) != 1:
+            return False
+        binding = bindings[0]
+        if self._scope_of(binding) is not self.tree:
+            return False
+        return isinstance(self._top_level_statement(binding), _TOP_LEVEL_BINDING_STATEMENTS)
+
+    def _top_level_statement(self, node: ast.AST) -> ast.AST | None:
+        """The direct child of the module body that contains ``node``."""
+
+        current: ast.AST | None = node
+        parent = self.parents.get(node)
+        while parent is not None and parent is not self.tree:
+            current = parent
+            parent = self.parents.get(parent)
+        return current if parent is self.tree else None
+
+    def _require_proven_name(self, name: str) -> None:
+        if not self._name_is_proven(name):
+            self._note_surface_gap(SURFACE_GAP_SHADOWED_DEFINITION)
+
+    def _resolve_extraction_evidence(
+        self, warnings_before: int, loaded_sources: list[LoadedToolSource]
+    ) -> None:
         """Settle each tool's extraction confidence on what this module proved.
 
         Runs once, after the whole module is walked, because completeness is a
         property of the file rather than of the agent that happened to be
         visited first: a dynamic tools expression on the last agent invalidates
         the proof for tools bound by the first.
+
+        ``loaded_sources`` carries the tools an OpenAPI or MCP toolset in this
+        module contributed. They are settled here too, because a module whose
+        *only* tools come from a resolved toolset still has a tool set this
+        file could not prove: ``Agent(**config)`` beside a resolved
+        ``McpToolset`` recorded ``dynamic_agent_kwargs`` into a loop over
+        function tools that was empty, and the gap evaporated (PR #400 review).
+        Their own schemas remain trustworthy, so they are only ever lowered,
+        never raised — this loop cannot promote a tool it did not extract.
 
         The unaccounted-warning backstop is the load-bearing part. A future
         ambiguity added with a plain ``artifacts.warnings.append`` would
@@ -838,6 +893,20 @@ class _PythonAdkExtractor:
             tool.extraction["surface_gaps"] = gaps
             tool.extraction["confidence"] = confidence
             tool.extraction_confidence = confidence
+        if not self.surface_gaps:
+            return
+        module_gaps = sorted(self.surface_gaps)
+        for loaded in loaded_sources:
+            for tool in loaded.tools:
+                raw_gaps = tool.extraction.get("surface_gaps")
+                local_gaps = raw_gaps if isinstance(raw_gaps, list) else []
+                tool.extraction["surface"] = SURFACE_PARTIAL
+                tool.extraction["surface_gaps"] = sorted(
+                    {*module_gaps, *local_gaps}
+                )
+                if tool.extraction_confidence == "high":
+                    tool.extraction["confidence"] = "medium"
+                    tool.extraction_confidence = "medium"
 
     def _agent_names_by_variable(self) -> dict[tuple[ast.AST | None, str], str | None]:
         """Map each ``variable = Agent(...)`` to the agent's declared ``name=``.
@@ -983,8 +1052,13 @@ class _PythonAdkExtractor:
     ) -> list[LoadedToolSource]:
         if isinstance(expr, ast.Name):
             if expr.id in self.wrappers:
+                # The variable's own name has to hold up too, not just the
+                # function it wraps: a wrapper reassigned later resolves
+                # through a last-write-wins map.
+                self._require_proven_name(expr.id)
                 self._append_wrapper_tool(expr.id, tools, agent_name, binding)
             elif expr.id in self.toolset_assignments:
+                self._require_proven_name(expr.id)
                 return self._extract_toolset_call(
                     self.toolset_assignments[expr.id], agent_name, binding
                 )
@@ -1009,6 +1083,19 @@ class _PythonAdkExtractor:
                         agent_name,
                         binding,
                         call_name in LONG_RUNNING_TOOL_NAMES,
+                    )
+                else:
+                    # A recognised wrapper whose ``func`` this module does not
+                    # define: an imported function, an attribute, a lambda, or
+                    # no ``func`` at all. The wrapper is a real tool the agent
+                    # can call and nothing else records it, so returning
+                    # silently here reported a strictly smaller tool surface
+                    # than the agent has — and called it proven (PR #400
+                    # review).
+                    self._surface_warning(
+                        f"Google ADK agent {agent_name!r} wraps a tool whose function "
+                        f"{func_name or '<unspecified>'!r} is not defined in this module.",
+                        SURFACE_GAP_UNRESOLVED_WRAPPER,
                     )
                 return []
             if call_name in OPENAPI_TOOLSET_NAMES | MCP_TOOLSET_NAMES:
@@ -1058,8 +1145,7 @@ class _PythonAdkExtractor:
         (and collide on tool observation identity).
         """
 
-        if node.name in self.unproven_function_names:
-            self._note_surface_gap(SURFACE_GAP_SHADOWED_DEFINITION)
+        self._require_proven_name(node.name)
         tool = self.canonical_function_tools.get(node.name)
         if tool is None:
             tool = self._function_to_tool(node, agent_name, long_running)
@@ -1178,7 +1264,7 @@ class _PythonAdkExtractor:
             extraction={
                 "method": "google_adk_python_ast",
                 "confidence": "medium",
-                "surface_gaps": _function_surface_gaps(node, parameters),
+                "surface_gaps": _function_surface_gaps(node),
             },
         )
         payload = self._function_tool_payload(tool, agent_name)
@@ -1616,8 +1702,18 @@ def _short_tool_name(name: str) -> str:
     return name.rsplit(".", 1)[-1]
 
 
-def _parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ToolParameter]:
-    parameters: list[ToolParameter] = []
+def _bound_args(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[tuple[ast.arg, bool]]:
+    """The arguments that become tool parameters, with their requiredness.
+
+    One owner for the "which arguments count" question, so the schema
+    (:func:`_parameters`) and the check on whether that schema is faithful
+    (:func:`_function_surface_gaps`) can never disagree about which arguments
+    they are talking about.
+    """
+
+    bound: list[tuple[ast.arg, bool]] = []
     positional_args = [*node.args.posonlyargs, *node.args.args]
     positional_defaults: list[ast.expr | None] = [
         None for _ in range(len(positional_args) - len(node.args.defaults))
@@ -1626,57 +1722,177 @@ def _parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ToolParame
     for arg, default in zip(positional_args, positional_defaults, strict=True):
         if arg.arg in {"self", "ctx", "context", "tool_context"}:
             continue
-        parameters.append(_parameter(arg, required=default is None))
+        bound.append((arg, default is None))
     for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults, strict=True):
         if arg.arg in {"self", "ctx", "context", "tool_context"}:
             continue
-        parameters.append(_parameter(arg, required=default is None))
-    return parameters
+        bound.append((arg, default is None))
+    return bound
 
 
-def _unproven_function_names(tree: ast.Module) -> set[str]:
-    """Names whose function definition the AST cannot stand behind.
+def _parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ToolParameter]:
+    return [
+        _parameter(arg, required=required) for arg, required in _bound_args(node)
+    ]
 
-    ``tools=[helper]`` is resolved through a flat ``name -> FunctionDef`` map
-    built by walking the whole module, which is what lets the adapter name a
-    tool at all. It is not what lets it *prove* one: the same map answers with
-    a definition nested inside a factory (``helper = build()``), a method
-    lifted out of a class body, whichever of two conditional definitions the
-    walk saw last, or a definition whose name was later rebound to an import.
-    Each of those reports a signature the running agent will not use.
 
-    A name is proven only when exactly one definition of it exists, that
-    definition is a direct child of the module, and nothing else in the file
-    binds the name. Everything else is listed here and costs the module its
-    completeness claim — the tool is still reported, just not as proven.
+#: Annotations :func:`_annotation_json_type` can name a JSON type for. Bare
+#: ``list``/``dict`` are included: ``{"type": "array"}`` omits the element
+#: schema but does not misstate the value, which is a different thing from a
+#: guess.
+_SCALAR_ANNOTATION_TYPES = {
+    "str": "string",
+    "int": "number",
+    "float": "number",
+    "bool": "boolean",
+    "list": "array",
+    "List": "array",
+    "dict": "object",
+    "Dict": "object",
+}
+
+
+def _annotation_json_type(node: ast.AST | None) -> str | None:
+    """The JSON type this annotation really denotes, or None if it denotes none.
+
+    Reads the annotation as a tree rather than as the unparsed string, so
+    ``set[str]``, ``tuple[int, str]``, ``int | None``, ``Optional[int]``,
+    ``Literal[...]``, a string forward reference, and any custom or Pydantic
+    class all answer None instead of silently becoming a scalar.
     """
 
-    definitions: dict[str, int] = {}
+    if isinstance(node, ast.Name):
+        return _SCALAR_ANNOTATION_TYPES.get(node.id)
+    if isinstance(node, ast.Subscript):
+        base = node.value
+        base_name = (
+            base.id
+            if isinstance(base, ast.Name)
+            else base.attr
+            if isinstance(base, ast.Attribute)
+            else None
+        )
+        if base_name in {"list", "List"}:
+            return "array" if _annotation_json_type(node.slice) else None
+        if base_name in {"dict", "Dict"}:
+            if isinstance(node.slice, ast.Tuple) and len(node.slice.elts) == 2:
+                key, value = node.slice.elts
+                keyed_by_string = isinstance(key, ast.Name) and key.id == "str"
+                if keyed_by_string and _annotation_json_type(value):
+                    return "object"
+            return None
+    return None
+
+
+def _annotation_is_faithful(node: ast.AST | None) -> bool:
+    """Whether the schema :func:`_json_schema_type` emits matches the annotation.
+
+    An annotation is not by itself evidence that the emitted schema is right.
+    ``_json_schema_type`` reads the *unparsed string* and falls back to
+    ``"string"`` for everything it does not recognise, so ``set[str]``,
+    ``int | None``, a Pydantic model, and even ``typing.List[str]`` (spelled
+    with the module prefix the string match misses) all ship as
+    ``{"type": "string"}``.
+
+    Rather than keep a second vocabulary in sync with the emitter's, this asks
+    the emitter what it would produce and compares it to what the annotation
+    denotes. Any spelling the emitter mishandles is unfaithful by construction,
+    including one added later.
+    """
+
+    expected = _annotation_json_type(node)
+    if expected is None:
+        return False
+    return _json_schema_type(_annotation_to_string(node)) == expected
+
+
+#: Statements that bind a name at module scope in a way the adapter can point
+#: at. A binding reached through anything else — an ``if``/``try``/``for`` body,
+#: a ``with`` block — is conditional or order-dependent, which is exactly what
+#: this check exists to refuse.
+_TOP_LEVEL_BINDING_STATEMENTS = (
+    ast.Assign,
+    ast.AnnAssign,
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.ClassDef,
+    ast.Import,
+    ast.ImportFrom,
+)
+
+
+#: Builtins that name an attribute with a string instead of a dotted access.
+#: Matched on the trailing name so ``builtins.setattr`` counts too.
+_REFLECTIVE_ATTRIBUTE_BUILTINS = {"getattr", "setattr", "delattr"}
+
+
+def _is_reflective_tools_access(node: ast.AST) -> bool:
+    """Whether ``node`` reaches an object's ``tools`` attribute by name."""
+
+    if not isinstance(node, ast.Call) or len(node.args) < 2:
+        return False
+    func = node.func
+    called = (
+        func.id
+        if isinstance(func, ast.Name)
+        else func.attr
+        if isinstance(func, ast.Attribute)
+        else None
+    )
+    if called not in _REFLECTIVE_ATTRIBUTE_BUILTINS:
+        return False
+    attribute = node.args[1]
+    return isinstance(attribute, ast.Constant) and attribute.value == "tools"
+
+
+def _name_binding_occurrences(tree: ast.Module) -> dict[str, list[ast.AST]]:
+    """Every node in the module that binds a name, keyed by the name.
+
+    Counting binding *occurrences* rather than definitions is the point.
+    ``tools=[helper]`` is resolved through a flat ``name -> FunctionDef`` map
+    built by walking the whole module, which is what lets the adapter name a
+    tool at all — it is not what lets it *prove* one. The same map answers with
+    a definition nested inside a factory, a method lifted out of a class body,
+    whichever of two conditional definitions the walk saw last, or a definition
+    whose name a parameter, class, import, or later assignment shadows.
+
+    Every Python binding form is collected, not just ``def`` and ``=``:
+    parameters are ``ast.arg``, classes bind through ``ClassDef.name``,
+    ``except E as name`` and ``case X() as name`` have their own shapes, and
+    ``global``/``nonlocal`` declare that a name is rebound out of view. Missing
+    one of those was how a parameter named after a module function slipped
+    through as a proven definition (PR #400 review).
+    """
+
+    bindings: dict[str, list[ast.AST]] = {}
+
+    def record(name: str | None, node: ast.AST) -> None:
+        if name:
+            bindings.setdefault(name, []).append(node)
+
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-            definitions[node.name] = definitions.get(node.name, 0) + 1
-    module_level = {
-        node.name
-        for node in tree.body
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
-    }
-    rebound: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store | ast.Del):
-            rebound.add(node.id)
-        elif isinstance(node, ast.Import | ast.ImportFrom):
-            for alias in node.names:
-                rebound.add(alias.asname or alias.name.split(".", 1)[0])
-    return {
-        name
-        for name, count in definitions.items()
-        if count > 1 or name not in module_level or name in rebound
-    }
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            record(node.name, node)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store | ast.Del):
+            record(node.id, node)
+        elif isinstance(node, ast.arg):
+            record(node.arg, node)
+        elif isinstance(node, ast.alias):
+            record(node.asname or node.name.split(".", 1)[0], node)
+        elif isinstance(node, ast.ExceptHandler):
+            record(node.name, node)
+        elif isinstance(node, ast.MatchAs | ast.MatchStar):
+            record(node.name, node)
+        elif isinstance(node, ast.MatchMapping):
+            record(node.rest, node)
+        elif isinstance(node, ast.Global | ast.Nonlocal):
+            for name in node.names:
+                record(name, node)
+    return bindings
 
 
 def _function_surface_gaps(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
-    parameters: list[ToolParameter],
 ) -> list[str]:
     """Reasons this one function's callable interface was not fully read.
 
@@ -1686,11 +1902,16 @@ def _function_surface_gaps(
 
     * A decorator replaces the callable ADK introspects, so the definition's
       parameters are not necessarily the tool's parameters.
-    * ``*args`` / ``**kwargs`` are dropped by :func:`_parameters` — the schema
+    * ``*args`` / ``**kwargs`` are dropped by :func:`_bound_args` — the schema
       would understate an open-ended surface rather than describe it.
     * An unannotated parameter is typed ``string`` by
       :func:`_json_schema_type`'s fallback. That is a guess presented as a
       schema, which is exactly what a high-confidence extraction may not do.
+    * An annotation the emitter cannot represent is the same guess with better
+      manners — ``set[str]`` and ``int | None`` also ship as ``string``. The
+      return annotation is checked too, because ``output_schema`` is built from
+      the same fallback; an *absent* return annotation is an honest omission
+      (``output_schema`` stays ``{}``) and is not a gap.
     """
 
     gaps: list[str] = []
@@ -1698,8 +1919,16 @@ def _function_surface_gaps(
         gaps.append(SURFACE_GAP_DECORATED_FUNCTION)
     if node.args.vararg is not None or node.args.kwarg is not None:
         gaps.append(SURFACE_GAP_VARIADIC_PARAMETERS)
-    if any(parameter.type is None for parameter in parameters):
+    annotations = [arg.annotation for arg, _ in _bound_args(node)]
+    if any(annotation is None for annotation in annotations):
         gaps.append(SURFACE_GAP_UNTYPED_PARAMETER)
+    declared = [
+        annotation for annotation in annotations if annotation is not None
+    ]
+    if node.returns is not None:
+        declared.append(node.returns)
+    if not all(_annotation_is_faithful(annotation) for annotation in declared):
+        gaps.append(SURFACE_GAP_UNREPRESENTABLE_ANNOTATION)
     return sorted(gaps)
 
 

--- a/src/agents_shipgate/inputs/google_adk.py
+++ b/src/agents_shipgate/inputs/google_adk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Literal
@@ -128,6 +129,16 @@ SURFACE_GAP_DYNAMIC_AGENT_KWARGS = "dynamic_agent_kwargs"
 #: was later rebound. Naming the tool is still useful; claiming its signature
 #: was proven is not.
 SURFACE_GAP_SHADOWED_DEFINITION = "shadowed_tool_definition"
+#: A call this adapter read as ``Agent``/``FunctionTool``/``*Toolset`` is only
+#: that framework's constructor while the name still refers to the import.
+#: ``from google.adk.tools import FunctionTool`` followed by
+#: ``FunctionTool = replacement`` leaves ``_qualified_name`` resolving the stale
+#: alias, so a foreign factory was read with Google's semantics (#400 review).
+SURFACE_GAP_SHADOWED_FRAMEWORK_SYMBOL = "shadowed_framework_symbol"
+#: ``from x import *`` can rebind any name in the module at import time, and
+#: the binding table can only record it under ``"*"``. Nothing in the file is
+#: provably what it appears to be, so nothing is proven.
+SURFACE_GAP_STAR_IMPORT = "star_import_shadowing"
 #: Emitted only by the fail-closed backstop in
 #: ``_PythonAdkExtractor._resolve_extraction_evidence``:
 #: a warning this module raised through neither surface helper. It means a new
@@ -146,6 +157,36 @@ SURFACE_GAP_UNREPRESENTABLE_ANNOTATION = "unrepresentable_annotation"
 #: An Agent Config lists tool *names*; there is no signature to read, so this
 #: path never claims an enumerated surface.
 SURFACE_GAP_TOOL_REFERENCE_ONLY = "tool_reference_only"
+#: Reasons that are about *this callable's* interface rather than about which
+#: tools exist. The distinction is load-bearing at exactly one place: a
+#: reviewed tool inventory is a human statement about a tool's own schema, so
+#: it can legitimately close these — that is what #386 is for — while no
+#: per-tool assertion can establish that a module exposes no *other* tools. A
+#: reason absent from this set therefore survives identity merging and keeps
+#: the canonical tool below high (#400 review).
+TOOL_INTERFACE_SURFACE_GAPS = frozenset(
+    {
+        SURFACE_GAP_UNTYPED_PARAMETER,
+        SURFACE_GAP_VARIADIC_PARAMETERS,
+        SURFACE_GAP_DECORATED_FUNCTION,
+        SURFACE_GAP_UNREPRESENTABLE_ANNOTATION,
+        SURFACE_GAP_TOOL_REFERENCE_ONLY,
+    }
+)
+#: Names Google ADK injects rather than exposing to the model. ADK identifies
+#: the injection by the parameter's *type*, with ``tool_context`` as a name
+#: fallback; dropping every parameter spelled ``ctx`` or ``context`` deleted
+#: ordinary model-visible inputs from the schema (#400 review).
+ADK_CONTEXT_TYPE_NAMES = {
+    "ToolContext",
+    "CallbackContext",
+    "ReadonlyContext",
+    "google.adk.tools.ToolContext",
+    "google.adk.tools.tool_context.ToolContext",
+    "google.adk.agents.callback_context.CallbackContext",
+    "google.adk.agents.readonly_context.ReadonlyContext",
+}
+ADK_CONTEXT_PARAMETER_NAME = "tool_context"
 
 
 def load_google_adk_artifacts(
@@ -693,9 +734,13 @@ class _PythonAdkExtractor:
         loaded_sources: list[LoadedToolSource] = []
         warnings_before = len(self.artifacts.warnings)
         self._record_eval_references()
+        self._record_star_imports()
         self._record_mutable_tool_bindings()
         for target_name, call in self.agent_call_list:
             agent_name = _kwarg_string(call, "name") or target_name or "adk_agent"
+            # The call is only ADK's ``Agent`` while the name still refers to
+            # the import it was resolved through.
+            self._require_proven_framework_symbol(call)
             if any(keyword.arg is None for keyword in call.keywords):
                 # ``Agent(**config)`` hides every keyword, ``tools`` included.
                 # Without ``tools=`` the agent silently records tool_count 0,
@@ -769,6 +814,43 @@ class _PythonAdkExtractor:
         if reason not in self.surface_gaps:
             self.surface_gaps.append(reason)
 
+    def _record_star_imports(self) -> None:
+        """A ``from x import *`` makes every name in the module unknowable.
+
+        The binding table can only record the alias under ``"*"``, so a local
+        ``def known(...)`` looked singly-bound and proven while the star import
+        may replace it at run time (#400 review). Nothing here is provable, so
+        the module says so once rather than per name.
+        """
+
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ImportFrom) and any(
+                alias.name == "*" for alias in node.names
+            ):
+                self._note_surface_gap(SURFACE_GAP_STAR_IMPORT)
+                return
+
+    def _require_proven_framework_symbol(self, call: ast.Call) -> None:
+        """Require a recognised framework constructor to really be that import.
+
+        ``_qualified_name`` maps a call back to ``google.adk...`` through the
+        import alias table, and that table is spelling-based: after
+        ``from google.adk.tools import FunctionTool`` and
+        ``FunctionTool = replacement``, a foreign factory was still read with
+        Google's semantics — its tools catalogued, its module proven (#400
+        review). The name has to be bound exactly once, by that import, for the
+        resolution to mean anything.
+        """
+
+        root = call.func
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        if not isinstance(root, ast.Name):
+            return
+        bindings = self.name_bindings.get(root.id, [])
+        if len(bindings) != 1 or not isinstance(bindings[0], ast.alias):
+            self._note_surface_gap(SURFACE_GAP_SHADOWED_FRAMEWORK_SYMBOL)
+
     def _record_mutable_tool_bindings(self) -> None:
         """Notice any reach for an agent's ``tools`` after it is constructed.
 
@@ -788,8 +870,9 @@ class _PythonAdkExtractor:
         those are packages, not agents.
 
         Reflective access is checked separately because it carries the
-        attribute name as data: ``getattr(root_agent, "tools").append(...)``
-        contains no ``Attribute`` node named ``tools`` at all and walked
+        attribute name as data: ``getattr(root_agent, "tools").append(...)``,
+        ``vars(root_agent)["tools"]``, and ``root_agent.__dict__["tools"]``
+        contain no ``Attribute`` node named ``tools`` at all and walked
         straight past the first check (PR #400 review).
         """
 
@@ -798,7 +881,7 @@ class _PythonAdkExtractor:
                 if not self._is_imported_module_path(node.value):
                     self._note_surface_gap(SURFACE_GAP_MUTABLE_TOOL_BINDING)
                     return
-            if _is_reflective_tools_access(node):
+            if _is_reflective_tools_access(node, self.aliases):
                 self._note_surface_gap(SURFACE_GAP_MUTABLE_TOOL_BINDING)
                 return
 
@@ -852,6 +935,24 @@ class _PythonAdkExtractor:
         if not self._name_is_proven(name):
             self._note_surface_gap(SURFACE_GAP_SHADOWED_DEFINITION)
 
+    def _name_is_canonical(self, name: str) -> bool:
+        """Whether an annotation spelling still means the type it looks like.
+
+        A builtin (``str``, ``int``, ``list``, …) is canonical only while the
+        module binds nothing of that name: ``from domain import Account as str``
+        makes ADK see ``Account`` where the emitter wrote ``{"type": "string"}``
+        (#400 review). A ``typing`` alias (``List``, ``Dict``) is canonical only
+        when its single binding is an import that resolves into ``typing``.
+        """
+
+        bindings = self.name_bindings.get(name, [])
+        if name in _TYPING_ANNOTATION_ALIASES:
+            if len(bindings) != 1 or not isinstance(bindings[0], ast.alias):
+                return False
+            resolved = self.aliases.get(name, "")
+            return resolved.rsplit(".", 1)[0] in {"typing", "typing_extensions"}
+        return not bindings
+
     def _resolve_extraction_evidence(
         self, warnings_before: int, loaded_sources: list[LoadedToolSource]
     ) -> None:
@@ -885,28 +986,47 @@ class _PythonAdkExtractor:
         for tool in self.canonical_function_tools.values():
             raw_gaps = tool.extraction.get("surface_gaps")
             local_gaps = raw_gaps if isinstance(raw_gaps, list) else []
-            gaps = sorted({*self.surface_gaps, *local_gaps})
-            confidence = "medium" if gaps else "high"
-            tool.extraction["surface"] = (
-                SURFACE_PARTIAL if gaps else SURFACE_ENUMERATED
-            )
-            tool.extraction["surface_gaps"] = gaps
-            tool.extraction["confidence"] = confidence
-            tool.extraction_confidence = confidence
+            self._record_surface_evidence(tool, {*self.surface_gaps, *local_gaps})
         if not self.surface_gaps:
             return
-        module_gaps = sorted(self.surface_gaps)
         for loaded in loaded_sources:
             for tool in loaded.tools:
                 raw_gaps = tool.extraction.get("surface_gaps")
                 local_gaps = raw_gaps if isinstance(raw_gaps, list) else []
-                tool.extraction["surface"] = SURFACE_PARTIAL
-                tool.extraction["surface_gaps"] = sorted(
-                    {*module_gaps, *local_gaps}
+                self._record_surface_evidence(
+                    tool, {*self.surface_gaps, *local_gaps}, lower_only=True
                 )
-                if tool.extraction_confidence == "high":
-                    tool.extraction["confidence"] = "medium"
-                    tool.extraction_confidence = "medium"
+
+    def _record_surface_evidence(
+        self, tool: Tool, gaps: set[str], *, lower_only: bool = False
+    ) -> None:
+        """Write one tool's completeness evidence.
+
+        ``tool_set_proven`` is the half that has to survive identity merging. A
+        reviewed inventory or identity binding is a human statement about a
+        *tool's own schema*, so it legitimately closes the interface reasons —
+        that is what #386 is for. Nothing a human can say about one tool
+        establishes that a module exposes no *other* tools, so a set-scoped
+        reason has to travel with the observation and keep the canonical tool
+        below high wherever it is merged (#400 review).
+        """
+
+        ordered = sorted(gaps)
+        tool.extraction["surface"] = SURFACE_PARTIAL if ordered else SURFACE_ENUMERATED
+        tool.extraction["surface_gaps"] = ordered
+        tool.extraction["tool_set_proven"] = not (
+            gaps - TOOL_INTERFACE_SURFACE_GAPS
+        )
+        if not ordered:
+            if lower_only:
+                return
+            tool.extraction["confidence"] = "high"
+            tool.extraction_confidence = "high"
+            return
+        if lower_only and tool.extraction_confidence != "high":
+            return
+        tool.extraction["confidence"] = "medium"
+        tool.extraction_confidence = "medium"
 
     def _agent_names_by_variable(self) -> dict[tuple[ast.AST | None, str], str | None]:
         """Map each ``variable = Agent(...)`` to the agent's declared ``name=``.
@@ -1075,6 +1195,7 @@ class _PythonAdkExtractor:
         if isinstance(expr, ast.Call):
             call_name = _qualified_name(expr.func, self.aliases)
             if call_name in FUNCTION_TOOL_NAMES | LONG_RUNNING_TOOL_NAMES:
+                self._require_proven_framework_symbol(expr)
                 func_name = _call_func_name(expr)
                 if func_name and func_name in self.functions:
                     self._bind_function_tool(
@@ -1114,6 +1235,9 @@ class _PythonAdkExtractor:
         binding: _AdkAgentBinding,
     ) -> None:
         wrapper = self.wrappers[wrapper_name]
+        wrapper_call = wrapper.get("call")
+        if isinstance(wrapper_call, ast.Call):
+            self._require_proven_framework_symbol(wrapper_call)
         func_name = wrapper.get("func_name")
         if isinstance(func_name, str) and func_name in self.functions:
             self._bind_function_tool(
@@ -1190,6 +1314,7 @@ class _PythonAdkExtractor:
         if cached is not None:
             self._bind_toolset_tools(cached, agent_name, binding)
             return []
+        self._require_proven_framework_symbol(call)
         call_name = _qualified_name(call.func, self.aliases)
         if call_name in OPENAPI_TOOLSET_NAMES:
             loaded_sources = self._extract_openapi_toolset(call, agent_name)
@@ -1223,7 +1348,7 @@ class _PythonAdkExtractor:
         agent_name: str,
         long_running: bool,
     ) -> Tool:
-        parameters = _parameters(node)
+        parameters = _parameters(node, self.aliases)
         return_type = _annotation_to_string(node.returns)
         signature = f"{node.name}({', '.join(param.name for param in parameters)})"
         if return_type:
@@ -1264,7 +1389,9 @@ class _PythonAdkExtractor:
             extraction={
                 "method": "google_adk_python_ast",
                 "confidence": "medium",
-                "surface_gaps": _function_surface_gaps(node),
+                "surface_gaps": _function_surface_gaps(
+                    node, self.aliases, self._name_is_canonical
+                ),
             },
         )
         payload = self._function_tool_payload(tool, agent_name)
@@ -1702,8 +1829,33 @@ def _short_tool_name(name: str) -> str:
     return name.rsplit(".", 1)[-1]
 
 
+def _is_injected_context_arg(
+    arg: ast.arg, aliases: dict[str, str], *, is_receiver: bool
+) -> bool:
+    """Whether ADK supplies this argument itself instead of the model.
+
+    Google ADK decides this by the parameter's *type* — a ``ToolContext`` and
+    friends are filled in by the framework — and falls back to the
+    ``tool_context`` name. Dropping every parameter merely *spelled* ``ctx`` or
+    ``context`` deleted ordinary model-visible inputs from the schema, so
+    ``def known(context: str, record_id: str)`` shipped a one-property schema
+    and called it proven (#400 review). Only a statically verifiable injection
+    is omitted now; anything else stays a parameter, where an unreadable
+    annotation gets caught by the usual checks.
+    """
+
+    if is_receiver and arg.arg == "self":
+        return True
+    if arg.arg == ADK_CONTEXT_PARAMETER_NAME:
+        return True
+    if arg.annotation is None:
+        return False
+    return _qualified_name(arg.annotation, aliases) in ADK_CONTEXT_TYPE_NAMES
+
+
 def _bound_args(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
+    aliases: dict[str, str],
 ) -> list[tuple[ast.arg, bool]]:
     """The arguments that become tool parameters, with their requiredness.
 
@@ -1719,91 +1871,26 @@ def _bound_args(
         None for _ in range(len(positional_args) - len(node.args.defaults))
     ]
     positional_defaults.extend(node.args.defaults)
-    for arg, default in zip(positional_args, positional_defaults, strict=True):
-        if arg.arg in {"self", "ctx", "context", "tool_context"}:
+    for index, (arg, default) in enumerate(
+        zip(positional_args, positional_defaults, strict=True)
+    ):
+        if _is_injected_context_arg(arg, aliases, is_receiver=index == 0):
             continue
         bound.append((arg, default is None))
     for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults, strict=True):
-        if arg.arg in {"self", "ctx", "context", "tool_context"}:
+        if _is_injected_context_arg(arg, aliases, is_receiver=False):
             continue
         bound.append((arg, default is None))
     return bound
 
 
-def _parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ToolParameter]:
+def _parameters(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, aliases: dict[str, str]
+) -> list[ToolParameter]:
     return [
-        _parameter(arg, required=required) for arg, required in _bound_args(node)
+        _parameter(arg, required=required)
+        for arg, required in _bound_args(node, aliases)
     ]
-
-
-#: Annotations :func:`_annotation_json_type` can name a JSON type for. Bare
-#: ``list``/``dict`` are included: ``{"type": "array"}`` omits the element
-#: schema but does not misstate the value, which is a different thing from a
-#: guess.
-_SCALAR_ANNOTATION_TYPES = {
-    "str": "string",
-    "int": "number",
-    "float": "number",
-    "bool": "boolean",
-    "list": "array",
-    "List": "array",
-    "dict": "object",
-    "Dict": "object",
-}
-
-
-def _annotation_json_type(node: ast.AST | None) -> str | None:
-    """The JSON type this annotation really denotes, or None if it denotes none.
-
-    Reads the annotation as a tree rather than as the unparsed string, so
-    ``set[str]``, ``tuple[int, str]``, ``int | None``, ``Optional[int]``,
-    ``Literal[...]``, a string forward reference, and any custom or Pydantic
-    class all answer None instead of silently becoming a scalar.
-    """
-
-    if isinstance(node, ast.Name):
-        return _SCALAR_ANNOTATION_TYPES.get(node.id)
-    if isinstance(node, ast.Subscript):
-        base = node.value
-        base_name = (
-            base.id
-            if isinstance(base, ast.Name)
-            else base.attr
-            if isinstance(base, ast.Attribute)
-            else None
-        )
-        if base_name in {"list", "List"}:
-            return "array" if _annotation_json_type(node.slice) else None
-        if base_name in {"dict", "Dict"}:
-            if isinstance(node.slice, ast.Tuple) and len(node.slice.elts) == 2:
-                key, value = node.slice.elts
-                keyed_by_string = isinstance(key, ast.Name) and key.id == "str"
-                if keyed_by_string and _annotation_json_type(value):
-                    return "object"
-            return None
-    return None
-
-
-def _annotation_is_faithful(node: ast.AST | None) -> bool:
-    """Whether the schema :func:`_json_schema_type` emits matches the annotation.
-
-    An annotation is not by itself evidence that the emitted schema is right.
-    ``_json_schema_type`` reads the *unparsed string* and falls back to
-    ``"string"`` for everything it does not recognise, so ``set[str]``,
-    ``int | None``, a Pydantic model, and even ``typing.List[str]`` (spelled
-    with the module prefix the string match misses) all ship as
-    ``{"type": "string"}``.
-
-    Rather than keep a second vocabulary in sync with the emitter's, this asks
-    the emitter what it would produce and compares it to what the annotation
-    denotes. Any spelling the emitter mishandles is unfaithful by construction,
-    including one added later.
-    """
-
-    expected = _annotation_json_type(node)
-    if expected is None:
-        return False
-    return _json_schema_type(_annotation_to_string(node)) == expected
 
 
 #: Statements that bind a name at module scope in a way the adapter can point
@@ -1819,30 +1906,51 @@ _TOP_LEVEL_BINDING_STATEMENTS = (
     ast.Import,
     ast.ImportFrom,
 )
-
-
 #: Builtins that name an attribute with a string instead of a dotted access.
-#: Matched on the trailing name so ``builtins.setattr`` counts too.
+#: Matched on the trailing name so ``builtins.setattr`` and an aliased import
+#: of the same builtin both count.
 _REFLECTIVE_ATTRIBUTE_BUILTINS = {"getattr", "setattr", "delattr"}
 
 
-def _is_reflective_tools_access(node: ast.AST) -> bool:
-    """Whether ``node`` reaches an object's ``tools`` attribute by name."""
+def _is_reflective_tools_access(node: ast.AST, aliases: dict[str, str]) -> bool:
+    """Whether ``node`` reaches an object's ``tools`` attribute by name.
 
-    if not isinstance(node, ast.Call) or len(node.args) < 2:
-        return False
-    func = node.func
-    called = (
-        func.id
-        if isinstance(func, ast.Name)
-        else func.attr
-        if isinstance(func, ast.Attribute)
-        else None
-    )
-    if called not in _REFLECTIVE_ATTRIBUTE_BUILTINS:
-        return False
-    attribute = node.args[1]
-    return isinstance(attribute, ast.Constant) and attribute.value == "tools"
+    Three spellings, all of which produced the same runtime mutation while
+    containing no ``Attribute`` node named ``tools``:
+    ``getattr(agent, "tools")`` and its ``setattr``/``delattr`` siblings,
+    ``vars(agent)["tools"]``, and ``agent.__dict__["tools"]``.
+
+    The builtin is matched through the import alias table as well as its bare
+    spelling, so ``from builtins import getattr as read_attr`` is recognised —
+    it calls the real builtin, and only the local name changed (#400 review).
+    The dictionary forms are matched narrowly, on ``vars(...)`` and
+    ``__dict__`` specifically, rather than on any ``["tools"]`` subscript: a
+    config dictionary with a ``"tools"`` key is ordinary and is not a mutation.
+    """
+
+    if isinstance(node, ast.Subscript):
+        key = node.slice
+        if not (isinstance(key, ast.Constant) and key.value == "tools"):
+            return False
+        target = node.value
+        if isinstance(target, ast.Attribute) and target.attr == "__dict__":
+            return True
+        return isinstance(target, ast.Call) and _called_builtin(target, aliases) == "vars"
+    if isinstance(node, ast.Call) and len(node.args) >= 2:
+        if _called_builtin(node, aliases) not in _REFLECTIVE_ATTRIBUTE_BUILTINS:
+            return False
+        attribute = node.args[1]
+        return isinstance(attribute, ast.Constant) and attribute.value == "tools"
+    return False
+
+
+def _called_builtin(call: ast.Call, aliases: dict[str, str]) -> str | None:
+    """The builtin ``call`` invokes, seen through imports and dotted access."""
+
+    qualified = _qualified_name(call.func, aliases)
+    if qualified:
+        return qualified.rsplit(".", 1)[-1]
+    return None
 
 
 def _name_binding_occurrences(tree: ast.Module) -> dict[str, list[ast.AST]]:
@@ -1891,8 +1999,103 @@ def _name_binding_occurrences(tree: ast.Module) -> dict[str, list[ast.AST]]:
     return bindings
 
 
+#: Annotations :func:`_annotation_json_type` can name a JSON type for. Bare
+#: ``list``/``dict`` are included: ``{"type": "array"}`` omits the element
+#: schema but does not misstate the value, which is a different thing from a
+#: guess.
+_SCALAR_ANNOTATION_TYPES = {
+    "str": "string",
+    "int": "number",
+    "float": "number",
+    "bool": "boolean",
+    "list": "array",
+    "List": "array",
+    "dict": "object",
+    "Dict": "object",
+}
+#: The subset of the above that has to arrive through ``typing``; the rest are
+#: builtins, which are canonical exactly while the module binds nothing of that
+#: name. See ``_PythonAdkExtractor._name_is_canonical``.
+_TYPING_ANNOTATION_ALIASES = {"List", "Dict"}
+
+
+def _annotation_json_type(
+    node: ast.AST | None, name_is_canonical: Callable[[str], bool]
+) -> str | None:
+    """The JSON type this annotation really denotes, or None if it denotes none.
+
+    Reads the annotation as a tree rather than as the unparsed string, so
+    ``set[str]``, ``tuple[int, str]``, ``int | None``, ``Optional[int]``,
+    ``Literal[...]``, a string forward reference, and any custom or Pydantic
+    class all answer None instead of silently becoming a scalar.
+
+    ``name_is_canonical`` decides whether a spelling still refers to the
+    builtin or ``typing`` alias it looks like. Trusting the spelling alone let
+    ``from domain import Account as str`` describe a model as a string, on a
+    tool marked proven (#400 review).
+    """
+
+    if isinstance(node, ast.Name):
+        if not name_is_canonical(node.id):
+            return None
+        return _SCALAR_ANNOTATION_TYPES.get(node.id)
+    if isinstance(node, ast.Subscript):
+        base = node.value
+        if not isinstance(base, ast.Name) or not name_is_canonical(base.id):
+            # A dotted base such as ``typing.List`` is left to the emitter
+            # comparison below, which already rejects it: the string match in
+            # ``_json_schema_type`` misses the module prefix.
+            return None
+        if base.id in {"list", "List"}:
+            return (
+                "array"
+                if _annotation_json_type(node.slice, name_is_canonical)
+                else None
+            )
+        if base.id in {"dict", "Dict"}:
+            if isinstance(node.slice, ast.Tuple) and len(node.slice.elts) == 2:
+                key, value = node.slice.elts
+                keyed_by_string = (
+                    isinstance(key, ast.Name)
+                    and key.id == "str"
+                    and name_is_canonical("str")
+                )
+                if keyed_by_string and _annotation_json_type(
+                    value, name_is_canonical
+                ):
+                    return "object"
+            return None
+    return None
+
+
+def _annotation_is_faithful(
+    node: ast.AST | None, name_is_canonical: Callable[[str], bool]
+) -> bool:
+    """Whether the schema :func:`_json_schema_type` emits matches the annotation.
+
+    An annotation is not by itself evidence that the emitted schema is right.
+    ``_json_schema_type`` reads the *unparsed string* and falls back to
+    ``"string"`` for everything it does not recognise, so ``set[str]``,
+    ``int | None``, a Pydantic model, and even ``typing.List[str]`` (spelled
+    with the module prefix the string match misses) all ship as
+    ``{"type": "string"}``.
+
+    Rather than keep a second vocabulary in sync with the emitter's, this asks
+    the emitter what it would produce and compares it to what the annotation
+    denotes. Any spelling the emitter mishandles is unfaithful by construction,
+    including one added later.
+    """
+
+    expected = _annotation_json_type(node, name_is_canonical)
+    if expected is None:
+        return False
+    return _json_schema_type(_annotation_to_string(node)) == expected
+
+
 def _function_surface_gaps(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
+    aliases: dict[str, str],
+    name_is_canonical: Callable[[str], bool],
 ) -> list[str]:
     """Reasons this one function's callable interface was not fully read.
 
@@ -1919,7 +2122,7 @@ def _function_surface_gaps(
         gaps.append(SURFACE_GAP_DECORATED_FUNCTION)
     if node.args.vararg is not None or node.args.kwarg is not None:
         gaps.append(SURFACE_GAP_VARIADIC_PARAMETERS)
-    annotations = [arg.annotation for arg, _ in _bound_args(node)]
+    annotations = [arg.annotation for arg, _ in _bound_args(node, aliases)]
     if any(annotation is None for annotation in annotations):
         gaps.append(SURFACE_GAP_UNTYPED_PARAMETER)
     declared = [
@@ -1927,7 +2130,10 @@ def _function_surface_gaps(
     ]
     if node.returns is not None:
         declared.append(node.returns)
-    if not all(_annotation_is_faithful(annotation) for annotation in declared):
+    if not all(
+        _annotation_is_faithful(annotation, name_is_canonical)
+        for annotation in declared
+    ):
         gaps.append(SURFACE_GAP_UNREPRESENTABLE_ANNOTATION)
     return sorted(gaps)
 
@@ -1947,13 +2153,23 @@ def _annotation_to_string(annotation: ast.AST | None) -> str | None:
 
 
 def _json_schema_type(annotation: str | None) -> str:
+    """The JSON type this adapter emits for an annotation, as a string match.
+
+    ``List[str]`` and ``Dict[str, int]`` are recognised alongside their builtin
+    spellings. Without that, ``from typing import List`` emitted ``string`` for
+    a list — which :func:`_annotation_is_faithful` correctly refused to certify,
+    so the tool was held at ``medium`` for what is really an emitter gap rather
+    than anything about the user's code.
+    """
+
     if annotation in {"int", "float"}:
         return "number"
     if annotation == "bool":
         return "boolean"
-    if annotation in {"list", "List"} or (annotation or "").startswith("list["):
+    text = annotation or ""
+    if annotation in {"list", "List"} or text.startswith(("list[", "List[")):
         return "array"
-    if annotation in {"dict", "Dict"} or (annotation or "").startswith("dict["):
+    if annotation in {"dict", "Dict"} or text.startswith(("dict[", "Dict[")):
         return "object"
     return "string"
 

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -22,13 +22,18 @@ from agents_shipgate.schemas.surfaces import (
 def _scan_google_adk_insufficient_evidence_project(tmp_path) -> ReadinessReport:
     project = tmp_path / "google-adk-project"
     project.mkdir()
+    # ``case_id`` is unannotated on purpose: since #393 the ADK AST path reports
+    # a proven surface for a module it fully resolved, so a project that is
+    # meant to reach ``insufficient_evidence`` needs a surface that genuinely is
+    # not proven. Here the parameter type is the part static extraction cannot
+    # read, which is exactly what the inventory remediation under test supplies.
     (project / "agent.py").write_text(
         '''
 from google.adk.agents import LlmAgent
 from google.adk.tools import FunctionTool
 
 
-def lookup_case(case_id: str) -> dict:
+def lookup_case(case_id) -> dict:
     """Look up read-only support case metadata."""
     return {"case_id": case_id}
 

--- a/tests/test_google_adk.py
+++ b/tests/test_google_adk.py
@@ -2228,3 +2228,435 @@ def test_the_conventional_functiontool_wrapper_variable_is_still_proven(tmp_path
     report = _scan_proven(tmp_path, project)
 
     assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+
+
+# --- PR #400 review: five fail-open paths in the high-confidence promotion ---
+#
+# Every case below reached `release_decision="passed"` with no evidence gaps
+# while a reachable tool was omitted from the catalog or its interface was
+# represented by a guessed schema. They are grouped by the finding they close.
+
+
+_INVENTORY_JSON = (
+    '{"tools": [{"name": "remote_lookup", "description": "Look up a remote '
+    'record by identifier.", "inputSchema": {"type": "object", "properties": '
+    '{"q": {"type": "string"}}}}]}'
+)
+
+
+def _toolset_project(tmp_path, *, body: str, agent_kwargs: str = "", trailer: str = ""):
+    """A module whose only tools come from a *resolved* MCP toolset."""
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "inventory.json").write_text(_INVENTORY_JSON, encoding="utf-8")
+    (project / "agent.py").write_text(
+        f'''
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool import McpToolset
+{body}
+
+root_agent = LlmAgent(
+    name="smart_closer",
+    instruction="Close deals.",
+    tools=[
+        McpToolset(
+            tool_filter=["remote_lookup"],
+            inventory_path="inventory.json",
+        ),
+    ],{agent_kwargs}
+)
+{trailer}''',
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        _PROVEN_MANIFEST
+        + """
+action_surface:
+  actions:
+    - tool: remote_lookup
+      effect: read
+      authority:
+        mode: none
+""",
+        encoding="utf-8",
+    )
+    return project
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        pytest.param("FunctionTool(func=imported_tool)", id="imported_function"),
+        pytest.param("FunctionTool(func=lambda record_id: {})", id="lambda"),
+        pytest.param("FunctionTool(func=helpers.thing)", id="attribute"),
+        pytest.param("FunctionTool()", id="missing_func"),
+        pytest.param(
+            "LongRunningFunctionTool(func=imported_tool)", id="long_running_imported"
+        ),
+    ],
+)
+def test_an_inline_wrapper_this_module_cannot_resolve_is_recorded(tmp_path, wrapper):
+    """A recognised wrapper naming a function the module does not define.
+
+    `_extract_tool_expr` returned unconditionally from the `FunctionTool`
+    branch, so an unresolvable `func` produced no tool, no warning, and no gap.
+    The agent could call it; the report said the surface was proven and
+    complete without it — a strictly smaller tool surface, labelled `passed`.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble=(
+                "from google.adk.tools import LongRunningFunctionTool\n"
+                "from external import imported_tool\n"
+                "import helpers\n"
+            ),
+            extra_tools=f"\n        {wrapper},",
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"medium"}
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert "unresolved_tool_wrapper" in gap.why
+
+
+@pytest.mark.parametrize(
+    "shadow",
+    [
+        pytest.param(
+            # Deliberately not `def build(lookup_account): return LlmAgent(...)`,
+            # which is the reported repro: a second module-level agent makes the
+            # root selector ambiguous, which drops the tools out of scope for an
+            # unrelated reason and would let this pass without the guard.
+            "\n\ndef build(lookup_account):\n    return lookup_account\n",
+            id="function_parameter",
+        ),
+        pytest.param(
+            "\n\nclass lookup_account:\n    pass\n",
+            id="class_of_the_same_name",
+        ),
+        pytest.param(
+            "\ntry:\n    pass\nexcept ValueError as lookup_account:\n    pass\n",
+            id="exception_target",
+        ),
+        pytest.param(
+            "\nimport sys\n\nmatch sys.argv:\n"
+            "    case [lookup_account]:\n        pass\n",
+            id="pattern_capture",
+        ),
+        pytest.param(
+            "\n\ndef rebind():\n"
+            "    global lookup_account\n"
+            "    lookup_account = None\n",
+            id="global_declaration",
+        ),
+    ],
+)
+def test_every_python_binding_form_costs_a_name_its_proof(tmp_path, shadow: str):
+    """`def` and `=` are not the only ways a name gets bound.
+
+    Parameters are `ast.arg`, classes bind through `ClassDef.name`, and
+    `except ... as`, `case ... as`, and `global` each have their own shape.
+    Collecting only `Name` stores let a parameter named after a module function
+    resolve as that function, be marked proven, and return `passed`.
+    """
+
+    project = _proven_project(
+        tmp_path, source=_proven_module(trailer=shadow.lstrip("\n"))
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("shadowed_tool_definition" in gap.why for gap in gaps)
+
+
+def test_a_wrapper_variable_rebound_after_assignment_is_not_proven(tmp_path):
+    """`_wrapper_assignments` is last-write-wins, so the variable needs checking too.
+
+    Checking only the wrapped function's name left `w = FunctionTool(func=known)`
+    followed by `w = imported_tool` resolving through the first assignment.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble="from external import imported_tool\n",
+            extra_tools="\n        wrapper,",
+            trailer=(
+                "wrapper = FunctionTool(func=lookup_account)\n"
+                "wrapper = imported_tool\n"
+            ),
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("shadowed_tool_definition" in gap.why for gap in gaps)
+
+
+@pytest.mark.parametrize(
+    "body, agent_kwargs, trailer, reason",
+    [
+        pytest.param(
+            "\noverrides = {}\n", "\n    **overrides,", "", "dynamic_agent_kwargs",
+            id="agent_built_from_kwargs",
+        ),
+        pytest.param(
+            "\nfrom external import imported_tool\n",
+            "",
+            "root_agent.tools.append(imported_tool)\n",
+            "mutable_tool_binding",
+            id="tools_mutated_after_construction",
+        ),
+        pytest.param(
+            "\nfrom external import helper_agent\n",
+            "\n    sub_agents=[helper_agent],",
+            "",
+            "unresolved_sub_agent",
+            id="unresolved_sub_agent",
+        ),
+    ],
+)
+def test_module_gaps_reach_tools_a_resolved_toolset_contributed(
+    tmp_path, body: str, agent_kwargs: str, trailer: str, reason: str
+):
+    """A module can be unproven while owning no function tools at all.
+
+    The finalizer walked only `canonical_function_tools`, so when every tool
+    came from a resolved OpenAPI/MCP toolset the loop was empty and the module's
+    recorded gaps evaporated. The toolset's own schema is still trustworthy —
+    what is not is the claim that these are *the* agent's tools — so the tools
+    are lowered, never raised.
+    """
+
+    project = _toolset_project(
+        tmp_path, body=body, agent_kwargs=agent_kwargs, trailer=trailer
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"medium"}
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert reason in gap.why
+
+
+def test_a_resolved_toolset_in_a_proven_module_keeps_its_high_confidence(tmp_path):
+    """The propagation only ever lowers; it must not disturb the clean case."""
+
+    report = _scan_proven(tmp_path, _toolset_project(tmp_path, body=""))
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+    assert report.release_decision.decision == "passed"
+
+
+@pytest.mark.parametrize(
+    "trailer",
+    [
+        pytest.param(
+            'getattr(root_agent, "tools").append(imported_tool)\n',
+            id="getattr_then_append",
+        ),
+        pytest.param(
+            "import builtins\n"
+            'builtins.setattr(root_agent, "tools", [imported_tool])\n',
+            id="setattr_through_a_module",
+        ),
+        pytest.param(
+            'delattr(root_agent, "tools")\n',
+            id="delattr",
+        ),
+    ],
+)
+def test_reflective_access_to_tools_is_not_a_way_around_the_mutation_guard(
+    tmp_path, trailer: str
+):
+    """`getattr(agent, "tools")` carries the attribute name as data.
+
+    It contains no `Attribute` node named `tools`, so the structural check
+    walked straight past it and the module kept claiming a proven surface while
+    a tool was appended to the agent at runtime.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble="from external import imported_tool\n", trailer=trailer
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("mutable_tool_binding" in gap.why for gap in gaps)
+
+
+def test_an_imported_name_rebound_to_an_agent_is_no_longer_a_package(tmp_path):
+    """The module-path exemption has to be binding-aware.
+
+    `from x import agents` leaves `agents` in the alias map; rebinding it to an
+    `LlmAgent` does not remove it. `agents.tools.append(...)` was therefore
+    exempted as a dotted package path.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble="from external import agents, imported_tool\n",
+            trailer="agents = root_agent\nagents.tools.append(imported_tool)\n",
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("mutable_tool_binding" in gap.why for gap in gaps)
+
+
+@pytest.mark.parametrize(
+    "annotation, returns",
+    [
+        pytest.param("set[str]", "dict", id="set"),
+        pytest.param("tuple[int, str]", "dict", id="tuple"),
+        pytest.param("int | None", "dict", id="optional_union"),
+        pytest.param("Optional[int]", "dict", id="typing_optional"),
+        pytest.param("Literal['a', 'b']", "dict", id="literal"),
+        pytest.param("SomeModel", "dict", id="custom_class"),
+        pytest.param("typing.List[str]", "dict", id="module_qualified_generic"),
+        pytest.param("list[SomeModel]", "dict", id="list_of_models"),
+        pytest.param("dict[int, str]", "dict", id="non_string_dict_key"),
+        pytest.param("str", "SomeModel", id="unrepresentable_return"),
+        pytest.param("str", "set[str]", id="unrepresentable_return_generic"),
+    ],
+)
+def test_an_annotation_the_emitter_cannot_represent_is_still_a_guess(
+    tmp_path, annotation: str, returns: str
+):
+    """Annotation presence is not proof the emitted schema is faithful.
+
+    `_json_schema_type` reads the unparsed string and falls back to `"string"`
+    for everything it does not recognise, so each of these shipped as
+    `{"type": "string"}` while the tool was reported high and enumerated.
+    `typing.List[str]` is the sharpest case: the type is representable, but the
+    emitter's string match misses the module prefix and emits a scalar anyway.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble=(
+                "import typing\n"
+                "from typing import Literal, Optional\n"
+                "from external import SomeModel\n"
+            ),
+            extra_tools="\n        loose_tool,",
+        )
+        + f'''
+
+def loose_tool(record_id: {annotation}) -> {returns}:
+    """Look up a record by identifier and return the stored fields."""
+    return {{}}
+''',
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    catalog = {tool["name"]: tool for tool in report.tool_catalog}
+    assert catalog["loose_tool"]["confidence"] == "medium"
+    assert catalog["lookup_account"]["confidence"] == "high"
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert gap.subject.startswith("loose_tool")
+    assert "unrepresentable_annotation" in gap.why
+
+
+@pytest.mark.parametrize(
+    "annotation, returns",
+    [
+        pytest.param("str", "dict", id="scalars"),
+        pytest.param("int", "list", id="bare_containers"),
+        pytest.param("list[str]", "dict[str, int]", id="parameterised_containers"),
+        pytest.param("bool", "list[dict[str, str]]", id="nested_containers"),
+        pytest.param("float", "dict", id="float"),
+    ],
+)
+def test_annotations_the_emitter_represents_faithfully_stay_proven(
+    tmp_path, annotation: str, returns: str
+):
+    """The faithfulness check must not demote what the emitter gets right.
+
+    Bare `list`/`dict` count: `{"type": "array"}` omits the element schema but
+    does not misstate the value, which is a different thing from a guess.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(extra_tools="\n        loose_tool,")
+        + f'''
+
+def loose_tool(record_id: {annotation}) -> {returns}:
+    """Look up a record by identifier and return the stored fields."""
+    return {{}}
+''',
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+
+
+def test_an_absent_return_annotation_is_an_omission_not_a_guess(tmp_path):
+    """`output_schema` stays `{}` with no return annotation, which claims nothing."""
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(extra_tools="\n        loose_tool,")
+        + '''
+
+def loose_tool(record_id: str):
+    """Look up a record by identifier and return the stored fields."""
+    return {}
+''',
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}

--- a/tests/test_google_adk.py
+++ b/tests/test_google_adk.py
@@ -1203,17 +1203,26 @@ agent_bindings:
 # --- #386: the prescribed remediation must close the gap it was issued for ---
 
 
+# Neither parameter list is annotated, so the AST can name these two tools but
+# cannot read their schemas: ``_json_schema_type`` falls back to ``string`` for
+# every one of them. That is a real ``incomplete_surface`` — and the reason a
+# reviewed inventory is worth writing, since the inventory is where the real
+# parameter types come from. Since #393 a *fully* annotated, fully resolvable
+# module reports a proven surface instead, so the inventory tests below need a
+# source whose surface genuinely is not proven; see
+# ``test_a_fully_static_adk_module_needs_no_inventory_to_reach_high_confidence``
+# for the other half of that pair.
 _ADK_AGENT_SOURCE = """
 from google.adk.agents import LlmAgent
 from google.adk.tools import FunctionTool
 
 
-def get_manager_email(employee_id: str) -> dict:
+def get_manager_email(employee_id) -> dict:
     \"\"\"Look up the manager's email for an employee.\"\"\"
     return {"email": "manager@example.com"}
 
 
-def send_email(to: str, body: str) -> dict:
+def send_email(to, body) -> dict:
     \"\"\"Send an email.\"\"\"
     return {"status": "sent"}
 
@@ -1676,3 +1685,546 @@ checks:
     assert "SHIP-DOC-MISSING-DESCRIPTION" in after_suppressed
     # ... and applying the remediation did not make the verdict worse.
     assert after_decision == before_decision
+
+
+
+# --- #393: extraction confidence is measured, not assumed ---------------------
+
+
+def _proven_module(
+    *,
+    preamble: str = "",
+    extra_tools: str = "",
+    agent_kwargs: str = "",
+    trailer: str = "",
+) -> str:
+    """One ADK module with exactly one root agent, varied at four points.
+
+    Every ambiguity below is injected into *this* agent rather than added as a
+    sibling. A second module-level ``Agent(...)`` makes the root selector
+    ambiguous, which excludes the tools from scope for an unrelated reason and
+    would have made these tests pass without measuring anything.
+    """
+
+    return f'''
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool
+{preamble}
+
+def lookup_account(record_id: str) -> dict:
+    """Look up a Salesforce account."""
+    return {{"record_id": record_id}}
+
+
+def create_quote(record_id: str, amount: float) -> dict:
+    """Create a quote against an opportunity."""
+    return {{"quote": record_id}}
+
+
+root_agent = LlmAgent(
+    name="smart_closer",
+    instruction="Close deals.",
+    tools=[
+        FunctionTool(func=lookup_account),
+        FunctionTool(func=create_quote),{extra_tools}
+    ],{agent_kwargs}
+)
+{trailer}'''
+
+
+_PROVEN_MANIFEST = """
+version: "0.1"
+project:
+  name: adk-proven-surface
+agent:
+  name: smart_closer
+  declared_purpose:
+    - close deals across salesforce records
+environment:
+  target: local
+tool_sources:
+  - id: adk_agent
+    type: google_adk
+    path: agent.py
+"""
+
+_PROVEN_ACTIONS = """
+action_surface:
+  actions:
+    - tool: lookup_account
+      effect: read
+      authority:
+        mode: none
+    - tool: create_quote
+      effect: write
+      authority:
+        mode: none
+"""
+
+
+def _proven_project(tmp_path, *, source: str | None = None, manifest_extra: str = ""):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        source if source is not None else _proven_module(), encoding="utf-8"
+    )
+    (project / "shipgate.yaml").write_text(
+        _PROVEN_MANIFEST + manifest_extra, encoding="utf-8"
+    )
+    return project
+
+
+def _scan_proven(tmp_path, project):
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+    )
+    return report
+
+
+def test_a_fully_static_adk_module_needs_no_inventory_to_reach_high_confidence(
+    tmp_path,
+):
+    """#393: `medium` used to be the ceiling of the ADK AST path.
+
+    Nothing a repository could do to its own source raised it, so
+    `insufficient_evidence` was not a property of any repository — it was the
+    framework's default first-run verdict, reproducible on the most statically
+    trivial module there is. The remedy it prescribed was transcription: copy
+    the tools Shipgate had just extracted correctly into
+    `suggested-inventory.json`, which adds no fact to the system.
+    """
+
+    report = _scan_proven(tmp_path, _proven_project(tmp_path))
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+    evidence = report.release_decision.evidence_coverage
+    assert evidence.low_confidence_tool_count == 0
+    assert evidence.source_warning_count == 0
+    # What remains is the human assertion the gate genuinely needs, not an
+    # extraction failure the repository cannot act on.
+    assert {gap.kind for gap in evidence.evidence_gaps} == {
+        "missing_effect_evidence",
+        "missing_authority_evidence",
+    }
+    # No transcription is requested, so the skeleton is not even written.
+    assert not (tmp_path / "reports" / "suggested-inventory.json").exists()
+
+
+def test_a_proven_adk_surface_with_declared_actions_reaches_a_merge_verdict(tmp_path):
+    """The loop terminates. Before #393 this exact project could not.
+
+    Declaring every action's effect and authority — the one thing the gate
+    genuinely needs a human for — still left `incomplete_surface` on every tool
+    and `insufficient_evidence` as the verdict, because the extraction ceiling
+    was unreachable from the manifest. Effect and authority remain human
+    assertions; what changed is that they are now the *last* step rather than
+    one behind a step no repository could take.
+    """
+
+    report = _scan_proven(
+        tmp_path, _proven_project(tmp_path, manifest_extra=_PROVEN_ACTIONS)
+    )
+
+    decision = report.release_decision
+    assert decision.decision == "passed"
+    assert decision.evidence_coverage.semantic_coverage.pass_eligible_actions == 2
+    assert decision.evidence_coverage.evidence_gaps == []
+
+
+#: One construct per row, each leaving some part of the tool surface unproven,
+#: with the reason code the adapter has to record for it. Every row starts from
+#: the module above, which reaches `high` on its own, so the construct is the
+#: only variable. The three `mutable_tool_binding` rows and
+#: `agent_built_from_kwargs` were all silently promoted to `high` by the first
+#: draft of this change.
+_UNPROVEN_CONSTRUCTS = [
+    pytest.param(
+        {
+            "preamble": "from external import imported_tool\n",
+            "extra_tools": "\n        imported_tool,",
+        },
+        "unresolved_tool_reference",
+        id="unresolved_tool_reference",
+    ),
+    pytest.param(
+        {
+            "preamble": "base_tools = []\n",
+            "extra_tools": "\n        *base_tools,",
+        },
+        "unresolved_tool_expression",
+        id="starred_tool_element",
+    ),
+    pytest.param(
+        {
+            "preamble": (
+                "from external import missing\n\nwrapper = FunctionTool(func=missing)\n"
+            ),
+            "extra_tools": "\n        wrapper,",
+        },
+        "unresolved_tool_wrapper",
+        id="unresolved_tool_wrapper",
+    ),
+    pytest.param(
+        {
+            "preamble": "from google.adk.tools.mcp_tool import McpToolset\n",
+            "extra_tools": '\n        McpToolset(tool_filter=["a"]),',
+        },
+        "dynamic_toolset",
+        id="dynamic_toolset",
+    ),
+    pytest.param(
+        {
+            "preamble": "from google.adk.tools import LongRunningFunctionTool\n",
+            "extra_tools": "\n        LongRunningFunctionTool(func=lookup_account),",
+        },
+        "conflicting_tool_contract",
+        id="conflicting_tool_contract",
+    ),
+    pytest.param(
+        {
+            "preamble": "from external import helper_agent\n",
+            "agent_kwargs": "\n    sub_agents=[helper_agent],",
+        },
+        "unresolved_sub_agent",
+        id="unresolved_sub_agent",
+    ),
+    pytest.param(
+        {
+            "preamble": "overrides = {}\n",
+            "agent_kwargs": "\n    **overrides,",
+        },
+        "dynamic_agent_kwargs",
+        id="agent_built_from_kwargs",
+    ),
+    pytest.param(
+        {
+            "preamble": "from external import imported_tool\n",
+            "trailer": "root_agent.tools.append(imported_tool)\n",
+        },
+        "mutable_tool_binding",
+        id="tools_mutated_after_construction",
+    ),
+    pytest.param(
+        {
+            "preamble": "from external import imported_tool\n",
+            "trailer": "bucket = root_agent.tools\nbucket.append(imported_tool)\n",
+        },
+        "mutable_tool_binding",
+        id="tools_mutated_through_an_alias",
+    ),
+    pytest.param(
+        {
+            "preamble": "from external import imported_tool\n",
+            "trailer": 'setattr(root_agent, "tools", [imported_tool])\n',
+        },
+        "mutable_tool_binding",
+        id="tools_replaced_by_setattr",
+    ),
+]
+
+
+@pytest.mark.parametrize("module_kwargs, reason", _UNPROVEN_CONSTRUCTS)
+def test_one_unproven_construct_holds_the_whole_module_at_medium(
+    tmp_path, module_kwargs: dict, reason: str
+):
+    """The proof is earned by the file, not by the agent that reads cleanest.
+
+    Scoping completeness per resolved tool would let `lookup_account` claim a
+    proof its own module cannot support: in every row here, a tool nobody
+    enumerated is reachable from the same agent.
+    """
+
+    project = _proven_project(tmp_path, source=_proven_module(**module_kwargs))
+
+    report = _scan_proven(tmp_path, project)
+
+    catalog = {tool["name"]: tool for tool in report.tool_catalog}
+    assert catalog["lookup_account"]["confidence"] == "medium"
+    assert catalog["create_quote"]["confidence"] == "medium"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert {gap.subject.split(" ")[0] for gap in gaps} == {
+        "lookup_account",
+        "create_quote",
+    }
+    # The row has to name the construct responsible: one sentence repeated on
+    # every AST tool in every repository is the defect #393 reports.
+    assert all(reason in gap.why for gap in gaps)
+
+
+def test_a_dynamic_tools_expression_holds_the_module_at_medium(tmp_path):
+    """The reported shape: `tools=` is not a literal sequence at all.
+
+    Kept apart from the table because it replaces the tools list rather than
+    adding to it, so the agent contributes no tools of its own and a second
+    agent has to own the ones under test.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble="extra_tools = []\n",
+            agent_kwargs="\n    sub_agents=[dynamic_agent],",
+        ).replace(
+            "root_agent = LlmAgent(",
+            'dynamic_agent = LlmAgent(name="dyn", tools=extra_tools + [])\n\n'
+            "root_agent = LlmAgent(",
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"medium"}
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("dynamic_tools_expression" in gap.why for gap in gaps)
+
+
+@pytest.mark.parametrize(
+    "signature, reason",
+    [
+        pytest.param("record_id", "untyped_parameter", id="untyped_parameter"),
+        pytest.param(
+            "record_id: str, **headers",
+            "variadic_parameters",
+            id="variadic_parameters",
+        ),
+        pytest.param(
+            "record_id: str",
+            "decorated_tool_function",
+            id="decorated_tool_function",
+        ),
+    ],
+)
+def test_a_function_whose_own_interface_is_unreadable_stays_medium(
+    tmp_path, signature: str, reason: str
+):
+    """A fully resolved module can still hold an unresolvable function.
+
+    An unannotated parameter is typed `string` by the JSON-schema fallback,
+    `**kwargs` is dropped altogether, and a decorator replaces the callable ADK
+    introspects — each would put a guess into the report wearing a schema's
+    clothes. Unlike the module-scoped reasons, this one is about one callable,
+    so its siblings keep their proof.
+    """
+
+    decorator = (
+        "import functools\n\n\n@functools.cache\n"
+        if reason == "decorated_tool_function"
+        else ""
+    )
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(extra_tools="\n        loose_tool,")
+        + f'''
+
+{decorator}def loose_tool({signature}) -> dict:
+    """A tool whose interface cannot be read."""
+    return {{}}
+''',
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    catalog = {tool["name"]: tool for tool in report.tool_catalog}
+    assert catalog["loose_tool"]["confidence"] == "medium"
+    assert catalog["lookup_account"]["confidence"] == "high"
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert gap.subject.startswith("loose_tool")
+    assert reason in gap.why
+
+
+def test_an_unclassified_extractor_warning_fails_closed(tmp_path, monkeypatch):
+    """The backstop, proven load-bearing by a negative control.
+
+    Every ambiguity the extractor knows about routes through
+    ``_surface_warning``, which records a reason. A future one added with a
+    plain ``artifacts.warnings.append`` would leave ``surface_gaps`` empty and
+    promote an unresolved module to ``high`` — the fail-open shape where a
+    block-level "safe" signal clears a path-wide guard. Simulating exactly that
+    slip must still cost the module its proof.
+    """
+
+    from agents_shipgate.inputs import google_adk
+
+    original = google_adk._PythonAdkExtractor._record_eval_references
+
+    def leak_an_unclassified_warning(self):
+        original(self)
+        self.artifacts.warnings.append("a future ambiguity nobody classified")
+
+    monkeypatch.setattr(
+        google_adk._PythonAdkExtractor,
+        "_record_eval_references",
+        leak_an_unclassified_warning,
+    )
+
+    report = _scan_proven(tmp_path, _proven_project(tmp_path))
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"medium"}
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert "unclassified_extractor_warning" in gap.why
+
+
+def test_an_eval_artifact_warning_never_costs_the_surface_its_proof(tmp_path):
+    """Eval collateral says nothing about which tools an agent can call."""
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(trailer='eval_set = "evals/missing.eval.json"\n'),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert any("eval reference" in warning for warning in report.source_warnings)
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+
+
+def test_a_qualified_module_path_is_not_mistaken_for_an_agent_attribute(tmp_path):
+    """``google.adk.tools`` is a package, not an agent's tool list.
+
+    The mutation guard keys on any ``.tools`` access, so without the
+    imported-root exclusion a module spelling its imports in full would be
+    accused of mutating a tool list it never touched.
+
+    This module is unproven either way: the dotted-import spelling is not one
+    ``_qualified_name`` resolves, so the element reads as an unresolvable tool
+    expression. That is a separate, pre-existing limitation — what matters here
+    is *which* reason is recorded.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble="import google.adk.tools\n",
+            extra_tools="\n        google.adk.tools.FunctionTool(func=lookup_account),",
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert "unresolved_tool_expression" in gap.why
+    assert "mutable_tool_binding" not in gap.why
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        pytest.param(
+            "def build():\n"
+            "    def loose_tool(x: str) -> dict:\n"
+            '        """Built at runtime."""\n'
+            "        return {}\n"
+            "    return loose_tool\n\n\n"
+            "loose_tool = build()\n",
+            id="defined_inside_a_factory",
+        ),
+        pytest.param(
+            "from external import replacement\n\n\n"
+            "def loose_tool(x: str) -> dict:\n"
+            '    """Outer."""\n'
+            "    return {}\n\n\n"
+            "loose_tool = replacement\n",
+            id="rebound_after_definition",
+        ),
+        pytest.param(
+            "class Ops:\n"
+            "    def loose_tool(self, x: str) -> dict:\n"
+            '        """Lifted out of a class body."""\n'
+            "        return {}\n",
+            id="only_defined_as_a_method",
+        ),
+        pytest.param(
+            "import os\n\n"
+            'if os.getenv("X"):\n'
+            "    def loose_tool(x: str) -> dict:\n"
+            '        """A."""\n'
+            "        return {}\n"
+            "else:\n"
+            "    def loose_tool(x: str, y: str) -> dict:\n"
+            '        """B."""\n'
+            "        return {}\n",
+            id="two_conditional_definitions",
+        ),
+        pytest.param(
+            "from external import loose_tool\n\n\n"
+            "def loose_tool(x: str) -> dict:\n"
+            '    """Shadowed by an import."""\n'
+            "    return {}\n",
+            id="shadowed_by_an_import",
+        ),
+    ],
+)
+def test_a_definition_the_name_may_not_refer_to_is_never_proven(
+    tmp_path, definition: str
+):
+    """Naming a tool and proving its signature are different claims.
+
+    ``tools=[loose_tool]`` resolves through a flat, scope-blind name map, which
+    is what lets the adapter report the tool at all. In each of these modules
+    that map answers with a definition the running agent will not use — the
+    factory's inner function, the pre-rebinding one, a method, whichever
+    conditional branch the walk saw last, the local one an import shadows. All
+    five reported a proven surface when this change was first written.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(extra_tools="\n        loose_tool,")
+        + "\n"
+        + definition,
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"medium"}
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert "shadowed_tool_definition" in gap.why
+
+
+def test_the_conventional_functiontool_wrapper_variable_is_still_proven(tmp_path):
+    """`lookup_tool = FunctionTool(func=lookup)` is the idiomatic ADK spelling.
+
+    The rebinding check keys on names bound anywhere in the module, so it has
+    to distinguish a name bound *beside* a definition from one bound *over* it.
+    Getting this wrong would demote almost every real ADK entrypoint.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module().replace(
+            "root_agent = LlmAgent(",
+            "lookup_tool = FunctionTool(func=lookup_account)\n\n"
+            "root_agent = LlmAgent(",
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}

--- a/tests/test_google_adk.py
+++ b/tests/test_google_adk.py
@@ -5,8 +5,12 @@ import yaml
 
 from agents_shipgate.checks.adk import _has_long_running_contract
 from agents_shipgate.cli.scan import inspect_sources, run_scan
+from agents_shipgate.core.artifact_models import GoogleAdkArtifacts
 from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.inputs.google_adk import load_google_adk_artifacts
+from agents_shipgate.inputs.google_adk import (
+    _load_python_path,
+    load_google_adk_artifacts,
+)
 from agents_shipgate.schemas.manifest import ToolSourceConfig
 
 # A shared mapping tool bound to a coordinator and two sub-agents: the
@@ -2660,3 +2664,377 @@ def loose_tool(record_id: str):
     report = _scan_proven(tmp_path, project)
 
     assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+
+
+# --- PR #400 second review: six more fail-open paths --------------------------
+
+
+def test_an_identity_binding_cannot_close_an_unproven_tool_set(tmp_path):
+    """An identity assertion proves operation sameness, not surface completeness.
+
+    `_merge_bound_observations` starts from the primary and copies nothing
+    about extraction across — deliberately, because promoting the primary's
+    fidelity is what naming a reviewed inventory is for (#386). That reasoning
+    only holds for claims about one tool's own interface. Here an ADK toolset
+    observation carrying `dynamic_agent_kwargs` merged into a high-confidence
+    direct-OpenAPI primary and came out high, pass-eligible, and `passed`, with
+    the module's gap nowhere in the report.
+    """
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "api.yaml").write_text(
+        """
+openapi: 3.1.0
+info:
+  title: Records
+  version: "1.0"
+paths:
+  /records/{id}:
+    get:
+      operationId: lookup_record
+      summary: Look up a record by identifier and return the stored fields.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (project / "agent.py").write_text(
+        '''
+from google.adk.agents import LlmAgent
+from google.adk.tools.openapi_tool.openapi_spec_parser.openapi_toolset import (
+    OpenAPIToolset,
+)
+
+overrides = {}
+root_agent = LlmAgent(
+    name="smart_closer",
+    instruction="Close deals.",
+    tools=[OpenAPIToolset(spec_path="api.yaml")],
+    **overrides,
+)
+'''.lstrip(),
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        '''
+version: "0.1"
+project:
+  name: adk-identity-merge
+agent:
+  name: smart_closer
+  declared_purpose:
+    - look up records
+environment:
+  target: local
+tool_sources:
+  - id: adk_agent
+    type: google_adk
+    path: agent.py
+  - id: direct_openapi
+    type: openapi
+    path: api.yaml
+
+tool_identity:
+  bindings:
+    - id: lookup-record
+      provider: records
+      reason: the ADK toolset and the direct spec expose one operation
+      primary:
+        source_id: direct_openapi
+        tool: lookup_record
+      members:
+        - source_id: direct_openapi
+          tool: lookup_record
+        - source_id: adk_agent:openapi:1
+          tool: lookup_record
+
+action_surface:
+  actions:
+    - tool: lookup_record
+      effect: read
+      authority:
+        mode: none
+'''.lstrip(),
+        encoding="utf-8",
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"medium"}
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert "dynamic_agent_kwargs" in gap.why
+    # The remediation must not ask for the spec that is already there.
+    assert gap.next_action.kind == "provide_source"
+    assert "cannot close this" in gap.next_action.expects
+
+
+@pytest.mark.parametrize(
+    "symbol, replacement",
+    [
+        pytest.param("FunctionTool", "imported_replacement", id="wrapper_rebound"),
+        pytest.param("LlmAgent", "replacement_agent", id="agent_class_rebound"),
+    ],
+)
+def test_a_rebound_framework_symbol_is_not_googles_constructor(
+    tmp_path, symbol: str, replacement: str
+):
+    """`_qualified_name` resolves through a spelling-based alias table.
+
+    After `from google.adk.tools import FunctionTool` and
+    `FunctionTool = replacement`, a foreign factory was still read with
+    Google's semantics: its argument catalogued as an ADK tool, the module
+    marked proven. Rebinding `LlmAgent` has the same effect one level up.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble=f"from external import {replacement}\n",
+            trailer=f"{symbol} = {replacement}\n",
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("shadowed_framework_symbol" in gap.why for gap in gaps)
+
+
+@pytest.mark.parametrize(
+    "signature, expected_properties",
+    [
+        pytest.param(
+            "context: str, record_id: str",
+            ["context", "record_id"],
+            id="context_is_an_ordinary_input",
+        ),
+        pytest.param(
+            "ctx: str, record_id: str",
+            ["ctx", "record_id"],
+            id="ctx_is_an_ordinary_input",
+        ),
+        pytest.param(
+            "tool_context, record_id: str",
+            ["record_id"],
+            id="tool_context_name_fallback",
+        ),
+        pytest.param(
+            "ctx: ToolContext, record_id: str",
+            ["record_id"],
+            id="injected_by_annotation",
+        ),
+    ],
+)
+def test_only_a_verifiable_injected_parameter_leaves_the_schema(
+    tmp_path, signature: str, expected_properties: list[str]
+):
+    """ADK identifies injected context by type, with `tool_context` as fallback.
+
+    Dropping every parameter merely *spelled* `ctx` or `context` deleted real
+    model-visible inputs: `def known(context: str, record_id: str)` shipped a
+    one-property schema, was marked proven, and returned `passed`.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble="from google.adk.tools import ToolContext\n",
+            extra_tools="\n        loose_tool,",
+        )
+        + f'''
+
+def loose_tool({signature}) -> dict:
+    """Look up a record by identifier and return the stored fields."""
+    return {{}}
+''',
+    )
+
+    artifacts = GoogleAdkArtifacts()
+    loaded = _load_python_path(
+        project / "agent.py", project, "adk_agent", "agent.py", artifacts
+    )
+    tool = next(
+        tool
+        for source in loaded
+        for tool in source.tools
+        if tool.name == "loose_tool"
+    )
+    assert sorted(tool.input_schema.get("properties", {})) == expected_properties
+    assert tool.extraction_confidence == "high"
+
+    report = _scan_proven(tmp_path, project)
+    catalog = {row["name"]: row for row in report.tool_catalog}
+    assert catalog["loose_tool"]["confidence"] == "high"
+
+
+@pytest.mark.parametrize(
+    "shadow, annotation",
+    [
+        pytest.param("from domain import Account as str", "str", id="str_shadowed"),
+        pytest.param("from domain import Bag as list", "list", id="list_shadowed"),
+        pytest.param("from domain import Rec as dict", "dict", id="dict_shadowed"),
+        pytest.param("from domain import Seq as List", "List", id="typing_list_faked"),
+    ],
+)
+def test_a_shadowed_annotation_name_is_not_the_type_it_looks_like(
+    tmp_path, shadow: str, annotation: str
+):
+    """`from domain import Account as str` makes ADK see `Account` at runtime.
+
+    The faithfulness check read the spelling only, so the emitted string schema
+    was accepted as accurate and the tool reported high and enumerated.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble=f"{shadow}\n", extra_tools="\n        loose_tool,"
+        )
+        + f'''
+
+def loose_tool(value: {annotation}) -> dict:
+    """Look up a record by identifier and return the stored fields."""
+    return {{}}
+''',
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    tool = next(
+        tool for tool in report.tool_catalog if tool["name"] == "loose_tool"
+    )
+    assert tool["confidence"] == "medium"
+    gap = next(
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    )
+    assert "unrepresentable_annotation" in gap.why
+
+
+def test_a_genuine_typing_alias_is_still_faithful(tmp_path):
+    """The provenance check must not reject `from typing import List`."""
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            preamble="from typing import Dict, List\n",
+            extra_tools="\n        loose_tool,",
+        )
+        + '''
+
+def loose_tool(items: List[str], index: Dict[str, int]) -> dict:
+    """Look up a record by identifier and return the stored fields."""
+    return {}
+''',
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+
+
+@pytest.mark.parametrize(
+    "preamble, trailer",
+    [
+        pytest.param(
+            "from builtins import getattr as read_attr\n"
+            "from external import imported_tool\n",
+            'read_attr(root_agent, "tools").append(imported_tool)\n',
+            id="aliased_builtin",
+        ),
+        pytest.param(
+            "from external import imported_tool\n",
+            'vars(root_agent)["tools"].append(imported_tool)\n',
+            id="vars_dictionary",
+        ),
+        pytest.param(
+            "from external import imported_tool\n",
+            'root_agent.__dict__["tools"].append(imported_tool)\n',
+            id="dunder_dict",
+        ),
+    ],
+)
+def test_indirect_reflective_mutation_is_still_a_mutation(
+    tmp_path, preamble: str, trailer: str
+):
+    """Three more spellings that carry the attribute name as data.
+
+    `from builtins import getattr as read_attr` calls the real builtin under a
+    local name; `vars()` and `__dict__` reach the same attribute through a
+    mapping. None contains an `Attribute` node named `tools`, and the raw
+    spelling check saw only `read_attr`.
+    """
+
+    project = _proven_project(
+        tmp_path, source=_proven_module(preamble=preamble, trailer=trailer)
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("mutable_tool_binding" in gap.why for gap in gaps)
+
+
+def test_an_ordinary_dictionary_with_a_tools_key_is_not_a_mutation(tmp_path):
+    """The dictionary forms are matched on `vars()`/`__dict__`, not on any key.
+
+    Flagging every `["tools"]` subscript would demote modules that merely carry
+    a config mapping, which is common and harmless.
+    """
+
+    project = _proven_project(
+        tmp_path,
+        source=_proven_module(
+            trailer='CONFIG = {"tools": []}\nENABLED = CONFIG["tools"]\n'
+        ),
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert {tool["confidence"] for tool in report.tool_catalog} == {"high"}
+
+
+def test_a_star_import_makes_every_name_in_the_module_unknowable(tmp_path):
+    """`from x import *` can rebind any name, and binds none the table can see.
+
+    The alias is recorded under `"*"`, so a local `def lookup_account(...)`
+    still looked singly-bound and proven while the import may replace it.
+    """
+
+    project = _proven_project(
+        tmp_path, source=_proven_module(trailer="from external import *\n")
+    )
+
+    report = _scan_proven(tmp_path, project)
+
+    assert report.release_decision.decision != "passed"
+    gaps = [
+        gap
+        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "low_confidence_tool"
+    ]
+    assert gaps and all("star_import_shadowing" in gap.why for gap in gaps)

--- a/tests/test_semantic_assessment.py
+++ b/tests/test_semantic_assessment.py
@@ -305,6 +305,105 @@ def test_ast_framework_declaration_cannot_replace_reviewed_inventory() -> None:
     assert "incomplete_surface" in {issue.kind for issue in assessment.effect.issues}
 
 
+def test_an_ast_adapter_that_proved_the_surface_closes_the_surface_gap() -> None:
+    """#393: an AST source type is a question, not a verdict.
+
+    Membership in ``_AST_ONLY_SOURCE_TYPES`` used to disqualify a tool outright,
+    which made ``incomplete_surface`` a constant for every repository on a
+    supported Python framework and left a reviewed inventory as the only exit.
+    An adapter that measured completeness may now answer for itself.
+    """
+
+    declaration = ActionDeclarationConfig.model_validate(
+        {
+            "tool": "process_order",
+            "effect": "write",
+            "authority": {"mode": "none"},
+        }
+    )
+
+    assessment = assess_tool_semantics(
+        _tool(
+            source_type="google_adk_function",
+            extraction={
+                "method": "google_adk_python_ast",
+                "confidence": "high",
+                "surface": "enumerated",
+                "surface_gaps": [],
+            },
+        ),
+        declaration,
+    )
+
+    assert assessment.pass_eligible is True
+    assert "incomplete_surface" not in {
+        issue.kind for issue in assessment.effect.issues
+    }
+
+
+@pytest.mark.parametrize(
+    "extraction",
+    [
+        pytest.param({"method": "google_adk_python_ast"}, id="no-claim"),
+        pytest.param(
+            {
+                "method": "google_adk_python_ast",
+                "surface": "partial",
+                "surface_gaps": ["dynamic_tools_expression"],
+            },
+            id="named-gap",
+        ),
+        pytest.param(
+            {"method": "google_adk_python_ast", "surface": "Enumerated"},
+            id="near-miss-spelling",
+        ),
+    ],
+)
+def test_an_ast_source_without_a_proof_stays_incomplete(extraction: dict) -> None:
+    """Only the exact attestation clears the gap; silence never does.
+
+    The dangerous shape here is the block-level "safe" signal that clears a
+    path-wide guard. Absence of a claim — an adapter never taught to answer, a
+    construct nobody classified, a value that does not match — has to read as
+    incomplete, or the promotion this test guards becomes a fail-open.
+    """
+
+    declaration = ActionDeclarationConfig.model_validate(
+        {
+            "tool": "process_order",
+            "effect": "write",
+            "authority": {"mode": "none"},
+        }
+    )
+
+    assessment = assess_tool_semantics(
+        _tool(source_type="google_adk_function", extraction=extraction),
+        declaration,
+    )
+
+    assert assessment.pass_eligible is False
+    assert "incomplete_surface" in {issue.kind for issue in assessment.effect.issues}
+
+
+def test_a_proven_surface_never_overrides_a_wildcard_exposure() -> None:
+    """Wildcard exposure outranks any completeness claim about the same tool."""
+
+    assessment = assess_tool_semantics(
+        _tool(
+            source_type="google_adk_function",
+            annotations={"wildcard_tools": True},
+            extraction={
+                "method": "google_adk_python_ast",
+                "confidence": "high",
+                "surface": "enumerated",
+            },
+        )
+    )
+
+    assert assessment.pass_eligible is False
+    assert "incomplete_surface" in {issue.kind for issue in assessment.effect.issues}
+
+
 def test_reviewed_inventory_and_declaration_can_close_framework_gaps() -> None:
     declaration = ActionDeclarationConfig.model_validate(
         {

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -854,13 +854,17 @@ def test_verify_real_base_scan_enables_head_diff(tmp_path: Path) -> None:
 
 def test_verify_text_projects_google_adk_primary_evidence_action(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
+    # ``case_id`` is unannotated on purpose. Since #393 the ADK AST path reports
+    # a proven surface for a module it fully resolved, so the inventory
+    # remediation this test projects needs a source whose surface genuinely is
+    # not proven — here, the parameter type static extraction cannot read.
     (repo / "agent.py").write_text(
         '''
 from google.adk.agents import LlmAgent
 from google.adk.tools import FunctionTool
 
 
-def lookup_case(case_id: str) -> dict:
+def lookup_case(case_id) -> dict:
     """Look up read-only support case metadata."""
     return {"case_id": case_id}
 


### PR DESCRIPTION
## Summary

- **Google ADK extraction confidence is measured on the parsed module instead of hardcoded.** `inputs/google_adk.py` set `extraction_confidence="medium"` on every tool the AST path produced, and the only code that ever set `"high"` applied to tools loaded from a `tool_inventory` artifact. Every gate tests `!= "high"`, so no ADK repository could reach a pass from source however statically analysable it was — `insufficient_evidence` was not a property of a repository, it was the framework's default first-run verdict (#393).
- **`_surface_is_complete` was the same constant one layer down.** `core/semantic_assessment.py` disqualified any `source_type in _AST_ONLY_SOURCE_TYPES` outright. Fixing only `extraction_confidence` would have changed nothing observable: `incomplete_surface` would still have fired on every tool and still forced the same verdict. Membership now poses the question; the adapter's own attestation answers it.
- **The `low_confidence_tool` evidence gap names the construct responsible** instead of repeating one sentence on every AST-extracted tool in every repository.
- Docs (`upstream-integrations.md`, `manifest-v0.1.md`), CHANGELOG, and the `samples/google_adk_agent` manifest comment updated — that sample's inventory is no longer what earns it high confidence.

### Why this is worth the churn

The reported subject was the most statically trivial case available: one file, twelve annotated module-level functions, `12/12` catalog tools reachable, `0` unbound, `0` source warnings. It still reported twelve `low_confidence_tool` gaps and abstained. A condition that holds for every input carries no information — it could not tell a toolkit factory from twelve plain functions — and the remedy it prescribed was transcription: copy the tools Shipgate had just extracted correctly into `suggested-inventory.json`, adding no fact to the system.

Measured on the reproduction fixture:

| | before | after |
|---|---|---|
| clean module, no declarations | `insufficient_evidence`, 36 semantic gaps, "Fix at `suggested-inventory.json`" | `insufficient_evidence`, 24 gaps, "Fix at `shipgate.yaml#action_surface`" — no skeleton written |
| clean module, actions declared | `insufficient_evidence`, 0/12 pass-eligible | **`passed`**, 12/12 pass-eligible |

The second row is the point. Before this change, declaring effect and authority for every tool — the one thing the gate genuinely needs a human for — still left `incomplete_surface` on all twelve, because the extraction ceiling was unreachable from the manifest. Effect and authority remain human assertions; what changed is that they are now the *last* step rather than one behind a step no repository could take.

## How it works

The adapter writes `Tool.extraction["surface"]` (`enumerated` / `partial`) plus `surface_gaps[]` reason codes. `extraction` is written only by adapter code — no loader copies it out of a parsed input file — so unlike `annotations` the claim cannot be self-declared by an untrusted artifact.

The proof is scoped to the **file**, not the agent: one unresolved construct anywhere holds every tool the file produced, because a fully-resolved agent in a half-resolved module can still reach tools nobody enumerated. Per-function reasons (`untyped_parameter`, `variadic_parameters`, `decorated_tool_function`) are separate and do not affect siblings.

Absence of the attestation reads as incomplete everywhere downstream, so LangChain, CrewAI, and the OpenAI Agents SDK static path keep their previous verdict untouched, and a wildcard exposure still outranks any completeness claim.

## Reviewer notes

**Promoting anything to `high` is where the risk lives — please read this section first.** I wrote 17 adversarial constructs as probes against `_load_python_path`. **Eight were fail-open in the first draft** and would have shipped a soundness bug:

- `root_agent.tools.append(x)`, the same through an alias (`bucket = root_agent.tools`), `setattr(agent, "tools", ...)`, and `agent.tools[0] = x` → `mutable_tool_binding`
- `Agent(**config)`, which hides `tools` entirely and silently records `tool_count: 0` → `dynamic_agent_kwargs`
- four name-resolution shapes → `shadowed_tool_definition`. `self.functions` is a flat `ast.walk` name map (it has to be, to name a tool at all), so `tools=[helper]` happily resolves to a factory's inner def, a method lifted out of a class body, whichever of two conditional defs the walk saw last, or a def a later import/assignment rebinds. Each reports a signature the running agent will not use.

All are closed, each with a parametrized regression test.

**The unaccounted-warning backstop is deliberate.** Every extractor warning routes through `_surface_warning` (records a reason) or `_note_warning` (surface-neutral — eval artifacts only). `_resolve_extraction_evidence` compares the accounted count against the real growth of `artifacts.warnings`; a mismatch records `unclassified_extractor_warning`. A future contributor adding an ambiguity with a plain `warnings.append` therefore demotes the module automatically rather than failing open. `test_an_unclassified_extractor_warning_fails_closed` proves it load-bearing by simulating exactly that slip.

**Four fixtures were repaired rather than deleted.** `_ADK_AGENT_SOURCE` (the #386 inventory tests), `_scan_google_adk_insufficient_evidence_project` in `test_ci.py`, and the ADK repo in `test_verify.py` all existed only because everything used to be `medium`. Each now drops a parameter annotation — a warning-free, per-tool gap that keeps their `source_warnings == []` assertions valid and gives the inventory a genuine job (the real parameter types).

**Scope held deliberately.** The mechanism is reusable, but `crewai`, `langchain`, `openai_sdk_static`, `conductor`, and `n8n` still hardcode `medium` and are untouched. Each needs its own probe list; doing five at once is how the eight fail-opens above would have slipped through. Worth a follow-up issue.

**One pre-existing gap found, not filed and not fixed here.** `import google.adk.agents` followed by `google.adk.agents.LlmAgent(...)` is not recognised as an agent call at all — `_qualified_name` mangles the dotted alias — so that spelling reports zero tools. It fails closed (`SHIP-INVENTORY-NOT-ENUMERABLE`), so it is out of scope for #393. `test_a_qualified_module_path_is_not_mistaken_for_an_agent_attribute` documents it.

## Type

- [x] Check or risk-model change
- [x] Input adapter change
- [ ] CLI or GitHub Action behavior
- [x] Report, schema, or SARIF output
- [ ] Documentation only

`Tool.extraction` is in-memory only and is not serialized into `report.json`, so no report schema version bump is required. The only user-visible output change is the `evidence_gaps[].why` free-text string on `low_confidence_tool` rows, which gains a trailing `Unresolved: <reasons>.` sentence for adapters that measure completeness.

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `ruff check .` — clean
- `compileall -q src tests` — clean
- Full suite, `pytest tests -n auto` — `PYTEST_EXIT=0`, zero failures
- End-to-end reproduction of the issue's `smart_closer` shape before and after, plus the fully-declared A/B that isolates the extraction ceiling as the terminal blocker
- 17-construct adversarial probe against `_load_python_path`; `samples/google_adk_agent` rescanned (unchanged: all four tools still `high`, no new source warnings)

One unrelated flake, `test_authorization_verify_integration.py::test_invalid_authorization_keeps_human_stop_and_receipt_valid[missing_trust]`, appeared in one intermediate `-n auto` run and did not recur; it passes standalone and on a clean tree, and nothing in this change touches authorization or trust policy.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — no check IDs added or changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — no schema change; see Type note above

Closes #393
