### PR TITLE
fix(control): ask for the checkout instead of dead-ending the loop (#397)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,11 +252,14 @@ agents-shipgate bootstrap --json
   name the project directly. `agent_scope_truncated: true` says the candidate
   list itself is a lower bound — the parse stopped at its cap, so any project
   in the part of the tree that was not read is missing from it. Never read
-  absence from a truncated list as an answer; raise the cap first. On an
-  unresolved scope `next_actions[]` ranks the decision first (`kind: "review"`,
-  no command) and then carries one exact `init --workspace <candidate> --write
-  --json` per candidate — the same list `init --write` publishes when it
-  refuses — so choosing the project is the only work left.
+  absence from a truncated list as an answer; raise the cap first. On
+  `agent_scope: "ambiguous"` with a complete parse, `next_actions[]` ranks the
+  decision first (`kind: "review"`, no command) and then carries one exact
+  `init --workspace <candidate> --write --json` per candidate — the same list
+  `init --write` publishes when it refuses — so choosing the project is the
+  only work left. A truncated parse outranks that, in `detect` and in `init`
+  alike: rank 1 is then the higher-cap rerun and no candidate commands are
+  offered, because the list they would be built from is a lower bound.
 - **`init`** — auto-detects by default. `--ci` writes
   `.github/workflows/agents-shipgate.yml`; orthogonal to `--write`. Use
   `--minimal` for the pre-v0.6 CHANGE_ME-heavy template.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,8 +255,11 @@ agents-shipgate bootstrap --json
   absence from a truncated list as an answer; raise the cap first. On
   `agent_scope: "ambiguous"` with a complete parse, `next_actions[]` ranks the
   decision first (`kind: "review"`, no command) and then carries one exact
-  `init --workspace <candidate> --write --json` per candidate — the same list
-  `init --write` publishes when it refuses — so choosing the project is the
+  `init --workspace <candidate> --write --json` per candidate — the list
+  `init --write` publishes when it refuses the same workspace, minus the setup
+  flags, which `detect` was not asked for and does not invent: if you want
+  `--ci` or `--agent-instructions`, add them, or take the command from `init`'s
+  own refusal, which repeats what you asked for. Choosing the project is the
   only work left. A truncated parse outranks that, in `detect` and in `init`
   alike: rank 1 is then the higher-cap rerun and no candidate commands are
   offered, because the list they would be built from is a lower bound.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,11 @@ agents-shipgate bootstrap --json
   name the project directly. `agent_scope_truncated: true` says the candidate
   list itself is a lower bound — the parse stopped at its cap, so any project
   in the part of the tree that was not read is missing from it. Never read
-  absence from a truncated list as an answer; raise the cap first.
+  absence from a truncated list as an answer; raise the cap first. On an
+  unresolved scope `next_actions[]` ranks the decision first (`kind: "review"`,
+  no command) and then carries one exact `init --workspace <candidate> --write
+  --json` per candidate — the same list `init --write` publishes when it
+  refuses — so choosing the project is the only work left.
 - **`init`** — auto-detects by default. `--ci` writes
   `.github/workflows/agents-shipgate.yml`; orthogonal to `--write`. Use
   `--minimal` for the pre-v0.6 CHANGE_ME-heavy template.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,8 +259,11 @@ agents-shipgate bootstrap --json
   `init --write` publishes when it refuses the same workspace, minus the setup
   flags, which `detect` was not asked for and does not invent: if you want
   `--ci` or `--agent-instructions`, add them, or take the command from `init`'s
-  own refusal, which repeats what you asked for. Choosing the project is the
-  only work left. A truncated parse outranks that, in `detect` and in `init`
+  own refusal, which repeats what you asked for. A candidate that already
+  carries a manifest gets `doctor --config <that manifest> --json` instead —
+  `init --write` there refuses a file it will not overwrite. Every candidate
+  gets an entry; the ten-item cap is on the human summary only. Choosing the
+  project is the only work left. A truncated parse outranks that, in `detect` and in `init`
   alike: rank 1 is then the higher-cap rerun and no candidate commands are
   offered, because the list they would be built from is a lower bound.
 - **`init`** — auto-detects by default. `--ci` writes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,9 +261,10 @@ agents-shipgate bootstrap --json
   `--ci` or `--agent-instructions`, add them, or take the command from `init`'s
   own refusal, which repeats what you asked for. A candidate that already
   carries a manifest gets `doctor --config <that manifest> --json` instead —
-  `init --write` there refuses a file it will not overwrite. Every candidate
-  gets an entry; the ten-item cap is on the human summary only. Choosing the
-  project is the only work left. A truncated parse outranks that, in `detect` and in `init`
+  `init --write` there refuses a file it will not overwrite — or, when you asked
+  for setup it still owes, an `init` carrying those flags. Every candidate gets
+  an entry, the workspace root as a `review` rather than a command; the ten-item
+  cap is on the human summary only. Choosing the project is the only work left. A truncated parse outranks that, in `detect` and in `init`
   alike: rank 1 is then the higher-cap rerun and no candidate commands are
   offered, because the list they would be built from is a lower bound.
 - **`init`** — auto-detects by default. `--ci` writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,9 @@
   list, but it was the one candidate the routing skipped: `init` there is the
   run that just refused, and `--allow-unresolved-scope` accepts the whole
   workspace as one scope, which is a different decision. It is now an explicit
-  human route saying exactly that.
+  human route saying exactly that, and the printed lists mark it — a caption
+  reading "re-run init on the one you are changing" over an unmarked `.` is the
+  human form of a run contradicting its own routing.
 
   `detect`'s `control.input_id` now covers the route it publishes, not only the
   classification behind it. Every emitted command is spelled for the entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,30 @@
   mechanical step the caller owns. The route is now the `fetch_base` action
   that already exists for exactly this shape: `agent_action_required`, no
   command (Shipgate never writes to a caller's worktree), and an `expects` that
-  names the input and a `why` that names the ref. Checking that ref out and
-  re-running the identical command resolves the project and emits the scoped
-  `init`. The two causes that no checkout can repair — evidence the change
-  deleted, an unreadable inventory — keep their human route. Plain `verify` is
-  unaffected: it reads `--head` from the object database, not the worktree.
+  names the input. The two causes that no checkout can repair — evidence the
+  change deleted, an unreadable inventory — keep their human route. Plain
+  `verify` is unaffected: it reads `--head` from the object database, not the
+  worktree.
+
+  **`expects` names a commit id, and the rerun it asks for is pinned.** The
+  step being requested moves `HEAD`, so a route spelled with the caller's own
+  revision expression does not survive it: `--head HEAD~1` names one commit
+  before the checkout and its parent after, and following the route walked
+  history backwards one commit per iteration instead of resolving. A
+  `HEAD`-relative `--base` re-ranges across the same checkout, which is quieter
+  and worse — the rerun succeeds against a diff nobody asked for. Both refs are
+  resolved to immutable ids before either is published.
+
+  The requested checkout also makes the preview's control pointer stale. It
+  bound no HEAD identity, so `agents-shipgate agent control` — the one refresh
+  entry point — kept returning the same `current_control_id` and the same
+  unmet-looking request after the caller performed it, which is how a
+  refresh-driven controller repeats an action forever. The pointer now binds
+  the worktree the preview actually read.
+
+  `fetch_base` accordingly means "make this input available" in both of its
+  senses, and the adoption scorer recognizes a `git checkout`/`git switch` as
+  input recovery alongside `git fetch`.
 
 - **`detect` now publishes the same per-candidate `init` commands `init` does
   when a workspace holds several agent projects.** Its escalation handed the
@@ -37,6 +56,28 @@
   build that list from one helper, so the two an adopter runs in sequence
   cannot publish different recoveries for one workspace; the workspace root
   stays out of it, since that is the scope `init` refuses.
+
+  **Every** candidate gets one. The ten-item cap that keeps a human refusal
+  readable had been applied to the routing too, which left candidate 11 onward
+  selectable and unrunnable — `detect --workspace samples --json` finds 22
+  projects and emitted 10 commands, and the reported pull request's repository
+  has 25.
+
+  And a candidate that **already carries a manifest** routes to
+  `doctor --config <that manifest> --json`, not to `init --write`. A nested
+  `shipgate.yaml` is itself evidence of a project, so adopted directories are
+  candidates too: on this repository's own `samples/`, 21 of 22 are, and every
+  command emitted for them exited 2 on a manifest `init` will not overwrite
+  while `expects` promised a file that already existed. The exception is
+  `--agent-instructions`, which makes `init --write` the advertised refresh and
+  exits 0 — there the `init` route is kept, flags and all.
+
+  `detect`'s `control.input_id` now covers the route it publishes, not only the
+  classification behind it. Every emitted command is spelled for the entry
+  point the process came in through, so the same workspace read as
+  `agents-shipgate` and as `/opt/custom/agents-shipgate` published different
+  commands under one identity — and that identity is the documented cache
+  boundary for the answer.
 
 - **`verify --preview` on a monorepo now names the project the pull request
   actually changed, instead of a repository root that `init` refuses.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
   find a file the change removed. An evaluated head that is not this worktree
   is the third such cause: discovery of the current tree answers about a
   different one, so no discovery command is offered there either — that route
-  asks for the checkout instead (below).
+  asks for the checkout instead (first entry above).
 
   Two blind spots in that probe are closed. It now bounds each directory's
   Python evidence to the files a `detect` *of that directory* would reach —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+- **`verify --preview` of a head that is not checked out now asks for the
+  checkout, instead of stopping.** Preview reads project markers from the
+  working tree, because that is the tree the `init` it recommends would write
+  to, so previewing some other ref establishes no project — on the reported
+  pull request the changed directory exists only on the PR branch. That state
+  routed to a human with `must_stop: true`, `command: null`, and
+  `allowed_next_commands: []`, which ended the loop `allowed_next_commands`
+  promises in one move; the remedy, derivable from the very ref preview was
+  handed, was never stated
+  ([#397](https://github.com/ThreeMoonsLab/agents-shipgate/issues/397)).
+
+  Nothing about the change is in doubt there. What is missing is an input — a
+  working tree holding the commit under review — and producing it is one
+  mechanical step the caller owns. The route is now the `fetch_base` action
+  that already exists for exactly this shape: `agent_action_required`, no
+  command (Shipgate never writes to a caller's worktree), and an `expects` that
+  names the input and a `why` that names the ref. Checking that ref out and
+  re-running the identical command resolves the project and emits the scoped
+  `init`. The two causes that no checkout can repair — evidence the change
+  deleted, an unreadable inventory — keep their human route. Plain `verify` is
+  unaffected: it reads `--head` from the object database, not the worktree.
+
+- **`detect` now publishes the same per-candidate `init` commands `init` does
+  when a workspace holds several agent projects.** Its escalation handed the
+  reader a JSON selector inside a shell command —
+  `init --workspace <agent_project_candidates[].path> --write` — and no
+  runnable command anywhere in `next_actions[]`, so a preview that routed to
+  `detect` reached a second dead end (#397). `detect --json` now ranks the
+  decision first, exactly as before (`kind: "review"`, `command: null`, because
+  naming one candidate would make the arbitrary pick `init --write` refuses to
+  make), and carries one exact `init --workspace <candidate> --write --json`
+  below it per candidate, with the `executable`/`args` pair. Both commands
+  build that list from one helper, so the two an adopter runs in sequence
+  cannot publish different recoveries for one workspace; the workspace root
+  stays out of it, since that is the scope `init` refuses.
+
 - **`verify --preview` on a monorepo now names the project the pull request
   actually changed, instead of a repository root that `init` refuses.** The
   change-scope resolver draws a project boundary around a bare
@@ -44,7 +80,8 @@
   another, and deleted evidence outranks a cap, because raising a bound cannot
   find a file the change removed. An evaluated head that is not this worktree
   is the third such cause: discovery of the current tree answers about a
-  different one, so that route carries no command either.
+  different one, so no discovery command is offered there either — that route
+  asks for the checkout instead (below).
 
   Two blind spots in that probe are closed. It now bounds each directory's
   Python evidence to the files a `detect` *of that directory* would reach —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,9 @@
   command emitted for them exited 2 on a manifest `init` will not overwrite
   while `expects` promised a file that already existed. The exception is
   `--agent-instructions`, which makes `init --write` the advertised refresh and
-  exits 0 — there the `init` route is kept, flags and all.
+  exits 0 — there the `init` route is kept, flags and all. `init`'s *printed*
+  refusal marks those candidates too, and names the `doctor` route: the human
+  and JSON forms of one run had begun answering the same question two ways.
 
   `detect`'s `control.input_id` now covers the route it publishes, not only the
   classification behind it. Every emitted command is spelled for the entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,23 @@
   the worktree the preview actually read.
 
   `fetch_base` accordingly means "make this input available" in both of its
-  senses, and the adoption scorer recognizes a `git checkout`/`git switch` as
-  input recovery alongside `git fetch`.
+  senses. Which sense a route asks for is read from `expects`, by every
+  consumer: the adoption scorer recognizes a checkout of *the requested commit*
+  — not a fetch, not a path-restoring `checkout --`, not a checkout of some
+  other commit — and still requires a fetch for a ref request.
+
+  The whole recovery is published in `expects`, which the envelope never
+  truncates, and the instruction leads `why`, which it caps at 400 bytes. A
+  sufficiently long branch name had pushed the checkout instruction and both
+  pinned refs out of the bounded field, leaving a consumer to re-derive the
+  rerun from its own `HEAD`-relative request — rebuilding the walk.
+
+  The pointer binds the *worktree* preview read, not only its HEAD. Preview
+  routinely routes on uncommitted evidence — an untracked `agent.py` beside an
+  untracked `pyproject.toml` is a project — and deleting one of those files
+  moves neither HEAD nor its tree, so the stale route stayed current. The path
+  set is derived from the live worktree on both sides, so any path entering or
+  leaving it, and any content change within it, refuses the pointer.
 
 - **`detect` now publishes the same per-candidate `init` commands `init` does
   when a workspace holds several agent projects.** Its escalation handed the
@@ -70,10 +85,23 @@
   command emitted for them exited 2 on a manifest `init` will not overwrite
   while `expects` promised a file that already existed. The exception is
   `--agent-instructions`, which makes `init --write` the advertised refresh and
-  exits 0 — there the `init` route is kept, flags and all. Both commands' *printed*
-  summaries mark those candidates and name the `doctor` route, from the one
-  formatter they now share: the human and JSON forms of a single run had begun
-  answering the same question two ways.
+  exits 0 — there the `init` route is kept, flags and all. Both commands'
+  *printed* summaries mark those candidates and name the `doctor` route, from
+  the one formatter they now share: the human and JSON forms of a single run had
+  begun answering the same question two ways.
+
+  Setup the caller asked for survives that route. A refused
+  `init --write --ci` writes no workflow, and handing the adopted candidate a
+  bare `doctor` dropped the request silently; it now carries `--ci` on an
+  `init` with `--write` omitted, which installs the workflow, leaves the
+  manifest alone, and exits 0.
+
+  The workspace root gets an answer too. `.` is a real entry in
+  `agent_project_candidates` and rank 1 tells the caller to choose from that
+  list, but it was the one candidate the routing skipped: `init` there is the
+  run that just refused, and `--allow-unresolved-scope` accepts the whole
+  workspace as one scope, which is a different decision. It is now an explicit
+  human route saying exactly that.
 
   `detect`'s `control.input_id` now covers the route it publishes, not only the
   classification behind it. Every emitted command is spelled for the entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,10 @@
   command emitted for them exited 2 on a manifest `init` will not overwrite
   while `expects` promised a file that already existed. The exception is
   `--agent-instructions`, which makes `init --write` the advertised refresh and
-  exits 0 — there the `init` route is kept, flags and all. `init`'s *printed*
-  refusal marks those candidates too, and names the `doctor` route: the human
-  and JSON forms of one run had begun answering the same question two ways.
+  exits 0 — there the `init` route is kept, flags and all. Both commands' *printed*
+  summaries mark those candidates and name the `doctor` route, from the one
+  formatter they now share: the human and JSON forms of a single run had begun
+  answering the same question two ways.
 
   `detect`'s `control.input_id` now covers the route it publishes, not only the
   classification behind it. Every emitted command is spelled for the entry

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -48,8 +48,9 @@ plugin manifests, `.mcp.json`, `.app.json`, or `SKILL.md`, run
 `control.state`. If it is `review_publishable`, a human must approve the merge
 and you may still commit, push, and update the PR; if it is
 `human_review_required`, stop for a human; if it is
-`agent_action_required`, perform only the exact coding-agent action and command
-in `control.next_action`.
+`agent_action_required`, perform only the exact coding-agent action in
+`control.next_action` — its `command` when it names one, and otherwise the
+input its `expects` names, which is the shape a `fetch_base` route carries.
 
 Do not claim completion unless `control.state` is `complete`. Conversation-level
 acknowledgement never changes control state; only a newly generated verifier

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -30,10 +30,10 @@ additionally wants `--head` **checked out**: it reads project markers from the
 working tree, because that is the tree the `init` it recommends would write to.
 Previewing some other ref establishes no project and returns
 `agent_action_required` with a `fetch_base` action whose `expects` names the
-missing input as a **commit id** — check that commit out, then re-run with the
-pinned `--base`/`--head` the `why` spells out, because a revision expression
-re-resolves against the new `HEAD`. Plain `verify` reads `--head` from the
-object database and needs no checkout. Read
+missing input as a **commit id**, together with the pinned `--base`/`--head` to
+re-run with — read them from `expects`, which is never truncated, because a
+revision expression re-resolves against the new `HEAD`. Plain `verify` reads
+`--head` from the object database and needs no checkout. Read
 `agents-shipgate-reports/agent-handoff.json` first and lead with
 `control.state`, `gate.merge_verdict`, `gate.can_merge_without_human`,
 `next_action`, `fix_task`, and `capability_review.top_changes[]`. Fall back to
@@ -169,8 +169,11 @@ Consume the response to decide whether to proceed. Key fields:
   Every candidate gets an entry; the workspace root is never offered, since it
   is the scope `init` refuses. A candidate that already carries a manifest gets
   `doctor --config <that manifest> --json` rather than an `init` that would
-  refuse to overwrite it — unless you asked for `--agent-instructions`, which
-  makes `init --write` the advertised refresh and exits 0.
+  refuse to overwrite it — unless you asked for setup it still owes: with
+  `--agent-instructions` the full `init --write` is the advertised refresh and
+  exits 0, and with `--ci` the command drops `--write` so the workflow is
+  installed and the manifest is left alone. The workspace root, when listed, is
+  a `review` entry rather than a command.
 
 **Stop condition.** Stop and skip `init` only when ALL of:
 

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -30,8 +30,10 @@ additionally wants `--head` **checked out**: it reads project markers from the
 working tree, because that is the tree the `init` it recommends would write to.
 Previewing some other ref establishes no project and returns
 `agent_action_required` with a `fetch_base` action whose `expects` names the
-missing input — check the ref out, then re-run the identical command. Plain
-`verify` reads `--head` from the object database and needs no checkout. Read
+missing input as a **commit id** — check that commit out, then re-run with the
+pinned `--base`/`--head` the `why` spells out, because a revision expression
+re-resolves against the new `HEAD`. Plain `verify` reads `--head` from the
+object database and needs no checkout. Read
 `agents-shipgate-reports/agent-handoff.json` first and lead with
 `control.state`, `gate.merge_verdict`, `gate.can_merge_without_human`,
 `next_action`, `fix_task`, and `capability_review.top_changes[]`. Fall back to
@@ -164,7 +166,11 @@ Consume the response to decide whether to proceed. Key fields:
   setup, so it promises none. Add `--ci` or `--agent-instructions` yourself if
   you want them, or take the command from `init`'s own refusal, which repeats
   the flags the run asked for. Match on the path rather than the ordering.
-  The workspace root is never offered: it is the scope `init` refuses.
+  Every candidate gets an entry; the workspace root is never offered, since it
+  is the scope `init` refuses. A candidate that already carries a manifest gets
+  `doctor --config <that manifest> --json` rather than an `init` that would
+  refuse to overwrite it — unless you asked for `--agent-instructions`, which
+  makes `init --write` the advertised refresh and exits 0.
 
 **Stop condition.** Stop and skip `init` only when ALL of:
 

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -159,8 +159,11 @@ Consume the response to decide whether to proceed. Key fields:
 - `next_actions[]` — the ranked route. On `agent_scope: "ambiguous"` rank 1 is
   the decision (`kind: "review"`, `command: null`) and every entry below it is
   one exact `init --workspace <candidate> --write --json`, with `executable`
-  and `args`, in candidate order — the same list `init --write` publishes when
-  it refuses the same workspace. Match on the path rather than the ordering.
+  and `args`, in candidate order — the list `init --write` publishes when it
+  refuses the same workspace, minus the setup flags: `detect` asked for no
+  setup, so it promises none. Add `--ci` or `--agent-instructions` yourself if
+  you want them, or take the command from `init`'s own refusal, which repeats
+  the flags the run asked for. Match on the path rather than the ordering.
   The workspace root is never offered: it is the scope `init` refuses.
 
 **Stop condition.** Stop and skip `init` only when ALL of:

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -25,7 +25,13 @@ agents-shipgate verify --workspace . --config shipgate.yaml \
 ```
 
 For local uncommitted work, omit `--base`/`--head`. For committed PR/CI refs,
-make the base ref available first because `verify` never fetches. Read
+make the base ref available first because `verify` never fetches. `--preview`
+additionally wants `--head` **checked out**: it reads project markers from the
+working tree, because that is the tree the `init` it recommends would write to.
+Previewing some other ref establishes no project and returns
+`agent_action_required` with a `fetch_base` action whose `expects` names the
+missing input — check the ref out, then re-run the identical command. Plain
+`verify` reads `--head` from the object database and needs no checkout. Read
 `agents-shipgate-reports/agent-handoff.json` first and lead with
 `control.state`, `gate.merge_verdict`, `gate.can_merge_without_human`,
 `next_action`, `fix_task`, and `capability_review.top_changes[]`. Fall back to
@@ -149,6 +155,12 @@ Consume the response to decide whether to proceed. Key fields:
 - `codex_plugin_candidates[]` — Codex plugin package or marketplace
   artifacts matched by convention. These also do NOT bump
   `is_agent_project` on their own.
+- `next_actions[]` — the ranked route. On `agent_scope: "ambiguous"` rank 1 is
+  the decision (`kind: "review"`, `command: null`) and every entry below it is
+  one exact `init --workspace <candidate> --write --json`, with `executable`
+  and `args`, in candidate order — the same list `init --write` publishes when
+  it refuses the same workspace. Match on the path rather than the ordering.
+  The workspace root is never offered: it is the scope `init` refuses.
 
 **Stop condition.** Stop and skip `init` only when ALL of:
 

--- a/docs/agents/protocol.md
+++ b/docs/agents/protocol.md
@@ -108,8 +108,13 @@ at all. The converse does not hold: `must_stop=false` is not a promise that
 publication is authorized — read `control.permissions`. `risk_level` remains explanatory.
 
 With `--format agent-boundary-json`, schema-valid results exit `0`; wrappers
-must switch on `control.state`, not `$?`. A missing ref may return an
-`agent_action_required` `fetch_base` action naming the exact required refs.
+must switch on `control.state`, not `$?`. A missing input may return an
+`agent_action_required` `fetch_base` action, which carries no `command` and
+names the input in `expects` instead: the exact refs to make available, or —
+from `verify --preview`, whose project markers are read from the working tree —
+the commit this worktree must have checked out. `expects` names a commit id
+rather than the ref you passed, because the checkout it asks for moves `HEAD`
+and a revision expression would then mean something else.
 An unreadable diff file, detached stdin/file diff that owes verification, or
 worktree/ref state Shipgate cannot bind returns `human_review_required` and
 authorizes no speculative rerun. Unsupported CLI shape errors such as an

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -94,9 +94,14 @@ So Shipgate scopes rather than guesses:
   reported pull request they disagreed completely: the changed directory
   existed only on the PR branch.) That is not a verdict about the change: the
   control route is `agent_action_required` with a `fetch_base` action whose
-  `expects` names what is missing (this worktree, at `<ref>`). Check the ref
-  out and re-run the identical command. Plain `verify` is unaffected — it reads
-  `--head` from the object database, not the worktree.
+  `expects` names what is missing: **a commit id**, not the ref you passed.
+  Check that commit out, then re-run the preview with the pinned
+  `--base`/`--head` the `why` spells out. The pinning is load-bearing —
+  `--head HEAD~1` names one commit before the checkout and its parent after, so
+  a route spelled with the expression would walk history backwards. `agent
+  control` refuses the old pointer once you check out, so a refresh-driven
+  caller re-runs preview rather than repeating the checkout. Plain `verify` is
+  unaffected — it reads `--head` from the object database, not the worktree.
 - `init --write` refuses a workspace whose agents live in more than one
   project: `manifest_status: "refused_unresolved_scope"`, exit `2`, and
   **nothing written** — no manifest, no CI workflow, no agent-instruction
@@ -135,9 +140,13 @@ So Shipgate scopes rather than guesses:
   `init --workspace <candidate> --write --json` per candidate, each with
   `executable`/`args`. Match on the path of the project you are changing and
   run that entry; the workspace root is never among them, since that is the
-  scope `init` refuses. A truncated parse outranks all of it: rank 1 is then
-  the higher-cap `detect` below, and no candidate commands are offered,
-  because the list they would be built from is a lower bound.
+  scope `init` refuses. Every candidate gets one — there is no display cap on
+  the routing — and a candidate that **already carries a manifest** gets
+  `doctor --config <that manifest> --json` instead, because `init --write`
+  there would refuse a file it will not overwrite. A truncated parse outranks
+  all of it: rank 1 is then the higher-cap `detect` below, and no candidate
+  commands are offered, because the list they would be built from is a lower
+  bound.
 - `python_parse_truncated: true` is the wider version of the same warning: the
   Python parse stopped at its cap, so *any* whole-workspace negative — most of
   all `is_agent_project: false` — describes the files that were read rather

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -86,6 +86,14 @@ So Shipgate scopes rather than guesses:
   beside a sibling project does not send the answer back to the root. When the
   changed project already carries its own `shipgate.yaml`, preview routes you
   to `verify` there instead of to setup.
+- Preview reads project markers from the **working tree**, because that is the
+  tree the `init` it recommends would write to. So `verify --preview --head
+  <ref>` while some other commit is checked out establishes no project — the
+  directory the pull request adds exists only on `<ref>`. That is not a verdict
+  about the change: the control route is `agent_action_required` with a
+  `fetch_base` action whose `expects` names what is missing (this worktree, at
+  `<ref>`). Check the ref out and re-run the identical command. Plain `verify`
+  is unaffected — it reads `--head` from the object database, not the worktree.
 - `init --write` refuses a workspace whose agents live in more than one
   project: `manifest_status: "refused_unresolved_scope"`, exit `2`, and
   **nothing written** — no manifest, no CI workflow, no agent-instruction
@@ -117,7 +125,13 @@ So Shipgate scopes rather than guesses:
   measured against.
 - `agents-shipgate detect --json` answers the same question without writing
   anything: read `agent_scope`, `agent_scope_truncated`, and
-  `agent_project_candidates[]`.
+  `agent_project_candidates[]`. Its `next_actions[]` carries the same shape
+  `init`'s refusal does — the decision first (`kind: "review"`, no command,
+  because naming one candidate would make the pick Shipgate declines to make),
+  then one exact `init --workspace <candidate> --write --json` per candidate,
+  each with `executable`/`args`. Match on the path of the project you are
+  changing and run that entry; the workspace root is never among them, since
+  that is the scope `init` refuses.
 - `python_parse_truncated: true` is the wider version of the same warning: the
   Python parse stopped at its cap, so *any* whole-workspace negative — most of
   all `is_agent_project: false` — describes the files that were read rather

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,11 +139,13 @@ So Shipgate scopes rather than guesses:
   the pick Shipgate declines to make), then one exact
   `init --workspace <candidate> --write --json` per candidate, each with
   `executable`/`args`. Match on the path of the project you are changing and
-  run that entry; the workspace root is never among them, since that is the
-  scope `init` refuses. Every candidate gets one — there is no display cap on
-  the routing — and a candidate that **already carries a manifest** gets
-  `doctor --config <that manifest> --json` instead, because `init --write`
-  there would refuse a file it will not overwrite. A truncated parse outranks
+  run that entry; the workspace root is never among the commands, since that is
+  the scope `init` refuses — it gets a `review` entry of its own instead, because
+  `--allow-unresolved-scope` adopts the whole workspace rather than that one
+  agent. Every candidate gets an entry — there is no display cap on the routing
+  — and one that **already carries a manifest** gets
+  `doctor --config <that manifest> --json`, because `init --write` there would
+  refuse a file it will not overwrite. A truncated parse outranks
   all of it: rank 1 is then the higher-cap `detect` below, and no candidate
   commands are offered, because the list they would be built from is a lower
   bound.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,12 +88,15 @@ So Shipgate scopes rather than guesses:
   to `verify` there instead of to setup.
 - Preview reads project markers from the **working tree**, because that is the
   tree the `init` it recommends would write to. So `verify --preview --head
-  <ref>` while some other commit is checked out establishes no project — the
-  directory the pull request adds exists only on `<ref>`. That is not a verdict
-  about the change: the control route is `agent_action_required` with a
-  `fetch_base` action whose `expects` names what is missing (this worktree, at
-  `<ref>`). Check the ref out and re-run the identical command. Plain `verify`
-  is unaffected — it reads `--head` from the object database, not the worktree.
+  <ref>` claims no scope whenever `<ref>` is not the commit the worktree has
+  checked out — whatever that worktree happens to hold, since the two trees can
+  disagree and only one of them is the tree `init` would run against. (On the
+  reported pull request they disagreed completely: the changed directory
+  existed only on the PR branch.) That is not a verdict about the change: the
+  control route is `agent_action_required` with a `fetch_base` action whose
+  `expects` names what is missing (this worktree, at `<ref>`). Check the ref
+  out and re-run the identical command. Plain `verify` is unaffected — it reads
+  `--head` from the object database, not the worktree.
 - `init --write` refuses a workspace whose agents live in more than one
   project: `manifest_status: "refused_unresolved_scope"`, exit `2`, and
   **nothing written** — no manifest, no CI workflow, no agent-instruction
@@ -125,13 +128,16 @@ So Shipgate scopes rather than guesses:
   measured against.
 - `agents-shipgate detect --json` answers the same question without writing
   anything: read `agent_scope`, `agent_scope_truncated`, and
-  `agent_project_candidates[]`. Its `next_actions[]` carries the same shape
-  `init`'s refusal does — the decision first (`kind: "review"`, no command,
-  because naming one candidate would make the pick Shipgate declines to make),
-  then one exact `init --workspace <candidate> --write --json` per candidate,
-  each with `executable`/`args`. Match on the path of the project you are
-  changing and run that entry; the workspace root is never among them, since
-  that is the scope `init` refuses.
+  `agent_project_candidates[]`. On `"ambiguous"` with a complete parse its
+  `next_actions[]` carries the same shape `init`'s refusal does — the decision
+  first (`kind: "review"`, no command, because naming one candidate would make
+  the pick Shipgate declines to make), then one exact
+  `init --workspace <candidate> --write --json` per candidate, each with
+  `executable`/`args`. Match on the path of the project you are changing and
+  run that entry; the workspace root is never among them, since that is the
+  scope `init` refuses. A truncated parse outranks all of it: rank 1 is then
+  the higher-cap `detect` below, and no candidate commands are offered,
+  because the list they would be built from is a lower bound.
 - `python_parse_truncated: true` is the wider version of the same warning: the
   Python parse stopped at its cap, so *any* whole-workspace negative — most of
   all `is_agent_project: false` — describes the files that were read rather

--- a/harness/adoption/scorer/rules.py
+++ b/harness/adoption/scorer/rules.py
@@ -1023,8 +1023,20 @@ def _action_satisfies_control(action: _TimelineItem, control: _ControlSnapshot) 
 
     # ``fetch_base`` is the sole structured input-recovery route that may omit
     # an exact command.  Everything else fails closed when no command exists.
+    #
+    # Two families of input satisfy it, because ``expects`` names an input and
+    # not always a ref: making history available (``git fetch``) and putting
+    # the evaluated commit in the worktree (``git checkout``), which is what
+    # ``verify --preview`` asks for when the head under review is not the
+    # commit checked out — project markers are read from the working tree, so
+    # a fetch would leave that request unmet (#397 review).
     if control.next_action.get("kind") == "fetch_base":
-        return bool(re.search(r"\bgit\s+(?:fetch|remote\s+update)\b", command))
+        return bool(
+            re.search(
+                r"\bgit\s+(?:fetch|remote\s+update|checkout|switch|restore)\b",
+                command,
+            )
+        )
     return False
 
 

--- a/harness/adoption/scorer/rules.py
+++ b/harness/adoption/scorer/rules.py
@@ -1030,10 +1030,15 @@ def _action_satisfies_control(action: _TimelineItem, control: _ControlSnapshot) 
     # ``verify --preview`` asks for when the head under review is not the
     # commit checked out — project markers are read from the working tree, so
     # a fetch would leave that request unmet (#397 review).
+    #
+    # ``checkout`` and ``switch`` and nothing else: those are the verbs that
+    # move ``HEAD``. ``git restore`` rewrites working-tree files and leaves
+    # ``HEAD`` where it was, so crediting it would pass a cell that never
+    # produced the commit the route asked for.
     if control.next_action.get("kind") == "fetch_base":
         return bool(
             re.search(
-                r"\bgit\s+(?:fetch|remote\s+update|checkout|switch|restore)\b",
+                r"\bgit\s+(?:fetch|remote\s+update|checkout|switch)\b",
                 command,
             )
         )

--- a/harness/adoption/scorer/rules.py
+++ b/harness/adoption/scorer/rules.py
@@ -1025,24 +1025,52 @@ def _action_satisfies_control(action: _TimelineItem, control: _ControlSnapshot) 
     # an exact command.  Everything else fails closed when no command exists.
     #
     # Two families of input satisfy it, because ``expects`` names an input and
-    # not always a ref: making history available (``git fetch``) and putting
-    # the evaluated commit in the worktree (``git checkout``), which is what
-    # ``verify --preview`` asks for when the head under review is not the
-    # commit checked out — project markers are read from the working tree, so
-    # a fetch would leave that request unmet (#397 review).
+    # not always a ref: making history available, and putting the evaluated
+    # commit in the worktree, which is what ``verify --preview`` asks for when
+    # the head under review is not the commit checked out (#397 review).
     #
-    # ``checkout`` and ``switch`` and nothing else: those are the verbs that
-    # move ``HEAD``. ``git restore`` rewrites working-tree files and leaves
-    # ``HEAD`` where it was, so crediting it would pass a cell that never
-    # produced the commit the route asked for.
+    # Which family is required is read from ``expects``, not accepted as a
+    # union.  Taking either satisfied a checkout request with ``git fetch`` and
+    # a fetch request with an unrelated checkout, so the criterion dropped an
+    # obligation the cell never met.
     if control.next_action.get("kind") == "fetch_base":
-        return bool(
-            re.search(
-                r"\bgit\s+(?:fetch|remote\s+update|checkout|switch)\b",
-                command,
-            )
-        )
+        requested = _CHECKOUT_REQUEST.search(control.next_action.get("expects") or "")
+        if requested is not None:
+            return _moves_head_to(command, requested.group("commit"))
+        return bool(re.search(r"\bgit\s+(?:fetch|remote\s+update)\b", command))
     return False
+
+
+# ``verify --preview`` spells a checkout request as "commit <id> checked out in
+# this worktree".  Matched as prose rather than imported, because this scorer
+# deliberately does not depend on the product schemas.
+_CHECKOUT_REQUEST = re.compile(
+    r"\bcommit\s+(?P<commit>[0-9a-f]{7,40})\b[^.]*?\bchecked out\b",
+    re.IGNORECASE,
+)
+
+
+def _moves_head_to(command: str, commit: str) -> bool:
+    """Whether ``command`` puts ``commit`` in the worktree.
+
+    Three near misses all read as checkouts and none of them satisfy the
+    request: ``git restore`` and ``git checkout -- <path>`` rewrite files while
+    leaving ``HEAD`` where it was, ``git switch main`` moves ``HEAD`` somewhere
+    else, and ``git checkout <other-sha>`` moves it to the wrong commit.  So the
+    verb has to be one that moves ``HEAD``, the path-restoring form is rejected,
+    and the target has to be the commit that was asked for — compared as a
+    prefix in either direction, since either side may be abbreviated.
+    """
+
+    if not re.search(r"\bgit\b.*\b(?:checkout|switch)\b", command, re.IGNORECASE):
+        return False
+    if re.search(r"\s--(?:\s|$)", command):
+        return False
+    commit = commit.casefold()
+    return any(
+        commit.startswith(token) or token.startswith(commit)
+        for token in re.findall(r"\b[0-9a-f]{7,40}\b", command.casefold())
+    )
 
 
 def _summary_satisfies_structured_request(summary: str, control: _ControlSnapshot) -> bool:

--- a/harness/adoption/scorer/rules.py
+++ b/harness/adoption/scorer/rules.py
@@ -1050,27 +1050,70 @@ _CHECKOUT_REQUEST = re.compile(
 )
 
 
+_ABBREVIATED_COMMIT = re.compile(r"[0-9a-f]{7,40}")
+# Git's own global options, and the ones among them that take a separate value.
+_GIT_GLOBAL_WITH_VALUE = frozenset(
+    {"-c", "-C", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+)
+_SHELL_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
+
+
+def _git_invocations(command: str) -> list[tuple[str, list[str]]]:
+    """Each git subcommand in a possibly compound line, with its own arguments.
+
+    Parsed rather than pattern-matched because the pieces of a checkout are
+    otherwise free to come from three different commands: ``git log <sha> &&
+    npm run checkout-preview`` has a ``git``, the word ``checkout`` and the
+    requested commit in it, and checks nothing out.
+    """
+
+    tokens = command.split()
+    invocations: list[tuple[str, list[str]]] = []
+    index = 0
+    while index < len(tokens):
+        if tokens[index].rsplit("/", 1)[-1] != "git":
+            index += 1
+            continue
+        cursor = index + 1
+        while cursor < len(tokens) and tokens[cursor].startswith("-"):
+            cursor += 2 if tokens[cursor] in _GIT_GLOBAL_WITH_VALUE else 1
+        if cursor >= len(tokens):
+            break
+        name = tokens[cursor]
+        cursor += 1
+        args: list[str] = []
+        while cursor < len(tokens) and tokens[cursor] not in _SHELL_SEPARATORS:
+            args.append(tokens[cursor])
+            cursor += 1
+        invocations.append((name, args))
+        index = cursor
+    return invocations
+
+
 def _moves_head_to(command: str, commit: str) -> bool:
     """Whether ``command`` puts ``commit`` in the worktree.
 
-    Three near misses all read as checkouts and none of them satisfy the
-    request: ``git restore`` and ``git checkout -- <path>`` rewrite files while
-    leaving ``HEAD`` where it was, ``git switch main`` moves ``HEAD`` somewhere
-    else, and ``git checkout <other-sha>`` moves it to the wrong commit.  So the
-    verb has to be one that moves ``HEAD``, the path-restoring form is rejected,
-    and the target has to be the commit that was asked for — compared as a
-    prefix in either direction, since either side may be abbreviated.
+    Several near misses read as checkouts and none of them satisfy the request:
+    ``git restore`` and ``git checkout -- <path>`` rewrite files while leaving
+    ``HEAD`` where it was, ``git switch main`` moves ``HEAD`` somewhere else,
+    and ``git checkout <other-sha>`` moves it to the wrong commit.  So the
+    subcommand has to be one that moves ``HEAD``, the path-restoring form is
+    rejected, and the target has to be the commit that was asked for — read
+    from that invocation's own arguments, and compared as a prefix in either
+    direction, since either side may be abbreviated.
     """
 
-    if not re.search(r"\bgit\b.*\b(?:checkout|switch)\b", command, re.IGNORECASE):
-        return False
-    if re.search(r"\s--(?:\s|$)", command):
-        return False
     commit = commit.casefold()
-    return any(
-        commit.startswith(token) or token.startswith(commit)
-        for token in re.findall(r"\b[0-9a-f]{7,40}\b", command.casefold())
-    )
+    for name, args in _git_invocations(command.casefold()):
+        if name not in {"checkout", "switch"} or "--" in args:
+            continue
+        if any(
+            commit.startswith(argument) or argument.startswith(commit)
+            for argument in args
+            if _ABBREVIATED_COMMIT.fullmatch(argument)
+        ):
+            return True
+    return False
 
 
 def _summary_satisfies_structured_request(summary: str, control: _ControlSnapshot) -> bool:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -284,8 +284,11 @@ agents-shipgate bootstrap --json
   `init --write` publishes when it refuses the same workspace, minus the setup
   flags, which `detect` was not asked for and does not invent: if you want
   `--ci` or `--agent-instructions`, add them, or take the command from `init`'s
-  own refusal, which repeats what you asked for. Choosing the project is the
-  only work left. A truncated parse outranks that, in `detect` and in `init`
+  own refusal, which repeats what you asked for. A candidate that already
+  carries a manifest gets `doctor --config <that manifest> --json` instead —
+  `init --write` there refuses a file it will not overwrite. Every candidate
+  gets an entry; the ten-item cap is on the human summary only. Choosing the
+  project is the only work left. A truncated parse outranks that, in `detect` and in `init`
   alike: rank 1 is then the higher-cap rerun and no candidate commands are
   offered, because the list they would be built from is a lower bound.
 - **`init`** — auto-detects by default. `--ci` writes
@@ -916,8 +919,10 @@ additionally wants `--head` **checked out**: it reads project markers from the
 working tree, because that is the tree the `init` it recommends would write to.
 Previewing some other ref establishes no project and returns
 `agent_action_required` with a `fetch_base` action whose `expects` names the
-missing input — check the ref out, then re-run the identical command. Plain
-`verify` reads `--head` from the object database and needs no checkout. Read
+missing input as a **commit id** — check that commit out, then re-run with the
+pinned `--base`/`--head` the `why` spells out, because a revision expression
+re-resolves against the new `HEAD`. Plain `verify` reads `--head` from the
+object database and needs no checkout. Read
 `agents-shipgate-reports/agent-handoff.json` first and lead with
 `control.state`, `gate.merge_verdict`, `gate.can_merge_without_human`,
 `next_action`, `fix_task`, and `capability_review.top_changes[]`. Fall back to
@@ -1050,7 +1055,11 @@ Consume the response to decide whether to proceed. Key fields:
   setup, so it promises none. Add `--ci` or `--agent-instructions` yourself if
   you want them, or take the command from `init`'s own refusal, which repeats
   the flags the run asked for. Match on the path rather than the ordering.
-  The workspace root is never offered: it is the scope `init` refuses.
+  Every candidate gets an entry; the workspace root is never offered, since it
+  is the scope `init` refuses. A candidate that already carries a manifest gets
+  `doctor --config <that manifest> --json` rather than an `init` that would
+  refuse to overwrite it — unless you asked for `--agent-instructions`, which
+  makes `init --write` the advertised refresh and exits 0.
 
 **Stop condition.** Stop and skip `init` only when ALL of:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -280,8 +280,11 @@ agents-shipgate bootstrap --json
   absence from a truncated list as an answer; raise the cap first. On
   `agent_scope: "ambiguous"` with a complete parse, `next_actions[]` ranks the
   decision first (`kind: "review"`, no command) and then carries one exact
-  `init --workspace <candidate> --write --json` per candidate — the same list
-  `init --write` publishes when it refuses — so choosing the project is the
+  `init --workspace <candidate> --write --json` per candidate — the list
+  `init --write` publishes when it refuses the same workspace, minus the setup
+  flags, which `detect` was not asked for and does not invent: if you want
+  `--ci` or `--agent-instructions`, add them, or take the command from `init`'s
+  own refusal, which repeats what you asked for. Choosing the project is the
   only work left. A truncated parse outranks that, in `detect` and in `init`
   alike: rank 1 is then the higher-cap rerun and no candidate commands are
   offered, because the list they would be built from is a lower bound.
@@ -1042,8 +1045,11 @@ Consume the response to decide whether to proceed. Key fields:
 - `next_actions[]` — the ranked route. On `agent_scope: "ambiguous"` rank 1 is
   the decision (`kind: "review"`, `command: null`) and every entry below it is
   one exact `init --workspace <candidate> --write --json`, with `executable`
-  and `args`, in candidate order — the same list `init --write` publishes when
-  it refuses the same workspace. Match on the path rather than the ordering.
+  and `args`, in candidate order — the list `init --write` publishes when it
+  refuses the same workspace, minus the setup flags: `detect` asked for no
+  setup, so it promises none. Add `--ci` or `--agent-instructions` yourself if
+  you want them, or take the command from `init`'s own refusal, which repeats
+  the flags the run asked for. Match on the path rather than the ordering.
   The workspace root is never offered: it is the scope `init` refuses.
 
 **Stop condition.** Stop and skip `init` only when ALL of:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -277,11 +277,14 @@ agents-shipgate bootstrap --json
   name the project directly. `agent_scope_truncated: true` says the candidate
   list itself is a lower bound — the parse stopped at its cap, so any project
   in the part of the tree that was not read is missing from it. Never read
-  absence from a truncated list as an answer; raise the cap first. On an
-  unresolved scope `next_actions[]` ranks the decision first (`kind: "review"`,
-  no command) and then carries one exact `init --workspace <candidate> --write
-  --json` per candidate — the same list `init --write` publishes when it
-  refuses — so choosing the project is the only work left.
+  absence from a truncated list as an answer; raise the cap first. On
+  `agent_scope: "ambiguous"` with a complete parse, `next_actions[]` ranks the
+  decision first (`kind: "review"`, no command) and then carries one exact
+  `init --workspace <candidate> --write --json` per candidate — the same list
+  `init --write` publishes when it refuses — so choosing the project is the
+  only work left. A truncated parse outranks that, in `detect` and in `init`
+  alike: rank 1 is then the higher-cap rerun and no candidate commands are
+  offered, because the list they would be built from is a lower bound.
 - **`init`** — auto-detects by default. `--ci` writes
   `.github/workflows/agents-shipgate.yml`; orthogonal to `--write`. Use
   `--minimal` for the pre-v0.6 CHANGE_ME-heavy template.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -277,7 +277,11 @@ agents-shipgate bootstrap --json
   name the project directly. `agent_scope_truncated: true` says the candidate
   list itself is a lower bound — the parse stopped at its cap, so any project
   in the part of the tree that was not read is missing from it. Never read
-  absence from a truncated list as an answer; raise the cap first.
+  absence from a truncated list as an answer; raise the cap first. On an
+  unresolved scope `next_actions[]` ranks the decision first (`kind: "review"`,
+  no command) and then carries one exact `init --workspace <candidate> --write
+  --json` per candidate — the same list `init --write` publishes when it
+  refuses — so choosing the project is the only work left.
 - **`init`** — auto-detects by default. `--ci` writes
   `.github/workflows/agents-shipgate.yml`; orthogonal to `--write`. Use
   `--minimal` for the pre-v0.6 CHANGE_ME-heavy template.
@@ -901,7 +905,13 @@ agents-shipgate verify --workspace . --config shipgate.yaml \
 ```
 
 For local uncommitted work, omit `--base`/`--head`. For committed PR/CI refs,
-make the base ref available first because `verify` never fetches. Read
+make the base ref available first because `verify` never fetches. `--preview`
+additionally wants `--head` **checked out**: it reads project markers from the
+working tree, because that is the tree the `init` it recommends would write to.
+Previewing some other ref establishes no project and returns
+`agent_action_required` with a `fetch_base` action whose `expects` names the
+missing input — check the ref out, then re-run the identical command. Plain
+`verify` reads `--head` from the object database and needs no checkout. Read
 `agents-shipgate-reports/agent-handoff.json` first and lead with
 `control.state`, `gate.merge_verdict`, `gate.can_merge_without_human`,
 `next_action`, `fix_task`, and `capability_review.top_changes[]`. Fall back to
@@ -1025,6 +1035,12 @@ Consume the response to decide whether to proceed. Key fields:
 - `codex_plugin_candidates[]` — Codex plugin package or marketplace
   artifacts matched by convention. These also do NOT bump
   `is_agent_project` on their own.
+- `next_actions[]` — the ranked route. On `agent_scope: "ambiguous"` rank 1 is
+  the decision (`kind: "review"`, `command: null`) and every entry below it is
+  one exact `init --workspace <candidate> --write --json`, with `executable`
+  and `args`, in candidate order — the same list `init --write` publishes when
+  it refuses the same workspace. Match on the path rather than the ordering.
+  The workspace root is never offered: it is the scope `init` refuses.
 
 **Stop condition.** Stop and skip `init` only when ALL of:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -286,9 +286,10 @@ agents-shipgate bootstrap --json
   `--ci` or `--agent-instructions`, add them, or take the command from `init`'s
   own refusal, which repeats what you asked for. A candidate that already
   carries a manifest gets `doctor --config <that manifest> --json` instead —
-  `init --write` there refuses a file it will not overwrite. Every candidate
-  gets an entry; the ten-item cap is on the human summary only. Choosing the
-  project is the only work left. A truncated parse outranks that, in `detect` and in `init`
+  `init --write` there refuses a file it will not overwrite — or, when you asked
+  for setup it still owes, an `init` carrying those flags. Every candidate gets
+  an entry, the workspace root as a `review` rather than a command; the ten-item
+  cap is on the human summary only. Choosing the project is the only work left. A truncated parse outranks that, in `detect` and in `init`
   alike: rank 1 is then the higher-cap rerun and no candidate commands are
   offered, because the list they would be built from is a lower bound.
 - **`init`** — auto-detects by default. `--ci` writes
@@ -919,10 +920,10 @@ additionally wants `--head` **checked out**: it reads project markers from the
 working tree, because that is the tree the `init` it recommends would write to.
 Previewing some other ref establishes no project and returns
 `agent_action_required` with a `fetch_base` action whose `expects` names the
-missing input as a **commit id** — check that commit out, then re-run with the
-pinned `--base`/`--head` the `why` spells out, because a revision expression
-re-resolves against the new `HEAD`. Plain `verify` reads `--head` from the
-object database and needs no checkout. Read
+missing input as a **commit id**, together with the pinned `--base`/`--head` to
+re-run with — read them from `expects`, which is never truncated, because a
+revision expression re-resolves against the new `HEAD`. Plain `verify` reads
+`--head` from the object database and needs no checkout. Read
 `agents-shipgate-reports/agent-handoff.json` first and lead with
 `control.state`, `gate.merge_verdict`, `gate.can_merge_without_human`,
 `next_action`, `fix_task`, and `capability_review.top_changes[]`. Fall back to
@@ -1058,8 +1059,11 @@ Consume the response to decide whether to proceed. Key fields:
   Every candidate gets an entry; the workspace root is never offered, since it
   is the scope `init` refuses. A candidate that already carries a manifest gets
   `doctor --config <that manifest> --json` rather than an `init` that would
-  refuse to overwrite it — unless you asked for `--agent-instructions`, which
-  makes `init --write` the advertised refresh and exits 0.
+  refuse to overwrite it — unless you asked for setup it still owes: with
+  `--agent-instructions` the full `init --write` is the advertised refresh and
+  exits 0, and with `--ci` the command drops `--write` so the workflow is
+  installed and the manifest is left alone. The workspace root, when listed, is
+  a `review` entry rather than a command.
 
 **Stop condition.** Stop and skip `init` only when ALL of:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -931,8 +931,9 @@ plugin manifests, `.mcp.json`, `.app.json`, or `SKILL.md`, run
 `control.state`. If it is `review_publishable`, a human must approve the merge
 and you may still commit, push, and update the PR; if it is
 `human_review_required`, stop for a human; if it is
-`agent_action_required`, perform only the exact coding-agent action and command
-in `control.next_action`.
+`agent_action_required`, perform only the exact coding-agent action in
+`control.next_action` — its `command` when it names one, and otherwise the
+input its `expects` names, which is the shape a `fetch_base` route carries.
 
 Do not claim completion unless `control.state` is `complete`. Conversation-level
 acknowledgement never changes control state; only a newly generated verifier

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -232,6 +232,7 @@ def _unresolved_scope_message(
                 "the project you are changing.",
             ]
         )
+    listed = candidates[:MAX_LISTED_SCOPE_CANDIDATES]
     if scope == "unknown":
         lines = [
             f"Refusing to write shipgate.yaml: discovery stopped at the "
@@ -241,7 +242,7 @@ def _unresolved_scope_message(
         ]
         if candidates:
             lines.append("Projects found before the cap:")
-            for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
+            for candidate in listed:
                 lines.append(f"  - {describe_candidate(candidate, workspace=workspace)}")
     else:
         lines = [
@@ -250,7 +251,7 @@ def _unresolved_scope_message(
             "and one manifest describes one agent surface.",
             "Candidate project directories:",
         ]
-        for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
+        for candidate in listed:
             lines.append(f"  - {describe_candidate(candidate, workspace=workspace)}")
     remaining = len(candidates) - MAX_LISTED_SCOPE_CANDIDATES
     if remaining > 0:
@@ -280,7 +281,7 @@ def _unresolved_scope_message(
         "or pass --allow-unresolved-scope to write one manifest for this "
         "workspace as a whole."
     )
-    lines.extend(candidate_caveats(workspace, candidates))
+    lines.extend(candidate_caveats(workspace, listed))
     if scope == "unknown" or parse_truncated:
         lines.append(
             f"Re-run with --max-python-files {python_file_total}, a bound that "

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -310,6 +310,7 @@ def _unresolved_scope_actions(
     python_file_total: int = 0,
     setup_command: list[str] | None = None,
     refreshes_existing: bool = False,
+    adopted_setup_flags: Sequence[str] = (),
 ) -> list[NextAction]:
     """Rank the decision above the commands that carry it out.
 
@@ -400,6 +401,7 @@ def _unresolved_scope_actions(
             workspace,
             candidates,
             setup_flags=setup_flags,
+            adopted_setup_flags=adopted_setup_flags,
             kit=kit,
             init_refreshes_existing=refreshes_existing,
         ),
@@ -1154,6 +1156,14 @@ def register(app: typer.Typer) -> None:
                 # refresh command — so an adopted candidate keeps its `init`
                 # route rather than being handed to `doctor` (#397 review).
                 refreshes_existing=bool(requested_targets),
+                # `--ci` is the one requested flag that still does its own work
+                # with `--write` omitted, so it is the one that can be carried
+                # to an adopted candidate without hitting the manifest refusal.
+                # `--claude-code` cannot: it is a dry run without `--write` —
+                # and it never reaches here, because it implies an
+                # `--agent-instructions` selection, which takes the refresh
+                # route above.
+                adopted_setup_flags=["--ci"] if ci else [],
             )
 
         # Routing. Computed from the manifest that is *on disk*, not from the

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -35,8 +35,8 @@ from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.discovery.scope import repository_root
 from agents_shipgate.cli.scope_routing import (
     MAX_LISTED_SCOPE_CANDIDATES,
+    candidate_caveats,
     describe_candidate,
-    is_adopted,
     scope_candidate_actions,
 )
 from agents_shipgate.cli.setup_control import (
@@ -280,15 +280,7 @@ def _unresolved_scope_message(
         "or pass --allow-unresolved-scope to write one manifest for this "
         "workspace as a whole."
     )
-    if any(
-        candidate.path != "." and is_adopted(workspace / candidate.path) is not None
-        for candidate in candidates
-    ):
-        lines.append(
-            "A project marked already adopted has a manifest init will not "
-            "overwrite; ask doctor --config <that manifest> what it still "
-            "owes instead."
-        )
+    lines.extend(candidate_caveats(workspace, candidates))
     if scope == "unknown" or parse_truncated:
         lines.append(
             f"Re-run with --max-python-files {python_file_total}, a bound that "

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -33,6 +33,10 @@ from agents_shipgate.cli.discovery.gitignore_block import (
 from agents_shipgate.cli.discovery.local_contract import LOCAL_CONTRACT_RELATIVE_PATH
 from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.discovery.scope import repository_root
+from agents_shipgate.cli.scope_routing import (
+    MAX_LISTED_SCOPE_CANDIDATES,
+    scope_candidate_actions,
+)
 from agents_shipgate.cli.setup_control import (
     SETUP_COMPLETE,
     SETUP_INCOMPLETE,
@@ -154,11 +158,6 @@ def _detect_json_indent(text: str) -> int:
     return 2
 
 
-# A monorepo can hold hundreds of agent projects. The refusal lists enough
-# of them to route on and points at the JSON payload for the rest.
-_MAX_LISTED_SCOPE_CANDIDATES = 10
-
-
 def _describe_candidate(candidate: AgentProjectCandidate) -> str:
     """One candidate as a line a human can choose from.
 
@@ -205,7 +204,7 @@ def _requested_setup_flags(
 
     ``--agent-instructions-kit`` is deliberately not here: it is a path,
     and a path is only meaningful relative to a workspace. See
-    :func:`_rebased_kit_flags`.
+    :func:`agents_shipgate.cli.scope_routing.rebased_kit_flags`.
     """
 
     flags: list[str] = []
@@ -216,28 +215,6 @@ def _requested_setup_flags(
     if agent_instructions is not None:
         flags.append(f"--agent-instructions={agent_instructions}")
     return flags
-
-
-def _rebased_kit_flags(
-    kit: Path | None, *, source: Path, target: Path
-) -> list[str] | None:
-    """``--agent-instructions-kit`` for a command run in ``target``.
-
-    Returns ``None`` when the kit cannot be named from there, which is a
-    refusal rather than a fallback: a kit path is resolved *under the
-    workspace*, so copying a root-relative ``.agents-shipgate/kit.yaml``
-    into a command that runs in ``apps/a`` points at a file that does not
-    exist, and the emitted command exits 2 (#363 review).
-    """
-
-    if kit is None:
-        return []
-    resolved = kit if kit.is_absolute() else (source / kit)
-    try:
-        relative = resolved.resolve().relative_to(target.resolve())
-    except (OSError, ValueError):
-        return None
-    return ["--agent-instructions-kit", relative.as_posix()]
 
 
 def _unresolved_scope_message(
@@ -275,7 +252,7 @@ def _unresolved_scope_message(
         ]
         if candidates:
             lines.append("Projects found before the cap:")
-            for candidate in candidates[:_MAX_LISTED_SCOPE_CANDIDATES]:
+            for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
                 lines.append(f"  - {_describe_candidate(candidate)}")
     else:
         lines = [
@@ -284,9 +261,9 @@ def _unresolved_scope_message(
             "and one manifest describes one agent surface.",
             "Candidate project directories:",
         ]
-        for candidate in candidates[:_MAX_LISTED_SCOPE_CANDIDATES]:
+        for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
             lines.append(f"  - {_describe_candidate(candidate)}")
-    remaining = len(candidates) - _MAX_LISTED_SCOPE_CANDIDATES
+    remaining = len(candidates) - MAX_LISTED_SCOPE_CANDIDATES
     if remaining > 0:
         lines.append(
             f"  - ... ({remaining} more; see auto_detected.agent_project_candidates "
@@ -417,54 +394,13 @@ def _unresolved_scope_actions(
             "auto_detected.agent_project_candidates."
         ),
     )
-    actions = [retry, decision] if retry is not None else [decision]
-    # The workspace root is never offered as a command: it is the scope this
-    # run just refused, so running it again returns here. `.` stays in the
-    # reported candidate list because agent files that belong to no
-    # sub-project are real evidence of why the answer is unresolved, and
-    # `--allow-unresolved-scope` is the route that accepts them.
-    routable = [candidate for candidate in candidates if candidate.path != "."]
-    for candidate in routable[:_MAX_LISTED_SCOPE_CANDIDATES]:
-        target = workspace / candidate.path
-        defines = ", ".join(candidate.agent_names)
-        kit_flags = _rebased_kit_flags(kit, source=workspace, target=target)
-        if kit_flags is None:
-            actions.append(
-                NextAction(
-                    kind="review",
-                    why=(
-                        f"{candidate.path} is a candidate, but the adoption kit "
-                        f"at {kit} sits outside it and a kit path is resolved "
-                        "under the workspace. Relocate the kit into the project "
-                        "or drop --agent-instructions-kit before initializing "
-                        "there."
-                    ),
-                    expects=f"An adoption kit reachable from {candidate.path}.",
-                )
-            )
-            continue
-        actions.append(
-            NextAction(
-                kind="command",
-                command=render_command(
-                    [
-                        "init",
-                        "--workspace",
-                        str(target),
-                        "--write",
-                        *setup_flags,
-                        *kit_flags,
-                        "--json",
-                    ]
-                ),
-                why=(
-                    f"Initialize only {candidate.path}"
-                    + (f", which defines {defines}." if defines else ".")
-                ),
-                expects=f"shipgate.yaml is created in {candidate.path}.",
-            )
-        )
-    return actions
+    return [
+        *([retry] if retry is not None else []),
+        decision,
+        *scope_candidate_actions(
+            workspace, candidates, setup_flags=setup_flags, kit=kit
+        ),
+    ]
 
 
 def _claude_code_outcome_lines(outcome: dict[str, object]) -> list[str]:

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -35,6 +35,7 @@ from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.discovery.scope import repository_root
 from agents_shipgate.cli.scope_routing import (
     MAX_LISTED_SCOPE_CANDIDATES,
+    is_adopted,
     scope_candidate_actions,
 )
 from agents_shipgate.cli.setup_control import (
@@ -158,17 +159,30 @@ def _detect_json_indent(text: str) -> int:
     return 2
 
 
-def _describe_candidate(candidate: AgentProjectCandidate) -> str:
+def _describe_candidate(
+    candidate: AgentProjectCandidate, *, workspace: Path | None = None
+) -> str:
     """One candidate as a line a human can choose from.
 
     Not every project names its agent in a string literal — a config-driven
     ``LlmAgent(name=CONFIG.agent_name)`` has none to parse — so the marker
     that made the directory a project stands in for it rather than leaving
     an empty pair of brackets.
+
+    A candidate that already carries a manifest says so. The routing published
+    beside this list sends those to ``doctor``, because the ``init --write``
+    the next line recommends refuses a manifest it will not overwrite — and a
+    list that reads identically for both leaves the human form of this refusal
+    contradicting the JSON form of the same run (#397 review).
     """
 
     detail = ", ".join(candidate.agent_names) or (candidate.marker or "project root")
-    return f"{candidate.path} ({detail})"
+    adopted = (
+        workspace is not None
+        and candidate.path != "."
+        and is_adopted(workspace / candidate.path) is not None
+    )
+    return f"{candidate.path} ({detail})" + (" — already adopted" if adopted else "")
 
 
 def _scan_command_config(target: Path) -> str:
@@ -253,7 +267,7 @@ def _unresolved_scope_message(
         if candidates:
             lines.append("Projects found before the cap:")
             for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
-                lines.append(f"  - {_describe_candidate(candidate)}")
+                lines.append(f"  - {_describe_candidate(candidate, workspace=workspace)}")
     else:
         lines = [
             f"Refusing to write shipgate.yaml: {workspace} holds "
@@ -262,7 +276,7 @@ def _unresolved_scope_message(
             "Candidate project directories:",
         ]
         for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
-            lines.append(f"  - {_describe_candidate(candidate)}")
+            lines.append(f"  - {_describe_candidate(candidate, workspace=workspace)}")
     remaining = len(candidates) - MAX_LISTED_SCOPE_CANDIDATES
     if remaining > 0:
         lines.append(
@@ -291,6 +305,15 @@ def _unresolved_scope_message(
         "or pass --allow-unresolved-scope to write one manifest for this "
         "workspace as a whole."
     )
+    if any(
+        candidate.path != "." and is_adopted(workspace / candidate.path) is not None
+        for candidate in candidates
+    ):
+        lines.append(
+            "A project marked already adopted has a manifest init will not "
+            "overwrite; ask doctor --config <that manifest> what it still "
+            "owes instead."
+        )
     if scope == "unknown" or parse_truncated:
         lines.append(
             f"Re-run with --max-python-files {python_file_total}, a bound that "

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -35,6 +35,7 @@ from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.discovery.scope import repository_root
 from agents_shipgate.cli.scope_routing import (
     MAX_LISTED_SCOPE_CANDIDATES,
+    describe_candidate,
     is_adopted,
     scope_candidate_actions,
 )
@@ -159,32 +160,6 @@ def _detect_json_indent(text: str) -> int:
     return 2
 
 
-def _describe_candidate(
-    candidate: AgentProjectCandidate, *, workspace: Path | None = None
-) -> str:
-    """One candidate as a line a human can choose from.
-
-    Not every project names its agent in a string literal — a config-driven
-    ``LlmAgent(name=CONFIG.agent_name)`` has none to parse — so the marker
-    that made the directory a project stands in for it rather than leaving
-    an empty pair of brackets.
-
-    A candidate that already carries a manifest says so. The routing published
-    beside this list sends those to ``doctor``, because the ``init --write``
-    the next line recommends refuses a manifest it will not overwrite — and a
-    list that reads identically for both leaves the human form of this refusal
-    contradicting the JSON form of the same run (#397 review).
-    """
-
-    detail = ", ".join(candidate.agent_names) or (candidate.marker or "project root")
-    adopted = (
-        workspace is not None
-        and candidate.path != "."
-        and is_adopted(workspace / candidate.path) is not None
-    )
-    return f"{candidate.path} ({detail})" + (" — already adopted" if adopted else "")
-
-
 def _scan_command_config(target: Path) -> str:
     """How the follow-up ``scan`` should name the manifest just written.
 
@@ -267,7 +242,7 @@ def _unresolved_scope_message(
         if candidates:
             lines.append("Projects found before the cap:")
             for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
-                lines.append(f"  - {_describe_candidate(candidate, workspace=workspace)}")
+                lines.append(f"  - {describe_candidate(candidate, workspace=workspace)}")
     else:
         lines = [
             f"Refusing to write shipgate.yaml: {workspace} holds "
@@ -276,7 +251,7 @@ def _unresolved_scope_message(
             "Candidate project directories:",
         ]
         for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
-            lines.append(f"  - {_describe_candidate(candidate, workspace=workspace)}")
+            lines.append(f"  - {describe_candidate(candidate, workspace=workspace)}")
     remaining = len(candidates) - MAX_LISTED_SCOPE_CANDIDATES
     if remaining > 0:
         lines.append(

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -311,6 +311,7 @@ def _unresolved_scope_actions(
     parse_truncated: bool = False,
     python_file_total: int = 0,
     setup_command: list[str] | None = None,
+    refreshes_existing: bool = False,
 ) -> list[NextAction]:
     """Rank the decision above the commands that carry it out.
 
@@ -398,7 +399,11 @@ def _unresolved_scope_actions(
         *([retry] if retry is not None else []),
         decision,
         *scope_candidate_actions(
-            workspace, candidates, setup_flags=setup_flags, kit=kit
+            workspace,
+            candidates,
+            setup_flags=setup_flags,
+            kit=kit,
+            init_refreshes_existing=refreshes_existing,
         ),
     ]
 
@@ -1146,6 +1151,11 @@ def register(app: typer.Typer) -> None:
                         agent_instructions=agent_instructions,
                     ),
                 ],
+                # With an instruction target selected, `init --write` leaves an
+                # existing manifest alone and still exits 0 — the advertised
+                # refresh command — so an adopted candidate keeps its `init`
+                # route rather than being handed to `doctor` (#397 review).
+                refreshes_existing=bool(requested_targets),
             )
 
         # Routing. Computed from the manifest that is *on disk*, not from the

--- a/src/agents_shipgate/cli/detect.py
+++ b/src/agents_shipgate/cli/detect.py
@@ -25,8 +25,8 @@ from agents_shipgate.cli.discovery import (
 )
 from agents_shipgate.cli.scope_routing import (
     MAX_LISTED_SCOPE_CANDIDATES,
+    candidate_caveats,
     describe_candidate,
-    is_adopted,
     scope_candidate_actions,
 )
 from agents_shipgate.cli.setup_control import (
@@ -432,16 +432,8 @@ def _echo_agent_scope(result: DetectResult, *, workspace: Path) -> None:
             "One shipgate.yaml describes one agent surface, so init --write "
             "refuses here until you name the project directory to initialize."
         )
-        if any(
-            candidate.path != "."
-            and is_adopted(workspace / candidate.path) is not None
-            for candidate in candidates
-        ):
-            typer.echo(
-                "A project marked already adopted has a manifest init will "
-                "not overwrite; ask doctor --config <that manifest> what it "
-                "still owes instead."
-            )
+        for caveat in candidate_caveats(workspace, list(candidates)):
+            typer.echo(caveat)
     if result.agent_scope_truncated:
         roots = result.workspace_signals.project_root_count
         typer.echo(

--- a/src/agents_shipgate/cli/detect.py
+++ b/src/agents_shipgate/cli/detect.py
@@ -97,7 +97,20 @@ def detect(
             operation="detect",
             workspace=workspace_resolved,
             manifest_path=(workspace_resolved / "shipgate.yaml" if has_manifest else None),
-            routing_facts=(result.model_dump(mode="json"), advance_decision),
+            # The *route*, not only the classification behind it. Every
+            # command published below is spelled for the entry point this
+            # process came in through (#322), so the same ambiguous workspace
+            # read as `agents-shipgate` and as `/opt/custom/agents-shipgate`
+            # publishes different `command`/`executable` values — and hashing
+            # the detection alone gave both one identity, which is the cache
+            # boundary for the answer. `init` and `doctor` already fold their
+            # own actions in for exactly this reason (#397 review).
+            routing_facts=(
+                result.model_dump(mode="json"),
+                advance_decision,
+                advance.model_dump(mode="json") if advance is not None else None,
+                [action.model_dump(mode="json") for action in advance_alternatives],
+            ),
         ),
         reason=_detect_reason(result, has_manifest=has_manifest),
         diagnostics=diagnostics,

--- a/src/agents_shipgate/cli/detect.py
+++ b/src/agents_shipgate/cli/detect.py
@@ -25,6 +25,8 @@ from agents_shipgate.cli.discovery import (
 )
 from agents_shipgate.cli.scope_routing import (
     MAX_LISTED_SCOPE_CANDIDATES,
+    describe_candidate,
+    is_adopted,
     scope_candidate_actions,
 )
 from agents_shipgate.cli.setup_control import (
@@ -180,7 +182,7 @@ def detect(
             if len(framework.evidence) > 5:
                 typer.echo(f"    · ... ({len(framework.evidence) - 5} more)")
         typer.echo("")
-    _echo_agent_scope(result)
+    _echo_agent_scope(result, workspace=workspace_resolved)
     if result.agent_name_candidates:
         # The same call `init` makes, not "candidate zero" — printing the
         # top-ranked entry regardless of selectability would tell a human
@@ -394,7 +396,7 @@ def _detect_advance(
     )
 
 
-def _echo_agent_scope(result: DetectResult) -> None:
+def _echo_agent_scope(result: DetectResult, *, workspace: Path) -> None:
     """Say when the workspace holds more than one manifest's worth of agents.
 
     Silent in the ordinary single-project case: the manifest scope is then
@@ -421,10 +423,7 @@ def _echo_agent_scope(result: DetectResult) -> None:
             + (" Projects found before the cap:" if candidates else "")
         )
     for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
-        # A config-driven ``LlmAgent(name=CONFIG.agent_name)`` leaves no name
-        # literal to parse; name the marker that made it a project instead.
-        detail = ", ".join(candidate.agent_names) or (candidate.marker or "project root")
-        typer.echo(f"- {candidate.path} ({detail})")
+        typer.echo(f"- {describe_candidate(candidate, workspace=workspace)}")
     remaining = len(candidates) - MAX_LISTED_SCOPE_CANDIDATES
     if remaining > 0:
         typer.echo(f"- ... ({remaining} more; see agent_project_candidates in --json)")
@@ -433,6 +432,16 @@ def _echo_agent_scope(result: DetectResult) -> None:
             "One shipgate.yaml describes one agent surface, so init --write "
             "refuses here until you name the project directory to initialize."
         )
+        if any(
+            candidate.path != "."
+            and is_adopted(workspace / candidate.path) is not None
+            for candidate in candidates
+        ):
+            typer.echo(
+                "A project marked already adopted has a manifest init will "
+                "not overwrite; ask doctor --config <that manifest> what it "
+                "still owes instead."
+            )
     if result.agent_scope_truncated:
         roots = result.workspace_signals.project_root_count
         typer.echo(

--- a/src/agents_shipgate/cli/detect.py
+++ b/src/agents_shipgate/cli/detect.py
@@ -422,7 +422,8 @@ def _echo_agent_scope(result: DetectResult, *, workspace: Path) -> None:
             "whether one manifest describes this workspace."
             + (" Projects found before the cap:" if candidates else "")
         )
-    for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
+    listed = candidates[:MAX_LISTED_SCOPE_CANDIDATES]
+    for candidate in listed:
         typer.echo(f"- {describe_candidate(candidate, workspace=workspace)}")
     remaining = len(candidates) - MAX_LISTED_SCOPE_CANDIDATES
     if remaining > 0:
@@ -432,7 +433,7 @@ def _echo_agent_scope(result: DetectResult, *, workspace: Path) -> None:
             "One shipgate.yaml describes one agent surface, so init --write "
             "refuses here until you name the project directory to initialize."
         )
-        for caveat in candidate_caveats(workspace, list(candidates)):
+        for caveat in candidate_caveats(workspace, listed):
             typer.echo(caveat)
     if result.agent_scope_truncated:
         roots = result.workspace_signals.project_root_count

--- a/src/agents_shipgate/cli/detect.py
+++ b/src/agents_shipgate/cli/detect.py
@@ -23,6 +23,10 @@ from agents_shipgate.cli.discovery import (
     detect_workspace,
     select_agent_name,
 )
+from agents_shipgate.cli.scope_routing import (
+    MAX_LISTED_SCOPE_CANDIDATES,
+    scope_candidate_actions,
+)
 from agents_shipgate.cli.setup_control import (
     SETUP_INCOMPLETE,
     setup_control_envelope,
@@ -34,10 +38,6 @@ from agents_shipgate.invocation import render_command
 from agents_shipgate.schemas.agent_control import AgentActionKind
 from agents_shipgate.schemas.detect import DetectResult
 from agents_shipgate.schemas.diagnostics import Diagnostic, NextAction
-
-# A monorepo can hold hundreds of agent projects; the human summary lists
-# enough to recognize the shape and points at --json for the rest.
-_MAX_ECHOED_SCOPE_CANDIDATES = 10
 
 
 def detect(
@@ -88,7 +88,7 @@ def detect(
     diagnostics: list[Diagnostic] = diagnose_detect(
         result, has_manifest=has_manifest, workspace=workspace_resolved
     )
-    advance, advance_kind, advance_decision = _detect_advance(
+    advance, advance_kind, advance_decision, advance_alternatives = _detect_advance(
         result, has_manifest=has_manifest, workspace=workspace_resolved
     )
     routing = setup_control_envelope(
@@ -104,6 +104,7 @@ def detect(
         advance=advance,
         advance_kind=advance_kind,
         advance_decision=advance_decision,
+        advance_alternatives=advance_alternatives,
         # `detect` classifies; it never fails a gate. This JSON path always
         # exits 0, and reporting the fact beats leaving a reader to infer it.
         exit_code=0,
@@ -226,7 +227,7 @@ def _detect_advance(
     *,
     has_manifest: bool,
     workspace: Path,
-) -> tuple[NextAction | None, AgentActionKind, str]:
+) -> tuple[NextAction | None, AgentActionKind, str, list[NextAction]]:
     """The stage this classification hands off to when nothing is wrong.
 
     ``DetectResult.next_action`` already names ``init`` in the adoptable case,
@@ -262,6 +263,14 @@ def _detect_advance(
     unrunnable string, and typing it as an agent route would ask the agent to
     make the choice; it is a human route.
 
+    That is why the fourth element exists. A human route is a decision to be
+    made, not an absence of work: below it go the exact ``init`` commands that
+    carry the decision out, one per candidate, which is the shape ``init``'s
+    own refusal has always published. Returned from here rather than recomposed
+    at the call site, because the condition that selects the route is the same
+    condition that makes the commands correct, and reading it twice is how the
+    two drift (#397).
+
     ``None`` when the workspace is not adoptable at all; the negative-control
     diagnostics own that route and end in a human stop.
     """
@@ -290,6 +299,7 @@ def _detect_advance(
             ),
             "configure",
             SETUP_INCOMPLETE,
+            [],
         )
     if result.python_parse_truncated:
         # Raising the cap is a mechanical, read-only retry, not a judgement —
@@ -328,6 +338,7 @@ def _detect_advance(
             ),
             "discover",
             SETUP_INCOMPLETE,
+            [],
         )
     if result.agent_scope != "single":
         return (
@@ -344,6 +355,11 @@ def _detect_advance(
             ),
             "discover",
             SETUP_INCOMPLETE,
+            # The decision is a person's; carrying it out is not. `init`
+            # publishes the per-candidate command for every project it refuses
+            # to choose between, and `detect` reporting the same fact one step
+            # earlier owed the caller the same list (#397).
+            scope_candidate_actions(workspace, result.agent_project_candidates),
         )
     adoptable = bool(
         result.is_agent_project
@@ -351,7 +367,7 @@ def _detect_advance(
         or result.codex_plugin_candidates
     )
     if not adoptable:
-        return (None, "discover", SETUP_INCOMPLETE)
+        return (None, "discover", SETUP_INCOMPLETE, [])
     return (
         NextAction(
             kind="command",
@@ -361,6 +377,7 @@ def _detect_advance(
         ),
         "initialize",
         SETUP_INCOMPLETE,
+        [],
     )
 
 
@@ -390,12 +407,12 @@ def _echo_agent_scope(result: DetectResult) -> None:
             "whether one manifest describes this workspace."
             + (" Projects found before the cap:" if candidates else "")
         )
-    for candidate in candidates[:_MAX_ECHOED_SCOPE_CANDIDATES]:
+    for candidate in candidates[:MAX_LISTED_SCOPE_CANDIDATES]:
         # A config-driven ``LlmAgent(name=CONFIG.agent_name)`` leaves no name
         # literal to parse; name the marker that made it a project instead.
         detail = ", ".join(candidate.agent_names) or (candidate.marker or "project root")
         typer.echo(f"- {candidate.path} ({detail})")
-    remaining = len(candidates) - _MAX_ECHOED_SCOPE_CANDIDATES
+    remaining = len(candidates) - MAX_LISTED_SCOPE_CANDIDATES
     if remaining > 0:
         typer.echo(f"- ... ({remaining} more; see agent_project_candidates in --json)")
     if result.agent_scope == "ambiguous":

--- a/src/agents_shipgate/cli/install_hooks.py
+++ b/src/agents_shipgate/cli/install_hooks.py
@@ -1073,7 +1073,7 @@ def _route_verify_result(
             expects = next_action.get("expects") or "the requested Git ref"
             return _emit_stop_block(
                 f"Agents Shipgate verify ran before completion: {summary}.{base_note} "
-                f"Make {expects!r} available locally, then rerun the verifier. "
+                f"Provide {expects!r}, then rerun the verifier. "
                 f"{why} No executable command was authorized by the control result."
             )
         if not isinstance(command, str) or command not in allowed_commands:

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -88,24 +88,58 @@ def describe_candidate(candidate: AgentProjectCandidate, *, workspace: Path) -> 
     that made the directory a project stands in for it rather than leaving
     an empty pair of brackets.
 
-    A candidate that already carries a manifest says so, because the routing
-    published beside this list sends those to ``doctor``: the ``init --write``
-    both commands recommend in prose refuses a manifest it will not overwrite.
+    Two candidates say more than their name, because the routing published
+    beside this list sends them somewhere other than the ``init --write`` the
+    surrounding prose recommends: one that already carries a manifest goes to
+    ``doctor``, and the workspace root goes to a human, since ``init`` there is
+    the run that just refused. Both would otherwise read as ordinary entries in
+    a list captioned "re-run init on the one you are changing" (#397 review).
+
     Shared rather than written once per command — ``detect`` and ``init`` each
     print this list, and a second copy is how one of them kept saying ``init``
-    after the other stopped (#397 review).
-
-    ``workspace`` is required rather than defaulted for the same reason: an
-    optional one would let a third surface print this list unmarked, and be
-    right back to a human summary that contradicts the routes beside it.
+    after the other stopped. ``workspace`` is required rather than defaulted
+    for the same reason: an optional one would let a third surface print this
+    list unmarked, and be right back to a human summary that contradicts the
+    routes beside it.
     """
 
     detail = ", ".join(candidate.agent_names) or (candidate.marker or "project root")
-    adopted = (
-        candidate.path != "."
-        and is_adopted(workspace / candidate.path) is not None
-    )
+    if candidate.path == ".":
+        return f"{candidate.path} ({detail}) — the workspace itself, not a project"
+    adopted = is_adopted(workspace / candidate.path) is not None
     return f"{candidate.path} ({detail})" + (" — already adopted" if adopted else "")
+
+
+def candidate_caveats(
+    workspace: Path, candidates: Sequence[AgentProjectCandidate]
+) -> list[str]:
+    """What the "re-run init on one of these" line does not cover.
+
+    Emitted only for the candidates actually present, so neither line becomes
+    boilerplate. `detect` prints the same pair from the same helper — a printed
+    list that reads uniformly while the routing beside it splits three ways is
+    the divergence this is here to prevent (#397 review).
+    """
+
+    lines: list[str] = []
+    if any(
+        candidate.path != "." and is_adopted(workspace / candidate.path) is not None
+        for candidate in candidates
+    ):
+        lines.append(
+            "A project marked already adopted has a manifest init will not "
+            "overwrite; ask doctor --config <that manifest> what it still "
+            "owes instead."
+        )
+    if any(candidate.path == "." for candidate in candidates):
+        lines.append(
+            "The workspace itself is listed because agent files there belong "
+            "to no project — which is why this scope is unresolved. Give them "
+            "a project directory, or accept the whole workspace as one scope "
+            "with --allow-unresolved-scope; re-running init at the root "
+            "returns this refusal."
+        )
+    return lines
 
 
 def scope_candidate_actions(
@@ -290,6 +324,7 @@ def scope_candidate_actions(
 
 __all__ = [
     "MANIFEST_NAME",
+    "candidate_caveats",
     "describe_candidate",
     "MAX_LISTED_SCOPE_CANDIDATES",
     "is_adopted",

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -78,9 +78,7 @@ def is_adopted(directory: Path) -> Path | None:
     return candidate
 
 
-def describe_candidate(
-    candidate: AgentProjectCandidate, *, workspace: Path | None = None
-) -> str:
+def describe_candidate(candidate: AgentProjectCandidate, *, workspace: Path) -> str:
     """One candidate as a line a human can choose from.
 
     Not every project names its agent in a string literal — a config-driven
@@ -94,12 +92,15 @@ def describe_candidate(
     Shared rather than written once per command — ``detect`` and ``init`` each
     print this list, and a second copy is how one of them kept saying ``init``
     after the other stopped (#397 review).
+
+    ``workspace`` is required rather than defaulted for the same reason: an
+    optional one would let a third surface print this list unmarked, and be
+    right back to a human summary that contradicts the routes beside it.
     """
 
     detail = ", ".join(candidate.agent_names) or (candidate.marker or "project root")
     adopted = (
-        workspace is not None
-        and candidate.path != "."
+        candidate.path != "."
         and is_adopted(workspace / candidate.path) is not None
     )
     return f"{candidate.path} ({detail})" + (" — already adopted" if adopted else "")

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -2,11 +2,20 @@
 
 ``init --write`` refuses when a workspace holds several self-contained projects
 that define agents, and ``detect`` reports the same fact one step earlier. Both
-then owe the caller the same thing: for every candidate, the one command that
-advances *that* project, so the decision "which project is this change about?"
-is the only work left to do. For a project with no manifest that is ``init``;
-for one that already has a manifest it is ``doctor``, because ``init --write``
-there refuses a file it will not overwrite.
+then owe the caller the same thing: for every candidate, the step that advances
+*that* project, so the decision "which project is this change about?" is the
+only work left to do.
+
+Which step that is depends on the candidate, and this module is where that is
+decided once for both commands:
+
+* no manifest — ``init --write``, carrying the setup flags the caller asked for;
+* a manifest already — ``doctor``, because ``init --write`` refuses a file it
+  will not overwrite; or an ``init`` *without* ``--write`` when the caller
+  asked for setup that manifest does not supply;
+* the workspace root — a human route and no command, because ``init`` there is
+  the run that just refused and ``--allow-unresolved-scope`` adopts the whole
+  workspace rather than that one agent.
 
 ``init`` published those commands and ``detect`` published a JSON selector
 inside prose — ``init --workspace <agent_project_candidates[].path> --write`` —

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -78,6 +78,33 @@ def is_adopted(directory: Path) -> Path | None:
     return candidate
 
 
+def describe_candidate(
+    candidate: AgentProjectCandidate, *, workspace: Path | None = None
+) -> str:
+    """One candidate as a line a human can choose from.
+
+    Not every project names its agent in a string literal — a config-driven
+    ``LlmAgent(name=CONFIG.agent_name)`` has none to parse — so the marker
+    that made the directory a project stands in for it rather than leaving
+    an empty pair of brackets.
+
+    A candidate that already carries a manifest says so, because the routing
+    published beside this list sends those to ``doctor``: the ``init --write``
+    both commands recommend in prose refuses a manifest it will not overwrite.
+    Shared rather than written once per command — ``detect`` and ``init`` each
+    print this list, and a second copy is how one of them kept saying ``init``
+    after the other stopped (#397 review).
+    """
+
+    detail = ", ".join(candidate.agent_names) or (candidate.marker or "project root")
+    adopted = (
+        workspace is not None
+        and candidate.path != "."
+        and is_adopted(workspace / candidate.path) is not None
+    )
+    return f"{candidate.path} ({detail})" + (" — already adopted" if adopted else "")
+
+
 def scope_candidate_actions(
     workspace: Path,
     candidates: Sequence[AgentProjectCandidate],
@@ -192,6 +219,7 @@ def scope_candidate_actions(
 
 __all__ = [
     "MANIFEST_NAME",
+    "describe_candidate",
     "MAX_LISTED_SCOPE_CANDIDATES",
     "is_adopted",
     "rebased_kit_flags",

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -119,6 +119,11 @@ def candidate_caveats(
     boilerplate. `detect` prints the same pair from the same helper — a printed
     list that reads uniformly while the routing beside it splits three ways is
     the divergence this is here to prevent (#397 review).
+
+    Pass the candidates that are *printed*, not every candidate. These lines
+    refer to the marking on the list they sit under ("a project marked already
+    adopted"), so one raised by a candidate the display cap cut leaves a reader
+    hunting a mark that is not on screen.
     """
 
     lines: list[str] = []

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -60,7 +60,7 @@ def rebased_kit_flags(
     return ["--agent-instructions-kit", relative.as_posix()]
 
 
-def _adopted(directory: Path) -> Path | None:
+def is_adopted(directory: Path) -> Path | None:
     """The manifest already in ``directory``, when one is there to route to.
 
     A symlinked manifest is treated as absent: the loader refuses a manifest
@@ -128,7 +128,7 @@ def scope_candidate_actions(
     for candidate in routable:
         target = workspace / candidate.path
         defines = ", ".join(candidate.agent_names)
-        manifest = _adopted(target)
+        manifest = is_adopted(target)
         if manifest is not None and not init_refreshes_existing:
             actions.append(
                 NextAction(
@@ -193,6 +193,7 @@ def scope_candidate_actions(
 __all__ = [
     "MANIFEST_NAME",
     "MAX_LISTED_SCOPE_CANDIDATES",
+    "is_adopted",
     "rebased_kit_flags",
     "scope_candidate_actions",
 ]

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -23,10 +23,19 @@ from agents_shipgate.invocation import render_command
 from agents_shipgate.schemas.detect import AgentProjectCandidate
 from agents_shipgate.schemas.diagnostics import NextAction
 
-# A monorepo can hold hundreds of agent projects. A refusal, and the routing
-# beside it, list enough of them to choose from and point at the JSON payload
-# for the rest.
+# A monorepo can hold hundreds of agent projects. A *human* refusal lists
+# enough of them to recognize the shape and points at the JSON payload for the
+# rest. This cap belongs to that summary alone: applying it to the machine
+# routes below silently left candidate 11 onward with no command, which is the
+# dead end this module exists to close — `detect --workspace samples --json`
+# found 22 candidates and emitted 10 commands, and issue #397's own
+# reproduction has 25 (#397 review).
 MAX_LISTED_SCOPE_CANDIDATES = 10
+
+# The manifest `init` writes and `doctor` reads. Fixed rather than threaded
+# through: `init --write` writes this name and nothing else, so a candidate
+# carrying it is a candidate `init` would refuse.
+MANIFEST_NAME = "shipgate.yaml"
 
 
 def rebased_kit_flags(
@@ -51,18 +60,57 @@ def rebased_kit_flags(
     return ["--agent-instructions-kit", relative.as_posix()]
 
 
+def _adopted(directory: Path) -> Path | None:
+    """The manifest already in ``directory``, when one is there to route to.
+
+    A symlinked manifest is treated as absent: the loader refuses a manifest
+    path with symlink components, so routing ``doctor`` at one would publish a
+    command that exits 2 (#363 review). The ``init`` route is emitted instead,
+    and reports the real problem.
+    """
+
+    candidate = directory / MANIFEST_NAME
+    try:
+        if candidate.is_symlink() or not candidate.is_file():
+            return None
+    except OSError:  # pragma: no cover - unreadable directory
+        return None
+    return candidate
+
+
 def scope_candidate_actions(
     workspace: Path,
     candidates: Sequence[AgentProjectCandidate],
     *,
     setup_flags: Sequence[str] = (),
     kit: Path | None = None,
+    init_refreshes_existing: bool = False,
 ) -> list[NextAction]:
-    """One ``init`` command per candidate project, in the caller's order.
+    """One exact command per candidate project, in the caller's order.
 
     These are ranked *below* the decision that selects among them — promoting
     one would make the same arbitrary pick the refusal exists to prevent — so
     this returns only the commands and leaves rank 1 to the caller.
+
+    Every candidate gets one, with no cap. The list is exactly as long as the
+    ``agent_project_candidates[]`` the same payload already publishes in full,
+    and a candidate the reader can select but not run is the dead end this is
+    here to close.
+
+    **A candidate that already carries a manifest routes to ``doctor``, not to
+    ``init``.** A nested ``shipgate.yaml`` is itself evidence of a project, so
+    adopted directories are candidates too — on this repository's own
+    ``samples/``, 21 of 22 are — and ``init --write`` there exits 2 on a
+    manifest it will not overwrite while ``expects`` promises a file that
+    already exists. ``doctor`` is the command that answers what is actually
+    outstanding for an adopted project, and it is the same handoff ``detect``
+    already makes for an adopted workspace root (#397 review).
+
+    ``init_refreshes_existing`` is the one exception, and the caller owns it
+    because only the caller knows what it asked for: with
+    ``--agent-instructions`` selected, ``init --write`` deliberately leaves an
+    existing manifest alone and exits 0, which makes it the advertised refresh
+    command rather than a refusal.
 
     ``setup_flags`` is repeated into each command because a recovery that
     silently drops ``--ci`` or an agent-instruction selection completes with
@@ -77,9 +125,31 @@ def scope_candidate_actions(
     # sub-project are real evidence of why the answer is unresolved, and
     # `--allow-unresolved-scope` is the route that accepts them.
     routable = [candidate for candidate in candidates if candidate.path != "."]
-    for candidate in routable[:MAX_LISTED_SCOPE_CANDIDATES]:
+    for candidate in routable:
         target = workspace / candidate.path
         defines = ", ".join(candidate.agent_names)
+        manifest = _adopted(target)
+        if manifest is not None and not init_refreshes_existing:
+            actions.append(
+                NextAction(
+                    kind="command",
+                    command=render_command(
+                        ["doctor", "--config", str(manifest), "--json"]
+                    ),
+                    why=(
+                        f"{candidate.path} already carries a manifest"
+                        + (f" and defines {defines}." if defines else ".")
+                        + " Ask doctor what it still owes rather than "
+                        "initializing over it."
+                    ),
+                    expects=(
+                        "A doctor payload whose control state names the "
+                        f"outstanding setup obligation for {candidate.path}, "
+                        "or the release gate when there is none."
+                    ),
+                )
+            )
+            continue
         kit_flags = rebased_kit_flags(kit, source=workspace, target=target)
         if kit_flags is None:
             actions.append(
@@ -121,6 +191,7 @@ def scope_candidate_actions(
 
 
 __all__ = [
+    "MANIFEST_NAME",
     "MAX_LISTED_SCOPE_CANDIDATES",
     "rebased_kit_flags",
     "scope_candidate_actions",

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -113,6 +113,7 @@ def scope_candidate_actions(
     candidates: Sequence[AgentProjectCandidate],
     *,
     setup_flags: Sequence[str] = (),
+    adopted_setup_flags: Sequence[str] = (),
     kit: Path | None = None,
     init_refreshes_existing: bool = False,
 ) -> list[NextAction]:
@@ -142,6 +143,23 @@ def scope_candidate_actions(
     existing manifest alone and exits 0, which makes it the advertised refresh
     command rather than a refusal.
 
+    ``adopted_setup_flags`` keeps the flag-preservation contract on that route.
+    Setup the caller asked for does not stop being owed because the manifest
+    already exists — a refused ``init --write --ci`` writes no workflow, and
+    handing back a bare ``doctor`` dropped the request silently. These are the
+    requested flags that still do their work with ``--write`` omitted, so the
+    manifest is left alone and the setup is installed in one command that exits
+    0; the caller decides which qualify, because only it knows which of its
+    flags need a write (#397 review).
+
+    ``.`` is a candidate the caller can pick and Shipgate cannot route: agent
+    files that belong to no project are why the scope is unresolved in the
+    first place, and neither ``init`` at the root (which returns this refusal)
+    nor ``--allow-unresolved-scope`` (which accepts the *whole workspace* as one
+    scope, a different decision) is a route for that one project. It gets an
+    explicit human route saying so, rather than being listed as selectable and
+    silently left out.
+
     ``setup_flags`` is repeated into each command because a recovery that
     silently drops ``--ci`` or an agent-instruction selection completes with
     less than the caller asked for. ``detect`` passes none: it asked for no
@@ -149,17 +167,67 @@ def scope_candidate_actions(
     """
 
     actions: list[NextAction] = []
-    # The workspace root is never offered as a command: it is the scope this
-    # run just refused, so running it again returns here. `.` stays in the
-    # reported candidate list because agent files that belong to no
-    # sub-project are real evidence of why the answer is unresolved, and
-    # `--allow-unresolved-scope` is the route that accepts them.
+    root = next((c for c in candidates if c.path == "."), None)
+    if root is not None:
+        defines = ", ".join(root.agent_names)
+        actions.append(
+            NextAction(
+                kind="review",
+                why=(
+                    "The workspace root is a candidate"
+                    + (f" because it defines {defines}" if defines else "")
+                    + ", and it is the one candidate with no command: agent "
+                    "files that belong to no project are why this scope is "
+                    "unresolved. Give them a project directory of their own, "
+                    "or accept the workspace as a single scope with "
+                    "--allow-unresolved-scope — which adopts every project "
+                    "under it, not this agent alone."
+                ),
+                expects=(
+                    "Either the root agent files moved into a project "
+                    "directory, or a deliberate whole-workspace adoption."
+                ),
+            )
+        )
+    # The workspace root is never offered as a *command*: `init` there is the
+    # run that just refused, so it returns straight here.
     routable = [candidate for candidate in candidates if candidate.path != "."]
     for candidate in routable:
         target = workspace / candidate.path
         defines = ", ".join(candidate.agent_names)
         manifest = is_adopted(target)
         if manifest is not None and not init_refreshes_existing:
+            if adopted_setup_flags:
+                # The manifest is not the outstanding work here; the setup the
+                # caller asked for is. Without `--write` these flags do their
+                # own work and the existing manifest is never touched, so this
+                # exits 0 where `init --write` would refuse it.
+                actions.append(
+                    NextAction(
+                        kind="command",
+                        command=render_command(
+                            [
+                                "init",
+                                "--workspace",
+                                str(target),
+                                *adopted_setup_flags,
+                                "--json",
+                            ]
+                        ),
+                        why=(
+                            f"{candidate.path} already carries a manifest"
+                            + (f" and defines {defines}," if defines else ",")
+                            + " so this installs the setup you asked for and "
+                            "leaves the manifest alone. Ask doctor what that "
+                            "manifest still owes afterwards."
+                        ),
+                        expects=(
+                            f"The requested setup present in {candidate.path} "
+                            "with its manifest unchanged."
+                        ),
+                    )
+                )
+                continue
             actions.append(
                 NextAction(
                     kind="command",

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -2,9 +2,11 @@
 
 ``init --write`` refuses when a workspace holds several self-contained projects
 that define agents, and ``detect`` reports the same fact one step earlier. Both
-then owe the caller the same thing: the exact ``init`` invocation for each
-candidate, so the decision "which project is this change about?" is the only
-work left to do.
+then owe the caller the same thing: for every candidate, the one command that
+advances *that* project, so the decision "which project is this change about?"
+is the only work left to do. For a project with no manifest that is ``init``;
+for one that already has a manifest it is ``doctor``, because ``init --write``
+there refuses a file it will not overwrite.
 
 ``init`` published those commands and ``detect`` published a JSON selector
 inside prose — ``init --workspace <agent_project_candidates[].path> --write`` —

--- a/src/agents_shipgate/cli/scope_routing.py
+++ b/src/agents_shipgate/cli/scope_routing.py
@@ -1,0 +1,127 @@
+"""The commands that carry out a scope decision, for every command that reports one.
+
+``init --write`` refuses when a workspace holds several self-contained projects
+that define agents, and ``detect`` reports the same fact one step earlier. Both
+then owe the caller the same thing: the exact ``init`` invocation for each
+candidate, so the decision "which project is this change about?" is the only
+work left to do.
+
+``init`` published those commands and ``detect`` published a JSON selector
+inside prose — ``init --workspace <agent_project_candidates[].path> --write`` —
+and no runnable command at all, so the loop that ``allowed_next_commands``
+promises ended at the first ``detect`` (#397). One builder here rather than a
+copy in each: two commands an adopter runs in sequence must not publish
+different recoveries for one workspace.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from agents_shipgate.invocation import render_command
+from agents_shipgate.schemas.detect import AgentProjectCandidate
+from agents_shipgate.schemas.diagnostics import NextAction
+
+# A monorepo can hold hundreds of agent projects. A refusal, and the routing
+# beside it, list enough of them to choose from and point at the JSON payload
+# for the rest.
+MAX_LISTED_SCOPE_CANDIDATES = 10
+
+
+def rebased_kit_flags(
+    kit: Path | None, *, source: Path, target: Path
+) -> list[str] | None:
+    """``--agent-instructions-kit`` for a command run in ``target``.
+
+    Returns ``None`` when the kit cannot be named from there, which is a
+    refusal rather than a fallback: a kit path is resolved *under the
+    workspace*, so copying a root-relative ``.agents-shipgate/kit.yaml``
+    into a command that runs in ``apps/a`` points at a file that does not
+    exist, and the emitted command exits 2 (#363 review).
+    """
+
+    if kit is None:
+        return []
+    resolved = kit if kit.is_absolute() else (source / kit)
+    try:
+        relative = resolved.resolve().relative_to(target.resolve())
+    except (OSError, ValueError):
+        return None
+    return ["--agent-instructions-kit", relative.as_posix()]
+
+
+def scope_candidate_actions(
+    workspace: Path,
+    candidates: Sequence[AgentProjectCandidate],
+    *,
+    setup_flags: Sequence[str] = (),
+    kit: Path | None = None,
+) -> list[NextAction]:
+    """One ``init`` command per candidate project, in the caller's order.
+
+    These are ranked *below* the decision that selects among them — promoting
+    one would make the same arbitrary pick the refusal exists to prevent — so
+    this returns only the commands and leaves rank 1 to the caller.
+
+    ``setup_flags`` is repeated into each command because a recovery that
+    silently drops ``--ci`` or an agent-instruction selection completes with
+    less than the caller asked for. ``detect`` passes none: it asked for no
+    setup, so promising any here would be inventing it.
+    """
+
+    actions: list[NextAction] = []
+    # The workspace root is never offered as a command: it is the scope this
+    # run just refused, so running it again returns here. `.` stays in the
+    # reported candidate list because agent files that belong to no
+    # sub-project are real evidence of why the answer is unresolved, and
+    # `--allow-unresolved-scope` is the route that accepts them.
+    routable = [candidate for candidate in candidates if candidate.path != "."]
+    for candidate in routable[:MAX_LISTED_SCOPE_CANDIDATES]:
+        target = workspace / candidate.path
+        defines = ", ".join(candidate.agent_names)
+        kit_flags = rebased_kit_flags(kit, source=workspace, target=target)
+        if kit_flags is None:
+            actions.append(
+                NextAction(
+                    kind="review",
+                    why=(
+                        f"{candidate.path} is a candidate, but the adoption kit "
+                        f"at {kit} sits outside it and a kit path is resolved "
+                        "under the workspace. Relocate the kit into the project "
+                        "or drop --agent-instructions-kit before initializing "
+                        "there."
+                    ),
+                    expects=f"An adoption kit reachable from {candidate.path}.",
+                )
+            )
+            continue
+        actions.append(
+            NextAction(
+                kind="command",
+                command=render_command(
+                    [
+                        "init",
+                        "--workspace",
+                        str(target),
+                        "--write",
+                        *setup_flags,
+                        *kit_flags,
+                        "--json",
+                    ]
+                ),
+                why=(
+                    f"Initialize only {candidate.path}"
+                    + (f", which defines {defines}." if defines else ".")
+                ),
+                expects=f"shipgate.yaml is created in {candidate.path}.",
+            )
+        )
+    return actions
+
+
+__all__ = [
+    "MAX_LISTED_SCOPE_CANDIDATES",
+    "rebased_kit_flags",
+    "scope_candidate_actions",
+]

--- a/src/agents_shipgate/cli/setup_control.py
+++ b/src/agents_shipgate/cli/setup_control.py
@@ -258,7 +258,6 @@ def setup_control_envelope(
     alternatives = [diag.next_actions[0] for diag in ordered]
 
     blocking = next((diag for diag in ordered if diag.severity == "block"), None)
-    selected_is_advance = False
     if blocking is not None:
         selected, kind, decision = _route_for(blocking)
     elif advance_blocking and advance is not None:
@@ -270,7 +269,6 @@ def setup_control_envelope(
         # not skipped, only deferred: it is derived from the manifest on every
         # run, so the next one surfaces it.
         selected, kind, decision = advance, advance_kind, advance_decision
-        selected_is_advance = True
     elif pending_human:
         selected = NextAction(
             kind="review",
@@ -282,7 +280,6 @@ def setup_control_envelope(
         selected, kind, decision = _route_for(ordered[0])
     elif advance is not None:
         selected, kind, decision = advance, advance_kind, advance_decision
-        selected_is_advance = True
     else:
         # No obligation and no onward step is not "done": setup never completes
         # a task, so the honest answer is that a person decides what happens
@@ -326,7 +323,13 @@ def setup_control_envelope(
         # decision nobody made: `detect` on a workspace whose only agent
         # evidence is two nested manifests emitted `stop` — "not a Shipgate
         # target" — and then an `init --write` for each of the two (#397).
-        actions = [selected, *(advance_alternatives if selected_is_advance else ())]
+        #
+        # Asked of the object rather than tracked in a flag beside the two
+        # branches that assign it: `advance` is the only route any branch
+        # selects without building a fresh `NextAction`, so identity answers
+        # this exactly, and a precedence tier added later cannot forget to
+        # keep a mirror in step.
+        actions = [selected, *(advance_alternatives if selected is advance else ())]
         control: AgentControl = _human_route(selected.why, stop=selected.kind == "stop")
     else:
         actions = [selected, *(item for item in alternatives if item is not selected)][:3]

--- a/src/agents_shipgate/cli/setup_control.py
+++ b/src/agents_shipgate/cli/setup_control.py
@@ -258,6 +258,7 @@ def setup_control_envelope(
     alternatives = [diag.next_actions[0] for diag in ordered]
 
     blocking = next((diag for diag in ordered if diag.severity == "block"), None)
+    selected_is_advance = False
     if blocking is not None:
         selected, kind, decision = _route_for(blocking)
     elif advance_blocking and advance is not None:
@@ -269,6 +270,7 @@ def setup_control_envelope(
         # not skipped, only deferred: it is derived from the manifest on every
         # run, so the next one surfaces it.
         selected, kind, decision = advance, advance_kind, advance_decision
+        selected_is_advance = True
     elif pending_human:
         selected = NextAction(
             kind="review",
@@ -280,6 +282,7 @@ def setup_control_envelope(
         selected, kind, decision = _route_for(ordered[0])
     elif advance is not None:
         selected, kind, decision = advance, advance_kind, advance_decision
+        selected_is_advance = True
     else:
         # No obligation and no onward step is not "done": setup never completes
         # a task, so the honest answer is that a person decides what happens
@@ -316,7 +319,14 @@ def setup_control_envelope(
         # the case: rank 1 is "choose a project", and the per-candidate commands
         # below it are how the chosen one gets initialized. A caller that
         # supplies them has already ranked the decision above them.
-        actions = [selected, *advance_alternatives]
+        #
+        # They ride with *that* decision and no other. When a diagnostic
+        # outranked the advance, rank 1 is a different question, and appending
+        # the advance's commands under it publishes steps that carry out a
+        # decision nobody made: `detect` on a workspace whose only agent
+        # evidence is two nested manifests emitted `stop` — "not a Shipgate
+        # target" — and then an `init --write` for each of the two (#397).
+        actions = [selected, *(advance_alternatives if selected_is_advance else ())]
         control: AgentControl = _human_route(selected.why, stop=selected.kind == "stop")
     else:
         actions = [selected, *(item for item in alternatives if item is not selected)][:3]

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -76,6 +76,7 @@ from agents_shipgate.core.verification_identity import (
     build_terminal_receipt,
     build_unit_result,
     build_verification_plan,
+    worktree_overlay,
 )
 from agents_shipgate.invocation import retarget_command
 from agents_shipgate.packet.json_packet import load_packet_json, write_packet_json
@@ -3364,6 +3365,15 @@ def _current_control_workspace_identity(
     ``current_control_id`` after the caller performed it — the refresh entry
     point reported the request as still outstanding, which is how a
     refresh-driven controller repeats an action forever (#397 review).
+
+    HEAD is not enough on its own, because the evidence a preview routes on is
+    frequently *uncommitted*: a route selected from an untracked ``agent.py``
+    survived that file being deleted, since neither HEAD nor its tree moved. So
+    the overlay of the paths that differ from HEAD is bound too, and the
+    pointer declares itself a worktree snapshot. The path set is derived from
+    the live worktree on both sides rather than recorded — the reader excludes
+    the same reports directory this run wrote into, because that is the
+    directory it was pointed at to find the pointer at all.
     """
 
     plan_path = out_dir / "verification-plan.json"
@@ -3374,6 +3384,7 @@ def _current_control_workspace_identity(
             plan = None
         if plan is not None:
             return workspace_identity_from_plan(plan)
+    bound, overlay = _safe_worktree_overlay(git_root, exclude=out_dir)
     return CurrentControlWorkspaceIdentity(
         repository=_safe_repository_identity(git_root),
         head_ref=verifier.head_ref,
@@ -3381,7 +3392,31 @@ def _current_control_workspace_identity(
         # An evaluated tree, when the run recorded one, is what this answer
         # describes; otherwise the worktree's own HEAD tree is.
         head_tree_sha=verifier.head_tree_sha or _safe_worktree_sha(git_root, tree_sha),
+        snapshot_kind="worktree_overlay" if bound else None,
+        worktree_overlay_sha256=overlay,
     )
+
+
+def _safe_worktree_overlay(git_root: Path, *, exclude: Path) -> tuple[bool, str | None]:
+    """The overlay of everything that differs from HEAD right now.
+
+    Returns ``(bound, digest)``. The pair is needed because ``None`` is a
+    *value* here and not only a failure: a clean worktree has no overlay rows,
+    and the reader spells that as ``None`` too, so the two must agree. Reporting
+    the clean case as unbound instead would leave the pointer with nothing to
+    validate, and a later edit invisible — which is the state this is fixing.
+
+    ``bound=False`` is the genuinely unknown case, and it declares no snapshot
+    kind at all rather than manufacturing currency from an unreadable tree.
+    """
+
+    try:
+        changed, _ = working_tree_context(git_root, exclude=exclude)
+        rows = worktree_overlay(git_root, list(changed))
+    except Exception:  # noqa: BLE001 - pointer identity is best-effort here.
+        return (False, None)
+    # The reader's own rule, so an empty overlay compares equal on both sides.
+    return (True, content_id(rows) if rows else None)
 
 
 def _safe_worktree_sha(
@@ -4138,25 +4173,26 @@ def _unresolved_scope_route(
         return (
             CodingAgentFetchBaseAction(
                 kind="fetch_base",
-                # A crisp noun phrase, because consumers interpolate it:
-                # the Claude Code stop hook renders `fetch_base` as
-                # "Provide <expects>".
-                expects=f"commit {target} checked out in this worktree",
-                # Short enough that an ordinary ref name leaves the whole
-                # route inside the envelope's 400-byte prose cap, and the
-                # instruction leads so a long one still survives truncation.
+                # The whole recovery, in the one field the envelope never
+                # truncates: `truncate_prose` caps `why` at 400 bytes and
+                # leaves `expects` alone, so the immutable ids survive a ref
+                # name long enough to push everything else out. A consumer
+                # that re-derived the rerun from the caller's own
+                # `HEAD`-relative request would rebuild the backward walk
+                # this route exists to end (#397 review).
+                expects=(
+                    f"commit {target} checked out in this worktree"
+                    + (f", then this preview re-run with {rerun}" if rerun else "")
+                ),
+                # The instruction leads for the same reason: what gets cut is
+                # the diagnosis, never the step.
                 why=(
-                    "The project this change belongs to could not be "
-                    f"established ({resolution.detail}). Check {target} out in "
-                    "this worktree, then re-run this preview"
-                    + (
-                        f" with {rerun}: a revision expression re-resolves "
-                        "against the new HEAD"
-                        if rerun is not None
-                        else ""
-                    )
-                    + ". Discovery of the worktree as it stands answers about "
-                    "a different tree."
+                    f"Check {target} out in this worktree, then re-run this "
+                    + (f"preview with {rerun}. " if rerun else "preview. ")
+                    + "The project this change belongs to could not be "
+                    f"established ({resolution.detail}); discovery of the "
+                    "worktree as it stands answers about a different tree, and "
+                    "a revision expression re-resolves against the new HEAD."
                 ),
             ),
             f"The evaluated head {target} is not checked out here, so no "

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -4067,15 +4067,21 @@ def _unresolved_scope_route(
         return (
             HumanControlAction(
                 kind="review",
+                # The reason `detect` is not offered here is *not* that it
+                # would read some other tree — both causes are produced only
+                # after the head was confirmed to be this worktree. It is that
+                # the evidence is missing from the tree everything can read, so
+                # discovery reports the surviving project as the single scope
+                # and its `init` adopts an agent this change never touched.
                 why=(
                     "The project this change belongs to could not be "
                     f"established ({resolution.detail}), and no read-only "
-                    "command settles it: the evidence is not in the tree this "
-                    "run can read. Decide from the change itself which project "
-                    "it belongs to and initialize that directory by name. "
-                    "Discovery of the current worktree would answer about a "
-                    "different tree, and initializing the workspace root would "
-                    "adopt a scope nobody chose."
+                    "command settles it: the evidence is missing from the tree "
+                    "this run reads, so discovery would report whatever "
+                    "survived as the workspace's single scope. Decide from the "
+                    "change itself which project it belongs to and initialize "
+                    "that directory by name; initializing the workspace root "
+                    "would adopt a scope nobody chose."
                 ),
             ),
             "Shipgate could not establish which project this change belongs "

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -12,6 +12,7 @@ import stat
 import tempfile
 import unicodedata
 from collections import Counter
+from collections.abc import Callable
 from contextvars import Token
 from datetime import date
 from pathlib import Path, PurePosixPath
@@ -3353,8 +3354,16 @@ def _current_control_workspace_identity(
 
     The verification plan is the authoritative source when the run produced
     one, because that is the same subject the receipt closes over.  Runs that
-    stopped before plan construction fall back to the verifier's coarser view,
-    which is enough for a consumer to notice that HEAD moved.
+    stopped before plan construction fall back to the verifier's coarser view.
+
+    That fallback binds *this worktree's* HEAD, which is deliberately not
+    ``head_ref``: a preview reads project markers from the working tree, so the
+    tree it actually read is the one a later reader has to still be sitting in.
+    Binding nothing left the pointer permanently current, and a preview that
+    asked for a checkout kept answering ``agent_action_required`` with the same
+    ``current_control_id`` after the caller performed it — the refresh entry
+    point reported the request as still outstanding, which is how a
+    refresh-driven controller repeats an action forever (#397 review).
     """
 
     plan_path = out_dir / "verification-plan.json"
@@ -3368,8 +3377,22 @@ def _current_control_workspace_identity(
     return CurrentControlWorkspaceIdentity(
         repository=_safe_repository_identity(git_root),
         head_ref=verifier.head_ref,
-        head_tree_sha=verifier.head_tree_sha,
+        head_commit_sha=_safe_worktree_sha(git_root, commit_sha),
+        # An evaluated tree, when the run recorded one, is what this answer
+        # describes; otherwise the worktree's own HEAD tree is.
+        head_tree_sha=verifier.head_tree_sha or _safe_worktree_sha(git_root, tree_sha),
     )
+
+
+def _safe_worktree_sha(
+    git_root: Path, resolve: Callable[[Path, str], str | None]
+) -> str | None:
+    """This worktree's HEAD identity, or ``None`` outside a readable repository."""
+
+    try:
+        return resolve(git_root, "HEAD")
+    except Exception:  # noqa: BLE001 - pointer identity is best-effort here.
+        return None
 
 
 def _safe_repository_identity(workspace: Path) -> str | None:
@@ -3904,8 +3927,31 @@ def _scoped_manifest_path(directory: Path, name: str) -> Path | None:
     return candidate
 
 
-def _head_is_current_worktree(root: Path, head: str | None) -> bool:
-    """Whether the evaluated head is the commit the worktree has checked out.
+@dataclasses.dataclass(frozen=True)
+class _HeadPosition:
+    """Where the evaluated head sits relative to this worktree, and what it is.
+
+    ``commit`` is the immutable id the requested ref resolved to, and it is the
+    whole reason this is a pair rather than a boolean. ``--head`` accepts
+    revision expressions: ``HEAD~1`` names one commit before the recovery's
+    checkout and a different one after it, so a route spelled with the
+    *expression* walks history backwards one commit per iteration instead of
+    terminating — and a ``HEAD``-relative ``--base`` silently re-ranges the
+    same way (#397 review). Only a commit id says the same thing on both sides
+    of the checkout it asks for.
+
+    ``None`` when the ref could not be resolved at all. Preview never reaches
+    the scope routing in that state — an unreadable ref is a diff-input
+    failure, which outranks it — so the routes below fall back to the ref's own
+    spelling rather than inventing an id.
+    """
+
+    matches_worktree: bool
+    commit: str | None = None
+
+
+def _head_position(root: Path, head: str | None) -> _HeadPosition:
+    """Resolve the evaluated head against the commit this worktree holds.
 
     Manifest-scope evidence is read from the working tree, so a preview of
     some *other* ref would authorize a directory the diff never described.
@@ -3913,13 +3959,28 @@ def _head_is_current_worktree(root: Path, head: str | None) -> bool:
     """
 
     if head is None:
-        return True
+        return _HeadPosition(matches_worktree=True)
     try:
         head_sha = commit_sha(root, head)
         worktree_sha = commit_sha(root, "HEAD")
     except Exception:  # noqa: BLE001 - preview must never crash.
-        return False
-    return head_sha is not None and head_sha == worktree_sha
+        return _HeadPosition(matches_worktree=False)
+    return _HeadPosition(
+        matches_worktree=head_sha is not None and head_sha == worktree_sha,
+        commit=head_sha,
+    )
+
+
+def _pinned_ref(root: Path, ref: str | None) -> str | None:
+    """``ref`` as a short commit id, for a command that must survive a checkout."""
+
+    if ref is None:
+        return None
+    try:
+        resolved = commit_sha(root, ref)
+    except Exception:  # noqa: BLE001 - preview must never crash.
+        return None
+    return resolved[:12] if resolved else None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -3931,20 +3992,28 @@ class _PreviewScope:
     diff deleted, and a head that is not this worktree, and the honest next
     step differs for each (#399 review).
 
-    ``head`` is carried beside the cause that names it rather than read again
-    at the route: the ``head_mismatch`` recovery *is* "check this ref out", so
-    the ref and the cause have to be produced together or the two can drift
-    (#397).
+    ``head`` and the two pinned commit ids are carried beside the cause that
+    names them rather than read again at the route: the ``head_mismatch``
+    recovery *is* "check this commit out, then re-run against it", so the refs
+    and the cause have to be produced together or the two can drift (#397).
+    The ids are what make that recovery terminate — see :class:`_HeadPosition`.
     """
 
     resolution: ScopeResolution
     cause: str | None = None
     python_file_total: int = 0
     head: str | None = None
+    head_commit: str | None = None
+    base_commit: str | None = None
 
 
 def _preview_scope(
-    *, root: Path, changed_files: list[str], limit: Path | None, head: str | None
+    *,
+    root: Path,
+    changed_files: list[str],
+    limit: Path | None,
+    head: str | None,
+    base: str | None = None,
 ) -> _PreviewScope:
     """Which project the changed paths belong to, for the routing below.
 
@@ -3966,18 +4035,24 @@ def _preview_scope(
     (#399 review).
     """
 
-    if not _head_is_current_worktree(root, head):
+    position = _head_position(root, head)
+    if not position.matches_worktree:
+        pinned = position.commit[:12] if position.commit else None
         return _PreviewScope(
             resolution=ScopeResolution(
                 status="not_evaluated",
                 detail=(
-                    f"the evaluated head {head!r} is not the commit this "
-                    "worktree has checked out, and project markers are read "
-                    "from the worktree that init would run against"
+                    f"the evaluated head {head!r}"
+                    + (f" ({pinned})" if pinned else "")
+                    + " is not the commit this worktree has checked out, and "
+                    "project markers are read from the worktree that init "
+                    "would run against"
                 ),
             ),
             cause="head_mismatch",
             head=head,
+            head_commit=pinned,
+            base_commit=_pinned_ref(root, base),
         )
     evidence = weak_marker_evidence_dirs(root, changed_files)
     if evidence.undetermined:
@@ -4041,27 +4116,40 @@ def _unresolved_scope_route(
     resolution = scope.resolution
     if scope.cause == "head_mismatch":
         # ``head_mismatch`` is only produced for a non-None ``--head``: an
-        # absent one is the working tree by definition.
-        ref = scope.head or "the evaluated head"
+        # absent one is the working tree by definition. The commit id is
+        # preferred over the caller's spelling everywhere below, because the
+        # step being asked for *moves HEAD*: `--head HEAD~1` names one commit
+        # before the checkout and its parent after, so the expression form
+        # walks history backwards forever instead of resolving (#397 review).
+        target = scope.head_commit or scope.head or "the evaluated head"
+        rerun = f"--head {target}"
+        if scope.base_commit is not None:
+            # A `HEAD`-relative base re-ranges across the same checkout, which
+            # is quieter than the loop and worse: the rerun succeeds while
+            # evaluating a diff nobody asked for.
+            rerun = f"--base {scope.base_commit} {rerun}"
         return (
             CodingAgentFetchBaseAction(
                 kind="fetch_base",
                 # A crisp noun phrase, because consumers interpolate it:
                 # the Claude Code stop hook renders `fetch_base` as
-                # "Make <expects> available locally".
-                expects=f"{ref} checked out in this worktree",
+                # "Provide <expects>".
+                expects=f"commit {target} checked out in this worktree",
                 # Short enough that an ordinary ref name leaves the whole
                 # route inside the envelope's 400-byte prose cap, and the
                 # instruction leads so a long one still survives truncation.
                 why=(
                     "The project this change belongs to could not be "
-                    f"established ({resolution.detail}). Check {ref} out in "
-                    "this worktree and re-run this same preview: discovery of "
-                    "the worktree as it stands answers about a different tree."
+                    f"established ({resolution.detail}). Check {target} out in "
+                    f"this worktree, then re-run this preview with {rerun}: "
+                    "discovery of the worktree as it stands answers about a "
+                    "different tree, and a revision expression re-resolves "
+                    "against the new HEAD."
                 ),
             ),
-            f"The evaluated head {ref} is not checked out here, so no project "
-            "could be named; check it out and re-run this preview.",
+            f"The evaluated head {target} is not checked out here, so no "
+            "project could be named; check it out and re-run this preview "
+            "against that commit.",
         )
     if scope.cause in ("deleted_evidence", "unreadable_inventory"):
         return (
@@ -4328,7 +4416,11 @@ def run_preview(
     # the two disagree — the same refs would recommend different directories
     # depending on what happens to be checked out — so no scope is claimed.
     preview_scope = _preview_scope(
-        root=root, changed_files=changed_files, limit=requested_root, head=head
+        root=root,
+        changed_files=changed_files,
+        limit=requested_root,
+        head=head,
+        base=base,
     )
     resolution = preview_scope.resolution
     scope = resolution.scope

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -3930,11 +3930,17 @@ class _PreviewScope:
     ``resolution`` alone: ``not_evaluated`` covers a capped probe, evidence the
     diff deleted, and a head that is not this worktree, and the honest next
     step differs for each (#399 review).
+
+    ``head`` is carried beside the cause that names it rather than read again
+    at the route: the ``head_mismatch`` recovery *is* "check this ref out", so
+    the ref and the cause have to be produced together or the two can drift
+    (#397).
     """
 
     resolution: ScopeResolution
     cause: str | None = None
     python_file_total: int = 0
+    head: str | None = None
 
 
 def _preview_scope(
@@ -3971,6 +3977,7 @@ def _preview_scope(
                 ),
             ),
             cause="head_mismatch",
+            head=head,
         )
     evidence = weak_marker_evidence_dirs(root, changed_files)
     if evidence.undetermined:
@@ -4019,10 +4026,44 @@ def _unresolved_scope_route(
     Deleted evidence is a question no read-only command can answer, so it
     gets a human route and no command at all — publishing one here would be
     publishing a step that cannot take.
+
+    A head that is not this worktree is neither. Nothing about the change is
+    in doubt there: the missing input is a *working tree* holding the commit
+    under review, and producing it is one mechanical step the caller owns.
+    Shipgate never writes to a caller's worktree, so it cannot spell that
+    step as a command it runs — which is exactly what ``fetch_base`` is for.
+    Naming the input and letting the caller produce it keeps the loop moving;
+    routing it to a human published ``must_stop`` and ``command: null`` for a
+    state the coding agent clears itself, and the remedy — derivable from the
+    ref preview was handed — went unsaid (#397).
     """
 
     resolution = scope.resolution
-    if scope.cause in ("deleted_evidence", "unreadable_inventory", "head_mismatch"):
+    if scope.cause == "head_mismatch":
+        # ``head_mismatch`` is only produced for a non-None ``--head``: an
+        # absent one is the working tree by definition.
+        ref = scope.head or "the evaluated head"
+        return (
+            CodingAgentFetchBaseAction(
+                kind="fetch_base",
+                # A crisp noun phrase, because consumers interpolate it:
+                # the Claude Code stop hook renders `fetch_base` as
+                # "Make <expects> available locally".
+                expects=f"{ref} checked out in this worktree",
+                # Short enough that an ordinary ref name leaves the whole
+                # route inside the envelope's 400-byte prose cap, and the
+                # instruction leads so a long one still survives truncation.
+                why=(
+                    "The project this change belongs to could not be "
+                    f"established ({resolution.detail}). Check {ref} out in "
+                    "this worktree and re-run this same preview: discovery of "
+                    "the worktree as it stands answers about a different tree."
+                ),
+            ),
+            f"The evaluated head {ref} is not checked out here, so no project "
+            "could be named; check it out and re-run this preview.",
+        )
+    if scope.cause in ("deleted_evidence", "unreadable_inventory"):
         return (
             HumanControlAction(
                 kind="review",

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -4122,12 +4122,19 @@ def _unresolved_scope_route(
         # before the checkout and its parent after, so the expression form
         # walks history backwards forever instead of resolving (#397 review).
         target = scope.head_commit or scope.head or "the evaluated head"
-        rerun = f"--head {target}"
-        if scope.base_commit is not None:
-            # A `HEAD`-relative base re-ranges across the same checkout, which
-            # is quieter than the loop and worse: the rerun succeeds while
-            # evaluating a diff nobody asked for.
-            rerun = f"--base {scope.base_commit} {rerun}"
+        if scope.head_commit is None:
+            # Nothing resolved, so there is no id to pin to and no honest way
+            # to promise the rerun means the same thing afterwards. Say what is
+            # missing and stop there rather than printing an instruction that
+            # contradicts the sentence next to it.
+            rerun = None
+        else:
+            rerun = f"--head {target}"
+            if scope.base_commit is not None:
+                # A `HEAD`-relative base re-ranges across the same checkout,
+                # which is quieter than the loop and worse: the rerun succeeds
+                # while evaluating a diff nobody asked for.
+                rerun = f"--base {scope.base_commit} {rerun}"
         return (
             CodingAgentFetchBaseAction(
                 kind="fetch_base",
@@ -4141,10 +4148,15 @@ def _unresolved_scope_route(
                 why=(
                     "The project this change belongs to could not be "
                     f"established ({resolution.detail}). Check {target} out in "
-                    f"this worktree, then re-run this preview with {rerun}: "
-                    "discovery of the worktree as it stands answers about a "
-                    "different tree, and a revision expression re-resolves "
-                    "against the new HEAD."
+                    "this worktree, then re-run this preview"
+                    + (
+                        f" with {rerun}: a revision expression re-resolves "
+                        "against the new HEAD"
+                        if rerun is not None
+                        else ""
+                    )
+                    + ". Discovery of the worktree as it stands answers about "
+                    "a different tree."
                 ),
             ),
             f"The evaluated head {target} is not checked out here, so no "

--- a/src/agents_shipgate/core/current_control.py
+++ b/src/agents_shipgate/core/current_control.py
@@ -750,6 +750,15 @@ def _validate_worktree_currency(
                 ),
                 path=out_dir,
             )
+        # A route published without a plan — `verify --preview`, which reads
+        # project markers from the working tree and reaches no release
+        # decision — still committed to the worktree it read. Its path set is
+        # not recorded, so it is derived from the live worktree on both sides:
+        # the same `working_tree_context` over the same repository, excluding
+        # the same reports directory, which is the one this reader was pointed
+        # at to find the pointer. Any path entering or leaving that set, and
+        # any content change within it, moves the digest (#397 review).
+        _validate_live_overlay(out_dir, pointer, live)
         return
     try:
         data = read_regular_file_beneath(
@@ -798,6 +807,32 @@ def _validate_worktree_currency(
         raise CurrentControlUnavailable(
             "workspace_changed",
             _unseen_change_detail(unseen, "this decision never saw"),
+            path=out_dir,
+        )
+
+
+def _validate_live_overlay(
+    out_dir: Path, pointer: CurrentControlPointer, live: LiveWorkspace
+) -> None:
+    """Compare a plan-less worktree pointer against the tree as it stands."""
+
+    if live.changed_paths is None:
+        # Unreadable is unknown, not drifted. This pointer authorizes nothing,
+        # so it keeps its route rather than being denied on a failure to look.
+        return
+    try:
+        rows = worktree_overlay(live.root, list(live.changed_paths))
+    except (ValueError, OSError):
+        return
+    observed = content_id(rows) if rows else None
+    if observed != pointer.workspace_identity.worktree_overlay_sha256:
+        raise CurrentControlUnavailable(
+            "workspace_changed",
+            (
+                "The working tree changed since this answer was published: the "
+                "uncommitted paths it was read from no longer have the content "
+                "they had. Re-run it."
+            ),
             path=out_dir,
         )
 

--- a/tests/test_adoption_scorer_input_recovery.py
+++ b/tests/test_adoption_scorer_input_recovery.py
@@ -56,6 +56,7 @@ def _satisfied(expects: str, command: str) -> bool:
         # Either side may be abbreviated, and the request may be reached from
         # elsewhere in the repository.
         "git -C repo checkout 66f837355087550877",
+        "cd repo && git checkout 66f837355087",
     ],
 )
 def test_a_checkout_of_the_requested_commit_satisfies_the_route(command: str) -> None:
@@ -76,6 +77,11 @@ def test_a_checkout_of_the_requested_commit_satisfies_the_route(command: str) ->
         "git checkout deadbeef",
         "git switch main",
         "npm test",
+        # The three pieces of a checkout, from three unrelated commands.
+        "git log 66f837355087 && npm run checkout-preview",
+        "git fetch origin 66f837355087 && ./tools/switch-env.sh",
+        # The requested commit appears, but not as what was checked out.
+        "git log 66f837355087 && git checkout deadbeefcafe",
     ],
 )
 def test_a_command_that_does_not_produce_the_commit_leaves_it_open(

--- a/tests/test_adoption_scorer_input_recovery.py
+++ b/tests/test_adoption_scorer_input_recovery.py
@@ -38,39 +38,63 @@ def _fetch_base(expects: str) -> rules._ControlSnapshot:
     )
 
 
+CHECKOUT_REQUEST = "commit 66f837355087 checked out in this worktree"
+FETCH_REQUEST = "origin/main...feature"
+
+
+def _satisfied(expects: str, command: str) -> bool:
+    return rules._action_satisfies_control(
+        rules._TimelineItem(kind="action", command=command), _fetch_base(expects)
+    )
+
+
 @pytest.mark.parametrize(
     "command",
     [
-        "git fetch --no-tags origin main",
-        "git remote update",
-        "git checkout pr-1745",
-        "git switch --detach 66f837355087",
+        "git checkout 66f837355087",
+        "git switch --detach 66f8373",
+        # Either side may be abbreviated, and the request may be reached from
+        # elsewhere in the repository.
+        "git -C repo checkout 66f837355087550877",
     ],
 )
-def test_either_family_of_input_recovery_satisfies_a_commandless_route(
-    command: str,
-) -> None:
-    control = _fetch_base("commit 66f837355087 checked out in this worktree")
-    item = rules._TimelineItem(kind="action", command=command)
-
-    assert rules._action_satisfies_control(item, control)
+def test_a_checkout_of_the_requested_commit_satisfies_the_route(command: str) -> None:
+    assert _satisfied(CHECKOUT_REQUEST, command)
 
 
 @pytest.mark.parametrize(
     "command",
     [
-        "npm test",
-        # `restore` rewrites working-tree files and leaves HEAD where it was,
-        # so it cannot produce the commit the route asked for.
+        # The other family entirely: a fetch leaves the worktree where it was,
+        # and project markers are read from the worktree.
+        "git fetch origin main",
+        # `restore` and the path-restoring form of `checkout` rewrite files and
+        # leave HEAD where it was.
         "git restore --source=66f837355087 python/",
+        "git checkout -- AGENTS.md",
+        # Moves HEAD, to the wrong place.
+        "git checkout deadbeef",
+        "git switch main",
+        "npm test",
     ],
 )
-def test_a_command_that_does_not_produce_the_input_leaves_it_open(
+def test_a_command_that_does_not_produce_the_commit_leaves_it_open(
     command: str,
 ) -> None:
-    """The route stays fail-closed: only input recovery clears it."""
+    """The obligation is the *requested* input, not the shape of the verb."""
 
-    control = _fetch_base("commit 66f837355087 checked out in this worktree")
-    item = rules._TimelineItem(kind="action", command=command)
+    assert not _satisfied(CHECKOUT_REQUEST, command)
 
-    assert not rules._action_satisfies_control(item, control)
+
+@pytest.mark.parametrize(
+    "command", ["git fetch --no-tags origin main", "git remote update"]
+)
+def test_a_fetch_satisfies_a_ref_request(command: str) -> None:
+    assert _satisfied(FETCH_REQUEST, command)
+
+
+@pytest.mark.parametrize("command", ["git checkout 66f837355087", "npm test"])
+def test_a_checkout_does_not_satisfy_a_ref_request(command: str) -> None:
+    """Matching is split by what was asked for, in both directions."""
+
+    assert not _satisfied(FETCH_REQUEST, command)

--- a/tests/test_adoption_scorer_input_recovery.py
+++ b/tests/test_adoption_scorer_input_recovery.py
@@ -60,10 +60,21 @@ def test_either_family_of_input_recovery_satisfies_a_commandless_route(
     assert rules._action_satisfies_control(item, control)
 
 
-def test_an_unrelated_command_still_leaves_the_obligation_open() -> None:
+@pytest.mark.parametrize(
+    "command",
+    [
+        "npm test",
+        # `restore` rewrites working-tree files and leaves HEAD where it was,
+        # so it cannot produce the commit the route asked for.
+        "git restore --source=66f837355087 python/",
+    ],
+)
+def test_a_command_that_does_not_produce_the_input_leaves_it_open(
+    command: str,
+) -> None:
     """The route stays fail-closed: only input recovery clears it."""
 
     control = _fetch_base("commit 66f837355087 checked out in this worktree")
-    item = rules._TimelineItem(kind="action", command="npm test")
+    item = rules._TimelineItem(kind="action", command=command)
 
     assert not rules._action_satisfies_control(item, control)

--- a/tests/test_adoption_scorer_input_recovery.py
+++ b/tests/test_adoption_scorer_input_recovery.py
@@ -1,0 +1,69 @@
+"""The adoption scorer's view of the one command-less coding-agent route.
+
+``fetch_base`` is the sole ``agent_action_required`` route that may carry no
+``command``: the obligation is an *input*, named in ``expects``, and the scorer
+has to recognize the agent producing it. Two families of input satisfy it —
+making history available, and putting the evaluated commit in the worktree,
+which is what ``verify --preview`` asks for when the head under review is not
+the commit checked out (#397 review).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:  # the harness is not an installed package
+    sys.path.insert(0, str(REPO_ROOT))
+
+from harness.adoption.scorer import rules  # noqa: E402
+
+
+def _fetch_base(expects: str) -> rules._ControlSnapshot:
+    return rules._ControlSnapshot(
+        state="agent_action_required",
+        reason="An input is missing.",
+        completion_allowed=False,
+        must_stop=False,
+        verify_required=True,
+        next_action={
+            "actor": "coding_agent",
+            "kind": "fetch_base",
+            "command": None,
+            "expects": expects,
+            "why": "Provide the input, then rerun.",
+        },
+        allowed_next_commands=(),
+        human_review_required=False,
+        source_schema="test",
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git fetch --no-tags origin main",
+        "git remote update",
+        "git checkout pr-1745",
+        "git switch --detach 66f837355087",
+    ],
+)
+def test_either_family_of_input_recovery_satisfies_a_commandless_route(
+    command: str,
+) -> None:
+    control = _fetch_base("commit 66f837355087 checked out in this worktree")
+    item = rules._TimelineItem(kind="action", command=command)
+
+    assert rules._action_satisfies_control(item, control)
+
+
+def test_an_unrelated_command_still_leaves_the_obligation_open() -> None:
+    """The route stays fail-closed: only input recovery clears it."""
+
+    control = _fetch_base("commit 66f837355087 checked out in this worktree")
+    item = rules._TimelineItem(kind="action", command="npm test")
+
+    assert not rules._action_satisfies_control(item, control)

--- a/tests/test_adoption_scorer_input_recovery.py
+++ b/tests/test_adoption_scorer_input_recovery.py
@@ -10,16 +10,12 @@ the commit checked out (#397 review).
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:  # the harness is not an installed package
-    sys.path.insert(0, str(REPO_ROOT))
-
-from harness.adoption.scorer import rules  # noqa: E402
+# The harness is not an installed package; `pythonpath = ["src", "."]` in
+# pyproject puts the repository root on the path for the test session, which is
+# the one mechanism that should decide this.
+from harness.adoption.scorer import rules
 
 
 def _fetch_base(expects: str) -> rules._ControlSnapshot:

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -1592,7 +1592,15 @@ def test_detect_and_init_publish_the_same_candidate_commands(monorepo: Path) -> 
             if action["kind"] == "command"
         ]
 
-    assert commands(json.loads(detected.output)) == commands(json.loads(refused.output))
+    published = commands(json.loads(detected.output))
+    # Not `[] == []`: a regression that drops the commands from the shared
+    # builder drops them from both callers at once, and equality alone would
+    # report that green.
+    assert published == [
+        _init_command(monorepo / "python/agents/RAG"),
+        _init_command(monorepo / "python/agents/crypto-payroll-agent"),
+    ]
+    assert published == commands(json.loads(refused.output))
 
 
 def test_following_a_detect_candidate_command_adopts_that_project(

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -1866,6 +1866,36 @@ def test_an_adopted_candidate_with_no_requested_setup_still_asks_doctor(
     assert [action["args"][0] for action in commands] == ["doctor", "init"]
 
 
+def test_a_caveat_never_points_at_a_candidate_the_cap_cut(tmp_path: Path) -> None:
+    """These lines describe the marking on the list they sit under.
+
+    Raised by a candidate the ten-item display cap removed, the note sends a
+    reader hunting a mark that is not on screen (#397 review)."""
+
+    repo = _init_repo(tmp_path)
+    for index in range(14):
+        _write_agent_project(
+            repo, f"apps/p{index:02d}", name=f"agent_{index:02d}", tool=f"t{index:02d}"
+        )
+    _adopt(repo / "apps/p12")
+    _commit_all(repo, "fourteen projects, the twelfth adopted")
+
+    for argv in (
+        ["detect", "--workspace", str(repo)],
+        ["init", "--workspace", str(repo), "--write"],
+    ):
+        printed = runner.invoke(app, argv).output
+        assert "apps/p12" not in printed, "the cap cut it"
+        assert "already adopted" not in printed
+
+    # Within the cap it is marked, and the note is kept.
+    _adopt(repo / "apps/p03")
+    _commit_all(repo, "and the fourth")
+    printed = runner.invoke(app, ["detect", "--workspace", str(repo)]).output
+    assert "apps/p03 (agent_03) — already adopted" in printed
+    assert "A project marked already adopted" in printed
+
+
 def test_the_printed_refusal_agrees_with_the_routes_beside_it(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -34,6 +34,7 @@ from agents_shipgate.cli.discovery.scope import (
 )
 from agents_shipgate.cli.discovery.signals import weak_marker_evidence_dirs
 from agents_shipgate.cli.main import app
+from agents_shipgate.invocation import render_command
 
 runner = CliRunner()
 
@@ -134,6 +135,12 @@ def _preview(
     result = runner.invoke(app, argv)
     assert result.exit_code == 0, result.output
     return json.loads(result.output)
+
+
+def _init_command(target: Path) -> str:
+    """The scoped ``init`` exactly as this process would spell it (#322)."""
+
+    return render_command(["init", "--workspace", str(target), "--write", "--json"])
 
 
 # --- resolve_change_scope ---------------------------------------------------
@@ -425,6 +432,24 @@ def test_preview_routes_to_discovery_when_the_change_spans_projects(
     assert "python/agents/crypto-payroll-agent" in action["why"]
 
 
+def _preview_other_head(repo: Path) -> dict:
+    argv = [
+        "verify",
+        "--workspace",
+        str(repo),
+        "--preview",
+        "--base",
+        "origin/main",
+        "--head",
+        "feature",
+        "--format",
+        "json",
+    ]
+    result = runner.invoke(app, argv)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
 def test_preview_claims_no_scope_for_a_head_that_is_not_checked_out(
     monorepo: Path,
 ) -> None:
@@ -435,37 +460,56 @@ def test_preview_claims_no_scope_for_a_head_that_is_not_checked_out(
     Nor a *command* about whichever agent it holds: discovery of the current
     worktree answers a question about a different tree, and its single-scope
     answer routes straight back to a root `init` for the unrelated project
-    (#399 review). There is no read-only command that settles this, so the
-    route carries none."""
+    (#399 review).
+
+    What is missing is an input, not a judgement — a working tree holding the
+    commit under review — so the route names it and stays with the coding
+    agent. Handing this to a human published `must_stop` and `command: null`
+    for a state one checkout clears (#397)."""
 
     _touch_one_project(monorepo)
     subprocess.run(["git", "branch", "feature"], cwd=monorepo, check=True)
     subprocess.run(["git", "checkout", "-q", "origin/main"], cwd=monorepo, check=True)
 
-    result = runner.invoke(
-        app,
-        [
-            "verify",
-            "--workspace",
-            str(monorepo),
-            "--preview",
-            "--base",
-            "origin/main",
-            "--head",
-            "feature",
-            "--format",
-            "json",
-        ],
-    )
+    payload = _preview_other_head(monorepo)
 
-    assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    action = payload["control"]["next_action"]
-    assert action["actor"] == "human"
-    assert action["kind"] == "review"
+    control = payload["control"]
+    action = control["next_action"]
+    assert control["state"] == "agent_action_required"
+    assert control["must_stop"] is False
+    assert action["actor"] == "coding_agent"
+    assert action["kind"] == "fetch_base"
     assert action["command"] is None
+    assert action["expects"] == "feature checked out in this worktree"
     assert "not the commit this worktree has checked out" in action["why"]
-    assert payload["control"]["allowed_next_commands"] == []
+    assert "Check feature out in this worktree" in action["why"]
+    # A `fetch_base` route carries no command by contract, and none is smuggled
+    # in beside it: the step that changes the answer is the checkout.
+    assert control["allowed_next_commands"] == []
+    assert control["permissions"]["report_complete"] is False
+
+
+def test_checking_the_head_out_clears_the_preview_that_asked_for_it(
+    monorepo: Path,
+) -> None:
+    """The route is only worth publishing if taking it moves the loop.
+
+    Same command, same refs, one checkout apart: the second run must name the
+    project the pull request changed rather than return the same request."""
+
+    _touch_one_project(monorepo)
+    subprocess.run(["git", "branch", "feature"], cwd=monorepo, check=True)
+    subprocess.run(["git", "checkout", "-q", "origin/main"], cwd=monorepo, check=True)
+    assert _preview_other_head(monorepo)["control"]["next_action"]["kind"] == "fetch_base"
+
+    subprocess.run(["git", "checkout", "-q", "feature"], cwd=monorepo, check=True)
+
+    action = _preview_other_head(monorepo)["control"]["next_action"]
+    assert action["kind"] == "initialize"
+    assert (
+        f"--workspace {monorepo / 'python/agents/crypto-payroll-agent'} --write"
+        in action["command"]
+    )
 
 
 def test_preview_prefers_the_changed_project_manifest_over_the_root_one(
@@ -1493,6 +1537,140 @@ def test_detect_reports_the_ambiguous_scope_and_its_candidates(monorepo: Path) -
         "python/agents/crypto-payroll-agent",
     ]
     assert payload["agent_project_candidates"][0]["agent_names"] == ["ask_rag_agent"]
+
+
+def test_detect_publishes_the_init_command_for_each_candidate(monorepo: Path) -> None:
+    """The decision is a person's; carrying it out is not.
+
+    `detect` published the choice as a JSON selector inside a shell command —
+    ``init --workspace <agent_project_candidates[].path> --write`` — and no
+    runnable command at all, so an agent following `allowed_next_commands` had
+    nowhere to go (#397). `init`'s own refusal has always ranked the decision
+    first and the per-candidate commands below it; `detect` now emits the same
+    shape."""
+
+    result = runner.invoke(app, ["detect", "--workspace", str(monorepo), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    actions = payload["next_actions"]
+    # Rank 1 stays the decision: promoting one candidate would make the same
+    # arbitrary pick `init --write` refuses to make.
+    assert actions[0]["kind"] == "review"
+    assert actions[0]["command"] is None
+    commands = [action for action in actions[1:] if action["kind"] == "command"]
+    assert [action["command"] for action in commands] == [
+        _init_command(monorepo / "python/agents/RAG"),
+        _init_command(monorepo / "python/agents/crypto-payroll-agent"),
+    ]
+    # Structured argv, not only a string a caller has to re-parse (#369).
+    assert commands[0]["args"] == [
+        "init",
+        "--workspace",
+        str(monorepo / "python/agents/RAG"),
+        "--write",
+        "--json",
+    ]
+    assert "ask_rag_agent" in commands[0]["why"]
+
+
+def test_detect_and_init_publish_the_same_candidate_commands(monorepo: Path) -> None:
+    """Two commands an adopter runs in sequence must not disagree about the
+    recovery for one workspace."""
+
+    detected = runner.invoke(app, ["detect", "--workspace", str(monorepo), "--json"])
+    assert detected.exit_code == 0, detected.output
+    refused = runner.invoke(
+        app, ["init", "--workspace", str(monorepo), "--write", "--json"]
+    )
+    assert refused.exit_code == 2, refused.output
+
+    def commands(payload: dict) -> list[str]:
+        return [
+            action["command"]
+            for action in payload["next_actions"]
+            if action["kind"] == "command"
+        ]
+
+    assert commands(json.loads(detected.output)) == commands(json.loads(refused.output))
+
+
+def test_following_a_detect_candidate_command_adopts_that_project(
+    monorepo: Path,
+) -> None:
+    """A published step is only a step if running it changes the answer."""
+
+    detected = runner.invoke(app, ["detect", "--workspace", str(monorepo), "--json"])
+    assert detected.exit_code == 0, detected.output
+    first = next(
+        action
+        for action in json.loads(detected.output)["next_actions"]
+        if action["kind"] == "command"
+    )
+
+    written = runner.invoke(app, first["args"])
+
+    assert written.exit_code == 0, written.output
+    assert (monorepo / "python/agents/RAG" / "shipgate.yaml").is_file()
+    # Scoped, not folded into a root manifest for every agent in the repository.
+    assert not (monorepo / "shipgate.yaml").exists()
+
+
+def test_detect_never_offers_the_workspace_root_as_a_candidate_command(
+    monorepo: Path,
+) -> None:
+    """`.` is the scope `init` would refuse, so a command naming it returns
+    here. It stays in the reported candidate list — unattributed agent files
+    are real evidence of why the answer is unresolved — but not in the
+    routing."""
+
+    (monorepo / "loose_agent.py").write_text(
+        _ADK_AGENT_MODULE.format(name="loose_agent", tool="loose"), encoding="utf-8"
+    )
+    _commit_all(monorepo, "an agent that belongs to no project")
+
+    payload = json.loads(
+        runner.invoke(app, ["detect", "--workspace", str(monorepo), "--json"]).output
+    )
+
+    assert "." in [candidate["path"] for candidate in payload["agent_project_candidates"]]
+    assert all(
+        f"--workspace {monorepo} --write" not in (action["command"] or "")
+        for action in payload["next_actions"]
+    )
+
+
+def test_detect_offers_no_candidate_command_under_a_stop(tmp_path: Path) -> None:
+    """The per-candidate commands carry out one decision; they must not ride
+    under a different one.
+
+    A workspace whose only agent evidence is two nested manifests classifies as
+    a non-agent library — `stop`, `setup_not_applicable` — while still holding
+    two candidate scopes. Publishing "not a Shipgate target" and then an
+    `init --write` for each candidate is two answers to two different
+    questions in one ranked list (#397)."""
+
+    repo = _init_repo(tmp_path)
+    (repo / "pyproject.toml").write_text(_PYPROJECT.format(name="plain-lib"), encoding="utf-8")
+    (repo / "lib.py").write_text("def hello() -> int:\n    return 1\n", encoding="utf-8")
+    for name in ("a", "b"):
+        project = repo / "apps" / name
+        project.mkdir(parents=True)
+        (project / "shipgate.yaml").write_text(
+            f"schema_version: 0.1\nagent:\n  name: {name}\n"
+            '  declared_purpose: ["x"]\n',
+            encoding="utf-8",
+        )
+        (project / "mod.py").write_text("def f() -> int:\n    return 1\n", encoding="utf-8")
+    _commit_all(repo, "two adopted projects, no agent code")
+
+    payload = json.loads(
+        runner.invoke(app, ["detect", "--workspace", str(repo), "--json"]).output
+    )
+
+    assert payload["agent_scope"] == "ambiguous"
+    assert payload["control"]["decision"] == "setup_not_applicable"
+    assert [action["kind"] for action in payload["next_actions"]] == ["stop"]
 
 
 def test_detect_reports_a_single_scope_for_the_adk_sample() -> None:

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -1779,6 +1779,32 @@ def test_the_printed_refusal_agrees_with_the_routes_beside_it(
     assert "apps/fresh (fresh)\n" in refused.output
     assert "ask doctor --config <that manifest>" in refused.output
 
+    # `detect` prints the same list from the same formatter, so the two
+    # commands cannot drift apart the way one fix reaching only one of them
+    # would let them.
+    classified = runner.invoke(app, ["detect", "--workspace", str(repo)])
+    assert classified.exit_code == 0, classified.output
+    assert "apps/adopted (adopted) — already adopted" in classified.output
+    assert "apps/fresh (fresh)\n" in classified.output
+    assert "ask doctor --config <that manifest>" in classified.output
+
+
+def test_an_unadopted_workspace_says_nothing_about_doctor(tmp_path: Path) -> None:
+    """The adopted-candidate note is conditional, not boilerplate."""
+
+    repo = _init_repo(tmp_path)
+    _write_agent_project(repo, "apps/one", name="one", tool="a")
+    _write_agent_project(repo, "apps/two", name="two", tool="b")
+    _commit_all(repo, "neither adopted")
+
+    for argv in (
+        ["detect", "--workspace", str(repo)],
+        ["init", "--workspace", str(repo), "--write"],
+    ):
+        output = runner.invoke(app, argv).output
+        assert "already adopted" not in output
+        assert "ask doctor" not in output
+
 
 def test_an_instruction_refresh_keeps_init_for_an_adopted_candidate(
     tmp_path: Path,

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -1797,6 +1797,17 @@ def test_the_root_candidate_gets_a_route_of_its_own(tmp_path: Path) -> None:
     assert root_route["kind"] == "review"
     assert root_route["command"] is None
     assert "--allow-unresolved-scope" in root_route["why"]
+
+    # And the printed lists say the same thing, in both commands: a caption
+    # reading "re-run init on the one you are changing" over an unmarked `.` is
+    # the human form contradicting the route beside it.
+    for argv in (
+        ["detect", "--workspace", str(repo)],
+        ["init", "--workspace", str(repo), "--write"],
+    ):
+        printed = runner.invoke(app, argv).output
+        assert ". (rooty) — the workspace itself, not a project" in printed
+        assert "re-running init at the root returns this refusal" in printed
     # Still never a command naming the root: that run is this refusal.
     assert all(
         f"--workspace {repo} --write" not in (action["command"] or "")
@@ -1903,6 +1914,7 @@ def test_an_unadopted_workspace_says_nothing_about_doctor(tmp_path: Path) -> Non
         output = runner.invoke(app, argv).output
         assert "already adopted" not in output
         assert "ask doctor" not in output
+        assert "the workspace itself" not in output
 
 
 def test_an_instruction_refresh_keeps_init_for_an_adopted_candidate(

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -137,6 +137,14 @@ def _preview(
     return json.loads(result.output)
 
 
+def _adopt(project: Path) -> None:
+    """Adopt one project the way an adopter would, so `doctor` can read it."""
+
+    written = runner.invoke(app, ["init", "--workspace", str(project), "--write"])
+    assert written.exit_code == 0, written.output
+    assert (project / "shipgate.yaml").is_file()
+
+
 def _init_command(target: Path) -> str:
     """The scoped ``init`` exactly as this process would spell it (#322)."""
 
@@ -480,9 +488,19 @@ def test_preview_claims_no_scope_for_a_head_that_is_not_checked_out(
     assert action["actor"] == "coding_agent"
     assert action["kind"] == "fetch_base"
     assert action["command"] is None
-    assert action["expects"] == "feature checked out in this worktree"
+    # The commit, not the caller's spelling: the checkout being asked for moves
+    # HEAD, so a revision expression would name something else afterwards.
+    feature = subprocess.run(
+        ["git", "rev-parse", "feature"],
+        cwd=monorepo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert action["expects"] == f"commit {feature[:12]} checked out in this worktree"
     assert "not the commit this worktree has checked out" in action["why"]
-    assert "Check feature out in this worktree" in action["why"]
+    assert f"Check {feature[:12]} out in this worktree" in action["why"]
+    assert f"--head {feature[:12]}" in action["why"]
     # A `fetch_base` route carries no command by contract, and none is smuggled
     # in beside it: the step that changes the answer is the checkout.
     assert control["allowed_next_commands"] == []
@@ -510,6 +528,113 @@ def test_checking_the_head_out_clears_the_preview_that_asked_for_it(
         f"--workspace {monorepo / 'python/agents/crypto-payroll-agent'} --write"
         in action["command"]
     )
+
+
+def test_a_head_relative_ref_is_pinned_before_the_checkout_is_asked_for(
+    monorepo: Path,
+) -> None:
+    """The recovery must not move the target it is asking the caller to reach.
+
+    `--head HEAD~1` names one commit before the checkout this route asks for
+    and its parent after it, so a route spelled with the expression walks
+    history backwards one commit per iteration instead of resolving. A
+    `HEAD`-relative `--base` re-ranges the same way, which is quieter and
+    worse: the rerun succeeds against a diff nobody asked for (#397 review)."""
+
+    _touch_one_project(monorepo)
+    (monorepo / "NOTES.md").write_text("later\n", encoding="utf-8")
+    _commit_all(monorepo, "a third commit, so HEAD~1 has somewhere to walk")
+
+    def preview() -> dict:
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                "--workspace",
+                str(monorepo),
+                "--preview",
+                "--base",
+                "HEAD~2",
+                "--head",
+                "HEAD~1",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        return json.loads(result.output)["control"]["next_action"]
+
+    def rev(ref: str) -> str:
+        return subprocess.run(
+            ["git", "rev-parse", ref],
+            cwd=monorepo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()[:12]
+
+    target, base = rev("HEAD~1"), rev("HEAD~2")
+    action = preview()
+
+    assert action["kind"] == "fetch_base"
+    assert action["expects"] == f"commit {target} checked out in this worktree"
+    # Both refs pinned, so the instruction means the same thing after the
+    # checkout as before it.
+    assert f"--base {base} --head {target}" in action["why"]
+    assert "HEAD~1" not in action["expects"]
+
+    # And following it terminates: the pinned rerun resolves the project.
+    subprocess.run(["git", "checkout", "-q", target], cwd=monorepo, check=True)
+    resolved = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(monorepo),
+            "--preview",
+            "--base",
+            base,
+            "--head",
+            target,
+            "--format",
+            "json",
+        ],
+    )
+    assert resolved.exit_code == 0, resolved.output
+    assert json.loads(resolved.output)["control"]["next_action"]["kind"] == "initialize"
+
+
+def test_the_requested_checkout_makes_the_preview_pointer_stale(
+    monorepo: Path,
+) -> None:
+    """A refresh that still reports the request as outstanding is a loop.
+
+    `agent control` is the one refresh entry point. Preview bound no HEAD
+    identity, so after the caller performed exactly the checkout `expects`
+    named, the pointer stayed current and handed back the same
+    `current_control_id` and the same unmet-looking request (#397 review)."""
+
+    _touch_one_project(monorepo)
+    subprocess.run(["git", "branch", "feature"], cwd=monorepo, check=True)
+    subprocess.run(["git", "checkout", "-q", "origin/main"], cwd=monorepo, check=True)
+    _preview_other_head(monorepo)
+
+    def refresh() -> int:
+        return runner.invoke(
+            app,
+            [
+                "agent",
+                "control",
+                "--workspace",
+                str(monorepo),
+                "--reports-dir",
+                str(monorepo / "agents-shipgate-reports"),
+            ],
+        ).exit_code
+
+    assert refresh() == 0
+    subprocess.run(["git", "checkout", "-q", "feature"], cwd=monorepo, check=True)
+    assert refresh() != 0
 
 
 def test_preview_prefers_the_changed_project_manifest_over_the_root_one(
@@ -1572,6 +1697,126 @@ def test_detect_publishes_the_init_command_for_each_candidate(monorepo: Path) ->
         "--json",
     ]
     assert "ask_rag_agent" in commands[0]["why"]
+
+
+def test_every_candidate_gets_a_command_however_many_there_are(
+    tmp_path: Path,
+) -> None:
+    """The display cap belongs to the human summary, not to the routing.
+
+    Slicing the machine list left candidate 11 onward selectable and
+    unrunnable, which is the dead end this list exists to close — issue #397's
+    own reproduction has 25 projects (#397 review)."""
+
+    repo = _init_repo(tmp_path)
+    for index in range(14):
+        _write_agent_project(
+            repo, f"apps/p{index:02d}", name=f"agent_{index:02d}", tool=f"t{index:02d}"
+        )
+    _commit_all(repo, "fourteen projects")
+
+    payload = json.loads(
+        runner.invoke(app, ["detect", "--workspace", str(repo), "--json"]).output
+    )
+
+    routable = [c["path"] for c in payload["agent_project_candidates"] if c["path"] != "."]
+    commands = [a for a in payload["next_actions"] if a["kind"] == "command"]
+    assert len(routable) == 14
+    assert [action["args"][2] for action in commands] == [
+        str(repo / path) for path in routable
+    ]
+
+
+def test_an_adopted_candidate_routes_to_doctor_not_init(tmp_path: Path) -> None:
+    """`init --write` there exits 2 on a manifest it will not overwrite, while
+    `expects` promises a file that already exists.
+
+    A nested `shipgate.yaml` is itself evidence of a project, so adopted
+    directories are candidates too: on this repository's own `samples/`, 21 of
+    22 are, and every command emitted for them refused (#397 review)."""
+
+    repo = _init_repo(tmp_path)
+    adopted = _write_agent_project(repo, "apps/adopted", name="adopted", tool="a")
+    _write_agent_project(repo, "apps/fresh", name="fresh", tool="f")
+    _adopt(adopted)
+    _commit_all(repo, "one adopted, one not")
+
+    payload = json.loads(
+        runner.invoke(app, ["detect", "--workspace", str(repo), "--json"]).output
+    )
+    commands = [a for a in payload["next_actions"] if a["kind"] == "command"]
+
+    assert [action["args"][0] for action in commands] == ["doctor", "init"]
+    for_adopted = commands[0]
+    assert for_adopted["args"][2] == str(adopted / "shipgate.yaml")
+    assert "already carries a manifest" in for_adopted["why"]
+
+    # And it runs: a published step that exits 2 is not a step.
+    followed = runner.invoke(app, for_adopted["args"])
+    assert followed.exit_code == 0, followed.output
+
+
+def test_an_instruction_refresh_keeps_init_for_an_adopted_candidate(
+    tmp_path: Path,
+) -> None:
+    """The one case where `init --write` on an existing manifest exits 0.
+
+    With `--agent-instructions` selected it leaves the manifest alone and
+    refreshes the instruction targets, so routing that candidate to `doctor`
+    would drop the setup the caller asked for."""
+
+    repo = _init_repo(tmp_path)
+    adopted = _write_agent_project(repo, "apps/adopted", name="adopted", tool="a")
+    _write_agent_project(repo, "apps/fresh", name="fresh", tool="f")
+    _adopt(adopted)
+    _commit_all(repo, "one adopted, one not")
+
+    refused = runner.invoke(
+        app,
+        [
+            "init",
+            "--workspace",
+            str(repo),
+            "--write",
+            "--agent-instructions=agents-md",
+            "--json",
+        ],
+    )
+    assert refused.exit_code == 2, refused.output
+    commands = [
+        a for a in json.loads(refused.output)["next_actions"] if a["kind"] == "command"
+    ]
+
+    assert [action["args"][0] for action in commands] == ["init", "init"]
+    assert "--agent-instructions=agents-md" in commands[0]["args"]
+
+
+def test_the_setup_identity_moves_with_the_command_it_publishes(
+    monorepo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`input_id` is the cache boundary for the answer, and the answer includes
+    the commands.
+
+    Every command is spelled for the entry point this process came in through
+    (#322), so the same workspace read two ways publishes two different
+    routes — and hashing the detection alone gave them one identity, letting a
+    cache replay a command that is not available here (#397 review)."""
+
+    def published(entry_point: str) -> tuple[str, str]:
+        monkeypatch.setenv("AGENTS_SHIPGATE_CLI", entry_point)
+        payload = json.loads(
+            runner.invoke(app, ["detect", "--workspace", str(monorepo), "--json"]).output
+        )
+        command = next(
+            a["command"] for a in payload["next_actions"] if a["kind"] == "command"
+        )
+        return payload["control"]["input_id"], command
+
+    first_id, first_command = published("agents-shipgate")
+    second_id, second_command = published("/opt/custom/agents-shipgate")
+
+    assert first_command != second_command
+    assert first_id != second_id
 
 
 def test_detect_and_init_publish_the_same_candidate_commands(monorepo: Path) -> None:

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -1642,10 +1642,17 @@ def test_detect_never_offers_the_workspace_root_as_a_candidate_command(
     )
 
     assert "." in [candidate["path"] for candidate in payload["agent_project_candidates"]]
-    assert all(
-        f"--workspace {monorepo} --write" not in (action["command"] or "")
+    commands = [
+        action["command"]
         for action in payload["next_actions"]
-    )
+        if action["kind"] == "command"
+    ]
+    # Named exactly, so an empty list cannot satisfy the exclusion below.
+    assert commands == [
+        _init_command(monorepo / "python/agents/RAG"),
+        _init_command(monorepo / "python/agents/crypto-payroll-agent"),
+    ]
+    assert all(f"--workspace {monorepo} --write" not in command for command in commands)
 
 
 def test_detect_offers_no_candidate_command_under_a_stop(tmp_path: Path) -> None:

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -35,6 +35,7 @@ from agents_shipgate.cli.discovery.scope import (
 from agents_shipgate.cli.discovery.signals import weak_marker_evidence_dirs
 from agents_shipgate.cli.main import app
 from agents_shipgate.invocation import render_command
+from agents_shipgate.schemas.agent_control_envelope import truncate_prose
 
 runner = CliRunner()
 
@@ -497,10 +498,16 @@ def test_preview_claims_no_scope_for_a_head_that_is_not_checked_out(
         text=True,
         check=True,
     ).stdout.strip()
-    assert action["expects"] == f"commit {feature[:12]} checked out in this worktree"
+    assert action["expects"].startswith(
+        f"commit {feature[:12]} checked out in this worktree"
+    )
     assert "not the commit this worktree has checked out" in action["why"]
-    assert f"Check {feature[:12]} out in this worktree" in action["why"]
+    assert action["why"].startswith(f"Check {feature[:12]} out in this worktree")
     assert f"--head {feature[:12]}" in action["why"]
+    # The envelope caps `why` at 400 bytes and never touches `expects`, so the
+    # immutable rerun has to survive both.
+    assert f"--head {feature[:12]}" in action["expects"]
+    assert f"--head {feature[:12]}" in truncate_prose(action["why"])
     # A `fetch_base` route carries no command by contract, and none is smuggled
     # in beside it: the step that changes the answer is the checkout.
     assert control["allowed_next_commands"] == []
@@ -577,10 +584,14 @@ def test_a_head_relative_ref_is_pinned_before_the_checkout_is_asked_for(
     action = preview()
 
     assert action["kind"] == "fetch_base"
-    assert action["expects"] == f"commit {target} checked out in this worktree"
+    assert action["expects"].startswith(
+        f"commit {target} checked out in this worktree"
+    )
     # Both refs pinned, so the instruction means the same thing after the
-    # checkout as before it.
+    # checkout as before it — in `why`, and in the field the envelope never
+    # truncates.
     assert f"--base {base} --head {target}" in action["why"]
+    assert f"--base {base} --head {target}" in action["expects"]
     assert "HEAD~1" not in action["expects"]
 
     # And following it terminates: the pinned rerun resolves the project.
@@ -1754,6 +1765,94 @@ def test_an_adopted_candidate_routes_to_doctor_not_init(tmp_path: Path) -> None:
     # And it runs: a published step that exits 2 is not a step.
     followed = runner.invoke(app, for_adopted["args"])
     assert followed.exit_code == 0, followed.output
+
+
+def test_the_root_candidate_gets_a_route_of_its_own(tmp_path: Path) -> None:
+    """`.` is presented as selectable, so it cannot be the one entry with no
+    answer.
+
+    Agent files that belong to no project are exactly why the scope is
+    unresolved; `init` at the root returns this same refusal, and
+    `--allow-unresolved-scope` accepts the *whole workspace* as one scope,
+    which is a different decision and not a route for that agent (#397
+    review)."""
+
+    repo = _init_repo(tmp_path)
+    (repo / "agent.py").write_text(
+        _ADK_AGENT_MODULE.format(name="rooty", tool="r"), encoding="utf-8"
+    )
+    _write_agent_project(repo, "nested", name="nested_agent", tool="n")
+    _commit_all(repo, "a root agent and a nested project")
+
+    payload = json.loads(
+        runner.invoke(app, ["detect", "--workspace", str(repo), "--json"]).output
+    )
+
+    assert "." in [c["path"] for c in payload["agent_project_candidates"]]
+    root_route = next(
+        action
+        for action in payload["next_actions"][1:]
+        if "workspace root is a candidate" in action["why"]
+    )
+    assert root_route["kind"] == "review"
+    assert root_route["command"] is None
+    assert "--allow-unresolved-scope" in root_route["why"]
+    # Still never a command naming the root: that run is this refusal.
+    assert all(
+        f"--workspace {repo} --write" not in (action["command"] or "")
+        for action in payload["next_actions"]
+    )
+
+
+def test_requested_ci_survives_an_adopted_candidate(tmp_path: Path) -> None:
+    """Setup the caller asked for is not owed less because a manifest exists.
+
+    A refused `init --write --ci` writes no workflow, so handing the adopted
+    candidate a bare `doctor` dropped the request silently (#397 review)."""
+
+    repo = _init_repo(tmp_path)
+    adopted = _write_agent_project(repo, "apps/adopted", name="adopted", tool="a")
+    _write_agent_project(repo, "apps/fresh", name="fresh", tool="f")
+    _adopt(adopted)
+    _commit_all(repo, "one adopted, one not")
+
+    refused = runner.invoke(
+        app, ["init", "--workspace", str(repo), "--write", "--ci", "--json"]
+    )
+    assert refused.exit_code == 2, refused.output
+    assert not (repo / ".github").exists(), "the refusal writes nothing"
+    commands = [
+        a for a in json.loads(refused.output)["next_actions"] if a["kind"] == "command"
+    ]
+
+    for_adopted = next(a for a in commands if str(adopted) in a["args"])
+    assert "--ci" in for_adopted["args"]
+    # Without `--write`, so the manifest it will not overwrite is never touched.
+    assert "--write" not in for_adopted["args"]
+
+    followed = runner.invoke(app, for_adopted["args"])
+    assert followed.exit_code == 0, followed.output
+    assert list((repo / ".github" / "workflows").glob("agents-shipgate*.yml"))
+    assert (adopted / "shipgate.yaml").is_file()
+
+
+def test_an_adopted_candidate_with_no_requested_setup_still_asks_doctor(
+    tmp_path: Path,
+) -> None:
+    """The carry-the-flags route is conditional on flags being asked for."""
+
+    repo = _init_repo(tmp_path)
+    adopted = _write_agent_project(repo, "apps/adopted", name="adopted", tool="a")
+    _write_agent_project(repo, "apps/fresh", name="fresh", tool="f")
+    _adopt(adopted)
+    _commit_all(repo, "one adopted, one not")
+
+    payload = json.loads(
+        runner.invoke(app, ["detect", "--workspace", str(repo), "--json"]).output
+    )
+    commands = [a for a in payload["next_actions"] if a["kind"] == "command"]
+
+    assert [action["args"][0] for action in commands] == ["doctor", "init"]
 
 
 def test_the_printed_refusal_agrees_with_the_routes_beside_it(

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -1756,6 +1756,30 @@ def test_an_adopted_candidate_routes_to_doctor_not_init(tmp_path: Path) -> None:
     assert followed.exit_code == 0, followed.output
 
 
+def test_the_printed_refusal_agrees_with_the_routes_beside_it(
+    tmp_path: Path,
+) -> None:
+    """One command must not answer the same question two ways.
+
+    The refusal listed every candidate identically and told the reader to
+    re-run `init --workspace` on the one they were changing, while the
+    `next_actions[]` in the same payload routed an adopted candidate to
+    `doctor` because that `init` refuses (#397 review)."""
+
+    repo = _init_repo(tmp_path)
+    adopted = _write_agent_project(repo, "apps/adopted", name="adopted", tool="a")
+    _write_agent_project(repo, "apps/fresh", name="fresh", tool="f")
+    _adopt(adopted)
+    _commit_all(repo, "one adopted, one not")
+
+    refused = runner.invoke(app, ["init", "--workspace", str(repo), "--write"])
+
+    assert refused.exit_code == 2, refused.output
+    assert "apps/adopted (adopted) — already adopted" in refused.output
+    assert "apps/fresh (fresh)\n" in refused.output
+    assert "ask doctor --config <that manifest>" in refused.output
+
+
 def test_an_instruction_refresh_keeps_init_for_an_adopted_candidate(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_discovery_scope.py
+++ b/tests/test_discovery_scope.py
@@ -1576,7 +1576,11 @@ def test_detect_publishes_the_init_command_for_each_candidate(monorepo: Path) ->
 
 def test_detect_and_init_publish_the_same_candidate_commands(monorepo: Path) -> None:
     """Two commands an adopter runs in sequence must not disagree about the
-    recovery for one workspace."""
+    recovery for one workspace.
+
+    Flagless on both sides, which is the whole of the claim: `init` repeats the
+    setup its invocation asked for, and `detect` was asked for none — see
+    :func:`test_detect_does_not_invent_setup_flags_init_was_asked_for`."""
 
     detected = runner.invoke(app, ["detect", "--workspace", str(monorepo), "--json"])
     assert detected.exit_code == 0, detected.output
@@ -1601,6 +1605,36 @@ def test_detect_and_init_publish_the_same_candidate_commands(monorepo: Path) -> 
         _init_command(monorepo / "python/agents/crypto-payroll-agent"),
     ]
     assert published == commands(json.loads(refused.output))
+
+
+def test_detect_does_not_invent_setup_flags_init_was_asked_for(
+    monorepo: Path,
+) -> None:
+    """The one place the two lists legitimately differ.
+
+    `init`'s recovery repeats the flags its own invocation carried, because a
+    recovery that silently drops `--ci` completes with less than the caller
+    requested and reports success for it. `detect` asked for no setup at all,
+    so promising any would be inventing it — and a reader told the lists are
+    identical would substitute the flagless command for the one they need."""
+
+    detected = json.loads(
+        runner.invoke(app, ["detect", "--workspace", str(monorepo), "--json"]).output
+    )
+    refused = runner.invoke(
+        app, ["init", "--workspace", str(monorepo), "--write", "--ci", "--json"]
+    )
+    assert refused.exit_code == 2, refused.output
+
+    def first_command(payload: dict) -> str:
+        return next(
+            action["command"]
+            for action in payload["next_actions"]
+            if action["kind"] == "command"
+        )
+
+    assert first_command(detected).endswith("--write --json")
+    assert first_command(json.loads(refused.output)).endswith("--write --ci --json")
 
 
 def test_following_a_detect_candidate_command_adopts_that_project(

--- a/tests/test_setup_control.py
+++ b/tests/test_setup_control.py
@@ -44,6 +44,7 @@ from agents_shipgate.cli.discovery.placeholders import (
 from agents_shipgate.cli.main import app
 from agents_shipgate.cli.setup_control import (
     SETUP_ACTION_KINDS,
+    SETUP_INCOMPLETE,
     setup_control_envelope,
     setup_input_id,
 )
@@ -61,7 +62,12 @@ from agents_shipgate.schemas.agent_control_envelope import (
     validate_agent_control_envelope,
 )
 from agents_shipgate.schemas.detect import DetectResult, WorkspaceSignals
-from agents_shipgate.schemas.diagnostics import ALL_DIAGNOSTIC_IDS
+from agents_shipgate.schemas.diagnostics import (
+    ALL_DIAGNOSTIC_IDS,
+    DIAG_NO_AGENT_SURFACE,
+    Diagnostic,
+    NextAction,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _PUBLISHED_SCHEMA = Draft202012Validator(
@@ -1122,13 +1128,71 @@ def test_detect_never_declares_setup_complete_from_a_file_existing(tmp_path: Pat
     from agents_shipgate.cli.detect import _detect_advance
 
     result = DetectResult(is_agent_project=True)
-    advance, _kind, decision = _detect_advance(
+    advance, _kind, decision, alternatives = _detect_advance(
         result, has_manifest=True, workspace=tmp_path
     )
 
     assert decision != "setup_complete"
     assert advance is not None
     assert "doctor" in (advance.command or "")
+    assert alternatives == []
+
+
+def _carry_out() -> NextAction:
+    return NextAction(
+        kind="command",
+        command="agents-shipgate init --workspace apps/a --write --json",
+        why="Initialize only apps/a.",
+        expects="shipgate.yaml is created in apps/a.",
+    )
+
+
+def _decision() -> NextAction:
+    return NextAction(kind="review", why="Choose the project this change is about.")
+
+
+def test_advance_alternatives_ride_with_the_decision_that_selects_them():
+    """They are the ways of carrying out rank 1, so they follow rank 1."""
+
+    routing = setup_control_envelope(
+        operation="detect",
+        input_id="sha256:" + "0" * 64,
+        reason="Agents live in more than one project.",
+        advance=_decision(),
+        advance_kind="discover",
+        advance_decision=SETUP_INCOMPLETE,
+        advance_alternatives=[_carry_out()],
+    )
+
+    assert [action.kind for action in routing.actions] == ["review", "command"]
+
+
+def test_advance_alternatives_are_dropped_when_a_diagnostic_outranks_the_advance():
+    """Rank 1 is then a different question, and these answer the one nobody
+    published: `detect` on a workspace whose only agent evidence is two nested
+    manifests emitted `stop` — "not a Shipgate target" — and then an
+    `init --write` for each of the two (#397)."""
+
+    routing = setup_control_envelope(
+        operation="detect",
+        input_id="sha256:" + "0" * 64,
+        reason="No agent surface matched.",
+        diagnostics=[
+            Diagnostic(
+                id=DIAG_NO_AGENT_SURFACE,
+                title="No agent surface",
+                severity="info",
+                next_actions=[NextAction(kind="stop", why="Not a Shipgate target.")],
+            )
+        ],
+        advance=_decision(),
+        advance_kind="discover",
+        advance_decision=SETUP_INCOMPLETE,
+        advance_alternatives=[_carry_out()],
+    )
+
+    assert [action.kind for action in routing.actions] == ["stop"]
+    assert routing.envelope.control_state == "human_review_required"
 
 
 def test_a_refused_instruction_target_still_reports_what_failed(unadopted: Path):


### PR DESCRIPTION
Closes #397.

## The loop, before

`verify --preview --head <ref>` while some other commit is checked out reads
project markers from the working tree — deliberately, because that is the tree
the `init` it recommends would write to. On [google/adk-samples#1745] the
changed directory exists only on the PR branch, so no project could be named.

That state routed to a human: `must_stop: true`, `next_action.command: null`,
`allowed_next_commands: []`. One move, no forward path for either actor — and
the remedy, derivable from the very ref preview was handed, went unsaid. The
`detect` the same walk reaches on a monorepo was the second dead end: its
escalation published a JSON selector inside a shell command
(`init --workspace <agent_project_candidates[].path> --write`) and no runnable
command anywhere in `next_actions[]`.

## The loop, after

**1 · The head-mismatch route asks for the checkout.** Nothing about the change
is in doubt there. What is missing is an *input* — a working tree holding the
commit under review — and producing it is one mechanical step the caller owns.
That is what `fetch_base` already exists for, so no new surface.

```json
"next_action": {
  "actor": "coding_agent",
  "kind": "fetch_base",
  "command": null,
  "expects": "commit 66f837355087 checked out in this worktree",
  "why": "The project this change belongs to could not be established (the evaluated head 'pr-1745' (66f837355087) is not the commit this worktree has checked out, and project markers are read from the worktree that init would run against). Check 66f837355087 out in this worktree, then re-run this preview with --base 20f865664ada --head 66f837355087: a revision expression re-resolves against the new HEAD. Discovery of the worktree as it stands answers about a different tree."
}
```

`expects` names a **commit id**, and the rerun is **pinned on both refs**,
because the step being requested moves `HEAD`. Spelled with the caller's own
`--head HEAD~1` the route named one commit before the checkout and its parent
after, and following it walked history backwards one commit per iteration; a
`HEAD`-relative `--base` re-ranges the same way, which is quieter and worse —
the rerun succeeds against a diff nobody asked for.

The requested checkout also makes the preview's control pointer stale, so
`agent control` — the one refresh entry point — stops reporting the request as
outstanding once it has been performed.

The two causes no checkout can repair — evidence the change deleted, an
unreadable inventory — keep their human route with no command. Plain `verify`
is unaffected: it reads `--head` from the object database, not the worktree.

**2 · `detect` publishes a runnable command for every candidate.** Rank 1 stays
the decision (`kind: "review"`, `command: null` — naming one candidate would
make the arbitrary pick `init --write` refuses to make), and below it goes one
exact command per candidate with `executable`/`args`. `init` and `detect` build
that list from one helper, so the two an adopter runs in sequence cannot publish
different recoveries for one workspace.

- **Every** candidate, not ten: the display cap that keeps a human refusal
  readable had been applied to the routing, leaving candidate 11 onward
  selectable and unrunnable. `detect --workspace samples --json` finds 22
  projects; the reported repository has 25.
- A candidate that **already carries a manifest** routes to
  `doctor --config <that manifest> --json`. A nested `shipgate.yaml` is itself
  evidence of a project, so adopted directories are candidates too — on this
  repository's own `samples/`, 21 of 22 are, and every `init --write` emitted
  for them exited 2. The exception is `--agent-instructions`, which makes
  `init --write` the advertised refresh and exits 0.
- Both commands' *printed* summaries mark those candidates and name the doctor
  route, from the one formatter they now share.
- `detect`'s `control.input_id` covers the route it publishes. Every command is
  spelled for the entry point the process came in through, so the same
  workspace read two ways published different commands under one identity —
  and that identity is the documented cache boundary for the answer.

**3 · A regression found while doing 2.** `setup_control_envelope` kept
`advance_alternatives` even when a *diagnostic* outranked the advance they carry
out, so a workspace whose only agent evidence is two nested manifests published
`stop` — "not a Shipgate target" — followed by an `init --write` for each of the
two. They now ride only with the decision that selected them.

## Deviations from the issue's suggested wording

The issue suggests saying "check out `<head>`, **or re-run with `--head`
omitted**". The second half is left out on purpose: this route only fires when
the worktree holds a *different* commit, so omitting `--head` would evaluate a
different subject and answer confidently about the wrong tree. The `why` says so
explicitly rather than leaving it implied.

`detect`'s ambiguous-scope control state stays `human_review_required`. Choosing
the project is the pick Shipgate refuses to make; the issue asked for the
runnable commands beneath that decision, not for the decision to be automated.

## Review

Nine passes over the branch, each fix its own commit. The two worth naming:

- **A defect the fix introduced.** Splitting `head_mismatch` into its own branch
  stranded its rationale on the branch it vacated — `deleted_evidence` and
  `unreadable_inventory` are produced only *after* the head is confirmed to be
  this worktree, yet still told the reader "discovery of the current worktree
  would answer about a different tree". Reproduced verbatim on a PR that deletes
  a project's only evidence file.
- **The same fix reaching one of two commands.** Marking adopted candidates in
  `init`'s printed refusal left `detect`'s summary saying `init --write` while
  its own JSON said `doctor`, because `_echo_agent_scope` recomputed the
  candidate line inline. Fixed by consolidating the formatter rather than
  copying the marker.

## Verification

- The issue's reproduction walked end to end: `fetch_base` → checkout → pinned
  rerun → `init --workspace python/agents/smart_closer --write --json` → manifest
  written → `human_review_required` on the `declared_purpose` a person owes.
- `samples/`: 21 routable candidates, 21 commands, all `doctor`, and the first
  one executed to exit 0.
- The `HEAD~1` walk, the pointer staleness, the entry-point identity split, the
  symlinked-manifest guard, and `--ci`/`--agent-instructions` flag handling each
  exercised directly.
- `ruff check .`, `scripts/generate_schemas.py --check`, `llms-full.txt`
  regenerated, full `pytest tests/`, all six CI jobs.

No new public surface: `fetch_base`, `advance_alternatives`, and `next_actions[]`
all already shipped. The `AgentControlAction` union is embedded in six durable
published schemas, so `fetch_base`'s documented meaning was widened — with its
consumers, including the adoption scorer — rather than a new action kind added.

[google/adk-samples#1745]: https://github.com/google/adk-samples/pull/1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
