### PR TITLE
fix(scaffold): carry the vocabulary, and reach the scans that need it (#361, #388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 ## Unreleased
 
+- **The first scan of an agent whose tools are imported symbols now scaffolds
+  both layers it needs, instead of emitting nothing.**
+  `suggested-declarations.yaml` was only written once the binding layer was
+  already closed, so during the two scans where an adopter is most stuck it
+  did not exist, and the binding gap that *was* reported carried
+  `declaration_template: null`
+  ([#361](https://github.com/ThreeMoonsLab/agents-shipgate/issues/361)).
+
+  Two templates close that. A repository whose agent lists tool symbols static
+  analysis cannot resolve extracts nothing at all, so it used to produce only
+  source warnings routed to `review_warning` — no path, no command, nothing to
+  open. It now raises one `incomplete_surface` row **per source** carrying the
+  exact `tool_inventories` entry, joined by `source_id` to the source it
+  completes, and the tool-inventory skeleton is written with the symbol names
+  the agent's own `tools=[...]` list publishes. Per source, not per symbol: six
+  unresolved symbols are one mechanism restated six times, and attaching a
+  repair to each row would have put raw loader prose back in the headline that
+  grouping removed.
+
+  Once that inventory is declared, the catalog is populated and nothing binds
+  it to the root agent. That gap now scaffolds the closed-world
+  `agent_bindings.declarations` row with the agent, every catalog tool's exact
+  selector, and the observed handoffs pre-filled — while `complete` and
+  `reason`, the two values that are a human judgement, stay
+  `<REVIEW_REQUIRED>`. Merging the block verbatim after answering those two
+  closes `binding_coverage.gap_count` in one iteration. Past a ceiling of 50
+  tools the template is withheld rather than truncated: `complete: true` claims
+  the listed tools are *all* the agent can reach, so a silently cut list would
+  be false exactly where a reviewer cannot see it.
+
+  Both instructions are also withdrawn once followed — the inventory skeleton
+  is deleted when the source it was written for has been completed, the way the
+  declaration scaffold already was.
+
+- **Every `<REVIEW_REQUIRED>` in `suggested-declarations.yaml` now says what a
+  legal answer is.** The one file an adopter is told to edit was the one file
+  that did not name the vocabulary: `effect:` and `authority.mode:` were bare
+  blanks while `report.json` carried their nine and four accepted values per
+  gap, and completing twelve tools meant roughly forty-eight values looked up
+  in a different file
+  ([#388](https://github.com/ThreeMoonsLab/agents-shipgate/issues/388)).
+
+  Each blank is preceded by a comment carrying either that field's
+  `accepted_values` — rendered from the gap's own list, never a second copy, so
+  the two artifacts cannot disagree — or, where the answer is not drawn from a
+  closed set, the shape it takes and which modes make it required. The
+  `agent_bindings.root` block additionally lists the agent objects the scan
+  observed, with their source, for a human to confirm: `object` matches the
+  agent's *declared* name rather than the Python variable it was assigned to,
+  which is what made guessing it a coin flip. Nothing is filled in — a comment
+  is not a value, and inferring the trust root from AST evidence remains the
+  self-declaration surface [#268](https://github.com/ThreeMoonsLab/agents-shipgate/issues/268)
+  closed.
+
+  Pasting an unfinished scaffold now also reports itself as one whatever field
+  the placeholder lands in. `agent_bindings.declarations[].complete` accepts
+  only `true`, so its own type answered first with "Input should be True",
+  which tells a reader nothing about the scaffold they pasted; the placeholder
+  is rejected before field validation, so one wording covers every field.
+
 - **`verify --preview` on a monorepo now names the project the pull request
   actually changed, instead of a repository root that `init` refuses.** The
   change-scope resolver draws a project boundary around a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,18 @@
   a verdict past `SHIP-INVENTORY-NOT-ENUMERABLE`. The inventory skeleton is
   deleted alongside it, the way the declaration scaffold already was.
 
+  A display name two sources share is withdrawn against only once **every**
+  source publishing it is complete: while any candidate is still owed an
+  inventory the warning could be about that one, and once none is, the
+  ambiguity no longer changes the answer. Both sides of the comparison are
+  stripped, since the manifest permits surrounding whitespace in an id.
+
+  The closed-world `declarations` row is also scaffolded for the other shape
+  that needs it — an agent whose tool list static analysis could only *partly*
+  read — and lists the agent's existing edges as well as the unbound catalog
+  tools, because a row omitting a tool the repository plainly wires to the
+  agent would be false.
+
 - **Every `<REVIEW_REQUIRED>` in `suggested-declarations.yaml` now says what a
   legal answer is.** The one file an adopter is told to edit was the one file
   that did not name the vocabulary: `effect:` and `authority.mode:` were bare
@@ -74,10 +86,13 @@
   only `true`, so its own type answered first with "Input should be True",
   which tells a reader nothing about the scaffold they pasted; the placeholder
   is rejected before field validation, so one wording covers every field. That
-  check reads raw input, which `yaml.safe_load` can hand back with recursive
-  aliases intact, so its traversal is cycle-safe — a manifest containing
-  `&loop {x: *loop}` gets the structured config error and its agent-mode
-  recovery payload rather than a `RecursionError`.
+  check reads raw input, which `yaml.safe_load` can hand back as a *graph*
+  rather than a tree, so its traversal visits each container once. A manifest
+  containing `&loop {x: *loop}` gets the structured config error and its
+  agent-mode recovery payload rather than a `RecursionError`, and an acyclic
+  alias DAG — the expensive case, doubling the walk at every level and
+  materializing `2**n` path strings for one placeholder — is bounded by the
+  size of the document.
 
 - `display_literal` now escapes Unicode noncharacters alongside the invisible
   code points it already covered. They are the same hazard — nothing reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,22 @@
   the listed tools are *all* the agent can reach, so a silently cut list would
   be false exactly where a reviewer cannot see it.
 
-  Both instructions are also withdrawn once followed — the inventory skeleton
-  is deleted when the source it was written for has been completed, the way the
-  declaration scaffold already was.
+  Both instructions are also withdrawn once followed, and so is the diagnostic
+  behind them. A reviewed `tool_inventories` entry naming a source in
+  `source_id` is the answer shipgate itself prescribes for that source's
+  unresolved-symbol warnings, but those warnings stayed on the report and
+  `evidence_below_ie_threshold` gates on their raw count — so a repository that
+  did exactly what it was told sat at `insufficient_evidence` forever, with no
+  non-warning gap left to act on. They are now withdrawn when the manifest
+  declares the source, **per source**, keyed on that reviewed completion
+  relationship and never on tool names: a name subtraction cleared an unrelated
+  source's warning by coincidence in one direction, and in the other it never
+  matched an inventory that had correctly split a toolset symbol into the tools
+  it exposes, so that source was prescribed the same inventory forever. Only
+  the warning is withdrawn — the loader's `surface_gaps` entry stays, so
+  extraction confidence is untouched, and an empty inventory still cannot reach
+  a verdict past `SHIP-INVENTORY-NOT-ENUMERABLE`. The inventory skeleton is
+  deleted alongside it, the way the declaration scaffold already was.
 
 - **Every `<REVIEW_REQUIRED>` in `suggested-declarations.yaml` now says what a
   legal answer is.** The one file an adopter is told to edit was the one file
@@ -60,7 +73,19 @@
   the placeholder lands in. `agent_bindings.declarations[].complete` accepts
   only `true`, so its own type answered first with "Input should be True",
   which tells a reader nothing about the scaffold they pasted; the placeholder
-  is rejected before field validation, so one wording covers every field.
+  is rejected before field validation, so one wording covers every field. That
+  check reads raw input, which `yaml.safe_load` can hand back with recursive
+  aliases intact, so its traversal is cycle-safe — a manifest containing
+  `&loop {x: *loop}` gets the structured config error and its agent-mode
+  recovery payload rather than a `RecursionError`.
+
+- `display_literal` now escapes Unicode noncharacters alongside the invisible
+  code points it already covered. They are the same hazard — nothing reaches
+  the reader, so two repository objects render identically — and two of them
+  are worse: PyYAML rejects U+FFFE and U+FFFF outright, so an agent name
+  carrying one made the generated declaration scaffold unparseable, because
+  the document quoting that name in a comment could not be loaded at all. The
+  encoding stays injective, so `undisplay_literal` still recovers the name.
 
 - **`verify --preview` on a monorepo now names the project the pull request
   actually changed, instead of a repository root that `init` refuses.** The

--- a/docs/engineering/insufficient-evidence-cold-start.md
+++ b/docs/engineering/insufficient-evidence-cold-start.md
@@ -410,3 +410,44 @@ reaching a sink that could not take it:
   generated scaffold unloadable by PyYAML. Both are fixed at the shared layer —
   cycle-safe traversal, and one more class in the escape predicate — rather
   than at the one call site that happened to surface them.
+
+### Known gap: the mixed local/imported surface
+
+Re-review of the fix above found a shape it does **not** close, and the reason
+is worth recording because three separate defects sit behind it. An ADK agent
+with `tools=[local_tool, remote_tool]` — one defined in the entrypoint, one
+imported — follows the generated skeleton, binds the inventory to its source,
+and still cannot reach a verdict:
+
+1. **`incomplete_surface` prescribes an inventory for an unproven tool *set*.**
+   `_evidence_gaps` already draws that distinction for the `low_confidence_tool`
+   row about the same tool ("a tool inventory cannot close this: it describes
+   tools, not which tools an agent has"), and `_semantic_gap` does not — so the
+   two rows give opposite advice. Worse, after the inventory merges, the
+   `source_id` the remediation prints is the *inventory's own* id, which the
+   loader then rejects as self-referential.
+2. **An agent whose list is not exhaustive still presents a "complete"
+   structural set.** `structural_complete` is derived from edge completeness,
+   and the one resolved edge is genuinely complete, so a reviewed closed-world
+   declaration adding the imported tool — the repair the gap asks for — is
+   rejected as "does not match the complete structural tool set".
+3. **A framework partial is never superseded by a reviewed declaration.**
+   `partials` is a bare `set[str]` with no agent attribution, so even an
+   accepted declaration leaves the row standing.
+
+Each was reproduced. None is fixed here, deliberately. (1) is a one-line
+routing change, but on its own it points the reader at a target (2) then
+rejects — replacing a wrong instruction with a right one the engine mishandles.
+(2) and (3) are changes to shared binding-resolver semantics that the OpenAI
+Agents SDK adapter also depends on, and the obvious version of (2) — marking
+the agent's edges incomplete — drops the tools that *were* resolved out of
+`reachable_tool_ids` entirely, so they stop being judged and the per-tool
+`low_confidence_tool` rows #393 added disappear. The fix has to separate "this
+edge is uncertain" from "this list is not exhaustive", and give `partials` an
+agent, before any of it is safe.
+
+**The rule this adds:** *when a remedy cannot be completed, say so rather than
+shipping the half of it that fits.* A gate that misdirects is not better than
+one that abstains, and a partial fix to shared resolver semantics is exactly
+where a silent fail-open gets introduced.
+

--- a/docs/engineering/insufficient-evidence-cold-start.md
+++ b/docs/engineering/insufficient-evidence-cold-start.md
@@ -285,10 +285,7 @@ Two templates close the two stages.
   completes, and the skeleton is written with the symbol names pre-filled.
   Per source, not per symbol: six warnings are one mechanism restated six
   times, and hanging a repair off each row would have put raw loader prose back
-  into the headline that the grouping work removed. The row is withdrawn once
-  the symbol has an observation — the entrypoint still cannot resolve the
-  import, so the warning stays, but re-prescribing a repair the reader has
-  already made is worse than silence.
+  into the headline that the grouping work removed.
 
 - **Stage 2 — the unbound catalog.** A resolved root, a populated catalog, and
   not one static edge between them now scaffolds the closed-world
@@ -351,3 +348,65 @@ field validation, so one wording covers every field whatever its type. Same
 rule as the round before: a promise printed in an artifact must be enforced
 somewhere, and the enforcement has to reach the fields people actually paste
 into.
+
+
+### What review found: the prescribed route did not terminate
+
+Two of the six findings on PR #401 were the same mistake seen from two sides,
+and both are about **what "this source is repaired" means**.
+
+The route was unreachable. Following it to the end — inventory, binding
+declaration, effect and authority for every tool — still returned
+`insufficient_evidence`, because the six unresolved-import warnings stayed on
+the report and `evidence_below_ie_threshold` gates on their raw count. A
+repository that did exactly what it was told had *nothing left to act on* and
+still could not be gated. An advertised remedy that cannot terminate is the
+same defect this whole document is about, one layer further in.
+
+The first attempt at "repaired" was a catalog-wide tool-name subtraction, and
+it was wrong in both directions:
+
+- an unrelated source exposing a tool named `search` silently cleared the ADK
+  source's unresolved `search` — a repair nobody had made; and
+- an inventory that had correctly *split* a toolset symbol into the tools it
+  exposes — which the skeleton's own instruction asks for — never matched the
+  symbol, so that source was prescribed the same inventory forever.
+
+The completion relationship is not a name. It is the reviewed
+`tool_inventories[].source_id`, already desugared into
+`LoadedToolSource.completes_source_id`, and it is *per source*. Withdrawal
+happens in the one place holding both halves of it: the loaded sources know
+which inventory completes which source, the ADK artifacts know which source
+each agent came from. Only the **warning** is withdrawn — the loader's
+`surface_gaps` entry stays, so nothing claims static analysis resolved what it
+could not and extraction confidence is unmoved.
+
+The obvious worry — silence the warnings by declaring an empty inventory — is
+already answered by a different check: `SHIP-INVENTORY-NOT-ENUMERABLE` fires on
+the empty surface and routes to `review_required`. The two are independent, and
+a test pins that they stay so.
+
+**The rule this adds:** *a remedy the tool prescribes must be able to reach a
+verdict.* Whatever the tool asks for, satisfying it has to move the gate — or
+the gate is asking for something else and should say so.
+
+Three smaller findings from the same review, each a case of repository data
+reaching a sink that could not take it:
+
+- **`complete:` closes the world over handoffs too.** The hint spoke only about
+  the tool list, while the scaffold pre-fills observed handoffs and the schema
+  treats both as closed. A reviewer could ratify the tools and silently assert
+  a downstream agent surface they never looked at. Both hints now name both
+  lists.
+- **A handoff has no source qualifier.** `handoffs:` is a bare list of names,
+  so a target whose name two agents share resolves to neither — the block
+  reports an unresolved binding instead of closing the gap it was offered for.
+  The template is withheld entirely rather than dropping the handoff, because
+  dropping it would understate a closed world the reviewer is about to assert.
+- **Two robustness holes with the same shape.** The raw-input sentinel check
+  recursed forever on a manifest carrying a recursive YAML alias, replacing a
+  structured config error with a stack overflow; and `display_literal` passed
+  Unicode noncharacters through, so an agent name containing U+FFFE made the
+  generated scaffold unloadable by PyYAML. Both are fixed at the shared layer —
+  cycle-safe traversal, and one more class in the escape predicate — rather
+  than at the one call site that happened to surface them.

--- a/docs/engineering/insufficient-evidence-cold-start.md
+++ b/docs/engineering/insufficient-evidence-cold-start.md
@@ -60,9 +60,11 @@ a correctness audit of the templates themselves, and three were wrong:
 - The **binding** template carried a `declarations` row pre-filled with
   `complete: true`, `tools: []`, `handoffs: []` — an assertion that the agent
   definitively reaches *no* tools, offered in a file whose header promised it
-  asserted nothing. It now scaffolds root selection only, and a guard test
+  asserted nothing. It was cut back to root selection only, and a guard test
   enumerates every shipped template and fails on any non-sentinel value in a
-  human-owned field (negative-tested against the original block).
+  human-owned field (negative-tested against the original block). (A
+  `declarations` template came back in 2026-08 — see *Second round* below —
+  with the assertion removed rather than the block.)
 - The **selector** template offered a flat `{tool, tool_id, provider}` while
   pointing at `tool_identity`, whose schema accepts only `bindings` entries —
   unfillable anywhere. It emits no template now; inventing a `bindings` row
@@ -253,3 +255,99 @@ The 2026-W27 re-evaluation attributed most of `benign_escalation_rate` 0.286 to
 a cold-start whole-repo-surface artifact. Re-run the labeled corpus after (1)
 and (2); the expected movement is benign escalation down with
 `must_block_caught` and `needs_human_caught` held at 1.0.
+
+## Second round (2026-08-21): the scaffold reaches the scans that need it
+
+Two follow-ups measured against the same walk, on
+[google/adk-samples#1917](https://github.com/google/adk-samples/pull/1917) and
+[#1745](https://github.com/google/adk-samples/pull/1745): issues
+[#361](https://github.com/ThreeMoonsLab/agents-shipgate/issues/361) and
+[#388](https://github.com/ThreeMoonsLab/agents-shipgate/issues/388).
+
+**The scaffold existed only after the layer that needed it was already closed.**
+It is written whenever a gap carries a template, and until now only *semantic*
+gaps did — so the two scans where an adopter is most stuck emitted no scaffold
+at all. In an ADK repository whose `tools=[...]` entries are all imported
+symbols, stage 1 extracts nothing (six source warnings, each routed to
+`review_warning`: no path, no command, nothing to open) and stage 2 reports a
+binding gap carrying `declaration_template: null`. The reader hand-authored a
+98-line inventory and an `agent_bindings` block, losing one round to an invalid
+enum a template would have named.
+
+Two templates close the two stages.
+
+- **Stage 1 — the unenumerable source.** The names are not lost: the loader
+  writes them into its own warning prose, and `core.source_warnings` owns both
+  halves of that prose, so they are read back through the same exact,
+  `repr`-delimited decoder `group_source_warnings` already relies on — never a
+  regex over loader text. One `incomplete_surface` row per **source** carries
+  the `tool_inventories` entry with `source_id` bound to the source it
+  completes, and the skeleton is written with the symbol names pre-filled.
+  Per source, not per symbol: six warnings are one mechanism restated six
+  times, and hanging a repair off each row would have put raw loader prose back
+  into the headline that the grouping work removed. The row is withdrawn once
+  the symbol has an observation — the entrypoint still cannot resolve the
+  import, so the warning stays, but re-prescribing a repair the reader has
+  already made is worse than silence.
+
+- **Stage 2 — the unbound catalog.** A resolved root, a populated catalog, and
+  not one static edge between them now scaffolds the closed-world
+  `declarations` row. The 2026-07 defect was not the block; it was the
+  *assertion* inside it. What is pre-filled is only what was read off the
+  surface — which agent, which catalog tools exist, which handoffs were
+  observed — and `complete` and `reason`, the two values that are a judgement,
+  stay `<REVIEW_REQUIRED>`. Merging it verbatim after answering those two
+  closes `binding_coverage.gap_count` in one iteration.
+
+  Past 50 tools the template is **withheld, not truncated**. `complete: true`
+  claims the listed tools are all the agent can reach, so a silently cut list
+  is false precisely where the reviewer cannot see it — the one failure mode
+  this template must not have.
+
+**The file users were told to edit was the file that did not name the
+vocabulary.** `effect:` and `authority.mode:` were bare blanks while
+`report.json` carried their nine and four accepted values *per gap*; completing
+twelve tools meant roughly forty-eight values looked up somewhere else. Each
+blank now carries a comment above it: the field's `accepted_values` where the
+answer comes from a closed set, otherwise the shape it takes and which other
+answers make it required.
+
+The vocabulary is rendered **from the gap's own `accepted_values`**, never from
+a second copy, so the two artifacts cannot drift. That is possible for exactly
+two fields, and the reason is worth writing down: `accepted_values` is
+*overloaded* on the wire. For most gap kinds it lists the manifest **keys** a
+repair must set (`["agent", "complete:true", "tools", …]`); for
+`declare_action_effect` and `declare_action_authority` it lists the legal
+**values** of one field. Printing the first reading above a blank would tell a
+reviewer that `agent` is a legal `effect`, so only the second is routed, and
+the routing table is pinned to the action-kind enum by a test.
+
+**The root block now offers what the scan already computed.** `agent_bindings.
+root` handed out two blanks for a value the binding graph holds. It lists the
+observed agent objects with their sources, as comments, for a human to confirm.
+Note what that also fixes: `object` matches the agent's **declared** name, not
+the Python variable it was assigned to — the issue's own worked example guessed
+the variable — so the candidate list is the difference between confirming and
+guessing wrong. Nothing is filled in; inferring the trust root from AST
+evidence remains the self-declaration surface
+[#268](https://github.com/ThreeMoonsLab/agents-shipgate/issues/268) closed.
+
+**Two things a comment-carrying renderer has to get right.** PyYAML cannot
+carry comments, so the block is emitted by hand — and a hand-rolled emitter is
+where a second opinion about YAML style creeps in. A test asserts that
+stripping the comment lines back out yields exactly what `safe_dump` writes for
+the same template, so the two cannot diverge. And a *name* is repository data:
+a tool name holding a newline renders as a multi-line scalar the emitter cannot
+indent correctly on its own (it falls back to a JSON-encoded one-line scalar),
+and an agent name holding one would close the `#` of a candidate comment and
+write a filled-in root selector for a reader to paste — so those are escaped
+with `display_literal`, injectively, and an adversarial test holds both shut.
+
+**And the promise is enforced one layer earlier.** `declarations[].complete`
+accepts only `true`, so pasting the scaffold unfinished failed with pydantic's
+"Input should be True" — a true statement that says nothing about the scaffold
+the reader pasted. The placeholder is now rejected from the raw input before
+field validation, so one wording covers every field whatever its type. Same
+rule as the round before: a promise printed in an artifact must be enforced
+somewhere, and the enforcement has to reach the fields people actually paste
+into.

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
 
 from agents_shipgate.ci.exit_policy import (
     effective_fail_on,
@@ -14,6 +17,12 @@ from agents_shipgate.core.evidence_actions import (
     evidence_gap_target,
     primary_evidence_gap,
     yaml_scalar,
+)
+from agents_shipgate.core.source_warnings import unresolved_adk_tool_symbols
+from agents_shipgate.schemas.bindings import (
+    AgentBindingGraphAssessment,
+    AgentBindingIssue,
+    AgentBindingNode,
 )
 from agents_shipgate.schemas.common import Severity
 from agents_shipgate.schemas.report import (
@@ -111,8 +120,20 @@ def build_release_decision(
     ci_mode: str,
     fail_on: list[Severity] | None,
     new_findings_only: bool,
+    tool_catalog: Sequence[Tool] | None = None,
 ) -> ReleaseDecision:
+    """Compute the release decision.
+
+    ``tools`` is the root-reachable surface — the population every count and
+    every gate reads. ``tool_catalog`` is everything extraction found, reachable
+    or not, and is used for exactly one thing: scaffolding the binding
+    declaration for a repository whose catalog is populated and whose reachable
+    set is therefore empty (#361). Nothing gates on it. It defaults to ``tools``
+    so a caller that never had the distinction keeps its behaviour.
+    """
+
     fail_on_resolved = effective_fail_on(ci_mode, fail_on)
+    catalog = tools if tool_catalog is None else tool_catalog
 
     # blockers/review_items consider the full findings set, NOT
     # new_findings_only: baseline-matched criticals must remain visible
@@ -255,7 +276,7 @@ def build_release_decision(
     low_confidence_tool_count = sum(1 for tool in tools if tool.extraction_confidence != "high")
     semantic_coverage, semantic_gaps = _semantic_coverage(tools)
     identity_coverage = _identity_coverage(tools)
-    binding_coverage, binding_gaps = _binding_coverage(report)
+    binding_coverage, binding_gaps = _binding_coverage(report, catalog)
     evidence = EvidenceCoverageDecision(
         level=report.summary.evidence_coverage,
         human_review_recommended=report.summary.human_review_recommended,
@@ -444,6 +465,120 @@ AGENT_BINDINGS_ROOT_TEMPLATE: dict[str, object] = {
         },
     }
 }
+
+# Ceiling on the tool rows a closed-world binding declaration is scaffolded
+# with. Above it the template is withheld rather than truncated: a
+# ``declarations`` row is a claim that the listed tools are ALL the agent can
+# reach, so a list silently cut at N would be false exactly where the reviewer
+# is least able to notice — and a repository with hundreds of unbound catalog
+# entries is telling us to wire the binding in source, not to retype it.
+_MAX_SCAFFOLDED_BINDING_TOOLS = 50
+
+
+def _inventory_declaration_template(
+    manifest_key: str, source_id: str | None
+) -> dict[str, object] | None:
+    """The manifest wiring that joins a reviewed inventory to its source.
+
+    ``_inventory_remediation`` already prescribes this entry as prose. Emitting
+    it as a template puts it in the file the reader was actually told to edit,
+    which is the whole point of the scaffold (#388): the vocabulary and the
+    shape stop being something to reconstruct from a sentence.
+
+    Withheld when the source has no id: an inventory referenced without
+    ``source_id`` is an *independent* source added beside the extracted tools
+    instead of completing them, so the gap that asked for the file stays open
+    (#386). A template that quietly does that is worse than none.
+    """
+
+    if not source_id:
+        return None
+    block, _, key = manifest_key.partition(".")
+    if not block or not key:
+        return None
+    return {
+        block: {key: [{"path": REVIEW_REQUIRED_SENTINEL, "source_id": source_id}]}
+    }
+
+
+def _binding_declaration_template(
+    graph: AgentBindingGraphAssessment,
+    issue: AgentBindingIssue,
+    tool_catalog: Sequence[Tool],
+) -> dict[str, object] | None:
+    """The manifest block one binding issue is repaired in, or ``None``.
+
+    Two binding issues are scaffoldable, and they want different blocks.
+
+    ``ambiguous_root_agent`` wants root *selection* only. In a decorator-only
+    repository there is no agent object for a filled root selector to match, so
+    offering one would send the reader after a value that cannot exist.
+
+    ``missing_binding_evidence`` — a resolved root, a populated catalog, and
+    not one static edge between them — wants a closed-world ``declarations``
+    row. Everything in it that a human owns stays a sentinel: ``complete`` is
+    the closed-world assertion and ``reason`` is how they verified it. What is
+    pre-filled is only what was *read off the surface*: which agent, which
+    catalog tools exist, and which handoffs were observed. That is the
+    retyping #361 measured — six tool names already extracted, hand-copied at
+    the point the user has the least context — not the judgement.
+
+    The other binding kinds are repaired in source wiring or in an existing
+    declaration, so a block aimed at ``agent_bindings.declarations`` would not
+    fit the path their action names.
+    """
+
+    if issue.kind == "ambiguous_root_agent":
+        return deepcopy(AGENT_BINDINGS_ROOT_TEMPLATE) if graph.agents else None
+    if issue.kind != "missing_binding_evidence":
+        return None
+    # Root-scoped only. The same kind is also raised per tool for capabilities
+    # bound to an agent the root does not reach (``_unbound_tool_gaps``); those
+    # are repaired by wiring the handoff, not by declaring the root's tool set.
+    if issue.tool_id is not None or issue.agent_id != graph.root_agent_id:
+        return None
+    catalog = {tool.id: tool for tool in tool_catalog}
+    unbound = [catalog[tool_id] for tool_id in graph.unbound_tool_ids if tool_id in catalog]
+    if not unbound or len(unbound) > _MAX_SCAFFOLDED_BINDING_TOOLS:
+        return None
+    names = {agent.agent_id: agent.name for agent in graph.agents}
+    root_name = names.get(issue.agent_id or "")
+    # ``root`` is the documented alias for the configured root agent, and it is
+    # what a duplicated agent name has to fall back to: a declaration naming a
+    # name two agents share resolves to neither.
+    agent = (
+        root_name
+        if root_name and sum(1 for value in names.values() if value == root_name) == 1
+        else "root"
+    )
+    handoffs = sorted(
+        {
+            names.get(edge.target_agent_id, edge.target_agent_id)
+            for edge in graph.handoff_edges
+            if edge.source_agent_id == issue.agent_id
+        }
+    )
+    return {
+        "agent_bindings": {
+            "declarations": [
+                {
+                    "agent": agent,
+                    "complete": REVIEW_REQUIRED_SENTINEL,
+                    # The same selector shape the action templates use: both
+                    # resolve through ToolSelectorIndex, where ``tool_id`` is
+                    # exact and the source qualifier keeps the row readable.
+                    "tools": [
+                        _action_selector(tool)
+                        for tool in sorted(unbound, key=lambda item: (item.name, item.id))
+                    ],
+                    "handoffs": handoffs,
+                    "reason": REVIEW_REQUIRED_SENTINEL,
+                }
+            ]
+        }
+    }
+
+
 _SEMANTIC_RERUN_COMMAND = (
     "agents-shipgate verify --workspace . --config shipgate.yaml --ci-mode advisory --format json"
 )
@@ -471,6 +606,7 @@ _MANDATORY_CURRENT_CONTROL_CHECKS = frozenset(
 
 def _binding_coverage(
     report: ReadinessReport,
+    tool_catalog: Sequence[Tool] = (),
 ) -> tuple[BindingCoverageDecision, list[EvidenceGap]]:
     graph = report.binding_surface_facts
     reason_counts: dict[str, int] = {}
@@ -507,17 +643,7 @@ def _binding_coverage(
             path = "shipgate.yaml#agent_bindings"
             accepted_values = ["literal_binding", "reviewed_declaration"]
             expects = "Correct the binding annotation or provide an exact reviewed declaration."
-        # Only root SELECTION is scaffoldable. The other binding issues are
-        # repaired under ``agent_bindings.declarations`` or in the source
-        # wiring, so a root-only block would not fit the path they name — and
-        # in a decorator-only repository there is no agent object for a filled
-        # root selector to match, so offering one would send the reader after a
-        # value that cannot exist.
-        root_template = (
-            AGENT_BINDINGS_ROOT_TEMPLATE
-            if issue.kind == "ambiguous_root_agent" and graph.agents
-            else None
-        )
+        template = _binding_declaration_template(graph, issue, tool_catalog)
         gaps.append(
             EvidenceGap(
                 kind=issue.kind,
@@ -529,9 +655,9 @@ def _binding_coverage(
                     command=_SEMANTIC_RERUN_COMMAND,
                     path=path,
                     why="A complete root-reachable static binding graph is required for passed.",
-                    expects=_with_scaffold_pointer(expects, root_template),
+                    expects=_with_scaffold_pointer(expects, template),
                     accepted_values=accepted_values,
-                    declaration_template=deepcopy(root_template) if root_template else None,
+                    declaration_template=template,
                 ),
             )
         )
@@ -816,6 +942,12 @@ def _semantic_gap(
     action_kind: str
     accepted_values: list[str]
     declaration_template: dict[str, object] | None = None
+    # Whether ``expects`` should also name the on-disk scaffold. Off for the
+    # inventory repair: that row's own ``path`` is the skeleton to open and its
+    # remediation spells the manifest entry inline, so naming a second file for
+    # the same one-line edit splits one instruction in two. The block is still
+    # written to the scaffold for a reader who works from there.
+    name_scaffold = True
     if kind in {"incomplete_tool_identity"}:
         action_kind = "declare_source_identity"
         accepted_values = ["unique_source_id", "stable_native_locator"]
@@ -886,6 +1018,10 @@ def _semantic_gap(
             expects = _inventory_remediation(
                 manifest_key, tool.source_id, rerun="rerun verification."
             )
+            declaration_template = _inventory_declaration_template(
+                manifest_key, tool.source_id
+            )
+            name_scaffold = False
         else:
             action_kind = "provide_complete_inventory"
             accepted_values = [
@@ -979,7 +1115,9 @@ def _semantic_gap(
             command=_SEMANTIC_RERUN_COMMAND,
             path=_semantic_gap_path(kind, tool),
             why=action_why,
-            expects=_with_scaffold_pointer(expects, declaration_template),
+            expects=_with_scaffold_pointer(
+                expects, declaration_template if name_scaffold else None
+            ),
             accepted_values=accepted_values,
             declaration_template=declaration_template,
         ),
@@ -1104,9 +1242,9 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
     """v0.26: one actionable row per measurable evidence gap.
 
     Deterministic projection of the same inputs the counts use:
-    low-confidence tools (sorted by name) first, then source warnings in
-    report order. Never gates — `build_release_decision` keeps deciding
-    on the counts alone.
+    low-confidence tools (sorted by name) first, then unenumerable sources by
+    id, then source warnings in report order. Never gates —
+    `build_release_decision` keeps deciding on the counts alone.
     """
     gaps: list[EvidenceGap] = []
     low_confidence = sorted(
@@ -1139,6 +1277,9 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
                 ),
             )
         elif manifest_key is not None:
+            inventory_template = _inventory_declaration_template(
+                manifest_key, tool.source_id
+            )
             action = EvidenceGapAction(
                 kind="declare_tool_inventory",
                 path=SUGGESTED_INVENTORY_FILENAME,
@@ -1150,6 +1291,12 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
                 expects=_inventory_remediation(
                     manifest_key, tool.source_id, rerun="rerun the scan."
                 ),
+                # No scaffold pointer: this row's own ``path`` is the skeleton
+                # to open, and its remediation already spells the manifest
+                # entry inline. Naming a second file for the same one-line edit
+                # splits one instruction across two artifacts. The block is
+                # still in the scaffold for a reader who works from there.
+                declaration_template=inventory_template,
             )
         else:
             action = EvidenceGapAction(
@@ -1173,6 +1320,55 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
                     f"{_surface_gap_note(tool)}"
                 ),
                 next_action=action,
+            )
+        )
+    covered_sources = {
+        tool.source_id for tool in low_confidence if tool.source_id
+    }
+    for source in unresolved_symbol_sources(report):
+        if source.source_id in covered_sources:
+            # A low-confidence row for this source already prescribes the same
+            # inventory; two rows would be one repair asked for twice.
+            continue
+        inventory_template = _inventory_declaration_template(
+            source.manifest_key, source.source_id
+        )
+        listed = ", ".join(source.symbols[:_MAX_LISTED_SYMBOLS])
+        more = (
+            f" (+{len(source.symbols) - _MAX_LISTED_SYMBOLS} more)"
+            if len(source.symbols) > _MAX_LISTED_SYMBOLS
+            else ""
+        )
+        agents = ", ".join(source.agents)
+        gaps.append(
+            EvidenceGap(
+                kind="incomplete_surface",
+                subject=f"{source.source_id} [{source.manifest_key.split('.')[0]}]",
+                source_type=source.manifest_key.split(".")[0],
+                source_ref=source.source_ref,
+                why=(
+                    f"{len(source.symbols)} tool symbol(s) {agents} lists are "
+                    f"not defined in this entrypoint, so the source produced no "
+                    f"observation for them: {listed}{more}."
+                ),
+                next_action=EvidenceGapAction(
+                    kind="declare_tool_inventory",
+                    path=f"shipgate.yaml#{source.manifest_key}",
+                    why=(
+                        "The complete statically-bound tool surface must be "
+                        "enumerable before any tool of it can be judged."
+                    ),
+                    expects=_with_scaffold_pointer(
+                        _inventory_remediation(
+                            source.manifest_key,
+                            source.source_id,
+                            rerun="rerun the scan.",
+                        ),
+                        inventory_template,
+                    ),
+                    accepted_values=["reviewed_explicit_inventory"],
+                    declaration_template=inventory_template,
+                ),
             )
         )
     for warning in report.source_warnings:
@@ -1212,6 +1408,110 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
             )
         )
     return gaps
+
+
+# Symbols quoted in a gap's reason before it stops being a sentence.
+_MAX_LISTED_SYMBOLS = 8
+
+
+@dataclass(frozen=True)
+class UnresolvedSymbolSource:
+    """A configured source whose agent names tool symbols it never observed.
+
+    The tool surface of such a source is not enumerable from its entrypoint —
+    the symbols are imported, or built at run time — so the repository owes a
+    reviewed inventory joined to it. Held per source rather than per symbol:
+    one mechanism, one repair, one row (#361).
+    """
+
+    source_id: str
+    manifest_key: str
+    source_ref: str | None
+    agents: tuple[str, ...]
+    symbols: tuple[str, ...]
+
+
+def unresolved_symbol_names(report: ReadinessReport) -> list[str]:
+    """Tool symbols an agent names that the catalog holds no observation for.
+
+    Once a reviewed inventory has been joined to the source, the symbol has an
+    observation and the repair is *made* — the entrypoint still cannot resolve
+    the import, so the warning stays, but re-prescribing the inventory would
+    tell the reader to do again what they just did.
+    """
+
+    known = {
+        str(row.get("name")) for row in report.tool_catalog if row.get("name")
+    }
+    return sorted(
+        {
+            symbol
+            for _agent, symbol in unresolved_adk_tool_symbols(report.source_warnings)
+            if symbol not in known
+        }
+    )
+
+
+def unresolved_symbol_sources(
+    report: ReadinessReport,
+) -> list[UnresolvedSymbolSource]:
+    """One row per source whose agent names tool symbols it never observed.
+
+    A repository where every tool symbol is imported extracts *nothing*, so
+    none of the per-tool gap rows exist and the only rows the first scan
+    produces are source warnings routed to ``review_warning`` — a dead end with
+    no path, no command, and no template (#361). The repair is a reviewed
+    inventory joined to the source: exactly what an ``incomplete_surface`` row
+    already prescribes, so the first scan raises one instead of leaving the
+    reader with prose.
+
+    Per *source*, never per warning. Six unresolved symbols are one fact
+    restated six times (see ``core.source_warnings``), and attaching a repair
+    to each row would put raw loader prose back in the headline the grouping
+    work removed.
+
+    The source id comes from the binding graph's agent nodes, not from the
+    warning: the prose names the agent, the graph knows which configured source
+    produced it. An agent name two sources both publish is skipped rather than
+    guessed — an inventory joined to the wrong source completes nothing (#386).
+    """
+
+    open_symbols = set(unresolved_symbol_names(report))
+    if not open_symbols:
+        return []
+    manifest_key = inventory_manifest_key("google_adk")
+    if manifest_key is None:  # pragma: no cover - google_adk is registered
+        return []
+    nodes: dict[str, list[AgentBindingNode]] = {}
+    for agent in report.binding_surface_facts.agents:
+        if agent.source_id:
+            nodes.setdefault(agent.name, []).append(agent)
+    by_source: dict[str, dict[str, Any]] = {}
+    for agent_name, symbol in unresolved_adk_tool_symbols(report.source_warnings):
+        candidates = nodes.get(agent_name, [])
+        if symbol not in open_symbols or len({a.source_id for a in candidates}) != 1:
+            continue
+        node = candidates[0]
+        source_id = node.source_id
+        if source_id is None:  # pragma: no cover - filtered when nodes was built
+            continue
+        entry = by_source.setdefault(
+            source_id,
+            {"source_ref": node.source_ref, "agents": [], "symbols": set()},
+        )
+        if agent_name not in entry["agents"]:
+            entry["agents"].append(agent_name)
+        entry["symbols"].add(symbol)
+    return [
+        UnresolvedSymbolSource(
+            source_id=source_id,
+            manifest_key=manifest_key,
+            source_ref=entry["source_ref"],
+            agents=tuple(entry["agents"]),
+            symbols=tuple(sorted(entry["symbols"])),
+        )
+        for source_id, entry in sorted(by_source.items())
+    ]
 
 
 def _rule(

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -558,6 +558,15 @@ def _binding_declaration_template(
             if edge.source_agent_id == issue.agent_id
         }
     )
+    # ``handoffs`` is a bare list of names with no source qualifier — the
+    # schema has nowhere to put one. A target whose name two agents share
+    # therefore resolves to neither, and the block would report an unresolved
+    # binding instead of closing the gap it was offered for (PR #401 review).
+    # Withhold the whole template rather than the handoff: dropping the target
+    # would understate a closed world the reviewer is about to assert, and the
+    # real repair for an ambiguous target is the source wiring.
+    if any(sum(1 for value in names.values() if value == target) != 1 for target in handoffs):
+        return None
     return {
         "agent_bindings": {
             "declarations": [
@@ -1432,23 +1441,21 @@ class UnresolvedSymbolSource:
 
 
 def unresolved_symbol_names(report: ReadinessReport) -> list[str]:
-    """Tool symbols an agent names that the catalog holds no observation for.
+    """Tool symbols still standing unanswered on this report's warnings.
 
-    Once a reviewed inventory has been joined to the source, the symbol has an
-    observation and the repair is *made* — the entrypoint still cannot resolve
-    the import, so the warning stays, but re-prescribing the inventory would
-    tell the reader to do again what they just did.
+    No name matching, deliberately. Subtracting a catalog-wide set of tool
+    names was wrong in both directions (PR #401 review): an unrelated source
+    exposing a same-named tool read as a repair that had not happened, and an
+    inventory that correctly split a toolset symbol into the tools it exposes
+    never matched the symbol, so its source was prescribed the same inventory
+    forever. The completion relationship is the reviewed
+    ``tool_inventories[].source_id``, and it is applied where both halves of it
+    are known — ``withdraw_completed_adk_tool_warnings``, during the scan. A
+    warning that survived to the report is one nothing has answered.
     """
 
-    known = {
-        str(row.get("name")) for row in report.tool_catalog if row.get("name")
-    }
     return sorted(
-        {
-            symbol
-            for _agent, symbol in unresolved_adk_tool_symbols(report.source_warnings)
-            if symbol not in known
-        }
+        {symbol for _agent, symbol in unresolved_adk_tool_symbols(report.source_warnings)}
     )
 
 
@@ -1476,8 +1483,8 @@ def unresolved_symbol_sources(
     guessed — an inventory joined to the wrong source completes nothing (#386).
     """
 
-    open_symbols = set(unresolved_symbol_names(report))
-    if not open_symbols:
+    symbols = unresolved_adk_tool_symbols(report.source_warnings)
+    if not symbols:
         return []
     manifest_key = inventory_manifest_key("google_adk")
     if manifest_key is None:  # pragma: no cover - google_adk is registered
@@ -1487,9 +1494,9 @@ def unresolved_symbol_sources(
         if agent.source_id:
             nodes.setdefault(agent.name, []).append(agent)
     by_source: dict[str, dict[str, Any]] = {}
-    for agent_name, symbol in unresolved_adk_tool_symbols(report.source_warnings):
+    for agent_name, symbol in symbols:
         candidates = nodes.get(agent_name, [])
-        if symbol not in open_symbols or len({a.source_id for a in candidates}) != 1:
+        if len({node.source_id for node in candidates}) != 1:
             continue
         node = candidates[0]
         source_id = node.source_id

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -514,10 +514,12 @@ def _binding_declaration_template(
     repository there is no agent object for a filled root selector to match, so
     offering one would send the reader after a value that cannot exist.
 
-    ``missing_binding_evidence`` — a resolved root, a populated catalog, and
-    not one static edge between them — wants a closed-world ``declarations``
-    row. Everything in it that a human owns stays a sentinel: ``complete`` is
-    the closed-world assertion and ``reason`` is how they verified it. What is
+    ``missing_binding_evidence`` (a resolved root, a populated catalog, and not
+    one static edge between them) and ``partial_binding_evidence`` (an agent
+    whose ``tools=[...]`` static analysis could only partly read) both want a
+    closed-world ``declarations`` row. Everything in it that a human owns stays
+    a sentinel: ``complete`` is the closed-world assertion and ``reason`` is how
+    they verified it. What is
     pre-filled is only what was *read off the surface*: which agent, which
     catalog tools exist, and which handoffs were observed. That is the
     retyping #361 measured — six tool names already extracted, hand-copied at
@@ -530,15 +532,35 @@ def _binding_declaration_template(
 
     if issue.kind == "ambiguous_root_agent":
         return deepcopy(AGENT_BINDINGS_ROOT_TEMPLATE) if graph.agents else None
-    if issue.kind != "missing_binding_evidence":
+    if issue.kind not in {"missing_binding_evidence", "partial_binding_evidence"}:
         return None
-    # Root-scoped only. The same kind is also raised per tool for capabilities
-    # bound to an agent the root does not reach (``_unbound_tool_gaps``); those
-    # are repaired by wiring the handoff, not by declaring the root's tool set.
-    if issue.tool_id is not None or issue.agent_id != graph.root_agent_id:
+    # Root-scoped only. ``missing_binding_evidence`` is also raised per tool for
+    # capabilities bound to an agent the root does not reach
+    # (``_unbound_tool_gaps``); those are repaired by wiring the handoff, not by
+    # declaring the root's tool set.
+    if issue.kind == "missing_binding_evidence" and (
+        issue.tool_id is not None or issue.agent_id != graph.root_agent_id
+    ):
+        return None
+    if issue.kind == "partial_binding_evidence" and issue.agent_id != graph.root_agent_id:
         return None
     catalog = {tool.id: tool for tool in tool_catalog}
-    unbound = [catalog[tool_id] for tool_id in graph.unbound_tool_ids if tool_id in catalog]
+    # Everything the declaration has to account for. ``unbound`` alone was
+    # right only while nothing at all was bound: on a mixed surface — one tool
+    # this module defines, one imported — the resolved tool is *already* an
+    # edge, and a closed-world row omitting it would assert the agent cannot
+    # reach a tool the repository plainly wires to it (PR #401 review).
+    candidate_ids = list(
+        dict.fromkeys(
+            [
+                edge.tool_id
+                for edge in graph.tool_edges
+                if edge.agent_id == issue.agent_id
+            ]
+            + list(graph.unbound_tool_ids)
+        )
+    )
+    unbound = [catalog[tool_id] for tool_id in candidate_ids if tool_id in catalog]
     if not unbound or len(unbound) > _MAX_SCAFFOLDED_BINDING_TOOLS:
         return None
     names = {agent.agent_id: agent.name for agent in graph.agents}

--- a/src/agents_shipgate/cli/scan/declarations.py
+++ b/src/agents_shipgate/cli/scan/declarations.py
@@ -13,17 +13,93 @@ This module assembles them into one reviewable YAML snippet next to
 low-confidence sources. It asserts nothing: every value the human owns stays
 ``<REVIEW_REQUIRED>``, and a file full of sentinels satisfies no gap. Deciding
 remains entirely the decision engine's job.
+
+**Self-sufficiency is the point** (#388). The file a user is told to edit was
+the one file that did not say what a legal answer looks like: ``effect:
+<REVIEW_REQUIRED>`` with the nine accepted values sitting in ``report.json``,
+and an ``agent_bindings.root`` block with two blanks whose answer the scan had
+already observed. Every sentinel now carries the vocabulary or the shape it
+takes, as a comment, and where the scan observed candidates they are listed for
+a human to confirm. Nothing about the human declaration property changes — a
+comment is not a value.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import json
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 import yaml
 
 from agents_shipgate.ci.release_decision import REVIEW_REQUIRED_SENTINEL
+from agents_shipgate.core.evidence_actions import display_literal, yaml_scalar
+from agents_shipgate.schemas.bindings import AgentBindingNode
 from agents_shipgate.schemas.report import EvidenceGap, ReadinessReport
+
+# Which template field an action's ``accepted_values`` is the vocabulary FOR.
+#
+# ``accepted_values`` is overloaded on the wire: for most gap kinds it lists
+# the manifest *keys* a repair must set (``["agent", "complete:true", …]``),
+# and for these two it lists the legal *values* of one field. Only the second
+# reading may be printed above a blank — rendering key names as "accepted
+# values" would tell a reviewer that `agent` is a legal `effect`.
+#
+# The values themselves are never copied here. The annotation is rendered from
+# the gap's own ``accepted_values``, so the two artifacts cannot disagree about
+# the vocabulary; only this routing could ever drift, and a test pins it.
+_VOCABULARY_FIELD_BY_ACTION_KIND: dict[str, str] = {
+    "declare_action_effect": "effect",
+    "declare_action_authority": "authority.mode",
+}
+
+# Fields whose answer is not drawn from a closed set. A vocabulary cannot be
+# printed for these, so the comment says what shape the answer takes and which
+# other answers make the field required — the co-requirement rules the header
+# states in general, restated where the reviewer's cursor actually is.
+#
+# Keyed by the tail of the template path, matched longest-suffix-first, so one
+# entry covers ``google_adk.tool_inventories[].path`` and its three sibling
+# framework blocks.
+_FIELD_HINTS: dict[str, str] = {
+    "authority.auth_type": (
+        "how this action authenticates, in your own words "
+        "(api_key, oauth2, service_account, workload_identity, …). "
+        "Required for every mode except `none`; delete this line for `none`."
+    ),
+    "authority.reason": (
+        "why this authority is the right one. Required for `unscoped` and "
+        "`ambient`; optional otherwise."
+    ),
+    "scopes": (
+        "the exact permission strings this action is granted, one per line. "
+        "Required and non-empty for `mode: scoped`; must be empty (delete "
+        "this block) for every other mode."
+    ),
+    "root.object": (
+        "the agent's declared name — what `Agent(name=…)` was given, not the "
+        "Python variable it was assigned to."
+    ),
+    "root.source_id": "the shipgate.yaml#tool_sources[].id that defines it.",
+    "declarations.complete": (
+        "`true`, and only once you have checked that the tools listed below "
+        "are the COMPLETE set this agent can reach — delete any it cannot. "
+        "This is the closed-world assertion: the list was read off the "
+        "catalog, the claim is yours."
+    ),
+    "declarations.reason": (
+        "how you checked that tools list — the file and construct you read, "
+        "so the next reviewer can re-check it."
+    ),
+    "tool_inventories.path": (
+        "repo-relative path where you saved the reviewed inventory (for "
+        "example `inventories/tools.json`). Start from the skeleton written "
+        "next to report.json."
+    ),
+}
+
+# Enough candidates to choose from without turning the block into a listing.
+_MAX_RENDERED_CANDIDATES = 10
 
 
 def scaffold_for_report(report: ReadinessReport) -> str | None:
@@ -32,14 +108,25 @@ def scaffold_for_report(report: ReadinessReport) -> str | None:
     decision = report.release_decision
     if decision is None or decision.evidence_coverage is None:
         return None
-    return build_declaration_scaffold(decision.evidence_coverage.evidence_gaps)
+    return build_declaration_scaffold(
+        decision.evidence_coverage.evidence_gaps,
+        agents=report.binding_surface_facts.agents,
+    )
 
 
-def build_declaration_scaffold(gaps: Sequence[EvidenceGap]) -> str | None:
+def build_declaration_scaffold(
+    gaps: Sequence[EvidenceGap],
+    *,
+    agents: Sequence[AgentBindingNode] = (),
+) -> str | None:
     """Render the paste-ready scaffold, or ``None`` when nothing is owed.
 
     Deterministic: gaps are consumed in the order the decision engine emitted
     them, and templates aimed at the same manifest target are merged once.
+
+    ``agents`` is the binding graph's observed agent nodes. They are rendered
+    as commented candidates under an ``agent_bindings.root`` block — the value
+    the scan computed, offered for confirmation rather than asserted (#388).
     """
 
     # Group by the manifest path plus the subject the template is about, then
@@ -62,12 +149,14 @@ def build_declaration_scaffold(gaps: Sequence[EvidenceGap]) -> str | None:
             str(gap.subject or ""),
             str(template.get("tool_id") or template.get("tool") or ""),
         )
+        vocabulary = _vocabulary_for(action)
         existing = by_target.get(target)
         if existing is None:
             entry: dict[str, Any] = {
                 "path": path,
                 "kinds": [str(gap.kind)],
                 "template": dict(template),
+                "vocabulary": dict(vocabulary),
             }
             by_target[target] = entry
             sections.append(entry)
@@ -76,7 +165,10 @@ def build_declaration_scaffold(gaps: Sequence[EvidenceGap]) -> str | None:
             existing["kinds"].append(str(gap.kind))
         for key, value in template.items():
             existing["template"].setdefault(key, value)
+        for field, values in vocabulary.items():
+            existing["vocabulary"].setdefault(field, values)
 
+    sections = _drop_duplicate_blocks(sections)
     if not sections:
         return None
 
@@ -92,9 +184,10 @@ def build_declaration_scaffold(gaps: Sequence[EvidenceGap]) -> str | None:
         "# a tool's effect, its authority, or which object is the root agent, and",
         f"# a block still containing {REVIEW_REQUIRED_SENTINEL} closes nothing.",
         "#",
-        "# Some fields are co-required: `authority.mode: none` takes no",
-        "# `auth_type` and no `scopes`, while `scoped` requires both. Delete the",
-        "# lines your answer does not take.",
+        "# Every blank carries the values it accepts, or the shape its answer",
+        "# takes, on the comment line above it. Where a field is only required",
+        "# for some answers the comment says so — delete the lines your answer",
+        "# does not take.",
     ]
     for entry in sections:
         # Each block is its own YAML document. Concatenated mappings would
@@ -104,13 +197,257 @@ def build_declaration_scaffold(gaps: Sequence[EvidenceGap]) -> str | None:
         lines.append("---")
         lines.append(f"# closes: {', '.join(entry['kinds'])}")
         lines.append(f"# merge into: {entry['path']}")
-        # sort_keys=False keeps the engine's own field order, which reads the
-        # way the manifest is written (subject first, then the declaration).
-        rendered = yaml.safe_dump(
-            entry["template"], sort_keys=False, default_flow_style=False
+        _emit_mapping(
+            entry["template"],
+            path="",
+            depth=0,
+            vocabulary=entry["vocabulary"],
+            agents=agents,
+            out=lines,
         )
-        lines.append(rendered.rstrip("\n"))
     return "\n".join(lines) + "\n"
+
+
+def _vocabulary_for(action: Any) -> dict[str, list[str]]:
+    """The ``field -> accepted values`` this action publishes, if any."""
+
+    field = _VOCABULARY_FIELD_BY_ACTION_KIND.get(str(getattr(action, "kind", "")))
+    values = list(getattr(action, "accepted_values", ()) or ())
+    return {field: values} if field and values else {}
+
+
+def _drop_duplicate_blocks(sections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse blocks that would render identically at the same path.
+
+    One mechanism restated per subject produces one gap row per subject — six
+    unresolved ADK tool symbols are six ``source_warning`` rows — and each
+    carries the same repair. Keyed on the subject alone those are six identical
+    ``tool_inventories`` blocks to paste, which reads as six separate things to
+    do. Byte-identical content at one path is one instruction.
+    """
+
+    kept: list[dict[str, Any]] = []
+    seen: dict[tuple[str, str], dict[str, Any]] = {}
+    for entry in sections:
+        key = (entry["path"], json.dumps(entry["template"], sort_keys=True, default=str))
+        first = seen.get(key)
+        if first is None:
+            seen[key] = entry
+            kept.append(entry)
+            continue
+        for kind in entry["kinds"]:
+            if kind not in first["kinds"]:
+                first["kinds"].append(kind)
+        for field, values in entry["vocabulary"].items():
+            first["vocabulary"].setdefault(field, values)
+    return kept
+
+
+def _hint_for(path: str) -> str | None:
+    """The guidance registered for this template path, longest suffix first."""
+
+    parts = path.split(".")
+    for start in range(len(parts)):
+        hint = _FIELD_HINTS.get(".".join(parts[start:]))
+        if hint is not None:
+            return hint
+    return None
+
+
+def _annotate(
+    path: str,
+    depth: int,
+    vocabulary: dict[str, list[str]],
+    agents: Sequence[AgentBindingNode],
+    out: list[str],
+) -> None:
+    """Write the comment lines that belong above the value at ``path``."""
+
+    pad = "  " * depth
+    for line in _candidate_lines(path, agents):
+        out.append(f"{pad}# {line}")
+    hint = _hint_for(path)
+    if hint is not None:
+        out.extend(_wrapped_comment(hint, pad))
+    values = vocabulary.get(path)
+    if values:
+        out.extend(_wrapped_comment("accepted: " + " | ".join(values), pad))
+
+
+def _candidate_lines(
+    path: str, agents: Sequence[AgentBindingNode]
+) -> list[str]:
+    """Observed root-agent candidates, for a human to confirm.
+
+    Instance 1 of #388: the scan resolves the agent objects and then hands the
+    reader two blanks. Naming what it saw removes the guessing game without
+    filling anything in — inferring ``agent_bindings.root`` from AST evidence
+    is the self-declaration surface #268 closed, and this does not do that.
+    """
+
+    if not path.endswith("agent_bindings.root") or not agents:
+        return []
+    lines = [
+        "shipgate observed these agent objects — confirm one and fill it in:"
+    ]
+    # By name rather than by the graph's agent_id order: the reader is choosing
+    # between names, and an id-hash ordering looks arbitrary to them.
+    ordered = sorted(agents, key=lambda agent: (agent.name, agent.source_id or ""))
+    for agent in ordered[:_MAX_RENDERED_CANDIDATES]:
+        # ``display_literal`` because these are repository-controlled identity
+        # strings, and the caller writes them into a YAML `#` comment. An
+        # `Agent(name="...\nroot:\n  object: X")` would otherwise close the
+        # comment and render a *filled-in* root block for a reader to paste —
+        # a self-declaration the scaffold exists to refuse (#268). Injective,
+        # so the escape still names exactly one object.
+        name = display_literal(agent.name)
+        source = (
+            f", source_id: {display_literal(agent.source_id)}"
+            if agent.source_id
+            else ""
+        )
+        where = (
+            f"  ({display_literal(agent.source_ref)})" if agent.source_ref else ""
+        )
+        lines.append(f"    object: {name}{source}{where}")
+    remaining = len(agents) - _MAX_RENDERED_CANDIDATES
+    if remaining > 0:
+        lines.append(
+            f"    (+{remaining} more — see report.json "
+            "binding_surface_facts.agents)"
+        )
+    return lines
+
+
+def _wrapped_comment(text: str, pad: str) -> list[str]:
+    """``text`` as comment lines that stay inside a readable column."""
+
+    limit = 78
+    lines: list[str] = []
+    current = ""
+    for word in text.split():
+        candidate = f"{current} {word}".strip()
+        if current and len(pad) + 2 + len(candidate) > limit:
+            lines.append(f"{pad}# {current}")
+            current = word
+            continue
+        current = candidate
+    if current:
+        lines.append(f"{pad}# {current}")
+    return lines
+
+
+def _scalar(value: Any) -> str:
+    """``value`` as the one-line YAML scalar ``yaml.safe_dump`` would emit.
+
+    One line is the load-bearing part. ``safe_dump`` renders a string holding a
+    newline as a *multi-line* single-quoted scalar whose continuation lines it
+    indents relative to the key it is dumping — knowledge this emitter does not
+    have when it formats a leaf on its own, so pasting the result at depth 2
+    produced continuation lines indented less than their key. Tool names come
+    from repository JSON, so that is reachable input, not a hypothetical.
+
+    ``yaml_scalar`` is the escape hatch for exactly those: a JSON string is a
+    valid YAML double-quoted scalar, total over anything a loader can produce,
+    and always one line. Ordinary values never reach it, so the common
+    rendering stays byte-identical to ``safe_dump``.
+    """
+
+    text = yaml.safe_dump(
+        value, default_flow_style=True, sort_keys=False, width=1 << 30
+    ).strip()
+    if text.endswith("..."):
+        text = text[:-3].strip()
+    # Only a string can carry the newline that forces the multi-line form.
+    return yaml_scalar(value) if isinstance(value, str) and "\n" in text else text
+
+
+def _emit_mapping(
+    node: dict[str, Any],
+    *,
+    path: str,
+    depth: int,
+    vocabulary: dict[str, list[str]],
+    agents: Sequence[AgentBindingNode],
+    out: list[str],
+    first_prefix: str | None = None,
+) -> None:
+    """Render a mapping in the block layout ``yaml.safe_dump`` produces.
+
+    Hand-rolled because comments have to be interleaved and PyYAML has no way
+    to carry them. The layout is not a second opinion about YAML style: a test
+    asserts that stripping the comment lines back out yields exactly what
+    ``yaml.safe_dump`` writes for the same template, so the two cannot drift.
+
+    ``first_prefix`` is the ``- `` of an enclosing sequence item, which YAML
+    puts on the same line as the item's first key.
+    """
+
+    pad = "  " * depth
+    for index, (key, value) in enumerate(node.items()):
+        child = f"{path}.{key}" if path else str(key)
+        on_dash = index == 0 and first_prefix is not None
+        lead = first_prefix if on_dash else pad
+        # The dash line's own annotation belongs above the dash, at the
+        # sequence's indentation rather than the item's.
+        _annotate(child, depth - 1 if on_dash else depth, vocabulary, agents, out)
+        if isinstance(value, dict) and value:
+            out.append(f"{lead}{key}:")
+            _emit_mapping(
+                value,
+                path=child,
+                depth=depth + 1,
+                vocabulary=vocabulary,
+                agents=agents,
+                out=out,
+            )
+        elif isinstance(value, (list, tuple)):
+            if not value:
+                out.append(f"{lead}{key}: []")
+                continue
+            out.append(f"{lead}{key}:")
+            _emit_sequence(
+                value,
+                path=child,
+                depth=depth,
+                vocabulary=vocabulary,
+                agents=agents,
+                out=out,
+            )
+        else:
+            # An empty mapping renders through the same scalar path (`{}`).
+            out.append(f"{lead}{key}: {_scalar(value)}")
+
+
+def _emit_sequence(
+    items: Iterable[Any],
+    *,
+    path: str,
+    depth: int,
+    vocabulary: dict[str, list[str]],
+    agents: Sequence[AgentBindingNode],
+    out: list[str],
+) -> None:
+    """Render a sequence: dashes at the key's indent, content one deeper.
+
+    Scalar items carry no annotation of their own — the guidance for a list
+    (``scopes``) is about the list, and was already written above its key.
+    """
+
+    pad = "  " * depth
+    for item in items:
+        if isinstance(item, dict) and item:
+            _emit_mapping(
+                item,
+                path=path,
+                depth=depth + 1,
+                vocabulary=vocabulary,
+                agents=agents,
+                out=out,
+                first_prefix=f"{pad}- ",
+            )
+            continue
+        out.append(f"{pad}- {_scalar(item)}")
 
 
 __all__ = ["build_declaration_scaffold", "scaffold_for_report"]

--- a/src/agents_shipgate/cli/scan/declarations.py
+++ b/src/agents_shipgate/cli/scan/declarations.py
@@ -82,14 +82,21 @@ _FIELD_HINTS: dict[str, str] = {
     ),
     "root.source_id": "the shipgate.yaml#tool_sources[].id that defines it.",
     "declarations.complete": (
-        "`true`, and only once you have checked that the tools listed below "
-        "are the COMPLETE set this agent can reach — delete any it cannot. "
-        "This is the closed-world assertion: the list was read off the "
-        "catalog, the claim is yours."
+        "`true`, and only once you have checked BOTH lists below — the tools "
+        "and the handoffs. This one word closes the world over each of them: "
+        "add anything reachable that is missing (a dynamically wired tool, a "
+        "sub-agent nothing static names) and delete anything listed that this "
+        "agent cannot reach. Both lists were read off what was observed; the "
+        "claim that they are complete is yours."
     ),
     "declarations.reason": (
-        "how you checked that tools list — the file and construct you read, "
-        "so the next reviewer can re-check it."
+        "how you checked both lists — the files and constructs you read for "
+        "the tools AND for the handoffs, so the next reviewer can re-check "
+        "them."
+    ),
+    "declarations.handoffs": (
+        "every agent this one can hand off to, by name. Covered by "
+        "`complete:` above, so an agent missing here is asserted unreachable."
     ),
     "tool_inventories.path": (
         "repo-relative path where you saved the reviewed inventory (for "

--- a/src/agents_shipgate/cli/scan/tools_agent.py
+++ b/src/agents_shipgate/cli/scan/tools_agent.py
@@ -35,13 +35,19 @@ def _completed_source_ids(loaded_sources: list[LoadedToolSource]) -> set[str]:
     }
 
 
-def _adk_agent_source_ids(adk: GoogleAdkArtifacts | None) -> dict[str, str]:
-    """Agent name -> the configured source that published it.
+def _adk_agent_source_ids(adk: GoogleAdkArtifacts | None) -> dict[str, set[str]]:
+    """Agent name -> every configured source that published that name.
 
     The unresolved-symbol warning names the agent; only the artifact bag knows
-    which source that agent was read from. A name two sources both publish is
-    dropped rather than guessed — withdrawing a warning against the wrong
-    source would clear a diagnostic nobody answered.
+    which source that agent was read from. The whole set is kept rather than
+    collapsed to a unique one: two sources publishing ``LlmAgent(name="Closer")``
+    are ambiguous only while *some* of them is still incomplete. Once every
+    candidate has a reviewed inventory, the warning is answered whichever one
+    raised it, and dropping the name kept it standing forever (PR #401 review).
+
+    Ids are stripped, because the completion side is: the manifest permits
+    surrounding whitespace, so ``' adk '`` on one side and ``'adk'`` on the
+    other compared unequal and left an answered warning in place.
     """
 
     if adk is None:
@@ -49,11 +55,9 @@ def _adk_agent_source_ids(adk: GoogleAdkArtifacts | None) -> dict[str, str]:
     by_name: dict[str, set[str]] = {}
     for agent in adk.agents:
         name, source_id = agent.get("name"), agent.get("source_id")
-        if isinstance(name, str) and isinstance(source_id, str):
-            by_name.setdefault(name, set()).add(source_id)
-    return {
-        name: next(iter(ids)) for name, ids in by_name.items() if len(ids) == 1
-    }
+        if isinstance(name, str) and isinstance(source_id, str) and source_id.strip():
+            by_name.setdefault(name, set()).add(source_id.strip())
+    return by_name
 
 
 def _build_tools_and_agent(

--- a/src/agents_shipgate/cli/scan/tools_agent.py
+++ b/src/agents_shipgate/cli/scan/tools_agent.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import logging
 
 from agents_shipgate.core.agent_bindings import resolve_agent_binding_graph
+from agents_shipgate.core.domain import LoadedToolSource
 from agents_shipgate.core.risk_hints import enrich_tools_with_risk_hints
 from agents_shipgate.core.semantic_assessment import attach_semantic_assessments
+from agents_shipgate.core.source_warnings import withdraw_completed_adk_tool_warnings
 from agents_shipgate.core.tool_identity import resolve_selectors_by_tool_id
+from agents_shipgate.inputs.google_adk import GoogleAdkArtifacts
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
 
 from .agent_builder import _build_agent
@@ -13,6 +16,44 @@ from .models import _LoadedInputs, _ToolsAndAgent
 from .source_loading import _build_canonical_tools
 
 logger = logging.getLogger(__name__)
+
+
+def _completed_source_ids(loaded_sources: list[LoadedToolSource]) -> set[str]:
+    """Source ids a reviewed inventory declares it completes.
+
+    ``completes_source_id`` is the desugared form of
+    ``<framework>.tool_inventories[].source_id`` — a human declaration in the
+    trust root, not an inference. Entries naming a source that is not
+    configured are reported separately (``unknown_inventory_source_warning``)
+    and cannot appear here, so this cannot be pointed at an arbitrary id.
+    """
+
+    return {
+        completes.strip()
+        for loaded in loaded_sources
+        if (completes := (loaded.completes_source_id or "").strip())
+    }
+
+
+def _adk_agent_source_ids(adk: GoogleAdkArtifacts | None) -> dict[str, str]:
+    """Agent name -> the configured source that published it.
+
+    The unresolved-symbol warning names the agent; only the artifact bag knows
+    which source that agent was read from. A name two sources both publish is
+    dropped rather than guessed — withdrawing a warning against the wrong
+    source would clear a diagnostic nobody answered.
+    """
+
+    if adk is None:
+        return {}
+    by_name: dict[str, set[str]] = {}
+    for agent in adk.agents:
+        name, source_id = agent.get("name"), agent.get("source_id")
+        if isinstance(name, str) and isinstance(source_id, str):
+            by_name.setdefault(name, set()).add(source_id)
+    return {
+        name: next(iter(ids)) for name, ids in by_name.items() if len(ids) == 1
+    }
 
 
 def _build_tools_and_agent(
@@ -43,6 +84,15 @@ def _build_tools_and_agent(
     # Some adapters expose the same warnings through both LoadedToolSource
     # and the artifact bag; keep report warning output stable and unique.
     warnings = list(dict.fromkeys(warnings))
+    # The one place holding both halves of the completion relationship: the
+    # loaded sources know which inventory completes which source, and the ADK
+    # artifacts know which source each agent came from. A warning asking for
+    # evidence the manifest now declares is answered, and must stop gating.
+    warnings = withdraw_completed_adk_tool_warnings(
+        warnings,
+        agent_source_ids=_adk_agent_source_ids(inputs.adk),
+        completed_source_ids=_completed_source_ids(inputs.loaded_sources),
+    )
     tool_catalog = enrich_tools_with_risk_hints(manifest, tools)
     binding_graph, tool_catalog = resolve_agent_binding_graph(
         manifest,

--- a/src/agents_shipgate/cli/scan/writing.py
+++ b/src/agents_shipgate/cli/scan/writing.py
@@ -9,6 +9,8 @@ from agents_shipgate.ci.release_decision import (
     SUGGESTED_DECLARATIONS_FILENAME,
     SUGGESTED_INVENTORY_FILENAME,
     inventory_manifest_key,
+    unresolved_symbol_names,
+    unresolved_symbol_sources,
 )
 from agents_shipgate.cli._artifact_lifecycle import clear_verifier_route_artifacts
 from agents_shipgate.core.current_control import (
@@ -78,6 +80,7 @@ def _write_outputs(
     )
     _write_suggested_inventory(
         sanitized_tools=sanitized.tools,
+        report=public_report,
         generated_paths=plan.generated_paths,
     )
     _write_suggested_declarations(
@@ -174,16 +177,23 @@ def _write_suggested_declarations(
     if scaffold is None:
         # Nothing is owed any more: a leftover scaffold from an earlier run
         # would keep asking for declarations that are already made.
-        if out_path.is_file():
-            try:
-                out_path.unlink()
-            except OSError:
-                pass
+        _remove_if_present(out_path)
         return
     out_path.write_text(scaffold, encoding="utf-8")
 
 
-def _inventory_reference_note(low_confidence: list[Tool]) -> str:
+def _remove_if_present(path: Path) -> None:
+    """Drop a superseded advisory artifact, tolerating a read-only directory."""
+
+    if not path.is_file():
+        return
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+def _inventory_reference_note(bindable: list[tuple[str, str]]) -> str:
     """How to reference this skeleton, for the sources that produced it.
 
     Only the framework blocks in ``_INVENTORY_MANIFEST_KEYS`` have a
@@ -197,16 +207,12 @@ def _inventory_reference_note(low_confidence: list[Tool]) -> str:
     An inventory entry completes ONE source, so a skeleton spanning several
     says to split it rather than letting the reader find that out from an
     ambiguity warning two runs later.
+
+    ``bindable`` is the ``(manifest key, source_id)`` pairs the skeleton's
+    entries came from — the low-confidence tools' own sources, plus any source
+    whose agent named symbols that produced no observation at all (#361).
     """
 
-    bindable = sorted(
-        {
-            (key, tool.source_id)
-            for tool in low_confidence
-            if tool.source_id
-            and (key := inventory_manifest_key(tool.source_type)) is not None
-        }
-    )
     if not bindable:
         return (
             "declare it for this source — as a `tool_sources[]` entry of type "
@@ -237,17 +243,20 @@ def _inventory_reference_note(low_confidence: list[Tool]) -> str:
 def _write_suggested_inventory(
     *,
     sanitized_tools: list[Tool],
+    report: ReadinessReport,
     generated_paths: dict[str, Path],
 ) -> None:
-    """v0.26: advisory tool-inventory skeleton for low-confidence sources.
+    """v0.26: advisory tool-inventory skeleton for under-enumerated sources.
 
-    Written next to report.json whenever low-confidence tools exist, in
+    Written next to report.json whenever low-confidence tools exist — or an
+    agent references tool symbols that produced no observation at all — in
     the MCP-export shape every ``tool_inventories`` manifest key loads
     (``load_mcp_tools`` ignores the top-level ``note``). The
     ``evidence_gaps`` rows in ``release_decision.evidence_coverage``
     reference this file by name. Consumes only sanitized tools so no
-    redacted content can leak into the skeleton. Deterministic: sorted
-    by (name, source_type), stable JSON.
+    redacted content can leak into the skeleton. Deterministic: observed
+    tools by (name, source_type), then unresolved symbols by name, stable
+    JSON.
     """
     anchor = generated_paths.get("json") or next(
         iter(generated_paths.values()), None
@@ -258,7 +267,19 @@ def _write_suggested_inventory(
         (tool for tool in sanitized_tools if tool.extraction_confidence != "high"),
         key=lambda tool: (tool.name, tool.source_type),
     )
-    if not low_confidence:
+    # The repository whose first scan is hardest to move is the one where
+    # *every* tool symbol is imported: extraction yields nothing, so there are
+    # no low-confidence tools, so no skeleton was written and the names the
+    # agent's ``tools=[...]`` list already published were left to be retyped by
+    # hand (#361). A symbol is a *name to review*, never an observation: it may
+    # name one tool or a toolset exposing many, and its schema is unknown
+    # either way — the entry below says so, and nothing here enters the catalog.
+    unresolved = unresolved_symbol_names(report)
+    if not low_confidence and not unresolved:
+        # Nothing is owed any more — the same rule the declaration scaffold
+        # follows. A skeleton left behind from the run before the inventory was
+        # declared reads as a fresh instruction to declare it again.
+        _remove_if_present(anchor.parent / SUGGESTED_INVENTORY_FILENAME)
         return
     entries = []
     for tool in low_confidence:
@@ -270,12 +291,36 @@ def _write_suggested_inventory(
         if tool.input_schema:
             entry["input_schema"] = tool.input_schema
         entries.append(entry)
+    entries.extend(
+        {
+            "name": symbol,
+            "description": (
+                "TODO: static analysis could not resolve this symbol, so this "
+                "name is the one the agent's tools=[...] list uses — confirm "
+                "it is the tool's real name, and split the entry if the "
+                "symbol is a toolset exposing several tools."
+            ),
+        }
+        for symbol in unresolved
+    )
+    bindable = sorted(
+        {
+            (key, tool.source_id)
+            for tool in low_confidence
+            if tool.source_id
+            and (key := inventory_manifest_key(tool.source_type)) is not None
+        }
+        | {
+            (source.manifest_key, source.source_id)
+            for source in unresolved_symbol_sources(report)
+        }
+    )
     payload = {
         "note": (
             "Skeleton tool inventory generated by agents-shipgate scan for "
             "sources static extraction could not fully enumerate. Review and "
             "complete each entry, save the file in your repo, and "
-            f"{_inventory_reference_note(low_confidence)} (see "
+            f"{_inventory_reference_note(bindable)} (see "
             "release_decision.evidence_coverage.evidence_gaps)."
         ),
         "tools": entries,

--- a/src/agents_shipgate/core/evidence_actions.py
+++ b/src/agents_shipgate/core/evidence_actions.py
@@ -81,6 +81,23 @@ def _is_default_ignorable(char: str) -> bool:
     return any(start <= point <= end for start, end in _DEFAULT_IGNORABLE_RANGES)
 
 
+def _is_noncharacter(char: str) -> bool:
+    """True for a Unicode noncharacter — permanently reserved, never rendered.
+
+    Same hazard as a Default_Ignorable code point: nothing reaches the reader,
+    so two different repository objects render identically. Two of them are
+    worse than invisible. PyYAML's reader accepts ``[#xE000-#xFFFD]`` and
+    *rejects* U+FFFE and U+FFFF outright, so an agent name carrying one made
+    the generated declaration scaffold unparseable — the document quoting the
+    name in a comment could not be loaded at all (PR #401 review). Escaping
+    them here fixes every sink at once rather than one file's comment writer,
+    and ``undisplay_literal`` still inverts it.
+    """
+
+    point = ord(char)
+    return 0xFDD0 <= point <= 0xFDEF or (point & 0xFFFE) == 0xFFFE
+
+
 def _escape(char: str) -> str:
     return f"<U+{ord(char):04X}>"
 
@@ -94,7 +111,8 @@ def _needs_escape(char: str, *, injective: bool) -> bool:
 
     Three classes always: characters that could end or reorder a line;
     characters that render as nothing, and so let one value impersonate
-    another; and lone surrogates, which no UTF-8 sink accepts.
+    another — Default_Ignorable code points and Unicode noncharacters alike;
+    and lone surrogates, which no UTF-8 sink accepts.
 
     ``injective`` adds the escape introducer. Identity-bearing values need it —
     without it ``a\nb.yaml`` and the literal filename ``a<U+000A>b.yaml``
@@ -109,6 +127,7 @@ def _needs_escape(char: str, *, injective: bool) -> bool:
         or char in _BIDI_CONTROLS
         or char in {"\u2028", "\u2029"}
         or _is_default_ignorable(char)
+        or _is_noncharacter(char)
     )
 
 

--- a/src/agents_shipgate/core/findings/report_builder.py
+++ b/src/agents_shipgate/core/findings/report_builder.py
@@ -119,6 +119,7 @@ def build_report(
     report.release_decision = build_release_decision(
         report=report,
         tools=tools,
+        tool_catalog=tool_catalog if tool_catalog is not None else tools,
         ci_mode=ci_mode,
         fail_on=fail_on,
         new_findings_only=new_findings_only,

--- a/src/agents_shipgate/core/source_warnings.py
+++ b/src/agents_shipgate/core/source_warnings.py
@@ -11,11 +11,18 @@ clears all six at once. This module holds both halves of that:
   into one line naming the cause, the fix, and the affected subjects.
 
 Grouping is **render time only**. ``report.source_warnings`` and
-``evidence_coverage.source_warning_count`` stay exactly as the loaders
-produced them, because that count is a gating input
-(``evidence_below_ie_threshold``) and folding it would silently recalibrate
-the ``insufficient_evidence`` threshold. Rendered surfaces show mechanisms;
-the JSON keeps warnings.
+``evidence_coverage.source_warning_count`` are never folded, because that
+count is a gating input (``evidence_below_ie_threshold``) and collapsing six
+restatements into one would silently recalibrate the
+``insufficient_evidence`` threshold. Rendered surfaces show mechanisms; the
+JSON keeps warnings.
+
+:func:`withdraw_completed_adk_tool_warnings` is the one thing that removes a
+row, and it is not folding: it drops a warning whose *prescribed repair has
+been made* — a reviewed inventory declared against the source the warning is
+about. A question the manifest has answered is not an open diagnostic, and
+leaving it counted made the route shipgate itself prescribes unreachable.
+Nothing about how many ways one mechanism was restated changes.
 
 Three rules keep grouping from inventing facts:
 
@@ -46,7 +53,7 @@ from __future__ import annotations
 
 import ast
 import hashlib
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass, field
 
 from agents_shipgate.core.evidence_actions import (
@@ -621,6 +628,46 @@ def unresolved_adk_tool_symbols(
     return found
 
 
+def withdraw_completed_adk_tool_warnings(
+    warnings: Sequence[str],
+    *,
+    agent_source_ids: Mapping[str, str],
+    completed_source_ids: Collection[str],
+) -> list[str]:
+    """Drop unresolved-symbol warnings for a source a human has since declared.
+
+    The warning asks one question: *this entrypoint's tool surface cannot be
+    enumerated from source, supply it.* A reviewed ``tool_inventories`` entry
+    naming the source in ``source_id`` is the answer shipgate itself
+    prescribes, and it is a human declaration in the trust root. Leaving the
+    warning standing after that answer made the prescribed route unreachable:
+    the count still crosses ``_MAX_TOLERATED_SOURCE_WARNINGS``, so a repository
+    that did exactly what it was told stayed ``insufficient_evidence`` forever
+    (PR #401 review).
+
+    Withdrawal is **per source**, keyed on the reviewed completion
+    relationship, never on tool names. Name matching failed both ways: an
+    unrelated source exposing a same-named tool read as a repair that had not
+    happened, and an inventory that correctly split a toolset symbol into the
+    tools it exposes never matched the symbol at all, so its source was
+    prescribed the same inventory forever.
+
+    Only the *warning* is withdrawn. The loader's ``surface_gaps`` entry stays,
+    so nothing here claims static analysis resolved what it could not, and
+    extraction confidence is untouched.
+    """
+
+    if not completed_source_ids:
+        return list(warnings)
+    completed = set(completed_source_ids)
+    withdrawn = {
+        adk_unresolved_tool_warning(agent, symbol)
+        for agent, symbol in unresolved_adk_tool_symbols(warnings)
+        if agent_source_ids.get(agent) in completed
+    }
+    return [warning for warning in warnings if warning not in withdrawn]
+
+
 __all__ = [
     "SourceWarningGroup",
     "visible_skeleton",
@@ -634,5 +681,6 @@ __all__ = [
     "unknown_inventory_source_warning",
     "unmatched_binding_member",
     "unresolved_adk_tool_symbols",
+    "withdraw_completed_adk_tool_warnings",
     "zero_observation_binding_member",
 ]

--- a/src/agents_shipgate/core/source_warnings.py
+++ b/src/agents_shipgate/core/source_warnings.py
@@ -631,7 +631,7 @@ def unresolved_adk_tool_symbols(
 def withdraw_completed_adk_tool_warnings(
     warnings: Sequence[str],
     *,
-    agent_source_ids: Mapping[str, str],
+    agent_source_ids: Mapping[str, Collection[str]],
     completed_source_ids: Collection[str],
 ) -> list[str]:
     """Drop unresolved-symbol warnings for a source a human has since declared.
@@ -652,6 +652,13 @@ def withdraw_completed_adk_tool_warnings(
     tools it exposes never matched the symbol at all, so its source was
     prescribed the same inventory forever.
 
+    ``agent_source_ids`` maps a name to *every* source that publishes it, and a
+    warning is withdrawn only when they are **all** complete. A display name
+    two sources share is ambiguous about which of them raised the warning, but
+    that ambiguity stops mattering once none of the candidates is still owed
+    anything — dropping such a name outright left an answered warning standing
+    forever (PR #401 review).
+
     Only the *warning* is withdrawn. The loader's ``surface_gaps`` entry stays,
     so nothing here claims static analysis resolved what it could not, and
     extraction confidence is untouched.
@@ -663,7 +670,7 @@ def withdraw_completed_adk_tool_warnings(
     withdrawn = {
         adk_unresolved_tool_warning(agent, symbol)
         for agent, symbol in unresolved_adk_tool_symbols(warnings)
-        if agent_source_ids.get(agent) in completed
+        if (candidates := agent_source_ids.get(agent)) and completed.issuperset(candidates)
     }
     return [warning for warning in warnings if warning not in withdrawn]
 

--- a/src/agents_shipgate/core/source_warnings.py
+++ b/src/agents_shipgate/core/source_warnings.py
@@ -591,6 +591,36 @@ _MECHANISMS: tuple[_Mechanism, ...] = (
 )
 
 
+def unresolved_adk_tool_symbols(
+    warnings: Sequence[str],
+) -> list[tuple[str, str]]:
+    """``(agent, symbol)`` for every ADK unresolved-tool warning, in order.
+
+    The names an ADK entrypoint lists in ``tools=[...]`` but static analysis
+    cannot resolve exist nowhere else in the report: the loader records the
+    *reason* as a surface gap and the *names* only in this prose. Both halves
+    of that prose live in this module, so decoding it here is reading back what
+    :func:`adk_unresolved_tool_warning` wrote — the same exact, repr-delimited
+    decode :func:`group_source_warnings` already relies on, never a regex over
+    loader text.
+
+    Callers use it to scaffold the repair those names are the input to: the
+    reviewed inventory that gives the agent an enumerable tool surface (#361).
+    A warning that does not decode as this mechanism contributes nothing.
+    """
+
+    found: list[tuple[str, str]] = []
+    for warning in warnings:
+        match = _match(warning)
+        if match is None or match[0] is not _ADK_UNRESOLVED_TOOL:
+            continue
+        fields = match[1]
+        pair = (fields["agent"], fields["symbol"])
+        if pair not in found:
+            found.append(pair)
+    return found
+
+
 __all__ = [
     "SourceWarningGroup",
     "visible_skeleton",
@@ -603,5 +633,6 @@ __all__ = [
     "unbound_inventory_duplicate_warning",
     "unknown_inventory_source_warning",
     "unmatched_binding_member",
+    "unresolved_adk_tool_symbols",
     "zero_observation_binding_member",
 ]

--- a/src/agents_shipgate/schemas/manifest/root.py
+++ b/src/agents_shipgate/schemas/manifest/root.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field, model_validator
 
 from agents_shipgate.schemas.common import Severity
@@ -59,6 +61,19 @@ def _sentinel_paths(node: object, path: str = "") -> list[str]:
     return []
 
 
+def _unfilled_sentinel_error(unfilled: list[str]) -> ValueError:
+    """One wording for the placeholder rejection, whenever it is detected."""
+
+    listed = ", ".join(unfilled[:5])
+    more = f" (+{len(unfilled) - 5} more)" if len(unfilled) > 5 else ""
+    return ValueError(
+        f"{REVIEW_REQUIRED_SENTINEL} is an unfilled scaffold placeholder "
+        f"and is not reviewed evidence: {listed}{more}. Replace each one "
+        "with a reviewed value, or delete the field if your answer does "
+        "not take it."
+    )
+
+
 class AgentsShipgateManifest(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
@@ -92,6 +107,25 @@ class AgentsShipgateManifest(BaseModel):
     # itself a trust-root change (SHIP-VERIFY-TRUST-ROOT-TOUCHED).
     human_ack: list[HumanAckDeclaration] = Field(default_factory=list)
 
+    @model_validator(mode="before")
+    @classmethod
+    def reject_raw_review_sentinels(cls, data: Any) -> Any:
+        """Catch a placeholder before the field it landed in rejects it first.
+
+        The after-validator below can only see values that already parsed, so a
+        sentinel in a *typed* field never reached it: pasting the binding
+        scaffold with ``complete: <REVIEW_REQUIRED>`` — where the schema accepts
+        only ``true`` — failed with "Input should be True", which does not tell
+        the reader they pasted an unfinished scaffold. Reading the raw input
+        first makes one wording cover every field, whatever its type.
+        """
+
+        if isinstance(data, dict):
+            unfilled = sorted(_sentinel_paths(data))
+            if unfilled:
+                raise _unfilled_sentinel_error(unfilled)
+        return data
+
     @model_validator(mode="after")
     def reject_unfilled_review_sentinels(self) -> AgentsShipgateManifest:
         """A scaffold placeholder must never read as reviewed evidence.
@@ -108,14 +142,7 @@ class AgentsShipgateManifest(BaseModel):
 
         unfilled = sorted(_sentinel_paths(self.model_dump(mode="python")))
         if unfilled:
-            listed = ", ".join(unfilled[:5])
-            more = f" (+{len(unfilled) - 5} more)" if len(unfilled) > 5 else ""
-            raise ValueError(
-                f"{REVIEW_REQUIRED_SENTINEL} is an unfilled scaffold placeholder "
-                f"and is not reviewed evidence: {listed}{more}. Replace each one "
-                "with a reviewed value, or delete the field if your answer does "
-                "not take it."
-            )
+            raise _unfilled_sentinel_error(unfilled)
         return self
 
     @model_validator(mode="after")

--- a/src/agents_shipgate/schemas/manifest/root.py
+++ b/src/agents_shipgate/schemas/manifest/root.py
@@ -41,20 +41,39 @@ from agents_shipgate.schemas.manifest.validation import ValidationConfig
 REVIEW_REQUIRED_SENTINEL = "<REVIEW_REQUIRED>"
 
 
-def _sentinel_paths(node: object, path: str = "") -> list[str]:
-    """Dotted paths of every unfilled scaffold placeholder in a manifest."""
+def _sentinel_paths(
+    node: object, path: str = "", _open: frozenset[int] = frozenset()
+) -> list[str]:
+    """Dotted paths of every unfilled scaffold placeholder in a manifest.
 
+    Cycle-safe, because this now also walks *raw* input. ``yaml.safe_load``
+    preserves recursive aliases, so a syntactically valid manifest such as
+    ``bogus: &loop {x: *loop}`` hands the before-validator a self-referential
+    dict; an unguarded walk raised ``RecursionError`` and replaced the
+    structured config error — and the agent-mode recovery payload that goes
+    with it — with a stack overflow (PR #401 review). A container already open
+    on this branch is not descended again: it can hold no placeholder its first
+    visit did not already report.
+    """
+
+    if isinstance(node, (dict, list, tuple)):
+        marker = id(node)
+        if marker in _open:
+            return []
+        _open = _open | {marker}
     if isinstance(node, dict):
         return [
             found
             for key, value in node.items()
-            for found in _sentinel_paths(value, f"{path}.{key}" if path else str(key))
+            for found in _sentinel_paths(
+                value, f"{path}.{key}" if path else str(key), _open
+            )
         ]
     if isinstance(node, (list, tuple)):
         return [
             found
             for index, value in enumerate(node)
-            for found in _sentinel_paths(value, f"{path}[{index}]")
+            for found in _sentinel_paths(value, f"{path}[{index}]", _open)
         ]
     if isinstance(node, str) and node.strip() == REVIEW_REQUIRED_SENTINEL:
         return [path or "<root>"]

--- a/src/agents_shipgate/schemas/manifest/root.py
+++ b/src/agents_shipgate/schemas/manifest/root.py
@@ -42,38 +42,49 @@ REVIEW_REQUIRED_SENTINEL = "<REVIEW_REQUIRED>"
 
 
 def _sentinel_paths(
-    node: object, path: str = "", _open: frozenset[int] = frozenset()
+    node: object, path: str = "", _seen: set[int] | None = None
 ) -> list[str]:
     """Dotted paths of every unfilled scaffold placeholder in a manifest.
 
-    Cycle-safe, because this now also walks *raw* input. ``yaml.safe_load``
-    preserves recursive aliases, so a syntactically valid manifest such as
-    ``bogus: &loop {x: *loop}`` hands the before-validator a self-referential
-    dict; an unguarded walk raised ``RecursionError`` and replaced the
-    structured config error — and the agent-mode recovery payload that goes
-    with it — with a stack overflow (PR #401 review). A container already open
-    on this branch is not descended again: it can hold no placeholder its first
-    visit did not already report.
+    Alias-safe, because this now also walks *raw* input. ``yaml.safe_load``
+    preserves aliases, so a syntactically valid manifest hands the
+    before-validator a graph rather than a tree.
+
+    ``_seen`` is **traversal-wide**, not per branch, and both halves of that
+    matter. A per-branch set stops a true cycle (``&loop {x: *loop}``) from
+    recursing forever, but leaves an acyclic *DAG* — repeated
+    ``{left: *prev, right: *prev}`` — visited once per path: 20 levels of it is
+    1.5 KB of YAML and over a second of work, doubling every level, and a
+    placeholder at the shared leaf materializes 2**n path strings before the
+    error is built (PR #401 review). Visiting each container once bounds the
+    walk by the size of the document.
+
+    The cost is that an aliased placeholder is reported at one representative
+    path instead of all of them, which is all rejecting it needs. No
+    placeholder is missed: a container skipped here was already fully walked
+    where it was first reached.
     """
 
+    if _seen is None:
+        _seen = set()
     if isinstance(node, (dict, list, tuple)):
         marker = id(node)
-        if marker in _open:
+        if marker in _seen:
             return []
-        _open = _open | {marker}
+        _seen.add(marker)
     if isinstance(node, dict):
         return [
             found
             for key, value in node.items()
             for found in _sentinel_paths(
-                value, f"{path}.{key}" if path else str(key), _open
+                value, f"{path}.{key}" if path else str(key), _seen
             )
         ]
     if isinstance(node, (list, tuple)):
         return [
             found
             for index, value in enumerate(node)
-            for found in _sentinel_paths(value, f"{path}[{index}]", _open)
+            for found in _sentinel_paths(value, f"{path}[{index}]", _seen)
         ]
     if isinstance(node, str) and node.strip() == REVIEW_REQUIRED_SENTINEL:
         return [path or "<root>"]

--- a/tests/test_declaration_scaffold.py
+++ b/tests/test_declaration_scaffold.py
@@ -800,6 +800,48 @@ def test_cold_start_walk_scaffolds_both_layers_in_two_iterations(tmp_path) -> No
         _COLD_START_TOOLS
     )
 
+    # --- and the route it advertises actually terminates ---------------------
+    # The prescribed repair used to be unreachable: the unresolved-import
+    # warnings stayed on the report after the inventory answered them, and
+    # `evidence_below_ie_threshold` gates on their raw count, so a repository
+    # that did exactly what it was told sat at `insufficient_evidence` forever
+    # with no non-warning gap left to act on (PR #401 review).
+    assert stage3.release_decision.evidence_coverage.source_warning_count == 0
+
+    manifest.write_text(
+        manifest.read_text()
+        + yaml.safe_dump(
+            {
+                "action_surface": {
+                    "actions": [
+                        {
+                            "tool": name,
+                            "effect": "read",
+                            "authority": {"mode": "none"},
+                        }
+                        for name in sorted(_COLD_START_TOOLS)
+                    ]
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    final = _scan_cold_start(project, reports)
+    assert final.release_decision is not None
+    coverage = final.release_decision.evidence_coverage
+    assert coverage.semantic_coverage.gap_count == 0
+    assert coverage.binding_coverage.gap_count == 0
+    assert coverage.source_warning_count == 0
+    # Whatever the verdict now turns on, it is a judgement about the declared
+    # surface — never the abstention the walk started in.
+    remaining = {gap.kind for gap in coverage.evidence_gaps}
+    assert "source_warning" not in remaining
+    assert all(
+        gap.next_action.path or gap.next_action.command
+        for gap in coverage.evidence_gaps
+    ), "a terminal verdict must leave nothing that cannot be acted on"
+
 
 def test_binding_scaffold_is_withheld_rather_than_truncated(tmp_path) -> None:
     """A closed-world list cut at N would be false where nobody can see it.
@@ -1048,3 +1090,339 @@ def test_repository_controlled_text_cannot_forge_a_line_in_the_scaffold() -> Non
     )
     assert rendered is not None
     assert yaml.safe_load(rendered) == hostile_row
+
+
+# --- PR #401 review: completion is per source, never per tool name -----------
+
+
+def _adk_project(
+    root: Path,
+    name: str,
+    *,
+    symbols: tuple[str, ...],
+    manifest_tail: str = "",
+) -> Path:
+    """An ADK agent whose ``tools=[...]`` entries are all imported symbols."""
+
+    project = root / name
+    project.mkdir()
+    (project / "agent.py").write_text(
+        "from google.adk.agents import LlmAgent\n\n"
+        "from .tools import (\n"
+        + "".join(f"    {symbol},\n" for symbol in symbols)
+        + ")\n\n"
+        "root_agent = LlmAgent(\n"
+        '    name="Closer",\n'
+        '    instruction="Close deals.",\n'
+        "    tools=[\n"
+        + "".join(f"        {symbol},\n" for symbol in symbols)
+        + "    ],\n)\n",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        'version: "0.1"\n'
+        f"project:\n  name: {name}\n"
+        "agent:\n  name: Closer\n  declared_purpose: [close opportunities]\n"
+        "environment:\n  target: local\n"
+        "tool_sources:\n  - id: adk_agent\n    type: google_adk\n    path: agent.py\n"
+        + manifest_tail,
+        encoding="utf-8",
+    )
+    return project
+
+
+def _inventory(project: Path, names: tuple[str, ...]) -> None:
+    (project / "inventories").mkdir(exist_ok=True)
+    (project / "inventories" / "tools.json").write_text(
+        json.dumps(
+            {"tools": [{"name": name, "description": f"reviewed {name}"} for name in names]}
+        ),
+        encoding="utf-8",
+    )
+
+
+def _open_symbols(report) -> set[str]:
+    from agents_shipgate.ci.release_decision import unresolved_symbol_names
+
+    return set(unresolved_symbol_names(report))
+
+
+def test_a_split_toolset_inventory_is_not_prescribed_forever(tmp_path) -> None:
+    """Completion is the reviewed `source_id`, not a name that happens to match.
+
+    The skeleton tells the reader to split a toolset symbol into the tools it
+    exposes, so following the instruction guarantees the symbol name never
+    appears in the inventory. Subtracting a catalog-wide name set therefore
+    re-prescribed the same inventory on every later run, forever (PR #401
+    review).
+    """
+
+    project = _adk_project(
+        tmp_path,
+        "split",
+        symbols=("search_toolset",),
+        manifest_tail=(
+            "google_adk:\n  tool_inventories:\n"
+            "  - path: inventories/tools.json\n    source_id: adk_agent\n"
+        ),
+    )
+    _inventory(project, ("web_search", "document_search"))
+    report = _scan_cold_start(project, tmp_path / "reports")
+
+    assert {row["name"] for row in report.tool_catalog} == {
+        "web_search",
+        "document_search",
+    }
+    # The symbol is nowhere in the inventory, and the repair is still complete.
+    assert _open_symbols(report) == set()
+    assert report.release_decision is not None
+    assert report.release_decision.evidence_coverage.source_warning_count == 0
+    assert not (tmp_path / "reports" / "suggested-inventory.json").exists()
+
+
+def test_a_same_named_tool_elsewhere_does_not_complete_this_source(tmp_path) -> None:
+    """Another source exposing the name is a coincidence, not a repair.
+
+    Under a catalog-wide name subtraction, an unrelated MCP server exposing
+    `search` silently cleared the ADK source's unresolved `search` — a repair
+    nobody had made (PR #401 review).
+    """
+
+    project = _adk_project(
+        tmp_path,
+        "crosssource",
+        symbols=("search",),
+        manifest_tail="  - id: other_mcp\n    type: mcp\n    path: mcp-tools.json\n",
+    )
+    (project / "mcp-tools.json").write_text(
+        json.dumps(
+            {
+                "tools": [
+                    {
+                        "name": "search",
+                        "description": "an unrelated server's search",
+                        "inputSchema": {"type": "object", "properties": {}},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    report = _scan_cold_start(project, tmp_path / "reports")
+
+    assert "search" in {row["name"] for row in report.tool_catalog}
+    # Still owed: nothing declared anything about the ADK source.
+    assert _open_symbols(report) == {"search"}
+    assert report.release_decision is not None
+    assert report.release_decision.evidence_coverage.source_warning_count == 1
+
+
+def test_withdrawal_needs_a_declared_surface_not_just_a_bound_file(tmp_path) -> None:
+    """Silencing the warnings cannot be a shortcut to a verdict.
+
+    Withdrawal is licensed by a reviewed inventory naming the source, so the
+    cheapest abuse is an *empty* one. The enumerability check is what stops it
+    reaching `passed`, and this pins that the two are independent.
+    """
+
+    project = _adk_project(
+        tmp_path,
+        "empty",
+        symbols=("create_quote", "send_quote_email"),
+        manifest_tail=(
+            "google_adk:\n  tool_inventories:\n"
+            "  - path: inventories/tools.json\n    source_id: adk_agent\n"
+        ),
+    )
+    _inventory(project, ())
+    report = _scan_cold_start(project, tmp_path / "reports")
+
+    assert report.release_decision is not None
+    assert report.release_decision.decision != "passed"
+    assert "SHIP-INVENTORY-NOT-ENUMERABLE" in {
+        finding.check_id for finding in report.findings
+    }
+
+
+def test_withdrawal_is_scoped_to_the_completed_source() -> None:
+    """Two ADK sources, one declared: only that one's warnings are withdrawn."""
+
+    from agents_shipgate.core.source_warnings import (
+        adk_unresolved_tool_warning,
+        withdraw_completed_adk_tool_warnings,
+    )
+
+    declared = adk_unresolved_tool_warning("Alpha", "pay")
+    undeclared = adk_unresolved_tool_warning("Beta", "pay")
+    unrelated = "some other loader said something"
+    kept = withdraw_completed_adk_tool_warnings(
+        [declared, undeclared, unrelated],
+        agent_source_ids={"Alpha": "adk_a", "Beta": "adk_b"},
+        completed_source_ids={"adk_a"},
+    )
+    assert kept == [undeclared, unrelated]
+
+    # An agent name two sources both publish is dropped from the map rather
+    # than guessed, so its warnings are never withdrawn against the wrong one.
+    assert withdraw_completed_adk_tool_warnings(
+        [declared],
+        agent_source_ids={},
+        completed_source_ids={"adk_a"},
+    ) == [declared]
+
+
+# --- PR #401 review: the remaining robustness findings -----------------------
+
+
+def test_complete_asks_the_reviewer_to_check_handoffs_too() -> None:
+    """`complete: true` closes the world over BOTH lists, so say both.
+
+    The scaffold pre-fills observed handoffs and the hint spoke only about
+    tools, so a reviewer could ratify the tool set while silently asserting a
+    downstream agent surface they never looked at (PR #401 review).
+    """
+
+    from agents_shipgate.cli.scan.declarations import _FIELD_HINTS
+
+    complete = _FIELD_HINTS["declarations.complete"]
+    reason = _FIELD_HINTS["declarations.reason"]
+    for hint in (complete, reason):
+        assert "handoff" in hint.lower()
+    assert "tool" in complete.lower()
+
+
+def test_ambiguous_handoff_target_withholds_the_whole_template() -> None:
+    """A handoff has no source qualifier, so an ambiguous name resolves nowhere.
+
+    Emitting `handoffs: [Twin]` when two agents are named `Twin` produced a
+    block that reports an unresolved binding instead of closing the gap it was
+    offered for. Withheld entirely: dropping just the handoff would understate
+    a closed world the reviewer is about to assert (PR #401 review).
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+    from agents_shipgate.schemas.bindings import (
+        AgentBindingGraphAssessment,
+        AgentBindingIssue,
+        AgentBindingNode,
+        AgentHandoffBindingEdge,
+    )
+
+    def _graph(second_twin_name: str) -> AgentBindingGraphAssessment:
+        return AgentBindingGraphAssessment(
+            root_agent_id="agent:root",
+            status="partial",
+            agents=[
+                AgentBindingNode(agent_id="agent:root", name="Root", source_id="a"),
+                AgentBindingNode(agent_id="agent:twin", name="Twin", source_id="a"),
+                AgentBindingNode(
+                    agent_id="agent:other", name=second_twin_name, source_id="b"
+                ),
+            ],
+            handoff_edges=[
+                AgentHandoffBindingEdge(
+                    source_agent_id="agent:root",
+                    target_agent_id="agent:twin",
+                    edge_type="subagent",
+                    confidence="high",
+                    provenance_kind="static_declaration",
+                    source="agent.py",
+                )
+            ],
+            unbound_tool_ids=["t1"],
+            issues=[
+                AgentBindingIssue(
+                    kind="missing_binding_evidence",
+                    message="no static edge",
+                    agent_id="agent:root",
+                )
+            ],
+        )
+
+    catalog = [Tool(id="t1", name="pay", source_type="mcp", source_id="s")]
+
+    ambiguous = _graph("Twin")
+    assert (
+        rd._binding_declaration_template(ambiguous, ambiguous.issues[0], catalog)
+        is None
+    )
+
+    # The same graph with a distinguishable second agent still scaffolds.
+    fine = _graph("Other")
+    template = rd._binding_declaration_template(fine, fine.issues[0], catalog)
+    assert template is not None
+    assert template["agent_bindings"]["declarations"][0]["handoffs"] == ["Twin"]
+
+
+def test_a_recursive_yaml_alias_still_gets_a_structured_error() -> None:
+    """The before-validator walks RAW input, which can be cyclic.
+
+    ``yaml.safe_load`` preserves recursive aliases, so `bogus: &loop {x: *loop}`
+    is a syntactically valid manifest carrying a self-referential dict. An
+    unguarded walk raised `RecursionError`, replacing the structured config
+    error — and the agent-mode recovery payload with it — with a stack
+    overflow (PR #401 review).
+    """
+
+    import pytest
+
+    from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+
+    cyclic = yaml.safe_load("bogus: &loop {x: *loop}\n")
+    assert cyclic["bogus"]["x"] is cyclic["bogus"]
+    with pytest.raises(ValueError) as caught:
+        AgentsShipgateManifest.model_validate(cyclic)
+    assert not isinstance(caught.value, RecursionError)
+
+    # Cycle-safety must not blind the check: a placeholder inside the cycle is
+    # still found and still named.
+    loop: dict = {"name": "a", "declared_purpose": ["<REVIEW_REQUIRED>"]}
+    loop["self"] = loop
+    with pytest.raises(ValueError) as found:
+        AgentsShipgateManifest.model_validate(
+            {
+                "version": "0.1",
+                "project": {"name": "p"},
+                "environment": {"target": "local"},
+                "agent": loop,
+            }
+        )
+    assert "unfilled scaffold placeholder" in str(found.value)
+
+
+def test_a_noncharacter_in_a_name_cannot_break_the_generated_scaffold() -> None:
+    """PyYAML rejects U+FFFE outright, so a raw one made the file unloadable.
+
+    `display_literal` escaped control and invisible code points but passed
+    noncharacters through, and the scaffold quotes repository-controlled agent
+    names in comments — so one such name meant `yaml.safe_load_all` could not
+    read the document at all (PR #401 review).
+    """
+
+    from agents_shipgate.core.evidence_actions import (
+        display_literal,
+        undisplay_literal,
+    )
+    from agents_shipgate.schemas.bindings import AgentBindingNode
+
+    hostile = "bad￾￿﷐"
+    rendered = display_literal(hostile)
+    assert "￾" not in rendered
+    # Escaping stays injective, so the name is still recoverable.
+    assert undisplay_literal(rendered) == hostile
+
+    template = {
+        "agent_bindings": {
+            "root": {
+                "source_id": "<REVIEW_REQUIRED>",
+                "object": "<REVIEW_REQUIRED>",
+            }
+        }
+    }
+    scaffold = build_declaration_scaffold(
+        [_gap("ambiguous_root_agent", "shipgate.yaml#agent_bindings.root", template)],
+        agents=[AgentBindingNode(agent_id="a1", name=hostile, source_id=hostile)],
+    )
+    assert scaffold is not None
+    assert yaml.safe_load(scaffold) == template

--- a/tests/test_declaration_scaffold.py
+++ b/tests/test_declaration_scaffold.py
@@ -6,7 +6,9 @@ something that closes a gap on its own.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import get_args
 
 import yaml
 
@@ -248,15 +250,20 @@ def test_no_shipped_template_asserts_on_a_humans_behalf() -> None:
             for index, value in enumerate(node):
                 assert_no_assertion(value, f"{path}[{index}]")
             return
-        # Selector fields identify WHICH row the declaration is about. They are
-        # read off the observed surface, not judged by a human, so they are not
-        # assertions the scaffold is making on the reviewer's behalf.
-        if path.rsplit(".", 1)[-1] in {
+        # Selector fields identify WHICH row the declaration is about, and
+        # ``agent``/``handoffs`` name which agents. They are read off the
+        # observed surface, not judged by a human, so they are not assertions
+        # the scaffold is making on the reviewer's behalf. The index is
+        # stripped so a list member (`handoffs[0]`) is judged as its field.
+        leaf = path.rsplit(".", 1)[-1].split("[", 1)[0]
+        if leaf in {
             "tool",
             "tool_id",
             "source_id",
             "source_type",
             "provider",
+            "agent",
+            "handoffs",
         }:
             return
         assert node == REVIEW_REQUIRED_SENTINEL, (
@@ -279,23 +286,83 @@ def _shipped_templates() -> list[dict]:
         source_type="sdk_function",
         source_id="openai_sdk_agent",
     )
-    # The binding root template is emitted from _binding_coverage, not
-    # _semantic_gap, so enumerate it explicitly — a guard that misses the
+    # An ADK tool as well: ``incomplete_surface`` only scaffolds an inventory
+    # for a source type that HAS a tool_inventories key, so a guard run only
+    # over sdk_function would never see that template at all.
+    adk_tool = Tool(
+        id="t2",
+        name="create_quote",
+        source_type="google_adk",
+        source_id="adk_agent",
+    )
+    # The binding templates are emitted from _binding_coverage, not
+    # _semantic_gap, so enumerate them explicitly — a guard that misses the
     # template which actually carried an assertion is false confidence.
-    templates: list[dict] = [dict(rd.AGENT_BINDINGS_ROOT_TEMPLATE)]
-    for kind in (
-        "inferred_effect_only",
-        "missing_authority_evidence",
-        "partial_authority_evidence",
-        "unresolved_tool_selector",
-        "incomplete_surface",
-    ):
-        gap = rd._semantic_gap(tool, kind=kind, why="test")
-        template = gap.next_action.declaration_template
-        if template:
-            templates.append(template)
+    templates: list[dict] = [
+        dict(rd.AGENT_BINDINGS_ROOT_TEMPLATE),
+        _binding_declarations_template(),
+    ]
+    for source in (tool, adk_tool):
+        for kind in (
+            "inferred_effect_only",
+            "missing_authority_evidence",
+            "partial_authority_evidence",
+            "unresolved_tool_selector",
+            "incomplete_surface",
+        ):
+            gap = rd._semantic_gap(source, kind=kind, why="test")
+            template = gap.next_action.declaration_template
+            if template:
+                templates.append(template)
     assert templates, "expected at least one shipped template"
     return templates
+
+
+def _binding_declarations_template() -> dict:
+    """The closed-world declaration scaffolded for an unbound catalog (#361)."""
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+    from agents_shipgate.schemas.bindings import (
+        AgentBindingGraphAssessment,
+        AgentBindingIssue,
+        AgentBindingNode,
+        AgentHandoffBindingEdge,
+    )
+
+    catalog = [
+        Tool(id="t1", name="create_quote", source_type="google_adk", source_id="adk"),
+        Tool(id="t2", name="send_email", source_type="google_adk", source_id="adk"),
+    ]
+    graph = AgentBindingGraphAssessment(
+        root_agent_id="agent:root",
+        status="partial",
+        agents=[
+            AgentBindingNode(agent_id="agent:root", name="Closer", source_id="adk"),
+            AgentBindingNode(agent_id="agent:sub", name="Helper", source_id="adk"),
+        ],
+        handoff_edges=[
+            AgentHandoffBindingEdge(
+                source_agent_id="agent:root",
+                target_agent_id="agent:sub",
+                edge_type="subagent",
+                confidence="high",
+                provenance_kind="static_declaration",
+                source="agent.py",
+            )
+        ],
+        unbound_tool_ids=["t1", "t2"],
+        issues=[
+            AgentBindingIssue(
+                kind="missing_binding_evidence",
+                message="no static edge",
+                agent_id="agent:root",
+            )
+        ],
+    )
+    template = rd._binding_declaration_template(graph, graph.issues[0], catalog)
+    assert template is not None
+    return template
 
 
 def test_unfilled_sentinel_is_rejected_by_the_manifest() -> None:
@@ -415,3 +482,569 @@ def test_binding_scaffold_only_offers_a_root_when_one_could_match() -> None:
     assert no_agents
     assert no_agents[0].next_action.declaration_template is None
     assert "suggested-declarations" not in (no_agents[0].next_action.expects or "")
+
+
+# --- #388: the scaffold says what a legal answer looks like ------------------
+
+
+def _strip_comments(scaffold: str) -> list[str]:
+    """The scaffold's YAML lines, with every comment line removed."""
+
+    return [
+        line
+        for line in scaffold.splitlines()
+        if not line.lstrip().startswith("#") and line not in {"", "---"}
+    ]
+
+
+def _blocks(scaffold: str) -> list[list[str]]:
+    """The scaffold's documents, each as its raw lines (comments included)."""
+
+    blocks: list[list[str]] = []
+    for line in scaffold.splitlines():
+        if line == "---":
+            blocks.append([])
+        elif blocks:
+            blocks[-1].append(line)
+    return blocks
+
+
+def test_every_blank_is_preceded_by_a_comment_that_says_what_to_write() -> None:
+    """The file a user is told to edit must say what a legal answer is (#388).
+
+    It shipped `effect: <REVIEW_REQUIRED>` with the nine accepted values living
+    only in report.json, and `authority.mode:` with its four — so the one file
+    a reader was directed to was the one that did not name the vocabulary. A
+    blank with nothing above it is the defect, whatever the field.
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+
+    tool = Tool(id="t1", name="process_order", source_type="sdk_function", source_id="s")
+    gaps = [
+        rd._semantic_gap(tool, kind=kind, why="test")
+        for kind in ("missing_effect_evidence", "missing_authority_evidence")
+    ]
+    scaffold = build_declaration_scaffold(gaps)
+    assert scaffold is not None
+
+    lines = scaffold.splitlines()
+    blanks = [i for i, line in enumerate(lines) if "<REVIEW_REQUIRED>" in line]
+    assert blanks, "expected the fixture to produce blanks"
+    for index in blanks:
+        # A list's guidance sits above the key that opens it (`scopes:`), which
+        # is where a reader looks; step over those bare container lines and
+        # require a comment before the blank either way.
+        cursor = index - 1
+        while lines[cursor].rstrip().endswith(":"):
+            cursor -= 1
+        assert lines[cursor].lstrip().startswith("#"), (
+            f"{lines[index]!r} has no guidance above it — the reader has to "
+            "leave the file to find out what it accepts"
+        )
+
+
+def test_the_printed_vocabulary_is_the_gaps_own_accepted_values() -> None:
+    """The scaffold and report.json cannot disagree about what is legal.
+
+    Acceptance criterion of #388: the comment is rendered FROM the gap's
+    ``accepted_values``, never from a second copy of the vocabulary, so adding
+    an effect or an authority mode to the engine reaches the scaffold with no
+    second edit.
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.cli.scan.declarations import (
+        _VOCABULARY_FIELD_BY_ACTION_KIND,
+    )
+    from agents_shipgate.core.domain import Tool
+    from agents_shipgate.schemas.report import EvidenceGapAction
+
+    # The routing table names real action kinds; a rename must break here
+    # rather than silently stop annotating.
+    valid = set(get_args(EvidenceGapAction.model_fields["kind"].annotation))
+    assert set(_VOCABULARY_FIELD_BY_ACTION_KIND) <= valid
+
+    tool = Tool(id="t1", name="process_order", source_type="sdk_function", source_id="s")
+    for kind, field in (
+        ("missing_effect_evidence", "effect"),
+        ("missing_authority_evidence", "authority.mode"),
+    ):
+        gap = rd._semantic_gap(tool, kind=kind, why="test")
+        scaffold = build_declaration_scaffold([gap])
+        assert scaffold is not None
+        rendered = " ".join(
+            line.lstrip("# ").strip()
+            for line in scaffold.splitlines()
+            if line.lstrip().startswith("#")
+        )
+        accepted = gap.next_action.accepted_values
+        assert accepted, f"{kind} publishes no vocabulary to print"
+        printed = rendered.split("accepted:", 1)[1]
+        for value in accepted:
+            assert value in printed, f"{field} omits {value!r} from its comment"
+
+
+def test_root_block_offers_the_agent_objects_the_scan_observed() -> None:
+    """Instance 1 of #388: stop asking for a value already computed.
+
+    `object` matches the agent's DECLARED name, not the Python variable it was
+    assigned to — the issue's own worked example guessed the variable — so
+    naming the observed candidates is also the fix for guessing wrong.
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.schemas.bindings import (
+        AgentBindingGraphAssessment,
+        AgentBindingIssue,
+        AgentBindingNode,
+    )
+    from agents_shipgate.schemas.report import ReadinessReport
+
+    graph = AgentBindingGraphAssessment(
+        root_agent_id=None,
+        status="unknown",
+        agents=[
+            AgentBindingNode(
+                agent_id="a2", name="BetaAgent", source_id="adk", source_ref="agent.py"
+            ),
+            AgentBindingNode(
+                agent_id="a1", name="AlphaAgent", source_id="adk", source_ref="agent.py"
+            ),
+        ],
+        issues=[AgentBindingIssue(kind="ambiguous_root_agent", message="ambiguous")],
+    )
+    report = ReadinessReport.model_construct(binding_surface_facts=graph)
+    _coverage, gaps = rd._binding_coverage(report)
+    scaffold = build_declaration_scaffold(gaps, agents=graph.agents)
+    assert scaffold is not None
+
+    assert "object: AlphaAgent, source_id: adk" in scaffold
+    assert "object: BetaAgent, source_id: adk" in scaffold
+    # Sorted by name, not by the graph's agent-id order, which reads arbitrary.
+    assert scaffold.index("AlphaAgent") < scaffold.index("BetaAgent")
+    # Offered, never filled in: the value stays the human's.
+    body = yaml.safe_load(scaffold)
+    assert body == {
+        "agent_bindings": {
+            "root": {
+                "source_id": "<REVIEW_REQUIRED>",
+                "object": "<REVIEW_REQUIRED>",
+            }
+        }
+    }
+
+
+def test_comments_are_the_only_difference_from_a_plain_yaml_dump() -> None:
+    """The annotated renderer is not a second opinion about YAML style.
+
+    It exists to interleave comments, which PyYAML cannot carry. Everything
+    else — key order, indentation, quoting — must be byte-identical to
+    ``safe_dump``, so a template's rendering cannot drift from what every other
+    consumer of that dict sees.
+    """
+
+    for template in _shipped_templates():
+        gap = _gap("inferred_effect_only", "shipgate.yaml", template)
+        scaffold = build_declaration_scaffold([gap])
+        assert scaffold is not None
+        expected = yaml.safe_dump(
+            template, sort_keys=False, default_flow_style=False
+        ).rstrip("\n")
+        assert _strip_comments(scaffold) == expected.splitlines()
+        # And it still parses back to exactly the template it rendered.
+        assert yaml.safe_load(scaffold) == template
+
+
+# --- #361: scaffold the binding layer, and from the first scan ---------------
+
+
+_COLD_START_TOOLS = (
+    "create_quote",
+    "escalate_case",
+    "lookup_account",
+    "send_quote_email",
+    "summarize_case",
+    "update_opportunity",
+)
+
+
+def _cold_start_project(root: Path) -> Path:
+    """An ADK agent whose every ``tools=[...]`` entry is an imported symbol.
+
+    The shape #361 was reported against (google/adk-samples#1917): static
+    extraction resolves none of them, so the first scan has no tool rows at all
+    and the reader is left to author both the inventory and the binding block
+    from the docs.
+    """
+
+    project = root / "cold-start"
+    project.mkdir()
+    listed = ",\n        ".join(_COLD_START_TOOLS)
+    (project / "agent.py").write_text(
+        "from google.adk.agents import LlmAgent\n\n"
+        f"from .tools import (\n    {',\n    '.join(_COLD_START_TOOLS)},\n)\n\n"
+        "root_agent = LlmAgent(\n"
+        '    name="SmartCloserAgent",\n'
+        '    instruction="Close deals.",\n'
+        f"    tools=[\n        {listed},\n    ],\n)\n",
+        encoding="utf-8",
+    )
+    (project / "shipgate.yaml").write_text(
+        'version: "0.1"\n'
+        "project:\n  name: smart-closer\n"
+        "agent:\n  name: SmartCloserAgent\n  declared_purpose: [close opportunities]\n"
+        "environment:\n  target: local\n"
+        "tool_sources:\n  - id: adk_agent\n    type: google_adk\n    path: agent.py\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def _scan_cold_start(project: Path, reports: Path):
+    from agents_shipgate.cli.scan import run_scan
+
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml",
+        output_dir=reports,
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=False,
+    )
+    return report
+
+
+def test_cold_start_walk_scaffolds_both_layers_in_two_iterations(tmp_path) -> None:
+    """The whole of #361, walked: 5 hand-authored iterations become 2.
+
+    Stage 1 (bare init) and stage 2 (inventory declared) both used to emit no
+    scaffold at all — the binding gap carried ``declaration_template: null`` —
+    so the reader hand-wrote a 98-line inventory and an ``agent_bindings``
+    block at exactly the point they had the least context.
+    """
+
+    project = _cold_start_project(tmp_path)
+    reports = tmp_path / "reports"
+
+    # --- stage 1: nothing is extracted, and the repair is named -------------
+    stage1 = _scan_cold_start(project, reports)
+    assert stage1.release_decision is not None
+    assert stage1.release_decision.decision == "insufficient_evidence"
+    assert not stage1.tool_catalog
+
+    skeleton = reports / "suggested-inventory.json"
+    scaffold_path = reports / "suggested-declarations.yaml"
+    assert skeleton.is_file(), "the six names the agent lists are still retyped"
+    assert scaffold_path.is_file(), "no scaffold at the point the user is stuck"
+
+    names = [entry["name"] for entry in json.loads(skeleton.read_text())["tools"]]
+    assert names == sorted(_COLD_START_TOOLS)
+    wiring = yaml.safe_load(scaffold_path.read_text())
+    assert wiring == {
+        "google_adk": {
+            "tool_inventories": [
+                {"path": "<REVIEW_REQUIRED>", "source_id": "adk_agent"}
+            ]
+        }
+    }
+
+    # --- stage 2: the inventory is declared; the binding block is scaffolded -
+    (project / "inventories").mkdir()
+    (project / "inventories" / "tools.json").write_text(
+        skeleton.read_text(), encoding="utf-8"
+    )
+    manifest = project / "shipgate.yaml"
+    manifest.write_text(
+        manifest.read_text()
+        + "google_adk:\n  tool_inventories:\n"
+        "    - path: inventories/tools.json\n      source_id: adk_agent\n",
+        encoding="utf-8",
+    )
+
+    stage2 = _scan_cold_start(project, reports)
+    assert stage2.release_decision is not None
+    coverage = stage2.release_decision.evidence_coverage
+    assert coverage.binding_coverage.gap_count == 1
+    assert len(stage2.tool_catalog) == len(_COLD_START_TOOLS)
+    assert scaffold_path.is_file()
+    # The repair is made, so the stage-1 inventory instruction is withdrawn
+    # rather than repeated at a reader who already followed it.
+    assert not skeleton.exists()
+
+    block = yaml.safe_load(scaffold_path.read_text())
+    declaration = block["agent_bindings"]["declarations"][0]
+    assert declaration["agent"] == "SmartCloserAgent"
+    assert [row["tool"] for row in declaration["tools"]] == sorted(_COLD_START_TOOLS)
+    assert all(row["tool_id"] for row in declaration["tools"])
+    # The judgement is untouched: nothing claims the set is complete, and
+    # nothing invents a reason for it.
+    assert declaration["complete"] == "<REVIEW_REQUIRED>"
+    assert declaration["reason"] == "<REVIEW_REQUIRED>"
+
+    # --- merging it verbatim closes the binding layer in ONE iteration ------
+    reviewed = yaml.safe_load(
+        scaffold_path.read_text()
+        .replace("complete: <REVIEW_REQUIRED>", "complete: true")
+        .replace("reason: <REVIEW_REQUIRED>", "reason: reviewed against agent.py")
+    )
+    manifest.write_text(
+        manifest.read_text() + yaml.safe_dump(reviewed, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    stage3 = _scan_cold_start(project, reports)
+    assert stage3.release_decision is not None
+    assert stage3.release_decision.evidence_coverage.binding_coverage.gap_count == 0
+    assert len(stage3.binding_surface_facts.reachable_tool_ids) == len(
+        _COLD_START_TOOLS
+    )
+
+
+def test_binding_scaffold_is_withheld_rather_than_truncated(tmp_path) -> None:
+    """A closed-world list cut at N would be false where nobody can see it.
+
+    ``complete: true`` says the listed tools are ALL the agent reaches, so a
+    silently truncated ``tools:`` is the one failure mode this template must
+    not have. Past the ceiling it offers nothing and the prose repair stands.
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+    from agents_shipgate.schemas.bindings import (
+        AgentBindingGraphAssessment,
+        AgentBindingIssue,
+        AgentBindingNode,
+    )
+
+    def _template(count: int):
+        catalog = [
+            Tool(id=f"t{i}", name=f"tool_{i}", source_type="mcp", source_id="s")
+            for i in range(count)
+        ]
+        graph = AgentBindingGraphAssessment(
+            root_agent_id="agent:root",
+            status="partial",
+            agents=[AgentBindingNode(agent_id="agent:root", name="Root")],
+            unbound_tool_ids=[tool.id for tool in catalog],
+            issues=[
+                AgentBindingIssue(
+                    kind="missing_binding_evidence",
+                    message="no static edge",
+                    agent_id="agent:root",
+                )
+            ],
+        )
+        return rd._binding_declaration_template(graph, graph.issues[0], catalog)
+
+    at_ceiling = _template(rd._MAX_SCAFFOLDED_BINDING_TOOLS)
+    assert at_ceiling is not None
+    tools = at_ceiling["agent_bindings"]["declarations"][0]["tools"]
+    assert len(tools) == rd._MAX_SCAFFOLDED_BINDING_TOOLS
+    assert _template(rd._MAX_SCAFFOLDED_BINDING_TOOLS + 1) is None
+
+
+def test_binding_scaffold_is_root_scoped_only(tmp_path) -> None:
+    """A tool reachable only by another agent is repaired by wiring a handoff.
+
+    ``_unbound_tool_gaps`` raises the same kind per tool for capabilities the
+    root cannot reach. Scaffolding the root's closed-world tool set there would
+    prescribe the wrong repair — and would invite declaring a tool as the
+    root's when the repository says another agent owns it.
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+    from agents_shipgate.schemas.bindings import (
+        AgentBindingGraphAssessment,
+        AgentBindingIssue,
+        AgentBindingNode,
+    )
+
+    catalog = [Tool(id="t1", name="pay", source_type="mcp", source_id="s")]
+    graph = AgentBindingGraphAssessment(
+        root_agent_id="agent:root",
+        status="partial",
+        agents=[AgentBindingNode(agent_id="agent:root", name="Root")],
+        unbound_tool_ids=["t1"],
+        issues=[
+            AgentBindingIssue(
+                kind="missing_binding_evidence",
+                message="bound to an agent the root does not reach",
+                agent_id="agent:other",
+                tool_id="t1",
+            )
+        ],
+    )
+    assert (
+        rd._binding_declaration_template(graph, graph.issues[0], catalog) is None
+    )
+
+
+def test_duplicate_named_root_falls_back_to_the_root_alias(tmp_path) -> None:
+    """A declaration naming a name two agents share resolves to neither."""
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+    from agents_shipgate.schemas.bindings import (
+        AgentBindingGraphAssessment,
+        AgentBindingIssue,
+        AgentBindingNode,
+    )
+
+    catalog = [Tool(id="t1", name="pay", source_type="mcp", source_id="s")]
+    graph = AgentBindingGraphAssessment(
+        root_agent_id="agent:root",
+        status="partial",
+        agents=[
+            AgentBindingNode(agent_id="agent:root", name="Twin", source_id="a"),
+            AgentBindingNode(agent_id="agent:other", name="Twin", source_id="b"),
+        ],
+        unbound_tool_ids=["t1"],
+        issues=[
+            AgentBindingIssue(
+                kind="missing_binding_evidence",
+                message="no static edge",
+                agent_id="agent:root",
+            )
+        ],
+    )
+    template = rd._binding_declaration_template(graph, graph.issues[0], catalog)
+    assert template is not None
+    assert template["agent_bindings"]["declarations"][0]["agent"] == "root"
+
+
+def test_a_pasted_scaffold_says_it_is_unfinished_whatever_field_it_lands_in(
+    tmp_path,
+) -> None:
+    """``complete`` accepts only ``true``, so its type used to answer first.
+
+    "Input should be True" does not tell a reader they pasted an unfinished
+    scaffold. The placeholder is rejected before the field's own type is
+    consulted, so one wording covers every field.
+    """
+
+    import pytest
+
+    from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+
+    base = {
+        "version": "0.1",
+        "project": {"name": "p"},
+        "agent": {"name": "a", "declared_purpose": ["do a thing"]},
+        "environment": {"target": "local"},
+        "tool_sources": [{"id": "s1", "type": "mcp", "path": "tools.json"}],
+    }
+    with pytest.raises(ValueError) as caught:
+        AgentsShipgateManifest.model_validate(
+            {
+                **base,
+                "agent_bindings": {
+                    "declarations": [
+                        {
+                            "agent": "root",
+                            "complete": "<REVIEW_REQUIRED>",
+                            "tools": [{"tool": "pay", "tool_id": "t1"}],
+                            "handoffs": [],
+                            "reason": "<REVIEW_REQUIRED>",
+                        }
+                    ]
+                },
+            }
+        )
+    message = str(caught.value)
+    assert "unfilled scaffold placeholder" in message
+    assert "agent_bindings.declarations[0].complete" in message
+    assert "Input should be True" not in message
+
+
+def test_one_repair_at_one_path_is_one_block() -> None:
+    """Two rows prescribing the same edit are one instruction, not two.
+
+    Every low-confidence tool of a framework source carries the same
+    ``tool_inventories`` wiring, and their subjects differ (the tool names), so
+    keyed on the subject alone they rendered as N identical blocks to paste —
+    which reads as N separate things to do.
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+
+    gaps = [
+        rd._semantic_gap(
+            Tool(
+                id=f"t{index}",
+                name=name,
+                source_type="google_adk",
+                source_id="adk_agent",
+            ),
+            kind="incomplete_surface",
+            why="test",
+        )
+        for index, name in enumerate(("create_quote", "send_email"))
+    ]
+    assert {gap.subject for gap in gaps} == {
+        "create_quote [adk_agent]",
+        "send_email [adk_agent]",
+    }
+    scaffold = build_declaration_scaffold(gaps)
+    assert scaffold is not None
+    docs = [doc for doc in yaml.safe_load_all(scaffold) if doc]
+    assert docs == [
+        {
+            "google_adk": {
+                "tool_inventories": [
+                    {"path": "<REVIEW_REQUIRED>", "source_id": "adk_agent"}
+                ]
+            }
+        }
+    ]
+
+
+def test_repository_controlled_text_cannot_forge_a_line_in_the_scaffold() -> None:
+    """A name is data. It must not become structure a reader would paste.
+
+    Two vectors, both fed by repository JSON. A tool name holding a newline
+    renders as a *multi-line* YAML scalar whose continuation the emitter cannot
+    indent correctly on its own. An agent name holding one closes the `#` of a
+    candidate comment — and the next line it wrote would be a filled-in root
+    selector, the self-declaration this file exists to refuse (#268).
+    """
+
+    from agents_shipgate.schemas.bindings import AgentBindingNode
+
+    forged = "evil\nroot:\n  object: attacker\n  source_id: attacker"
+    template = {
+        "agent_bindings": {
+            "root": {
+                "source_id": "<REVIEW_REQUIRED>",
+                "object": "<REVIEW_REQUIRED>",
+            }
+        }
+    }
+    scaffold = build_declaration_scaffold(
+        [_gap("ambiguous_root_agent", "shipgate.yaml#agent_bindings.root", template)],
+        agents=[
+            AgentBindingNode(
+                agent_id="a1", name=forged, source_id=forged, source_ref=forged
+            )
+        ],
+    )
+    assert scaffold is not None
+    # The newlines are escaped, so the forged text stays inside the one comment
+    # line that quotes it and never becomes structure of its own.
+    assert "<U+000A>" in scaffold
+    assert all(
+        line.lstrip().startswith("#")
+        for line in scaffold.splitlines()
+        if "attacker" in line
+    )
+    assert yaml.safe_load(scaffold) == template
+
+    # The same value as a template scalar stays one line and round-trips.
+    hostile_row = {"tool": forged, "tool_id": "t1", "effect": "<REVIEW_REQUIRED>"}
+    rendered = build_declaration_scaffold(
+        [_gap("inferred_effect_only", "shipgate.yaml#action_surface", hostile_row)]
+    )
+    assert rendered is not None
+    assert yaml.safe_load(rendered) == hostile_row

--- a/tests/test_declaration_scaffold.py
+++ b/tests/test_declaration_scaffold.py
@@ -808,39 +808,49 @@ def test_cold_start_walk_scaffolds_both_layers_in_two_iterations(tmp_path) -> No
     # with no non-warning gap left to act on (PR #401 review).
     assert stage3.release_decision.evidence_coverage.source_warning_count == 0
 
+    # The action blocks come from the scaffold itself, answered the way its
+    # own comments instruct: pick a value from the printed vocabulary, and
+    # delete the lines `mode: none` does not take. `send_quote_email` is
+    # reviewed as what it is — declaring everything `read` leaves a
+    # `mixed_policy_evidence` gap against the risk hint, which would make this
+    # test prove only that warnings were withdrawn (PR #401 review).
+    reviewed_effects = dict.fromkeys(_COLD_START_TOOLS, "read")
+    reviewed_effects["send_quote_email"] = "external_communication"
+
+    actions = []
+    for block in yaml.safe_load_all(scaffold_path.read_text()):
+        if not block or "tool" not in block:
+            continue
+        block.pop("scopes", None)
+        block["authority"] = {"mode": "none"}
+        block["effect"] = reviewed_effects[block["tool"]]
+        if block["effect"] == "external_communication":
+            block["safeguards"] = {"audit_log": True}
+        actions.append(block)
+    assert {block["tool"] for block in actions} == set(_COLD_START_TOOLS)
+
     manifest.write_text(
         manifest.read_text()
-        + yaml.safe_dump(
-            {
-                "action_surface": {
-                    "actions": [
-                        {
-                            "tool": name,
-                            "effect": "read",
-                            "authority": {"mode": "none"},
-                        }
-                        for name in sorted(_COLD_START_TOOLS)
-                    ]
-                }
-            },
-            sort_keys=False,
-        ),
+        + yaml.safe_dump({"action_surface": {"actions": actions}}, sort_keys=False),
         encoding="utf-8",
     )
     final = _scan_cold_start(project, reports)
     assert final.release_decision is not None
     coverage = final.release_decision.evidence_coverage
-    assert coverage.semantic_coverage.gap_count == 0
+
+    # Every evidence layer is closed — including the policy one, which a
+    # uniform `read` would have left open.
     assert coverage.binding_coverage.gap_count == 0
+    assert coverage.semantic_coverage.gap_count == 0
+    assert coverage.policy_gap_count == 0
     assert coverage.source_warning_count == 0
-    # Whatever the verdict now turns on, it is a judgement about the declared
-    # surface — never the abstention the walk started in.
-    remaining = {gap.kind for gap in coverage.evidence_gaps}
-    assert "source_warning" not in remaining
-    assert all(
-        gap.next_action.path or gap.next_action.command
-        for gap in coverage.evidence_gaps
-    ), "a terminal verdict must leave nothing that cannot be acted on"
+    assert coverage.evidence_gaps == []
+
+    # And the verdict is now a judgement about the declared surface rather
+    # than an abstention about the evidence: `blocked`, on a finding about the
+    # external-communication tool the walk just declared.
+    assert final.release_decision.decision == "blocked"
+    assert final.release_decision.blockers
 
 
 def test_binding_scaffold_is_withheld_rather_than_truncated(tmp_path) -> None:
@@ -1257,13 +1267,31 @@ def test_withdrawal_is_scoped_to_the_completed_source() -> None:
     unrelated = "some other loader said something"
     kept = withdraw_completed_adk_tool_warnings(
         [declared, undeclared, unrelated],
-        agent_source_ids={"Alpha": "adk_a", "Beta": "adk_b"},
+        agent_source_ids={"Alpha": {"adk_a"}, "Beta": {"adk_b"}},
         completed_source_ids={"adk_a"},
     )
     assert kept == [undeclared, unrelated]
 
-    # An agent name two sources both publish is dropped from the map rather
-    # than guessed, so its warnings are never withdrawn against the wrong one.
+    # A name two sources publish is ambiguous about which raised the warning,
+    # so it survives while EITHER candidate is still owed an inventory...
+    shared = adk_unresolved_tool_warning("Twin", "pay")
+    assert withdraw_completed_adk_tool_warnings(
+        [shared],
+        agent_source_ids={"Twin": {"adk_a", "adk_b"}},
+        completed_source_ids={"adk_a"},
+    ) == [shared]
+    # ...and is withdrawn once every candidate is complete, because then the
+    # ambiguity no longer changes the answer.
+    assert (
+        withdraw_completed_adk_tool_warnings(
+            [shared],
+            agent_source_ids={"Twin": {"adk_a", "adk_b"}},
+            completed_source_ids={"adk_a", "adk_b"},
+        )
+        == []
+    )
+
+    # An agent the artifacts never recorded is never withdrawn against.
     assert withdraw_completed_adk_tool_warnings(
         [declared],
         agent_source_ids={},
@@ -1426,3 +1454,121 @@ def test_a_noncharacter_in_a_name_cannot_break_the_generated_scaffold() -> None:
     )
     assert scaffold is not None
     assert yaml.safe_load(scaffold) == template
+
+
+def test_shared_aliases_do_not_blow_up_the_sentinel_walk() -> None:
+    """An acyclic alias DAG is not a cycle, and was the expensive case.
+
+    A per-branch guard stops infinite recursion but still walks a shared child
+    once per path, so `{left: *prev, right: *prev}` nested 20 deep — 1.5 KB of
+    YAML — doubled the work at every level and materialized 2**n path strings
+    for a placeholder at the shared leaf, stalling manifest loading before the
+    structured error was ever built (PR #401 review).
+    """
+
+    import time
+
+    from agents_shipgate.schemas.manifest.root import _sentinel_paths
+
+    node: dict = {"leaf": "<REVIEW_REQUIRED>"}
+    for _ in range(20):
+        node = {"left": node, "right": node}
+
+    started = time.monotonic()
+    paths = _sentinel_paths(node)
+    elapsed = time.monotonic() - started
+
+    # One container, one visit, one representative path — which is all
+    # rejecting the placeholder needs.
+    assert len(paths) == 1
+    assert paths[0].endswith("leaf")
+    assert elapsed < 2.0, f"traversal took {elapsed:.2f}s; it is not bounded"
+
+
+def test_source_ids_compare_after_the_same_normalization() -> None:
+    """Both sides of the completion comparison must be stripped.
+
+    The manifest permits surrounding whitespace in an id, so a source and the
+    inventory completing it could both be spelled `' adk '` and still compare
+    unequal — leaving a warning the manifest had answered (PR #401 review).
+    """
+
+    from agents_shipgate.cli.scan.tools_agent import (
+        _adk_agent_source_ids,
+        _completed_source_ids,
+    )
+    from agents_shipgate.core.domain import LoadedToolSource
+    from agents_shipgate.inputs.google_adk import GoogleAdkArtifacts
+
+    artifacts = GoogleAdkArtifacts()
+    artifacts.agents.append({"name": "Closer", "source_id": " adk "})
+    loaded = [
+        LoadedToolSource(
+            source_id="inv",
+            source_type="google_adk_inventory",
+            completes_source_id=" adk ",
+            is_tool_inventory=True,
+        )
+    ]
+    assert _completed_source_ids(loaded) == {"adk"}
+    assert _adk_agent_source_ids(artifacts) == {"Closer": {"adk"}}
+
+
+def test_a_partly_read_tool_list_gets_the_same_declaration_block() -> None:
+    """An incomplete edge is the other shape a closed-world row repairs.
+
+    An agent whose tool list static analysis could only partly read has real
+    edges *and* catalog tools nothing binds. Scaffolding only the unbound ones
+    would hand the reviewer a closed-world row asserting the agent cannot reach
+    a tool the repository plainly wires to it (PR #401 review).
+    """
+
+    import agents_shipgate.ci.release_decision as rd
+    from agents_shipgate.core.domain import Tool
+    from agents_shipgate.schemas.bindings import (
+        AgentBindingGraphAssessment,
+        AgentBindingIssue,
+        AgentBindingNode,
+        AgentToolBindingEdge,
+    )
+
+    catalog = [
+        Tool(id="t1", name="local_tool", source_type="google_adk", source_id="adk"),
+        Tool(id="t2", name="remote_tool", source_type="google_adk", source_id="adk"),
+    ]
+    graph = AgentBindingGraphAssessment(
+        root_agent_id="agent:root",
+        status="partial",
+        agents=[AgentBindingNode(agent_id="agent:root", name="Closer", source_id="adk")],
+        tool_edges=[
+            AgentToolBindingEdge(
+                agent_id="agent:root",
+                tool_id="t1",
+                edge_type="direct_tool",
+                confidence="medium",
+                provenance_kind="static_declaration",
+                source="agent.py",
+                complete=False,
+            )
+        ],
+        possible_tool_ids=["t1"],
+        unbound_tool_ids=["t2"],
+        issues=[
+            AgentBindingIssue(
+                kind="partial_binding_evidence",
+                message="a possibly reachable tool has an incomplete edge",
+                agent_id="agent:root",
+                tool_id="t1",
+            )
+        ],
+    )
+    template = rd._binding_declaration_template(graph, graph.issues[0], catalog)
+    assert template is not None
+    declaration = template["agent_bindings"]["declarations"][0]
+    # Both the bound tool and the unbound one, so the row can be true.
+    assert [row["tool"] for row in declaration["tools"]] == [
+        "local_tool",
+        "remote_tool",
+    ]
+    assert declaration["complete"] == "<REVIEW_REQUIRED>"
+    assert declaration["reason"] == "<REVIEW_REQUIRED>"

--- a/tests/test_evidence_gap_ranking.py
+++ b/tests/test_evidence_gap_ranking.py
@@ -368,23 +368,79 @@ def test_insufficient_evidence_reason_leads_with_the_gap_not_the_tally(
     assert reason.index("shipgate.yaml#agent_bindings") < reason.index("Context:")
 
 
-def test_reason_keeps_the_threshold_wording_when_no_gap_is_addressable(
+def test_imported_symbols_get_one_source_row_naming_the_inventory_repair(
     imported_symbols_report,
 ):
-    """Without a path to name, "below threshold" is still the honest lead.
+    """The first scan of an all-imports agent names a repair (#361).
 
-    This report's only gaps are source warnings, which no file can close;
-    ranking must not invent an action that does not exist.
+    This used to be the shape with nothing to open: six source warnings, each
+    routed to ``review_warning``, no path, no template — so the verdict led
+    with "Evidence coverage below threshold" and the reader had to author the
+    inventory wiring from the docs. The repair exists and is mechanical, so the
+    decision engine states it.
+
+    Exactly ONE row states it. The six warnings are one mechanism restated per
+    symbol (``core.source_warnings``); attaching an action to each would put
+    raw loader prose back into the headline, which is what grouping removed.
     """
 
     decision = imported_symbols_report.release_decision
     assert decision is not None
     assert decision.decision == "insufficient_evidence"
-    assert not any(
-        gap.next_action.path
-        for gap in decision.evidence_coverage.evidence_gaps
+    gaps = decision.evidence_coverage.evidence_gaps
+
+    addressable = [gap for gap in gaps if gap.next_action.path]
+    assert len(addressable) == 1
+    (repair,) = addressable
+    assert repair.kind == "incomplete_surface"
+    assert repair.next_action.kind == "declare_tool_inventory"
+    assert repair.next_action.path == "shipgate.yaml#google_adk.tool_inventories"
+    # The row is about the source, so nothing quotes a warning verbatim.
+    assert repair.subject == "adk_crypto_payroll_agent [google_adk]"
+    assert "references unresolved tool" not in repair.subject
+    # It carries the exact manifest entry, joined to the source it completes.
+    assert repair.next_action.declaration_template == {
+        "google_adk": {
+            "tool_inventories": [
+                {
+                    "path": "<REVIEW_REQUIRED>",
+                    "source_id": "adk_crypto_payroll_agent",
+                }
+            ]
+        }
+    }
+
+    # The restatements stay inert: no path, no command, nothing to open.
+    warnings = [gap for gap in gaps if gap.kind == "source_warning"]
+    assert len(warnings) == 6
+    assert not any(gap.next_action.path or gap.next_action.command for gap in warnings)
+    assert {gap.next_action.kind for gap in warnings} == {"review_warning"}
+
+    assert decision.reason.startswith("Insufficient evidence: ")
+    assert "shipgate.yaml#google_adk.tool_inventories" in decision.reason
+
+
+def test_reason_keeps_the_threshold_wording_when_no_gap_is_addressable():
+    """Without a path to name, "below threshold" is still the honest lead.
+
+    Ranking must not invent an action that does not exist: a warning whose
+    mechanism nothing recognises has no repair to prescribe, and the verdict
+    says so rather than pointing somewhere.
+    """
+
+    evidence = EvidenceCoverageDecision(
+        level="static",
+        human_review_recommended=True,
+        source_warning_count=6,
+        low_confidence_tool_count=0,
+        evidence_gaps=[
+            _gap("source_warning", "loader degraded reading foo", path=None),
+            _gap("source_warning", "loader degraded reading bar", path=None),
+        ],
     )
-    assert decision.reason.startswith("Evidence coverage below threshold")
+    assert primary_evidence_gap(evidence) is not None
+    assert not any(gap.next_action.path for gap in evidence.evidence_gaps)
+    assert evidence_gap_target(primary_evidence_gap(evidence)) == ""
 
 
 # --- repository-derived values cannot forge a line ---------------------------


### PR DESCRIPTION
## Summary

- **Closes #361** — `suggested-declarations.yaml` was written only once the binding layer was already closed, so during the two scans where an adopter is most stuck it did not exist, and the binding gap that *was* reported carried `declaration_template: null`. Two new templates cover those stages.
- **Closes #388** — every `<REVIEW_REQUIRED>` in the scaffold now carries the values it accepts (or the shape its answer takes) as a comment, and the `agent_bindings.root` block lists the agent objects the scan already observed for a human to confirm.

Both were filed from the same first-time-adoption walk on `google/adk-samples`, and both are adoption friction rather than engine accuracy.

### #361 — the scaffold reaches the scans that need it

Reproduced the reported walk (ADK agent, six imported tool symbols): stage 1 emitted no scaffold and no skeleton; stage 2's `missing_binding_evidence` gap carried a null template.

**Stage 1 — the unenumerable source.** The symbol names exist nowhere structured: the loader records the *reason* as a `surface_gap` and the *names* only in its own warning prose. `core.source_warnings` owns both halves of that prose, so they are read back through the same exact, `repr`-delimited decoder `group_source_warnings` already relies on — never a regex over loader text. That feeds one `incomplete_surface` row **per source** carrying the exact `tool_inventories` entry with `source_id` bound to the source it completes (#386), and the inventory skeleton is now written with those names pre-filled.

Per source, not per symbol, and that redirection came from a test failure worth calling out: a `source_warning` gap's `subject` **is** the raw warning text, so routing the repair onto those rows made one of six restatements addressable and put loader prose straight back into the CLI headline that the #362 grouping work removed (`test_cli_summary_prints_both_the_raw_count_and_the_mechanism_count` caught it). The six `source_warning` rows stay inert `review_warning`s with no path and no command.

**Stage 2 — the unbound catalog.** A resolved root, a populated catalog, and not one static edge between them now scaffolds the closed-world `agent_bindings.declarations` row. The 2026-07 defect this block was cut for was not the block, it was the *assertion* inside it: what is pre-filled here is only what was read off the surface (which agent, which catalog tools exist, which handoffs were observed), and `complete` and `reason` — the two values that are a judgement — stay `<REVIEW_REQUIRED>`.

Past **50 tools the template is withheld, not truncated**. `complete: true` claims the listed tools are *all* the agent can reach, so a silently cut list is false exactly where a reviewer cannot see it.

Both instructions are also withdrawn once followed: the inventory skeleton is deleted when the source it was written for has been completed, the way the declaration scaffold already was.

### #388 — the scaffold says what a legal answer is

Each blank is preceded by a comment carrying either the field's `accepted_values` or, where the answer is not from a closed set, the shape it takes and which modes make it required.

The vocabulary renders **from the gap's own `accepted_values`**, never a second copy, so the two artifacts cannot drift. That is possible for exactly two fields and the reason is worth a reviewer's attention: `accepted_values` is **overloaded** on the wire. For most gap kinds it lists the manifest *keys* a repair must set (`["agent", "complete:true", "tools", …]`); only for `declare_action_effect` and `declare_action_authority` does it list the legal *values* of one field. Printing the first reading above a blank would tell a reviewer that `agent` is a legal `effect`, so only the second is routed, and the routing table is pinned to the action-kind enum by a test.

The root block now lists the observed agent objects. Note what that also fixes: `agent_bindings.root.object` matches the agent's **declared** name (`_select_root` filters on `agent.name`), not the Python variable it was assigned to — the issue's own worked example guessed the variable and would not have matched. Nothing is filled in; inferring the trust root from AST evidence stays the self-declaration surface #268 closed.

### Two things found while self-reviewing

- PyYAML cannot carry comments, so the block is emitted by hand — and a hand-rolled emitter is where a second opinion about YAML style creeps in. A test asserts that stripping the comment lines back out yields **exactly** what `safe_dump` writes for the same template. A separate fallback covers a string holding a newline, which `safe_dump` renders as a multi-line scalar whose continuation indent this emitter cannot compute for a leaf on its own.
- A *name* is repository data. An agent name holding a newline would close the `#` of a candidate comment and write a **filled-in root selector** for a reader to paste. Names in comments are escaped with `display_literal` (injective), with an adversarial test holding both vectors shut.

### One layer earlier

`agent_bindings.declarations[].complete` is `Literal[True]`, so pasting the scaffold unfinished failed with pydantic's "Input should be True" — true, and silent about the scaffold the reader pasted. The placeholder is now rejected from the raw input before field validation, so one wording covers every field whatever its type.

## Type

- [x] Check or risk-model change  <!-- evidence-gap routing only; no gate input changes -->
- [ ] Input adapter change
- [x] CLI or GitHub Action behavior
- [x] Report, schema, or SARIF output  <!-- additive values in existing fields; no schema version bump -->
- [x] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `ruff check .` — clean; full `pytest -n auto` — green (unpiped, exit code checked).
- The three-stage cold-start walk driven end to end through `./shipgate scan`, and encoded as `test_cold_start_walk_scaffolds_both_layers_in_two_iterations`: stage 1 and 2 both emit `suggested-declarations.yaml`; merging the stage-2 block verbatim after replacing the two placeholders takes `binding_coverage.gap_count` 1 → 0 in one iteration and reaches 6/6 catalog tools.
- #388's own measurement on the generated file, which the issue reported as `0`: the effect vocabulary and the four authority modes now appear once per block.
- Sample goldens checked rather than assumed: regenerated `conductor_agent` into a temp dir and diffed — **no** `evidence_gaps` differences, so no golden needed regenerating (its `incomplete_surface` rows have no `tool_inventories` key to scaffold). `report.md` and `packet.*` are byte-compared by the suite and unchanged.

**Not verified:** #361's headline metric (cold-start iterations 5 → 2) is measured against the walk reconstructed in this repo, not against live `google/adk-samples#1917` — I did not clone that PR.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — no check IDs added or changed.
- [x] Report/schema changes are additive or documented in `STABILITY.md` — no `report_schema_version` bump. Existing optional fields (`declaration_template`, `accepted_values`) are populated where they were null, and `build_release_decision` gains a keyword-only `tool_catalog` that defaults to `tools`. **Nothing gates on any of it**: `evidence_below_ie_threshold` and every coverage count read the same inputs as before.

### Surface discipline

No new CLI command, no schema version, no adapter. The headline metric is cold-start iterations to a first gating verdict, and the change is confined to the one decision engine plus the artifact that projects it. `docs/engineering/insufficient-evidence-cold-start.md` carries the design record, including the earlier round this reverses part of and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
