### PR TITLE
fix(agent-mode): adopter-facing output stops naming the internal identity model (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,74 @@
   that has nothing to do with safety, and it is now pinned equal to what the
   engine emits by a test.
 
+- **Adopter-facing output stops naming the internal identity model.** Running
+  the tool on your own repository for the first time could produce
+  `Duplicate tool observation identity: source_type='google_adk_function',
+  source_id='google_adk:agent.py', native_locator='agent.py#map_account'` —
+  three internal concepts, none of them in the manifest you wrote, and the one
+  recoverable fact (a file was listed twice) unstated
+  ([#329](https://github.com/ThreeMoonsLab/agents-shipgate/issues/329),
+  invariant 5 of [#327](https://github.com/ThreeMoonsLab/agents-shipgate/issues/327)).
+
+  Every string whose purpose is to tell a person what to do next — console
+  output, the agent-mode `message` / `next_action` / `next_actions[]`,
+  `agent-handoff.json` prose, `fix_task.instructions[]`, PR comment text — now
+  names a file, a symbol, an agent, or a manifest key. That message reads
+  `Tool 'map_account' was read twice from 'agent.py' as one tool source. Check
+  shipgate.yaml for an entry naming 'agent.py' more than once…`, and the
+  identity triple moves to a new `details` object on the error envelope, where
+  a machine consumer or a bug report can still read it. `report.json` evidence
+  blocks and the tool catalog are untouched: they are the identity model, and
+  they are supposed to be precise.
+
+  *A digest was the subject of a shipped verdict.* A binding gap whose issue
+  named no tool fell back to the derived agent id, so `samples/conductor_agent`
+  shipped `Insufficient evidence: the agent's tool binding graph is incomplete
+  (agent_v1:7205d836…)` as the sentence under its verdict. It now reads
+  `(durable_order_agent [conductor_workflows])`. The report's conservation
+  invariant — which already refused a raw *tool* id in a gap subject — now
+  refuses any derived id, matched by shape: a guard scoped to one kind of
+  identifier passes vacuously for every other one.
+
+  *`verify` and `scan` disagreed about the same failure.* Each caught
+  `InputParseError` and wrote its own recovery, so a failure with a precise
+  route on one command got generic advice on the other. One resolver now serves
+  `scan`, `verify`, and the verifier assembly path — and it names the manifest
+  the run actually read, since `scan --workspace <repo>` can discover a sole
+  nested `services/billing/shipgate.yaml` while the emitted `edit` action said
+  `shipgate.yaml`, a different file in the caller's working directory.
+
+  *One failure, two repairs.* A tool read twice is either a repeated manifest
+  entry or a duplicate definition inside the artifact, and the structured
+  action carries one path — so naming both let a consumer delete a source
+  declaration when the file was the problem. The check now reports which cause
+  it saw in `details.cause` and the action follows it, reading the answer from
+  the manifest because the loaders that aggregate their artifacts cannot say
+  which one they read twice. `tool_sources[].id` is also stripped and refused
+  when blank, in the published JSON Schema as well as at runtime: it is the key
+  `tool_inventories[]` and `tool_identity.bindings[]` join on, both of which
+  were already stripped, so `id: " orders "` matched neither and silently
+  completed nothing.
+
+  *`next_actions[].path` is the one field a caller opens verbatim, so it is the
+  one field that is always resolved.* The manifest an `edit` action names is
+  the one the run read — through `--workspace` discovery, through a defaulted
+  `--config` on `verify` and `verification prepare`, and through an archived
+  `verify --base/--head`, where it used to name a temporary file that had
+  already been deleted. Two things follow: a declared artifact is never
+  published as a path, because it has no single base, and a failure evaluated
+  against a ref that is not checked out publishes none either — the action
+  names the commit instead of a working-tree file that may already hold the
+  fix. `ArtifactPathConfig.path` is also canonicalized, so declaring both
+  `tools.json` and `./tools.json` no longer reads one file twice and produces
+  two canonical tools.
+
+  `tests/test_adopter_vocabulary.py` is the guard: it enumerates the
+  adopter-facing strings four ways — every evidence-gap kind through the real
+  renderers, every published message builder, every hand-written string at an
+  emit site in the modules that produce this output, and the shipped sample
+  artifacts — and fails on reintroduced internal vocabulary.
+
 - **A declaration cannot discharge a category it does not cover, and a
   published schema keeps its bytes.** Three follow-ups to the monotone
   declaration rule, each a defect that shipped with it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,34 @@ tagged release (a check ID, a stable JSON field, a CLI flag) still follows the
 compatibility and deprecation rules in [`STABILITY.md`](STABILITY.md): a shipped
 check ID is deprecated for at least one minor cycle, never hard-removed.
 
+## Adopter-facing copy
+
+A separate rule from surface discipline, and easier to break by accident:
+**a string an adopter is expected to act on must name something they can
+open.** A file, a symbol, an agent, or a manifest key.
+
+Internal identity vocabulary — `source_type`, `source_id`, `native_locator`,
+observation ids, fingerprints, and derived `tool_v…` / `agent_v…` identifiers —
+belongs in `report.json` evidence blocks, the tool catalog, and the
+verification artifacts, where tooling reads it and precision is the point. It
+does not belong in console output, the agent-mode `message` / `next_action` /
+`next_actions[]`, `agent-handoff.json` prose, `fix_task.instructions[]`, or PR
+comment text. Where an internal identifier is load-bearing for diagnosis, keep
+it in the structured payload (`AgentsShipgateError.details`, the envelope's
+`details` object, `EvidenceGap.subject_id`) and write the sentence in the
+adopter's terms.
+
+`source_id` and `source_type` are the awkward pair: both are real manifest
+keys under `tool_identity.bindings[].members[]`, and `source_id` is one under
+`tool_inventories[]` and `agent_bindings.root` too. Spelled with the surface
+they belong to they are locatable; spelled bare they are the model leaking.
+
+The rule and its two categories live in
+[`core/adopter_text.py`](src/agents_shipgate/core/adopter_text.py);
+[`tests/test_adopter_vocabulary.py`](tests/test_adopter_vocabulary.py) enforces
+it. If you add a message builder to `core/source_warnings.py`, that test's
+sweep table will tell you.
+
 ## Schema Changes
 
 The JSON Schemas under `docs/` (`manifest-v0.1.json`, `checks.json`,

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -13,6 +13,135 @@ for reproducible CI.
 
 ---
 
+<a id="migration-note-unreleased-adopter-vocabulary"></a>
+
+## Migration Note: unreleased — adopter-facing output stops naming internal fields
+
+No version moves: `contract_version`, `report_schema_version`,
+`minimum_control_contract_version`, and every published schema document are
+unchanged. No field is removed or retyped and no error kind is added. What
+changes is the *wording* of strings a person is expected to read and act on,
+three published field values, one additive field on the agent-mode error
+envelope, and one narrowed manifest value — each detailed below.
+
+**The rule.** Internal identity vocabulary — `source_type`, `source_id`,
+`native_locator`, observation ids, fingerprints, and derived `tool_v…` /
+`agent_v…` identifiers — may appear as evidence in machine-read artifacts. It
+may not appear in anything whose purpose is to tell a person what to do next:
+console output, the agent-mode `next_action` / `next_actions[]` / `message`,
+`agent-handoff.json` prose, `fix_task.instructions[]`, and PR comment text.
+`report.json` evidence blocks, `tool_catalog`, `identity_assessment`, and the
+verification artifacts are unchanged — they are the identity model and are
+supposed to be precise. `tests/test_adopter_vocabulary.py` enforces the rule.
+
+**Messages that changed.** All are prose; none is a documented identifier.
+
+| Where | Before | After |
+|---|---|---|
+| `input_parse_error`, one artifact read twice for a source | `Duplicate tool observation identity: source_type='google_adk_function', source_id='google_adk:agent.py', native_locator='agent.py#map_account'` | `'agent.py' was read twice as one tool source, so the tool 'map_account' arrived twice. Remove the repeated shipgate.yaml entry naming 'agent.py', then re-run the scan.` |
+| `input_parse_error`, one artifact defining a tool twice | *(the same message — the two causes were indistinguishable)* | `'tools.json' defines the tool 'pay' more than once, so one tool source produced it twice. Remove the duplicate definition from 'tools.json', then re-run the scan.` |
+| source warning, one tool in several bindings | `Tool observation obs_v1_3f9a1c2b… appears in multiple bindings: b1, b2` | `Tool 'process_order' from 'agent.py' is claimed by more than one tool_identity.bindings entry: 'b1', 'b2'. …` |
+| source warning, binding member that resolves to the wrong count | `member source_id='orders_b', tool='process_order' matched 0 observations` | `… matched 0 tools in that source, not exactly one — correct the member at shipgate.yaml#tool_identity.bindings so it names one tool` |
+| `SHIP-DIAG-UNKNOWN-ADAPTER-SOURCE-TYPE` title | `Unknown adapter source_type 'acme' …` | `No adapter handles tool_sources[].type 'acme' in shipgate.yaml …` |
+| `incomplete_tool_identity` gap `accepted_values` | `["unique_source_id", "stable_native_locator"]` | `["unique_source_id", "stable_source_path"]` |
+
+**One gap subject changes value.** A binding gap whose issue names no tool
+falls back to the agent, and the fallback was the derived agent id. It is now
+the same kind of label a tool subject already is:
+
+| Report | `evidence_gaps[].subject` before | after |
+|---|---|---|
+| `samples/conductor_agent` | `agent_v1:7205d836e4b3fee257d90695` | `durable_order_agent [conductor_workflows]` |
+| `samples/support_refund_agent` | `agent_v1:7cb237a00d64b7400f4adc3b` | `refund_agent [openai_sdk_static]` |
+
+`release_decision.reason`, `agent_summary.first_recommended_action.why`, the
+CLI `Improve evidence:` line, and the GitHub step summary all print that
+subject, so they change with it. **A consumer that joined on
+`evidence_gaps[].subject` for these rows should read the agent id from
+`binding_surface_facts.agents[].agent_id` instead** — `subject` is documented
+as a display label, and this was the last kind of id still in it. The
+report's conservation invariant now refuses *any* derived id in a gap subject,
+matched by shape, so neither kind can return.
+
+**One field is added.** The agent-mode `input_parse_error` envelope may carry
+`details`, an object holding the diagnostic identifiers that left the message —
+for the duplicate-tool failure: `failure`, `cause`, `source_type`, `source_id`,
+`native_locator`, `tool_name`, `source_file`, and `manifest_path`; plus
+`manifest_placeholders` (the manifest fields still holding `CHANGE_ME`, which
+is what the placeholder recovery now routes on instead of searching the failure
+text) and `evaluated_ref` / `manifest_in_ref` for a failure evaluated against a
+ref. It is absent when a failure carries no such payload, and it is never
+required to act on the error. Route on `details.failure` and `details.cause`
+rather than on message text; `docs/errors.json` documents them.
+
+`details.manifest_path` is the manifest the run actually read. It matters
+because the emitted `edit` action names it: a `scan --workspace <repo>` that
+discovers a sole nested `services/billing/shipgate.yaml`, or a `verify` with no
+`--config`, previously published `path: "shipgate.yaml"` — a different file in
+the caller's working directory. A consumer reconstructing the manifest from the
+invocation should read this field instead.
+
+**Two published values move.** The `incomplete_tool_identity` gap's
+`next_action.path` is now `shipgate.yaml#tool_sources`, matching the repair its
+`expects` and `accepted_values` describe; it was `shipgate.yaml#tool_identity`,
+which sent an agent routing on `path` to a different section than the sentence
+beside it. And the gap kinds where a *reference* failed to resolve —
+`unresolved_agent_binding`, `unresolved_bound_tool`, `incomplete_handoff_graph`
+— are now subjected by their `source_pointer` rather than by the agent that
+made the reference, which is the healthy one: a handoff to a missing worker
+was subjected `root [sdk]` and carried that name into the verdict and the fix
+task.
+
+**`next_actions[].path` is the one field a caller may open verbatim, and it
+now always is.** An `edit` action names the manifest the run actually read:
+`--workspace` discovery can select a nested `services/billing/shipgate.yaml`,
+`verify` and `verification prepare` default `--config`, and an archived
+`verify --base/--head` reads a temporary tree that is deleted before the error
+is handled. The `CHANGE_ME` placeholder recovery, whose `path` was previously
+the literal string `shipgate.yaml`, is included.
+
+Two consequences follow from that rule rather than from any single fix.
+A **declared artifact** is never published as a `path` at all — it has no one
+base (the manifest's for most sources, the *entrypoint's* for an inventory a
+framework file mounts), so the duplicate-inside-an-artifact recovery is a
+`review` action that names the artifact in its sentence. And a failure
+**evaluated against a ref that is not checked out** publishes no `path`
+either: the archive is gone and the working tree may already hold the fix, so
+the action names the commit and the path within it (`details.evaluated_ref`,
+`details.manifest_in_ref`). Paths inside `details` are recorded as the loader
+saw them and are *not* verbatim-openable; `docs/errors.json` says so.
+
+**One manifest value is canonicalized.** `ArtifactPathConfig.path` — every
+declared artifact under a framework block — is normalized, so `./tools.json`
+and `tools.json` are one declaration. Declaring both used to read one file
+twice and produce *two* canonical tools, with no duplicate detected and no
+warning. A path containing a backslash is left exactly as written, and `..`
+segments are preserved so the containment checks downstream still see what the
+author wrote.
+
+**One manifest value is narrowed.** `tool_sources[].id` is stripped, and a
+blank id is now a `config_error` (exit 2) at manifest load instead of an
+`input_parse_error` (exit 3) during the scan. The id is the key
+`tool_inventories[].source_id` and `tool_identity.bindings[].members[].source_id`
+join on, and both of those were already stripped where they are declared — so
+`id: " orders "` matched neither and silently completed nothing. A manifest with
+a blank or padded id was already not doing what it looked like it was doing;
+now it says so at the point the value is read.
+
+`docs/manifest-v0.1.json` carries the rule too, as `"pattern": "\\S"` on
+`ToolSourceConfig.id`: the published schema is part of the manifest contract,
+and a consumer validating against it would otherwise accept an id the runtime
+refuses. A parity test asserts the two agree on empty, whitespace-only, and
+padded ids.
+
+**`verify` now routes this failure the way `scan` does.** Both commands, and
+the verifier assembly path, share one recovery resolver, so a duplicate tool
+source yields an `edit` action naming the manifest instead of the generic
+"inspect the file referenced in the error" review action. The error kind and
+exit code (3) are unchanged.
+
+---
+
 <a id="migration-note-unreleased-effect-coverage"></a>
 
 ## Migration Note: unreleased — effect coverage, and the schemas that stayed frozen

--- a/docs/errors.json
+++ b/docs/errors.json
@@ -10,7 +10,7 @@
     "yes",
     "on"
   ],
-  "stderr_format": "Single JSON line, one object per emitted error. Always carries an `error` field naming the kind plus `next_action` (single-string back-compat) and `next_actions` (ranked array). Additional fields per kind are command-dependent and may be absent when they are not relevant.",
+  "stderr_format": "Single JSON line, one object per emitted error. Always carries an `error` field naming the kind plus `next_action` (single-string back-compat) and `next_actions` (ranked array). Additional fields per kind are command-dependent and may be absent when they are not relevant. `message`, `next_action`, and `next_actions[]` are written for a person to act on and name files, symbols, and manifest keys rather than internal identity fields; a `details` object, where a kind emits one, carries those identifiers for routing and bug reports.",
   "exit_codes": {
     "0": "pass (advisory mode, or strict-no-blockers)",
     "2": "configuration, catalog lookup, or patch-payload error (config_error, config_already_exists, unknown_check_id, unknown_fingerprint, malformed_patch)",
@@ -57,10 +57,11 @@
       "additional_fields": [
         "message",
         "source_report",
+        "details",
         "next_action",
         "next_actions"
       ],
-      "recovery_hint": "Follow `next_actions[]`. For scan/doctor tool-source failures, run `agents-shipgate doctor -c shipgate.yaml --json` to inspect `unresolved_sources[]`. For report-consuming commands, inspect `source_report` when present (or the `--from` path in the message) and regenerate a current `report.json` if needed."
+      "recovery_hint": "Follow `next_actions[]`. For scan/doctor tool-source failures, run `agents-shipgate doctor -c shipgate.yaml --json` to inspect `unresolved_sources[]`. For report-consuming commands, inspect `source_report` when present (or the `--from` path in the message) and regenerate a current `report.json` if needed. `message` and `next_actions[]` name files, symbols, and manifest keys only; when a failure has internal identifiers behind it they are in `details`, which is for routing and bug reports and is never required to act on the error. **Open only `next_actions[].path`.** It is the one field resolved for the caller — against the manifest the run actually read, and omitted entirely when the failure belongs to a ref that is not checked out. `details` is for routing and bug reports and is never required to act on the error; its paths are recorded as the loader saw them and are not verbatim-openable. Route on `details.failure` rather than pattern-matching the prose: `duplicate_tool_in_source` means one tool source produced the same tool twice, and `details.cause` says which repair applies — `repeated_source_entry` (the manifest names one artifact twice, so the action edits the manifest) or `duplicate_in_source_artifact` (one artifact defines the tool twice, so the action is a review naming it). `details.manifest_placeholders` lists the manifest fields still holding `CHANGE_ME`; `details.evaluated_ref` appears when the failure was evaluated against a ref rather than the working tree."
     },
     {
       "id": "unknown_check_id",

--- a/docs/manifest-v0.1.json
+++ b/docs/manifest-v0.1.json
@@ -2301,6 +2301,7 @@
       "additionalProperties": false,
       "properties": {
         "id": {
+          "pattern": "\\S",
           "title": "Id",
           "type": "string"
         },

--- a/samples/conductor_agent/expected/report.json
+++ b/samples/conductor_agent/expected/report.json
@@ -64,7 +64,7 @@
   },
   "release_decision": {
     "decision": "insufficient_evidence",
-    "reason": "Insufficient evidence: the agent's tool binding graph is incomplete (agent_v1:7205d836e4b3fee257d90695). Fix at shipgate.yaml#agent_bindings. Context: 1 binding evidence gap(s), 1 semantic evidence gap(s), 1 low-confidence tool(s) and 4 source warning(s); scan results are not trustworthy enough to gate release.",
+    "reason": "Insufficient evidence: the agent's tool binding graph is incomplete (durable_order_agent [conductor_workflows]). Fix at shipgate.yaml#agent_bindings. Context: 1 binding evidence gap(s), 1 semantic evidence gap(s), 1 low-confidence tool(s) and 4 source warning(s); scan results are not trustworthy enough to gate release.",
     "blockers": [],
     "review_items": [
       {
@@ -122,7 +122,7 @@
       "evidence_gaps": [
         {
           "kind": "partial_binding_evidence",
-          "subject": "agent_v1:7205d836e4b3fee257d90695",
+          "subject": "durable_order_agent [conductor_workflows]",
           "subject_id": null,
           "source_type": null,
           "source_ref": "framework_extraction",
@@ -1277,7 +1277,7 @@
   "policy_evidence_gaps": [],
   "agent_summary": {
     "verdict": "insufficient_evidence",
-    "headline": "Insufficient evidence: the agent's tool binding graph is incomplete (agent_v1:7205d836e4b3fee257d90695). Fix at shipgate.yaml#agent_bindings. Context: 1 binding evidence gap(s), 1 semantic evidence gap(s), 1 low-confidence tool(s) and 4 source warning(s); scan results are not trustworthy enough to gate release.",
+    "headline": "Insufficient evidence: the agent's tool binding graph is incomplete (durable_order_agent [conductor_workflows]). Fix at shipgate.yaml#agent_bindings. Context: 1 binding evidence gap(s), 1 semantic evidence gap(s), 1 low-confidence tool(s) and 4 source warning(s); scan results are not trustworthy enough to gate release.",
     "blocker_count": 0,
     "review_item_count": 2,
     "auto_appliable_patches": 0,
@@ -1285,7 +1285,7 @@
     "first_recommended_action": {
       "kind": "info",
       "command": null,
-      "why": "Provide static wiring or an exact reviewed declaration for every reachable edge. Target: shipgate.yaml#agent_bindings. That is the gap this verdict names: the agent's tool binding graph is incomplete (agent_v1:7205d836e4b3fee257d90695). Applying patches does not clear an evidence verdict, so close this gap and re-run verification."
+      "why": "Provide static wiring or an exact reviewed declaration for every reachable edge. Target: shipgate.yaml#agent_bindings. That is the gap this verdict names: the agent's tool binding graph is incomplete (durable_order_agent [conductor_workflows]). Applying patches does not clear an evidence verdict, so close this gap and re-run verification."
     }
   },
   "policy_audit": {

--- a/samples/conductor_agent/expected/report.md
+++ b/samples/conductor_agent/expected/report.md
@@ -7,7 +7,7 @@ Target: local
 ## Release Decision
 
 Decision: insufficient_evidence
-Reason: Insufficient evidence: the agent's tool binding graph is incomplete \(agent\_v1:7205d836e4b3fee257d90695\). Fix at shipgate.yaml\#agent\_bindings. Context: 1 binding evidence gap\(s\), 1 semantic evidence gap\(s\), 1 low-confidence tool\(s\) and 4 source warning\(s\); scan results are not trustworthy enough to gate release.
+Reason: Insufficient evidence: the agent's tool binding graph is incomplete \(durable\_order\_agent \[conductor\_workflows\]\). Fix at shipgate.yaml\#agent\_bindings. Context: 1 binding evidence gap\(s\), 1 semantic evidence gap\(s\), 1 low-confidence tool\(s\) and 4 source warning\(s\); scan results are not trustworthy enough to gate release.
 
 Blockers (0): none
 

--- a/samples/support_refund_agent/expected/packet.json
+++ b/samples/support_refund_agent/expected/packet.json
@@ -2056,7 +2056,7 @@
           },
           "source_ref": "/agent_bindings/declarations/0",
           "source_type": null,
-          "subject": "agent_v1:7cb237a00d64b7400f4adc3b",
+          "subject": "refund_agent [openai_sdk_static]",
           "subject_id": null,
           "why": "Closed-world declaration for 'root' does not match the complete structural tool set."
         },

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -648,7 +648,7 @@
       "evidence_gaps": [
         {
           "kind": "conflicting_binding_evidence",
-          "subject": "agent_v1:7cb237a00d64b7400f4adc3b",
+          "subject": "refund_agent [openai_sdk_static]",
           "subject_id": null,
           "source_type": null,
           "source_ref": "/agent_bindings/declarations/0",

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -40,6 +40,7 @@ from agents_shipgate.core.semantic_assessment import (
 )
 from agents_shipgate.core.source_warnings import unresolved_adk_tool_symbols
 from agents_shipgate.core.surface_exclusions import (
+    agent_label_index,
     catalog_subject,
     unavailable_base_subject,
 )
@@ -663,6 +664,22 @@ _MANDATORY_CURRENT_CONTROL_CHECKS = frozenset(
 )
 
 
+#: Binding-issue kinds where something *referenced* did not resolve. The agent
+#: on these issues is the one doing the referencing — a handoff target that
+#: names nothing is attached to the perfectly healthy agent that declared it,
+#: and a declaration whose target is ambiguous carries that agent's id
+#: outright. Labelling the gap with it names the one agent that is not the
+#: problem and carries that name into the verdict and the fix task (#329
+#: review), so for these the pointer at the unresolved reference wins.
+_UNRESOLVED_TARGET_KINDS = frozenset(
+    {
+        "unresolved_agent_binding",
+        "unresolved_bound_tool",
+        "incomplete_handoff_graph",
+    }
+)
+
+
 def _binding_coverage(
     report: ReadinessReport,
     tool_catalog: Sequence[Tool] = (),
@@ -685,6 +702,40 @@ def _binding_coverage(
         if not tool_id:
             return fallback
         return catalog_subject(catalog_rows.get(tool_id) or {"tool_id": tool_id})
+
+    # The same rule for the other subject this loop can name. An issue that
+    # names no tool falls back to the agent, and the agent used to be spelled
+    # by its derived id — so the sentence under the verdict read "the agent's
+    # tool binding graph is incomplete (agent_v1:7205d836…)", naming something
+    # that appears in no file the reader has (#329). Resolved through one
+    # index, and chaining to the source pointer rather than back to the id:
+    # a fallback that returns the unreadable value defeats itself.
+    agent_labels = agent_label_index(graph.agents)
+
+    def _agent_subject(issue: AgentBindingIssue) -> str:
+        # Three answers, in the order they are true.
+        #
+        # For an unresolved *reference*, the pointer names what failed and the
+        # agent id names who referenced it, so the pointer wins outright — an
+        # `agent_id` present on these kinds is the healthy referrer, not the
+        # subject (#329 review).
+        #
+        # Otherwise the issue's own agent is the subject. A kind that names
+        # none is a statement about the whole extraction — "this entrypoint
+        # builds its tools dynamically" — where the root is the agent the
+        # reader is being told about, and naming it is the improvement.
+        #
+        # `source` is never a subject: it is `framework_extraction` or a bare
+        # `shipgate.yaml`, which names no agent and reads as jargon.
+        unresolved_reference = issue.kind in _UNRESOLVED_TARGET_KINDS
+        if unresolved_reference and issue.source_pointer:
+            return issue.source_pointer
+        agent_id = issue.agent_id or (
+            None if unresolved_reference else graph.root_agent_id
+        )
+        label = agent_labels.get(agent_id or "")
+        return label or issue.source_pointer or "agent binding graph"
+
     for issue in graph.issues:
         _increment(reason_counts, issue.kind)
         if issue.kind == "ambiguous_root_agent":
@@ -721,10 +772,7 @@ def _binding_coverage(
         gaps.append(
             EvidenceGap(
                 kind=issue.kind,
-                subject=_gap_subject(
-                    issue.tool_id,
-                    issue.agent_id or graph.root_agent_id or "agent_binding_graph",
-                ),
+                subject=_gap_subject(issue.tool_id, _agent_subject(issue)),
                 subject_id=issue.tool_id,
                 source_ref=issue.source_pointer or issue.source,
                 why=issue.message,
@@ -1351,9 +1399,19 @@ def _semantic_gap(
     name_scaffold = True
     if kind in {"incomplete_tool_identity"}:
         action_kind = "declare_source_identity"
-        accepted_values = ["unique_source_id", "stable_native_locator"]
-        action_why = "A stable source-scoped identity is required for every observation."
-        expects = "Declare a unique source identity and regenerate the report."
+        # `stable_native_locator` named a field that exists in no file the
+        # adopter has (#329). Both values now name what they actually ask for:
+        # a unique id per tool source, and a source whose file path does not
+        # move between runs.
+        accepted_values = ["unique_source_id", "stable_source_path"]
+        action_why = (
+            "Every tool needs a stable identity scoped to the source it was "
+            "read from."
+        )
+        expects = (
+            "Give each entry under shipgate.yaml#tool_sources a unique id and a "
+            "path that does not move between runs, then regenerate the report."
+        )
     elif kind in {"unresolved_tool_selector", "ambiguous_tool_selector", "ambiguous_legacy_tool_identity"}:
         action_kind = "qualify_tool_selector"
         accepted_values = ["tool_id", "provider", "source_type", "source_id"]
@@ -1373,7 +1431,10 @@ def _semantic_gap(
     elif kind == "conflicting_tool_identity":
         action_kind = "resolve_tool_identity_conflict"
         accepted_values = ["split_binding", "align_schema", "align_authority", "align_annotations"]
-        action_why = "Conflicting bound observations cannot share one canonical capability."
+        action_why = (
+            "Tools joined into one capability must agree about what that "
+            "capability does."
+        )
         expects = "Split the binding or reconcile its structural evidence, then rerun verification."
     elif kind == "invalid_evidence_provenance":
         action_kind = "provide_policy_evidence"
@@ -1744,6 +1805,13 @@ def _semantic_gap_path(kind: str, tool: Tool, issue_source: str | None = None) -
         return "shipgate.yaml#tool_sources"
     if kind in _SELECTOR_KINDS:
         return action_row
+    if kind == "incomplete_tool_identity":
+        # Not `tool_identity`: the repair this kind prescribes is a unique id
+        # and a stable path per configured source, and both live under
+        # `tool_sources`. An agent routes on `path` while a human reads
+        # `expects`, so the two disagreeing sent them to different sections of
+        # the same file (#329 review).
+        return "shipgate.yaml#tool_sources"
     if kind in _TOOL_IDENTITY_KINDS:
         return "shipgate.yaml#tool_identity"
     if kind in _AGENT_BINDING_KINDS:

--- a/src/agents_shipgate/cli/_register_scan.py
+++ b/src/agents_shipgate/cli/_register_scan.py
@@ -19,7 +19,7 @@ from agents_shipgate.cli._helpers import (
     _run_multi_scan,
 )
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error as _emit_agent_mode_error
-from agents_shipgate.cli.diagnostics import top_next_actions
+from agents_shipgate.cli.diagnostics import input_parse_recovery, top_next_actions
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_controls import git_root_for
@@ -453,50 +453,20 @@ def register(app: typer.Typer) -> None:
             raise typer.Exit(2) from exc
         except InputParseError as exc:
             typer.echo(f"Input parsing error: {exc}", err=True)
-            if "CHANGE_ME" in str(exc):
-                # `init --write` on a workspace where detect found no
-                # sources leaves CHANGE_ME placeholders; scanning then
-                # fails here. Route to the placeholder fix, not the
-                # generic missing-file advice.
-                guidance = (
-                    "shipgate.yaml still contains CHANGE_ME placeholders. "
-                    "Edit shipgate.yaml to point tool_sources at real "
-                    "artifacts, or run `agents-shipgate doctor` to list "
-                    "every placeholder."
-                )
-                actions = [
-                    NextAction(
-                        kind="edit",
-                        path="shipgate.yaml",
-                        why=guidance,
-                        expects=(
-                            "tool_sources entries reference files that exist "
-                            "in this workspace."
-                        ),
-                    )
-                ]
-            else:
-                guidance = (
-                    "Inspect the file referenced in the error; ensure it "
-                    "exists, is valid, and resolves under the manifest "
-                    "directory."
-                )
-                actions = [
-                    NextAction(
-                        kind="review",
-                        why=guidance,
-                        expects=(
-                            "Referenced file is present, parseable, and inside "
-                            "the manifest directory."
-                        ),
-                    )
-                ]
+            actions = input_parse_recovery(exc, manifest_path=config)
             _echo_next_action_hint(actions)
             _emit_agent_mode_error(
                 "input_parse_error",
                 message=str(exc),
-                next_action=guidance,
+                # The prose form, not `to_legacy_string()`: this surface has
+                # always published the sentence here, and `Edit <path>` drops
+                # the half that says what to change.
+                next_action=actions[0].why,
                 next_actions=[a.model_dump(mode="json") for a in actions],
+                # The identity model stays available to machine consumers and
+                # bug reports even though it left the sentence (#329). Absent
+                # for the failures that carry no structured payload.
+                details=exc.details or None,
             )
             raise typer.Exit(3) from exc
         except ArtifactLifecycleError as exc:

--- a/src/agents_shipgate/cli/agent_mode.py
+++ b/src/agents_shipgate/cli/agent_mode.py
@@ -75,6 +75,7 @@ def emit_agent_mode_error_action(
     message: object,
     exit_code: int,
     action: Any,
+    details: object | None = None,
     **fields: object,
 ) -> None:
     """Emit a structured error whose recovery is one ranked ``NextAction``.
@@ -92,6 +93,7 @@ def emit_agent_mode_error_action(
         exit_code=exit_code,
         next_action=action.to_legacy_string(),
         next_actions=[action.model_dump(mode="json")],
+        details=details,
         **fields,
     )
 
@@ -106,9 +108,17 @@ def emit_agent_mode_error(
     next_actions: object | None = None,
     diagnostics: object | None = None,
     artifacts: object | None = None,
+    details: object | None = None,
     **fields: object,
 ) -> None:
-    """Emit a structured one-line error for coding-agent callers."""
+    """Emit a structured one-line error for coding-agent callers.
+
+    ``details`` is the diagnostic payload a failure carries in
+    ``AgentsShipgateError.details`` — the internal identity fields that used to
+    be printed at the reader (#329). Named explicitly rather than passed
+    through ``**fields`` so it is omitted when empty instead of publishing
+    ``"details": null``, and so ``docs/errors.json`` has one place to point at.
+    """
     if not is_agent_mode():
         return
     payload: dict[str, object] = {"error": error_kind}
@@ -122,6 +132,8 @@ def emit_agent_mode_error(
         payload["next_action"] = _legacy_action(next_action, normalized_actions)
     if normalized_actions is not None:
         payload["next_actions"] = normalized_actions
+    if details is not None:
+        payload["details"] = details
     if diagnostics is not None:
         payload["diagnostics"] = diagnostics
     if artifacts is not None:

--- a/src/agents_shipgate/cli/diagnostics.py
+++ b/src/agents_shipgate/cli/diagnostics.py
@@ -18,9 +18,16 @@ blocking *condition*; the caller decides what to do.
 from __future__ import annotations
 
 import shlex
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from agents_shipgate.core.adopter_text import (
+    DUPLICATE_TOOL_IN_SOURCE,
+    REPEATED_SOURCE_ENTRY,
+    source_label,
+)
+from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.schemas.detect import DetectResult
 from agents_shipgate.schemas.diagnostics import (
     DIAG_CHANGE_ME_PLACEHOLDERS,
@@ -167,7 +174,8 @@ def diagnose_unknown_adapter_source_type(
                 why=(
                     "Enable third-party adapter discovery and re-run "
                     "the scan. If the adapter package is also "
-                    "installed, this resolves the source_type."
+                    "installed, this resolves the shipgate.yaml "
+                    "tool_sources[].type."
                 ),
                 expects=(
                     f"Scan completes; `report.loaded_adapters[]` "
@@ -210,13 +218,155 @@ def diagnose_unknown_adapter_source_type(
         Diagnostic(
             id=DIAG_UNKNOWN_ADAPTER_SOURCE_TYPE,
             title=(
-                f"Unknown adapter source_type {source_type!r} "
-                "(install/enable the adapter, or fix a typo)"
+                f"No adapter handles tool_sources[].type {source_type!r} "
+                "in shipgate.yaml (install/enable the adapter, or fix a typo)"
             ),
             severity="block",
             next_actions=next_actions,
         )
     ]
+
+
+def input_parse_recovery(
+    exc: InputParseError, *, manifest_path: Path | None = None
+) -> list[NextAction]:
+    """The ranked recovery for an ``input_parse_error``, for every command.
+
+    ``scan``, ``verify``, and the verifier assembly path each caught this
+    exception and each wrote its own recovery, so a failure that had a precise
+    route on one command got "inspect the file referenced in the error" on the
+    next — the second-implementation bug class (#322). One resolver, three
+    call sites.
+
+    Routing is on the exception's typed ``details["failure"]`` where it has
+    one. That is what lets the *message* be rewritten for a human without
+    breaking the route (#329): prose is for the reader, ``details`` is for the
+    caller, and neither is parsed to derive the other. The ``CHANGE_ME`` branch
+    predates typed details and still sniffs the text, because the placeholder
+    is genuinely a property of the manifest's contents rather than of a failure
+    site.
+    """
+
+    details = exc.details
+    # The manifest the run actually read, which is not always the one the CLI
+    # was spelled with: `--workspace` discovery can select a sole nested
+    # `services/billing/shipgate.yaml`, and `verify` may be invoked with no
+    # `--config` at all. `run_scan` records the resolved path on the way out,
+    # so an `edit` action cannot name an unrelated trust root in the caller's
+    # working directory (#329 review). The argument is the fallback for the
+    # failures raised before a scan started.
+    manifest = str(details.get("manifest_path") or manifest_path or "shipgate.yaml")
+    # A failure evaluated against a ref that is not the checked-out tree has no
+    # file the reader can open: the archive is gone and the working tree may
+    # already hold the fix. Say which commit and which path within it, and
+    # publish no `path` at all (#329 review 3).
+    evaluated_ref = details.get("evaluated_ref")
+    manifest_in_ref = details.get("manifest_in_ref")
+    if evaluated_ref and manifest_in_ref:
+        return [
+            NextAction(
+                kind="review",
+                why=(
+                    f"This failure is in {manifest_in_ref} as of {evaluated_ref}, "
+                    "which is not the tree you have checked out. Inspect that "
+                    "commit — the working copy may already differ."
+                ),
+                expects=(
+                    f"{manifest_in_ref} at {evaluated_ref} no longer produces "
+                    "this failure."
+                ),
+            )
+        ]
+    if details.get("failure") == DUPLICATE_TOOL_IN_SOURCE:
+        return [_duplicate_tool_action(details, manifest=manifest)]
+    # `init --write` on a workspace where detect found no sources leaves
+    # CHANGE_ME placeholders; scanning then fails here. Route to the
+    # placeholder fix, not the generic missing-file advice.
+    #
+    # Decided on typed manifest state, not on a substring of the failure text:
+    # a filled-in manifest pointing at a missing file named
+    # `CHANGE_ME-tools.json` matched the old search and was told it still held
+    # template placeholders (#329 review 3). A caller that recorded nothing
+    # gets the generic route — "we did not look" is not "there are none".
+    placeholders = details.get("manifest_placeholders")
+    if placeholders:
+        fields = ", ".join(str(field) for field in list(placeholders)[:4])
+        return [
+            NextAction(
+                kind="edit",
+                # The manifest the run read: `--workspace` can select a nested
+                # one, and this branch discarding it sent the reader to a
+                # different file than the one holding the placeholders.
+                path=manifest,
+                why=(
+                    f"{manifest} still declares CHANGE_ME at {fields}. Edit "
+                    "those fields to point at real artifacts, or run "
+                    "`agents-shipgate doctor` to list every placeholder."
+                ),
+                expects=(
+                    "tool_sources entries reference files that exist in this "
+                    "workspace."
+                ),
+            )
+        ]
+    return [
+        NextAction(
+            kind="review",
+            why=(
+                "Inspect the file referenced in the error; ensure it exists, is "
+                "valid, and resolves under the manifest directory."
+            ),
+            expects=(
+                "Referenced file is present, parseable, and inside the manifest "
+                "directory."
+            ),
+        )
+    ]
+
+
+def _duplicate_tool_action(
+    details: Mapping[str, Any], *, manifest: str
+) -> NextAction:
+    """One target, chosen from the cause the duplicate check reported.
+
+    A repeated entry is repaired in the manifest and a duplicate definition is
+    repaired in the artifact, so naming both would leave a consumer routing on
+    ``path`` free to delete a source declaration when the file was the problem.
+    Only the manifest is ever an ``edit`` target. A declared artifact path has
+    no single base — the manifest's for most sources, the *entrypoint's* for an
+    inventory a framework file mounts — so publishing one as a routable path
+    named a file that did not exist (#329 review 3). The artifact still
+    appears in the sentence, where it is a name to grep for rather than a path
+    to open, and the duplicate-inside-an-artifact case routes to review.
+    """
+
+    tool_name = str(details.get("tool_name") or "")
+    source_id = str(details.get("source_id") or "")
+    source_file = details.get("source_file")
+    where = source_label(
+        file_path=source_file if isinstance(source_file, str) else None,
+        source_id=source_id,
+    )
+    if details.get("cause") == REPEATED_SOURCE_ENTRY:
+        return NextAction(
+            kind="edit",
+            path=manifest,
+            why=(
+                f"{manifest} reads {where} twice as one tool source, so the "
+                f"tool {tool_name!r} arrived twice. Remove the repeated entry."
+            ),
+            expects="Each tool source names its artifact exactly once.",
+        )
+    return NextAction(
+        kind="review",
+        why=(
+            f"{where} produced the tool {tool_name!r} twice, so one artifact "
+            f"defines it more than once. Find it under the tool source "
+            f"{source_id!r} declared in {manifest} and remove the duplicate "
+            "definition; the manifest entry itself is correct."
+        ),
+        expects=f"The artifact behind {source_id!r} defines each tool once.",
+    )
 
 
 def diagnose_invalid_manifest(

--- a/src/agents_shipgate/cli/discovery/placeholders.py
+++ b/src/agents_shipgate/cli/discovery/placeholders.py
@@ -15,6 +15,7 @@ someone chose to spell their YAML.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator, Mapping, Sequence
 
 import yaml
@@ -225,3 +226,32 @@ def _scan_lines(template: str) -> list[dict[str, object]]:
                 }
             )
     return placeholders
+
+
+#: A value the template actually wrote: the sentinel alone, or the sentinel as
+#: a filename with an extension (``path: CHANGE_ME.yaml``), optionally under a
+#: directory the author already filled in. Deliberately stricter than
+#: :func:`collect_placeholders`, which reports any value *containing* the
+#: sentinel because listing one too many is harmless — a routing decision is
+#: not: ``CHANGE_ME-tools.json`` is a legal filename, and a manifest that is
+#: fully filled in and merely points at a missing file was being told it still
+#: held template placeholders (#329 review 3). Where the two disagree the
+#: reader gets the generic route, which says something true.
+_PLACEHOLDER_TOKEN = re.compile(
+    rf"(?:^|[/\\]){re.escape(PLACEHOLDER_VALUE)}(?:\.[A-Za-z0-9]+)?$"
+)
+
+
+def manifest_placeholder_fields(manifest_text: str) -> list[str]:
+    """The manifest fields still holding a ``CHANGE_ME``, as field paths.
+
+    Typed state for the recovery router, which used to decide by searching the
+    whole exception text for the sentinel. The placeholder is a property of the
+    manifest, so this reads it from the manifest — and reads it exactly.
+    """
+
+    return [
+        str(entry["path"])
+        for entry in collect_placeholders(manifest_text)
+        if _PLACEHOLDER_TOKEN.search(str(entry.get("current") or ""))
+    ]

--- a/src/agents_shipgate/cli/explain_finding.py
+++ b/src/agents_shipgate/cli/explain_finding.py
@@ -270,8 +270,14 @@ class FingerprintNotFound(LookupError):
     def __init__(self, fingerprint: str, *, suggestion: str | None) -> None:
         self.fingerprint = fingerprint
         self.suggestion = suggestion
+        # Name where the value comes from, not just that it did not match:
+        # the reader supplied an identifier and has to be told which field to
+        # copy the right one from (#329).
         suffix = f" Did you mean {suggestion}?" if suggestion else ""
-        super().__init__(f"Unknown fingerprint: {fingerprint}.{suffix}")
+        super().__init__(
+            f"Unknown fingerprint: {fingerprint}.{suffix} No entry in "
+            "findings[].fingerprint matches it."
+        )
 
 
 def explain_finding(
@@ -320,7 +326,9 @@ def explain_finding(
     except FingerprintNotFound as exc:
         suffix = f" Did you mean {exc.suggestion}?" if exc.suggestion else ""
         typer.echo(
-            f"Unknown fingerprint: {exc.fingerprint}.{suffix}", err=True
+            f"Unknown fingerprint: {exc.fingerprint}.{suffix} No entry in "
+            f"findings[].fingerprint in {source} matches it.",
+            err=True,
         )
         emit_agent_mode_error(
             "unknown_fingerprint",

--- a/src/agents_shipgate/cli/scan/orchestrator.py
+++ b/src/agents_shipgate/cli/scan/orchestrator.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from agents_shipgate import __version__, _perf
 from agents_shipgate.ci.github_summary import write_github_step_summary
+from agents_shipgate.cli.discovery.placeholders import manifest_placeholder_fields
 from agents_shipgate.core.capability_lock import build_capability_lock
-from agents_shipgate.core.errors import ConfigError
+from agents_shipgate.core.errors import AgentsShipgateError, ConfigError
 from agents_shipgate.schemas.capabilities import CapabilityLockFileV1
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.verification import VerificationContext
@@ -53,6 +54,91 @@ def run_scan(
     """
     if deep_import:
         raise ConfigError("Deep import is intentionally deferred and is not supported.")
+
+    try:
+        return _run_scan(
+            config_path=config_path,
+            output_dir=output_dir,
+            formats=formats,
+            ci_mode=ci_mode,
+            fail_on=fail_on,
+            baseline_path=baseline_path,
+            diff_from_path=diff_from_path,
+            baseline_mode=baseline_mode,
+            policy_pack_paths=policy_pack_paths,
+            plugins_enabled=plugins_enabled,
+            verbose=verbose,
+            suggest_patches=suggest_patches,
+            no_heuristics=no_heuristics,
+            packet_enabled=packet_enabled,
+            packet_formats=packet_formats,
+            packet_generated_at=packet_generated_at,
+            verification_context=verification_context,
+            capability_lock_callback=capability_lock_callback,
+            manifest_text=manifest_text,
+        )
+    except AgentsShipgateError as exc:
+        # Every recovery route that names a file to edit needs the manifest
+        # this run actually read, and only this frame knows it: the CLI is
+        # spelled `--workspace .` or `-c '*/shipgate.yaml'` as often as with a
+        # literal path, and the recovery emitted from the caller's `except`
+        # would otherwise name `shipgate.yaml` relative to the caller's CWD —
+        # an unrelated trust root (#329 review). Recorded once here rather
+        # than at each raise site, none of which knows the manifest either.
+        exc.details.setdefault("manifest_path", str(config_path))
+        # Typed placeholder state, read from the manifest rather than searched
+        # for in the failure text (#329 review 3). Absent — not empty — when
+        # the manifest could not be read at all, so the router can tell "no
+        # placeholders" from "we never looked".
+        placeholders = _manifest_placeholders(config_path, manifest_text)
+        if placeholders is not None:
+            exc.details.setdefault("manifest_placeholders", placeholders)
+        raise
+
+
+def _manifest_placeholders(
+    config_path: Path, manifest_text: str | None
+) -> list[str] | None:
+    """Placeholder fields in the manifest this run read, or ``None``.
+
+    Re-reads the file only when the caller supplied no text, and only on a
+    failure path: the manifest was already read once by this point, so the
+    cost is a second read of a file that is known small and known present.
+    """
+
+    text = manifest_text
+    if text is None:
+        try:
+            text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+    return manifest_placeholder_fields(text)
+
+
+def _run_scan(
+    *,
+    config_path: Path,
+    output_dir: Path | None,
+    formats: list[str] | None,
+    ci_mode: str | None,
+    fail_on: list[str] | None,
+    baseline_path: Path | None,
+    diff_from_path: Path | None,
+    baseline_mode: str,
+    policy_pack_paths: list[Path] | None,
+    plugins_enabled: bool | None,
+    verbose: bool,
+    suggest_patches: bool,
+    no_heuristics: bool,
+    packet_enabled: bool | None,
+    packet_formats: list[str] | None,
+    packet_generated_at: str | None,
+    verification_context: VerificationContext | None,
+    capability_lock_callback: Callable[[CapabilityLockFileV1], None] | None,
+    manifest_text: str | None,
+) -> tuple[ReadinessReport, int]:
+    """The pipeline itself. Split from :func:`run_scan` so the manifest the
+    run read can be attached to any failure on the way out, in one place."""
 
     # Phase-timing instrumentation (`_perf`): opt-in, zero overhead when
     # off. Phase names are stable strings — benchmark snapshots and the

--- a/src/agents_shipgate/cli/scan/source_loading.py
+++ b/src/agents_shipgate/cli/scan/source_loading.py
@@ -250,12 +250,14 @@ def _invoke_per_source_adapter(
 def _build_canonical_tools(
     loaded_sources: list[LoadedToolSource],
     identity_config: ToolIdentityConfig | None = None,
+    repeated_artifacts: frozenset[str] = frozenset(),
 ) -> tuple[list[Tool], list[str]]:
     """Build the provider-scoped identity catalog and return identity warnings."""
 
     return build_tool_identity_catalog(
         loaded_sources,
         identity_config or ToolIdentityConfig(),
+        repeated_artifacts,
     )
 
 

--- a/src/agents_shipgate/cli/scan/tools_agent.py
+++ b/src/agents_shipgate/cli/scan/tools_agent.py
@@ -9,7 +9,10 @@ from agents_shipgate.core.semantic_assessment import attach_semantic_assessments
 from agents_shipgate.core.source_warnings import withdraw_completed_adk_tool_warnings
 from agents_shipgate.core.tool_identity import resolve_selectors_by_tool_id
 from agents_shipgate.inputs.google_adk import GoogleAdkArtifacts
-from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.manifest import (
+    AgentsShipgateManifest,
+    repeated_declared_artifacts,
+)
 
 from .agent_builder import _build_agent
 from .models import _LoadedInputs, _ToolsAndAgent
@@ -73,6 +76,9 @@ def _build_tools_and_agent(
     tools, identity_warnings = _build_canonical_tools(
         inputs.loaded_sources,
         manifest.tool_identity,
+        # Read from the config, because a loader that aggregates its artifacts
+        # cannot report which of them it read twice (#329 review).
+        repeated_declared_artifacts(manifest),
     )
     # Assemble in pre-decomp order: source → identity → artifact →
     # placeholder → policy_pack. Identity warnings MUST come immediately

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -19,7 +19,7 @@ from agents_shipgate.cli.agent_mode import (
     emit_agent_mode_error,
     emit_agent_mode_error_action,
 )
-from agents_shipgate.cli.diagnostics import top_next_actions
+from agents_shipgate.cli.diagnostics import input_parse_recovery, top_next_actions
 from agents_shipgate.cli.verify.git import (
     archive_tree,
     commit_date,
@@ -66,7 +66,6 @@ from agents_shipgate.core.verification_identity import (
 from agents_shipgate.packet.json_packet import load_packet_json, write_packet_json
 from agents_shipgate.report.json_report import report_json_payload
 from agents_shipgate.schemas.current_control import RECEIPT_ARTIFACT_KEY
-from agents_shipgate.schemas.diagnostics import NextAction
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.verification_identity import (
     VerificationPlan,
@@ -177,20 +176,20 @@ def prepare(
         )
     except InputParseError as exc:
         typer.echo(f"Input parsing error: {exc}", err=True)
+        # One resolver across scan, verify, and the assembly path, so a
+        # failure that has a precise route keeps it here too (#329).
+        #
+        # `prepare` builds its plan through the input loader rather than
+        # `run_scan`, so nothing injects the resolved manifest for it and the
+        # resolver fell back to the literal `shipgate.yaml` — a different
+        # trust root whenever `--config` names a nested one (#329 review 3).
+        # This frame knows it exactly.
         emit_agent_mode_error_action(
             "input_parse_error",
             message=exc,
             exit_code=3,
-            action=NextAction(
-                kind="review",
-                why=(
-                    "Inspect the file referenced in the error; ensure it exists, "
-                    "is valid, and resolves under the manifest directory."
-                ),
-                expects=(
-                    "Referenced file is present, parseable, and inside the manifest directory."
-                ),
-            ),
+            action=input_parse_recovery(exc, manifest_path=root / config_relative)[0],
+            details=exc.details or None,
         )
         raise typer.Exit(3) from exc
     except ConfigError as exc:

--- a/src/agents_shipgate/cli/verify/command.py
+++ b/src/agents_shipgate/cli/verify/command.py
@@ -15,7 +15,7 @@ from agents_shipgate.cli._helpers import (
 )
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error, is_agent_mode
 from agents_shipgate.cli.current_workspace import live_workspace
-from agents_shipgate.cli.diagnostics import top_next_actions
+from agents_shipgate.cli.diagnostics import input_parse_recovery, top_next_actions
 from agents_shipgate.cli.discovery.gitignore_block import REPORTS_DIR_NAME
 from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_control_envelope import (
@@ -342,24 +342,16 @@ def verify(
         raise typer.Exit(2) from exc
     except InputParseError as exc:
         typer.echo(f"Input parsing error: {exc}", err=True)
-        guidance = (
-            "Inspect the file referenced in the error; ensure it exists, "
-            "is valid, and resolves under the manifest directory."
-        )
+        # The same resolver `scan` uses: `verify` is the command an adopter
+        # runs (#327), so a failure with a precise route must not lose it here.
+        actions = input_parse_recovery(exc, manifest_path=config)
         emit_agent_mode_error(
             "input_parse_error",
             message=str(exc),
             exit_code=3,
-            next_action=guidance,
-            next_actions=[
-                NextAction(
-                    kind="review",
-                    why=guidance,
-                    expects=(
-                        "Referenced file is present, parseable, and inside the manifest directory."
-                    ),
-                ).model_dump(mode="json")
-            ],
+            next_action=actions[0].why,
+            next_actions=[a.model_dump(mode="json") for a in actions],
+            details=exc.details or None,
         )
         raise typer.Exit(3) from exc
     except ArtifactLifecycleError as exc:

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -999,6 +999,40 @@ def run_verify(
                         head_manifest_text if archive_head else worktree_manifest_text
                     ),
                 )
+            except AgentsShipgateError as exc:
+                # `run_scan` records the manifest it read, and when the head is
+                # archived that is a path inside a temporary tree this function
+                # deletes on the way out — so the emitted recovery named a file
+                # that no longer exists by the time anyone read it (#329
+                # review).
+                #
+                # The checkout is only the right substitute when the archived
+                # head *is* the checkout. Evaluating an older commit and
+                # projecting its failure onto the working tree sends the reader
+                # to a file that may already contain the fix (#329 review 3),
+                # so the ref is named instead and no path is published — an
+                # honest "this commit, which is not the one you have" beats a
+                # precise pointer at the wrong tree.
+                # The prose names paths inside that same temporary tree —
+                # "Input file not found: /tmp/…/head/tools.json" — and telling
+                # a reader to inspect a deleted directory is worse than telling
+                # them nothing. Stripping the archive root leaves the path
+                # *within the evaluated tree*, which is true whichever ref that
+                # was; `evaluated_ref` says which. This is a substitution of a
+                # prefix we constructed, not a guess about the text.
+                if archive_head:
+                    archive_root = f"{head_tree_dir}/"
+                    exc.args = tuple(
+                        arg.replace(archive_root, "") if isinstance(arg, str) else arg
+                        for arg in exc.args
+                    )
+                    exc.details["evaluated_ref"] = head
+                    if head_tree == tree_sha(git_root, "HEAD"):
+                        exc.details["manifest_path"] = str(git_root / config_relative)
+                    else:
+                        exc.details.pop("manifest_path", None)
+                        exc.details["manifest_in_ref"] = config_relative.as_posix()
+                raise
             finally:
                 # Deactivated for the rest of the run so the worktree snapshot
                 # is restored for the externally supplied inputs it owns. It is

--- a/src/agents_shipgate/core/adopter_text.py
+++ b/src/agents_shipgate/core/adopter_text.py
@@ -1,0 +1,287 @@
+"""The vocabulary rule for text an adopter is expected to read and act on.
+
+Invariant 5 of the adoption walk (#327), filed as #329: *proceeding must not
+require understanding the internal identity model*. The clearest violation was
+the failure #321 reported, printed verbatim at someone running the tool on
+their own repository for the first time::
+
+    Duplicate tool observation identity: source_type='google_adk_function',
+    source_id='google_adk:agent.py',
+    native_locator='agent.py#map_salesforce_account_to_sap_bp'
+
+Three internal concepts, none of which appears in the manifest that person
+wrote, two of them derived — and the one recoverable fact, that a file was read
+twice, is the one thing the message does not say.
+
+The distinction this module enforces is *not* "internal identifiers are bad".
+They are the identity model and they are supposed to be precise wherever
+tooling reads them: ``report.json`` evidence blocks, the tool catalog, and the
+verification artifacts keep them. The rule applies to the other set — the
+strings whose whole purpose is to tell a person what to do next:
+
+* console output (failures, and the next-action hints printed beside them),
+* the agent-mode error envelope and its ``next_action`` / ``next_actions[]``,
+* ``agent-handoff.json`` prose, including ``fix_task.instructions[]``,
+* PR comment text,
+* and the evidence-gap rows those four render.
+
+Two categories, because the terms are not equally unlocatable.
+
+:data:`INTERNAL_ONLY_TERMS` name things that exist nowhere an adopter can open.
+There is no ``native_locator`` key in any manifest, no observation id in any
+file they wrote. These are refused outright.
+
+:data:`MANIFEST_SPELLED_TERMS` are the awkward ones: ``source_id`` and
+``source_type`` really are manifest keys — ``tool_identity.bindings[].members[]``
+accepts both, ``tool_inventories[].source_id`` and ``agent_bindings.root.source_id``
+accept the first — and ``fingerprint`` really is a published ``findings[]`` field.
+Spelled with the surface they belong to, they are locatable; spelled bare, they
+are the internal model leaking. So they are allowed only in a message that also
+names where to find them (:data:`LOCATABLE_ANCHORS`).
+
+The rule is checked on *rendered* messages, not on fragments, because the
+rendered message is what the person reads: an ``accepted_values`` list of
+selector keys is fine next to ``at shipgate.yaml#tool_identity.bindings`` and
+meaningless on its own.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+__all__ = [
+    "AGENT_ID_PATTERN",
+    "DUPLICATE_IN_SOURCE_ARTIFACT",
+    "DUPLICATE_TOOL_IN_SOURCE",
+    "FINGERPRINT_PATTERN",
+    "INTERNAL_ID_SHAPES",
+    "INTERNAL_ONLY_TERMS",
+    "LOCATABLE_ANCHORS",
+    "MANIFEST_SPELLED_TERMS",
+    "OBSERVATION_ID_PATTERN",
+    "REPEATED_SOURCE_ENTRY",
+    "TOOL_ID_PATTERN",
+    "duplicate_tool_observation_message",
+    "internal_vocabulary",
+    "names_a_locatable_anchor",
+    "overlapping_binding_message",
+    "source_label",
+]
+
+#: ``AgentsShipgateError.details["failure"]`` for a tool read twice from one
+#: source. Routing on a typed key rather than on the message text is what lets
+#: the sentence be rewritten for a human without breaking the recovery route.
+DUPLICATE_TOOL_IN_SOURCE = "duplicate_tool_in_source"
+
+#: ``details["cause"]``. Two different mistakes reach the duplicate check and
+#: they have opposite repairs, so the check reports which one it saw rather
+#: than naming both and letting the reader pick. Guessing here is not free:
+#: the structured action carries one ``path``, and a consumer routing on it
+#: would delete a source declaration when the real fix was inside the file.
+#:
+#: ``REPEATED_SOURCE_ENTRY`` — the same artifact was read twice for one source
+#: id, which is a repeated entry in the manifest.
+#: ``DUPLICATE_IN_SOURCE_ARTIFACT`` — one read of one artifact produced the
+#: same tool twice, which is a duplicate definition inside that artifact.
+REPEATED_SOURCE_ENTRY = "repeated_source_entry"
+DUPLICATE_IN_SOURCE_ARTIFACT = "duplicate_in_source_artifact"
+
+#: Identity-model terms with no counterpart in anything an adopter writes or
+#: opens. No anchor rescues these: there is nowhere to send the reader.
+INTERNAL_ONLY_TERMS: tuple[str, ...] = (
+    "native_locator",
+    "observation_id",
+    "observation identity",
+)
+
+#: Nothing may precede a derived id but a boundary. Agent names, tool names and
+#: source labels are adopter-controlled strings, and an unbounded search called
+#: an agent legitimately named ``customer_agent_v1_deadbeef`` a derived id —
+#: which, once that agent has an evidence gap, aborts an otherwise valid scan
+#: through the conservation invariant. The reserved shapes only ever appear at
+#: the start of a token or inside a bracketed label.
+_NOT_A_WORD_CHAR_BEFORE = r"(?<![0-9A-Za-z_])"
+
+#: And nothing may follow one either. A leading boundary alone still matched
+#: the *prefix* of an adopter identifier: `tool_v2_deadbeef_helper` is a legal
+#: tool name, and matching `tool_v2_deadbeef` inside it aborts validation on a
+#: gap that labels that tool. The digest is greedy, so a real 64-hex id is
+#: unaffected — the character after it is a bracket, a space, or the end.
+_NOT_A_WORD_CHAR_AFTER = r"(?![0-9A-Za-z_])"
+
+#: The producer's exact separator, not a permissive class. ``agent_v1:`` is the
+#: only form ``core.agent_bindings`` emits, so accepting ``agent_v1_`` bought
+#: nothing and matched adopter identifiers that merely read like one. Tools keep
+#: ``[_:]``: that pattern predates this module and guards a shipped invariant.
+TOOL_ID_PATTERN = re.compile(
+    _NOT_A_WORD_CHAR_BEFORE + r"tool_v[0-9]+[_:][0-9a-f]{8,}" + _NOT_A_WORD_CHAR_AFTER
+)
+AGENT_ID_PATTERN = re.compile(
+    _NOT_A_WORD_CHAR_BEFORE + r"agent_v[0-9]+:[0-9a-f]{8,}" + _NOT_A_WORD_CHAR_AFTER
+)
+OBSERVATION_ID_PATTERN = re.compile(
+    _NOT_A_WORD_CHAR_BEFORE + r"obs_v[0-9]+_[0-9a-f]{8,}" + _NOT_A_WORD_CHAR_AFTER
+)
+FINGERPRINT_PATTERN = re.compile(
+    _NOT_A_WORD_CHAR_BEFORE + r"fp_[0-9a-f]{16,}" + _NOT_A_WORD_CHAR_AFTER
+)
+
+#: Derived identifiers, matched by *shape* rather than by the field name that
+#: carries them. A message can print an observation id or a canonical tool id
+#: without ever saying "observation_id", and the digest is the part the reader
+#: cannot do anything with — the lesson the gap-subject conservation rule
+#: already learned: match the shape, not the spelling.
+#:
+#: These are refused like :data:`INTERNAL_ONLY_TERMS`, with one deliberate
+#: exception that is not in the swept set: a command whose *argument* is one of
+#: these identifiers — ``explain-finding <FINGERPRINT>`` — may show an example
+#: in its own ``--help``, because there the identifier is the input the reader
+#: supplies, and the help says which report field to copy it from.
+#:
+#: ``core.surface_exclusions`` builds the report's conservation invariant from
+#: the same patterns. One definition, because the two rules are one rule read
+#: from opposite ends: a subject a reader cannot open, and a sentence that
+#: names one.
+INTERNAL_ID_SHAPES: dict[str, re.Pattern[str]] = {
+    "observation": OBSERVATION_ID_PATTERN,
+    "tool": TOOL_ID_PATTERN,
+    "agent": AGENT_ID_PATTERN,
+    "finding": FINGERPRINT_PATTERN,
+}
+
+#: Internal spellings that are *also* real keys on a surface the adopter owns.
+#: Locatable when the message names that surface, internal vocabulary when not.
+MANIFEST_SPELLED_TERMS: tuple[str, ...] = (
+    "source_type",
+    "source_id",
+    "fingerprint",
+)
+
+#: Surfaces an adopter can open. Naming one of these anchors the terms in
+#: :data:`MANIFEST_SPELLED_TERMS`: the reader is told which file, and which key
+#: in it, rather than being expected to already know the field exists.
+#:
+#: ``baseline`` is the loosest entry and is deliberate: the baseline is a file
+#: the adopter owns and regenerates, and the messages about it explain
+#: fingerprints as a property of that file rather than asking the reader to
+#: know what one is. Everything else here is a filename or a manifest key path.
+LOCATABLE_ANCHORS: tuple[str, ...] = (
+    "shipgate.yaml",
+    "report.json",
+    "findings[]",
+    "tool_sources",
+    "tool_inventories",
+    "tool_identity",
+    "agent_bindings",
+    "action_surface",
+    "baseline",
+)
+
+
+def names_a_locatable_anchor(text: str) -> bool:
+    """Whether ``text`` names a file or manifest key the adopter can open."""
+
+    lowered = text.lower()
+    return any(anchor in lowered for anchor in LOCATABLE_ANCHORS)
+
+
+def internal_vocabulary(
+    text: str, *, given_id_kinds: Iterable[str] = ()
+) -> tuple[str, ...]:
+    """Internal identity terms ``text`` uses without making them locatable.
+
+    Empty for text that satisfies the rule. Sorted and de-duplicated so a
+    failure message reads the same on every run.
+
+    ``given_id_kinds`` names the id kinds a surface is allowed to carry,
+    because a derived id is not always a demand on the reader:
+
+    * a generated declaration template writes a **tool** id into the block for
+      them to paste, so a selector still resolves when two tools share a name
+      (#388); dropping it would put the ambiguity back;
+    * ``explain-finding`` echoes the **finding** fingerprint the reader just
+      supplied, with the report field to copy the right one from.
+
+    Per kind, not per surface. A blanket exemption forgave every shape on a
+    surface that had a reason for exactly one, so an agent id in the
+    `explain-finding` prose — which the reader was never given — passed
+    unnoticed (#329 review 3). The term rules apply either way: a template or
+    an echo may carry an id, not a sentence about one.
+    """
+
+    allowed = set(given_id_kinds)
+    unknown = allowed - set(INTERNAL_ID_SHAPES)
+    if unknown:
+        raise ValueError(f"unknown derived id kinds: {sorted(unknown)}")
+    offenders = {term for term in INTERNAL_ONLY_TERMS if term in text}
+    offenders.update(
+        match.group(0)
+        for kind, shape in INTERNAL_ID_SHAPES.items()
+        if kind not in allowed
+        for match in shape.finditer(text)
+    )
+    if not names_a_locatable_anchor(text):
+        offenders.update(term for term in MANIFEST_SPELLED_TERMS if term in text)
+    return tuple(sorted(offenders))
+
+
+def source_label(*, file_path: str | None, source_id: str) -> str:
+    """Name a tool source the way the adopter can find it.
+
+    A file wins whenever one is known: every framework entrypoint and every
+    declared artifact is a path the adopter listed in ``shipgate.yaml`` and can
+    open. Only a source whose loader recorded no path at all falls back to the
+    id, which for those is the ``tool_sources[].id`` the adopter wrote — still
+    something they can find, just one indirection further away.
+    """
+
+    return repr(file_path) if file_path else repr(source_id)
+
+
+def duplicate_tool_observation_message(
+    *, tool_name: str, file_path: str | None, source_id: str, cause: str
+) -> str:
+    """The adopter-facing form of a duplicate tool inside one tool source.
+
+    Two mistakes reach the duplicate check with opposite repairs, and ``cause``
+    says which one the check actually saw (see :data:`REPEATED_SOURCE_ENTRY`).
+    Naming both and hedging was the first draft of this message; it reads as
+    helpful and is not, because the structured action beside it can only carry
+    one target.
+
+    The identity triple that detected it — ``source_type``, ``source_id``,
+    ``native_locator`` — stays in the error's ``details`` for a bug report.
+    """
+
+    where = source_label(file_path=file_path, source_id=source_id)
+    if cause == REPEATED_SOURCE_ENTRY:
+        return (
+            f"{where} was read twice as one tool source, so the tool "
+            f"{tool_name!r} arrived twice. Remove the repeated shipgate.yaml "
+            f"entry naming {where}, then re-run the scan."
+        )
+    return (
+        f"{where} defines the tool {tool_name!r} more than once, so one tool "
+        f"source produced it twice. Remove the duplicate definition from "
+        f"{where}, then re-run the scan."
+    )
+
+
+def overlapping_binding_message(
+    *, tool_name: str, file_path: str | None, source_id: str, binding_ids: Iterable[str]
+) -> str:
+    """The adopter-facing form of one tool claimed by several bindings.
+
+    Previously written as ``Tool observation obs_v1_<64 hex> appears in
+    multiple bindings`` — an id that appears in no file the adopter has,
+    naming a tool they could otherwise have opened.
+    """
+
+    where = source_label(file_path=file_path, source_id=source_id)
+    ids = ", ".join(repr(binding_id) for binding_id in sorted(binding_ids))
+    return (
+        f"Tool {tool_name!r} from {where} is claimed by more than one "
+        f"tool_identity.bindings entry: {ids}. A tool may be joined by at most "
+        "one binding — leave it in a single entry, then re-run the scan."
+    )

--- a/src/agents_shipgate/core/errors.py
+++ b/src/agents_shipgate/core/errors.py
@@ -1,5 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
 class AgentsShipgateError(Exception):
-    """Base exception for expected Agents Shipgate failures."""
+    """Base exception for expected Agents Shipgate failures.
+
+    ``details`` carries the diagnostic identifiers a machine consumer or a bug
+    report needs — the internal identity triple, a source id, a check id —
+    *out of* the message. Adopter-facing text names files, symbols, and
+    manifest keys (see :mod:`agents_shipgate.core.adopter_text`); the precise
+    internal spelling still has to reach ``report.json`` consumers and issue
+    reports, and this is the channel for the failures that abort before any
+    report is written. Empty for the many failures that need no such payload.
+    """
+
+    def __init__(self, *args: Any, details: Mapping[str, Any] | None = None) -> None:
+        super().__init__(*args)
+        self.details: dict[str, Any] = dict(details or {})
 
 
 class ConfigError(AgentsShipgateError):

--- a/src/agents_shipgate/core/evidence_actions.py
+++ b/src/agents_shipgate/core/evidence_actions.py
@@ -262,7 +262,7 @@ _GAP_PHRASE: dict[str, str] = {
     "conflicting_authority_evidence": "an action carries conflicting authority evidence",
     "invalid_semantic_annotation": "a semantic annotation is invalid",
     "incomplete_tool_identity": "a tool identity is incomplete",
-    "conflicting_tool_identity": "bound observations disagree about one tool identity",
+    "conflicting_tool_identity": "tools joined as one capability disagree about it",
     "unresolved_tool_selector": "a manifest tool selector resolves to nothing",
     "ambiguous_tool_selector": "a manifest tool selector resolves to several tools",
     "ambiguous_legacy_tool_identity": "a legacy tool identity is ambiguous",

--- a/src/agents_shipgate/core/semantic_consistency.py
+++ b/src/agents_shipgate/core/semantic_consistency.py
@@ -5,7 +5,7 @@ from agents_shipgate.core.domain import Tool, ToolSemanticAssessment
 from agents_shipgate.core.surface_exclusions import (
     BINDING_GAP_KINDS,
     catalog_subject,
-    contains_tool_id,
+    derived_id_kind,
     unavailable_base_subject,
 )
 from agents_shipgate.schemas.report import ReadinessReport
@@ -318,12 +318,32 @@ def _validate_exclusion_ledger(report: ReadinessReport) -> None:
     # finding carrying a stale or invented id that is in no catalog to compare
     # against. Both are exactly as unreadable as the bare form (PR #408
     # review), and neither is recognisable to a membership test.
+    #
+    # Every derived id, not only a tool's. Scoping the rule to `tool_v…` left
+    # the identical defect standing one subject kind over: a binding issue
+    # naming no tool fell back to `agent_v1:7205d836…`, and
+    # `samples/conductor_agent` shipped that digest in `subject` and in the
+    # decision `reason` under it (#329). A guard scoped to one shape passes
+    # vacuously for every other shape — scope it to the property.
+    #
+    # Position is not quite enough on its own: a *bare* subject that is exactly
+    # an id shape is refused, and an adopter may legally name a tool
+    # `tool_v2_deadbeef`. So the run's own names exonerate it — structured
+    # provenance where there is some, shape where there is none, which is what
+    # keeps the plugin-supplied id in no catalog refused (#329 review 3).
+    adopter_names = {
+        str(row.get("name") or "") for row in report.tool_catalog if isinstance(row, dict)
+    } | {node.name for node in report.binding_surface_facts.agents}
     for gap in gaps:
-        if contains_tool_id(gap.subject):
+        noun = derived_id_kind(gap.subject)
+        if noun is not None and gap.subject.strip() in adopter_names:
+            continue
+        if noun is not None:
+            article = "an" if noun[0] in "aeiou" else "a"
             raise SemanticConsistencyError(
-                f"evidence gap labels a tool {gap.subject!r} with a canonical "
-                "id rather than its catalog subject; the id belongs in "
-                "subject_id, and this string is what a reader is shown"
+                f"evidence gap labels {article} {noun} {gap.subject!r} with a "
+                "derived id rather than its display subject; the id belongs "
+                "in subject_id, and this string is what a reader is shown"
             )
     gated_binding_subjects = {
         entry.accounted_by

--- a/src/agents_shipgate/core/source_warnings.py
+++ b/src/agents_shipgate/core/source_warnings.py
@@ -147,11 +147,35 @@ def invalid_tool_binding_warning(binding_id: str, reasons: Sequence[str]) -> str
 
 
 def unmatched_binding_member(source_id: str, tool: str, match_count: int) -> str:
-    """Reason fragment for a member selector that did not resolve to one tool."""
+    """Reason fragment for a member selector that did not resolve to one tool.
 
+    The arithmetic alone ("matched 2 observations") names an internal noun and
+    no surface, so the reader is told a number and left to guess which file
+    holds the selector that produced it (#329). The two zero-cases that have a
+    *different* repair are split out above; this fragment covers the rest, and
+    the only lever for those is the selector itself.
+
+    Kept short deliberately: one invalid binding joins every bad member's
+    fragment into a single warning, so anything said here is said once per
+    member. The anchor plus the repair is the whole message.
+
+    The repair differs by direction and only one of them is ever possible.
+    Narrowing a selector that matched nothing cannot produce a match, so a
+    zero count is told to name a tool the source exposes instead (#329
+    review); a count above one is told to narrow.
+    """
+
+    if match_count == 0:
+        return (
+            f"member source_id={source_id!r}, tool={tool!r} matched no tool in "
+            "that source — correct the member at "
+            "shipgate.yaml#tool_identity.bindings[].members to name a tool that "
+            "source exposes"
+        )
     return (
-        f"member source_id={source_id!r}, tool={tool!r} "
-        f"matched {match_count} observations"
+        f"member source_id={source_id!r}, tool={tool!r} matched "
+        f"{match_count} tools in that source — narrow the member at "
+        "shipgate.yaml#tool_identity.bindings[].members so it names one"
     )
 
 
@@ -215,8 +239,8 @@ def unknown_inventory_source_warning(
         f"Tool inventory {inventory_path!r} declares source_id {source_id!r}, "
         "for which no tool source is configured, so it completes no source and "
         "its entries stay separate catalog tools. Correct it to name a "
-        f"configured tool source id — {_quoted_list(configured)} — then rerun "
-        "the scan."
+        f"configured shipgate.yaml#tool_sources[].id — {_quoted_list(configured)} "
+        "— then rerun the scan."
     )
 
 

--- a/src/agents_shipgate/core/surface_exclusions.py
+++ b/src/agents_shipgate/core/surface_exclusions.py
@@ -25,8 +25,14 @@ import re
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, cast, get_args
 
+from agents_shipgate.core.adopter_text import (
+    AGENT_ID_PATTERN,
+    FINGERPRINT_PATTERN,
+    OBSERVATION_ID_PATTERN,
+    TOOL_ID_PATTERN,
+)
 from agents_shipgate.core.domain import SourceSurfaceOmission
-from agents_shipgate.schemas.bindings import AgentBindingIssue
+from agents_shipgate.schemas.bindings import AgentBindingIssue, AgentBindingNode
 from agents_shipgate.schemas.detect import DetectResult
 from agents_shipgate.schemas.exclusions import (
     SurfaceExclusion,
@@ -67,20 +73,106 @@ def unavailable_base_subject(report: ReadinessReport) -> str:
     )
 
 
-#: A canonical tool id anywhere inside a string, not only as the whole of it.
+#: A derived id anywhere inside a string, not only as the whole of it, with the
+#: noun each shape names so a guard can say which kind reached a display string.
+#:
 #: ``_stable_id`` builds every tool id as ``tool_v<n>`` plus a sha256 digest, and
 #: the spellings that reached users wrapped one in a label —
 #: ``create_refund [tool_v2_6dcebe…]`` — so a guard comparing the whole subject
 #: against the catalog never saw it. Matching the *shape* also covers an id that
 #: no longer resolves: a stale or plugin-supplied id is exactly as unreadable as
 #: a current one, and a current-catalog check cannot recognise it at all.
-_TOOL_ID_PATTERN = re.compile(r"tool_v[0-9]+[_:][0-9a-f]{8,}")
+#:
+#: The agent shape is the same rule one subject kind later:
+#: ``core.agent_bindings`` builds an agent id as ``agent_v1:`` plus a truncated
+#: sha256, and the binding gaps fell back to it whenever the issue named no
+#: tool — so ``samples/conductor_agent`` shipped ``…is incomplete
+#: (agent_v1:7205d836…)`` as the sentence under the verdict. A guard scoped to
+#: one kind of id passes vacuously for every other one (#329).
+#:
+#: The patterns themselves live in :mod:`agents_shipgate.core.adopter_text`,
+#: which owns the reader-facing half of the same rule. Two copies would drift,
+#: and the drift would be silent in exactly the direction that matters.
+#: All four shapes, not the two that had been seen in a subject. A
+#: ``source_warning`` is copied verbatim into an ``EvidenceGap.subject``, so
+#: loader text carrying an observation id or a fingerprint reached the field
+#: this rule exists to keep readable while passing validation — the same
+#: "scoped to today's instances" mistake one level down.
+DERIVED_ID_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("tool", TOOL_ID_PATTERN),
+    ("agent", AGENT_ID_PATTERN),
+    ("observation", OBSERVATION_ID_PATTERN),
+    ("finding", FINGERPRINT_PATTERN),
+)
 
 
-def contains_tool_id(value: str) -> bool:
-    """True when a display label carries a canonical tool id anywhere in it."""
+#: The one position a derived id can occupy in a display subject *without*
+#: being an adopter-controlled name: the bracketed qualifier
+#: ``catalog_subject`` appends, as in ``create_refund [tool_v2_6dcebe…]``.
+_BRACKETED_QUALIFIER = re.compile(r"\[([^\[\]]*)\]")
 
-    return _TOOL_ID_PATTERN.search(value) is not None
+
+def derived_id_kind(value: str) -> str | None:
+    """Which derived identifier ``value`` carries *as an identifier*.
+
+    ``"tool"``, ``"agent"``, ``"observation"``, ``"finding"``, or ``None``.
+
+    Shape alone is not enough, and getting that wrong is expensive in one
+    direction only: this predicate aborts a scan, so a false positive on an
+    adopter-controlled name is an outage rather than a lint. A tool may legally
+    be named ``tool_v2_deadbeef`` or ``tool_v2_deadbeef-helper``, and word
+    boundaries cannot separate those from the real thing — ``-`` and ``.`` are
+    name characters (#329 review 3).
+
+    So position decides. A derived id is refused when it is the *whole*
+    subject, or when it sits inside the bracketed qualifier, which is the only
+    part of a subject that emitters build rather than adopters — that is where
+    every spelling this rule was written for actually appeared. A shape in the
+    *name* position, with a qualifier beside it, is a name.
+    """
+
+    stripped = value.strip()
+    for noun, pattern in DERIVED_ID_PATTERNS:
+        match = pattern.fullmatch(stripped)
+        if match is not None:
+            return noun
+        for qualifier in _BRACKETED_QUALIFIER.findall(stripped):
+            if pattern.search(qualifier):
+                return noun
+    return None
+
+
+def agent_subject(node: AgentBindingNode) -> str:
+    """The subject string an agent-binding node is named by.
+
+    ``catalog_subject`` for agents, and deliberately the same shape: the
+    declared name, qualified by the source it was read from when there is one,
+    because two sources can define an agent of the same name. The reader
+    recognises ``closer_agent [google_adk:agent.py]``; they cannot do anything
+    at all with ``agent_v1:507abc67``.
+
+    An unnamed agent — an extractor that resolved no literal ``name=`` — falls
+    back to where it was read, never to the id. Returning the id here would
+    not merely be unreadable: :func:`derived_id_kind` refuses a derived id in
+    any gap subject, so the fallback would abort the scan it was written to
+    describe.
+    """
+
+    name = node.name.strip()
+    if not name:
+        return node.source_ref or node.source_pointer or node.source_id or "unnamed agent"
+    return f"{name} [{node.source_id}]" if node.source_id else name
+
+
+def agent_label_index(agents: Iterable[AgentBindingNode]) -> dict[str, str]:
+    """Map agent id to the one display label that names that agent.
+
+    Resolved from the binding graph through one index, for the reason
+    :func:`catalog_label_index` exists: an emitter that renders a label from
+    its own fields produces a second spelling of the same subject.
+    """
+
+    return {node.agent_id: agent_subject(node) for node in agents}
 
 
 def catalog_label_index(rows: Iterable[Any]) -> dict[str, str]:
@@ -468,8 +560,11 @@ def build_detect_exclusions(result: DetectResult) -> SurfaceExclusionLedger:
 
 __all__ = [
     "BINDING_GAP_KINDS",
+    "DERIVED_ID_PATTERNS",
+    "agent_label_index",
+    "agent_subject",
     "catalog_label_index",
-    "contains_tool_id",
+    "derived_id_kind",
     "tool_label",
     "unavailable_base_subject",
     "build_detect_exclusions",

--- a/src/agents_shipgate/core/tool_identity.py
+++ b/src/agents_shipgate/core/tool_identity.py
@@ -8,6 +8,13 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, cast
 
+from agents_shipgate.core.adopter_text import (
+    DUPLICATE_IN_SOURCE_ARTIFACT,
+    DUPLICATE_TOOL_IN_SOURCE,
+    REPEATED_SOURCE_ENTRY,
+    duplicate_tool_observation_message,
+    overlapping_binding_message,
+)
 from agents_shipgate.core.domain import (
     SURFACE_PARTIAL,
     LoadedToolSource,
@@ -32,6 +39,7 @@ from agents_shipgate.schemas.manifest import (
     ToolIdentityConfig,
     ToolObservationSelectorConfig,
 )
+from agents_shipgate.schemas.manifest._artifacts import _normalized_declared_path
 
 _MCP_LIKE = {
     "mcp",
@@ -260,6 +268,7 @@ class ToolSelectorIndex:
 def build_tool_identity_catalog(
     loaded_sources: list[LoadedToolSource],
     config: ToolIdentityConfig,
+    repeated_artifacts: frozenset[str] = frozenset(),
 ) -> tuple[list[Tool], list[str]]:
     """Build canonical tools without ever joining observations by name.
 
@@ -274,7 +283,7 @@ def build_tool_identity_catalog(
     inventory file never joins itself to anything by name.
     """
 
-    observations = _observations(loaded_sources)
+    observations = _observations(loaded_sources, repeated_artifacts)
     synthesized, warnings = _inventory_completion_bindings(
         loaded_sources, observations, config
     )
@@ -343,12 +352,23 @@ def build_tool_identity_catalog(
             assert tool.observation_id is not None
             observation_bindings[tool.observation_id].append(binding.id)
 
+    observations_by_id = {
+        tool.observation_id: tool for tool in observations if tool.observation_id
+    }
     for observation_id, binding_ids in observation_bindings.items():
         if len(binding_ids) <= 1:
             continue
-        message = (
-            f"Tool observation {observation_id} appears in multiple bindings: "
-            + ", ".join(sorted(binding_ids))
+        # The observation id detected the overlap; it is not what the reader
+        # opens. Name the tool and the file it came from (#329) — the id is
+        # already on the row this issue is attached to. Indexed directly:
+        # every key here came from an observation, and a KeyError is a better
+        # answer to that invariant breaking than a message naming ''.
+        overlapping = observations_by_id[observation_id]
+        message = overlapping_binding_message(
+            tool_name=overlapping.name,
+            file_path=_source_file(overlapping),
+            source_id=overlapping.source_id or "",
+            binding_ids=binding_ids,
         )
         warnings.append(message)
         binding_issues[observation_id].append(
@@ -638,18 +658,44 @@ def _unbound_inventory_warnings(
     ]
 
 
-def _observations(loaded_sources: list[LoadedToolSource]) -> list[Tool]:
+def _observations(
+    loaded_sources: list[LoadedToolSource],
+    repeated_artifacts: frozenset[str] = frozenset(),
+) -> list[Tool]:
     observations: list[Tool] = []
-    seen: set[tuple[str, str, str]] = set()
-    for loaded in loaded_sources:
+    # Which *read* first produced each identity, not merely that something did.
+    # A repeated manifest entry and a duplicate definition inside one artifact
+    # both land here, and they are repaired in different files — the reader
+    # gets one structured action, so the check has to know which (#329 review).
+    seen: dict[tuple[str, str, str], int] = {}
+    for read_index, loaded in enumerate(loaded_sources):
         source_id = loaded.source_id.strip()
         if not source_id:
-            raise InputParseError("loaded tool source has a blank source_id")
+            # Ours, not theirs — and only since `tool_sources[].id` became
+            # non-blank at manifest load (#329 review). A blank id used to be
+            # reachable from a valid manifest, which made this sentence false
+            # for the case that actually produced it. What remains is a loader
+            # contract violation: no manifest edit can cause or repair it.
+            raise InputParseError(
+                "A tool source loader returned tools without naming the source "
+                "they came from. That is a defect in the loader, not in this "
+                "repository's configuration — check report.json "
+                "loaded_adapters[] if a third-party adapter is installed.",
+                details={"source_id": loaded.source_id},
+            )
         for original in loaded.tools:
             if original.source_id is not None and original.source_id != source_id:
                 raise InputParseError(
-                    f"Tool {original.name!r} source_id {original.source_id!r} does not match "
-                    f"loaded source {source_id!r}"
+                    f"A tool source loader reported tool {original.name!r} as "
+                    "belonging to a different source than the one it was read "
+                    "from. That is a defect in the loader, not in this "
+                    "repository's configuration — check report.json "
+                    "loaded_adapters[] if a third-party adapter is installed.",
+                    details={
+                        "tool_name": original.name,
+                        "tool_source_id": original.source_id,
+                        "loaded_source_id": source_id,
+                    },
                 )
             # The extraction graph is no longer consumed after catalog
             # construction.  A shallow copy isolates identity fields while
@@ -658,13 +704,49 @@ def _observations(loaded_sources: list[LoadedToolSource]) -> list[Tool]:
             tool.source_id = source_id
             locator = _native_locator(tool)
             key = (tool.source_type, source_id, locator)
-            if key in seen:
-                raise InputParseError(
-                    "Duplicate tool observation identity: "
-                    f"source_type={tool.source_type!r}, source_id={source_id!r}, "
-                    f"native_locator={locator!r}"
+            first_read = seen.get(key)
+            if first_read is not None:
+                # Theirs, and repairable — but only if the message names what
+                # to open. The identity triple that detected the collision is
+                # kept in ``details`` for machine consumers and bug reports
+                # (#329); the sentence names the tool and the one file to edit.
+                source_file = _source_file(tool)
+                # Two reads of one source id is always a repeated entry. One
+                # read is *not* always a duplicate definition: the OpenAI and
+                # Anthropic loaders aggregate every configured artifact into a
+                # single ``LoadedToolSource``, so listing one file twice under
+                # ``openai_api.tools`` collides inside one read and used to be
+                # reported as a defect in a perfectly valid file (#329
+                # review). The manifest settles it — a path it declares twice
+                # in one list is a repeated entry whatever the loader did with
+                # it — and it is read from the config rather than inferred
+                # from the observations, which cannot tell the two apart.
+                declared_twice = source_file is not None and (
+                    _normalized_declared_path(source_file) in repeated_artifacts
                 )
-            seen.add(key)
+                cause = (
+                    REPEATED_SOURCE_ENTRY
+                    if first_read != read_index or declared_twice
+                    else DUPLICATE_IN_SOURCE_ARTIFACT
+                )
+                raise InputParseError(
+                    duplicate_tool_observation_message(
+                        tool_name=tool.name,
+                        file_path=source_file,
+                        source_id=source_id,
+                        cause=cause,
+                    ),
+                    details={
+                        "failure": DUPLICATE_TOOL_IN_SOURCE,
+                        "cause": cause,
+                        "source_type": tool.source_type,
+                        "source_id": source_id,
+                        "native_locator": locator,
+                        "tool_name": tool.name,
+                        "source_file": source_file,
+                    },
+                )
+            seen[key] = read_index
             observation_id = _stable_id(
                 "obs_v1",
                 {
@@ -679,6 +761,30 @@ def _observations(loaded_sources: list[LoadedToolSource]) -> list[Tool]:
             tool.provider = source_id
             observations.append(tool)
     return observations
+
+
+def _source_file(tool: Tool) -> str | None:
+    """The file this tool was read from, when the loader recorded one.
+
+    Only two fields can answer this, and only one of them structurally.
+    ``source_path`` is the typed field: the adapters that set it set a path and
+    nothing else. ``source_ref`` is accepted as a fallback *only* when it
+    carries no ``#``, because that is the shape the plain-path producers write
+    (Google ADK, MCP) and any other shape is a locator we would be guessing at.
+
+    ``source_location`` and ``source_pointer`` are deliberately absent.
+    They are separate optional provenance fields and a third-party adapter may
+    legally set either without a path at all — ``agent.py:12`` and
+    ``/tools/0`` both reached an edit action as if they were files (#329
+    review 3). A value that names no file is worth less than no value: the
+    caller has a review route for exactly that case.
+    """
+
+    if tool.source_path:
+        return tool.source_path
+    if tool.source_ref and "#" not in tool.source_ref:
+        return tool.source_ref.strip() or None
+    return None
 
 
 def _native_locator(tool: Tool) -> str:

--- a/src/agents_shipgate/inputs/adapter_validation.py
+++ b/src/agents_shipgate/inputs/adapter_validation.py
@@ -140,14 +140,18 @@ def validate_adapter_entry_point(
         return _fail(
             info,
             SOURCE_TYPE_COLLISION,
-            f"source_type {source_type!r} is reserved by a built-in adapter",
+            # Rendered into `report.md` under Loaded Adapters, so it is read
+            # by the adopter as well as by the adapter's author (#329
+            # review 3): name the manifest key, not the class attribute.
+            f"shipgate.yaml#tool_sources[].type {source_type!r} is reserved "
+            "by a built-in adapter",
         )
     if source_type in already_registered_source_types:
         return _fail(
             info,
             SOURCE_TYPE_COLLISION,
-            f"source_type {source_type!r} is already registered by another "
-            "third-party adapter",
+            f"shipgate.yaml#tool_sources[].type {source_type!r} is already "
+            "registered by another third-party adapter",
         )
 
     # All gates pass.
@@ -299,8 +303,8 @@ def _protocol_error(adapter: Any) -> str | None:
     source_type = getattr(adapter, "source_type", None)
     if not isinstance(source_type, str) or not source_type:
         return (
-            "adapter source_type must be a non-empty string; got "
-            f"{source_type!r}"
+            "the adapter declares no shipgate.yaml#tool_sources[].type to "
+            f"register itself under; got {source_type!r}"
         )
 
     load_method = getattr(adapter, "load", None)

--- a/src/agents_shipgate/inputs/protocol.py
+++ b/src/agents_shipgate/inputs/protocol.py
@@ -209,7 +209,8 @@ class AdapterRegistry:
             if discovery_enabled:
                 remediation = (
                     "Either (a) install the third-party adapter "
-                    "package that registers this source_type, or "
+                    "package that registers this "
+                    "shipgate.yaml#tool_sources[].type, or "
                     "(b) fix a typo of a built-in name "
                     "(`agents-shipgate list-checks --json` exposes "
                     "the catalog and `agents-shipgate doctor --json` "

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -579,7 +579,7 @@ def _append_loaded_adapters(lines: list[str], report: ReadinessReport) -> None:
     for adapter in adapters:
         distribution = adapter.get("distribution") or "unknown distribution"
         version = adapter.get("version")
-        source_type = adapter.get("source_type") or "unknown source_type"
+        source_type = adapter.get("source_type") or "unknown source type"
         status = adapter.get("validation_status") or "unknown"
         suffix = f" {version}" if version else ""
         head = (

--- a/src/agents_shipgate/schemas/manifest/__init__.py
+++ b/src/agents_shipgate/schemas/manifest/__init__.py
@@ -28,6 +28,7 @@ from agents_shipgate.schemas.manifest._artifacts import (
     ArtifactPathConfig,
     NamedArtifactPathConfig,
     ToolInventoryConfig,
+    repeated_declared_artifacts,
 )
 from agents_shipgate.schemas.manifest._common import STRICT_MODEL_CONFIG
 from agents_shipgate.schemas.manifest.action_surface import (
@@ -205,6 +206,7 @@ __all__ = [
     "SuppressionConfig",
     # tool_sources
     "ToolSourceConfig",
+    "repeated_declared_artifacts",
     # tool_identity
     "ToolIdentityBindingConfig",
     "ToolIdentityConfig",

--- a/src/agents_shipgate/schemas/manifest/_artifacts.py
+++ b/src/agents_shipgate/schemas/manifest/_artifacts.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import posixpath
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from agents_shipgate.schemas.manifest._common import (
     STRICT_MODEL_CONFIG,
@@ -15,6 +16,28 @@ class ArtifactPathConfig(BaseModel):
 
     path: str
     optional: bool = False
+
+    @field_validator("path", mode="before")
+    @classmethod
+    def canonical_path(cls, value: Any) -> Any:
+        """One spelling per file, decided where the file is declared.
+
+        ``./tools.json`` and ``tools.json`` are the same artifact, and the
+        loaders carry the spelling into ``source_ref`` — so declaring both read
+        one file twice and produced *two* canonical tools, with no duplicate
+        detected and no warning (#329 review 3). Collapsing the spelling at the
+        boundary makes them one declaration, which the existing duplicate check
+        then sees.
+
+        Left alone when the value carries a backslash: a Windows-style path is
+        not this function's to reinterpret, and `posixpath` would not normalize
+        it correctly anyway. ``../outside.yaml`` is preserved exactly, so the
+        containment checks downstream still see what the author wrote.
+        """
+
+        if not isinstance(value, str) or not value.strip() or "\\" in value:
+            return value
+        return posixpath.normpath(value)
 
 
 class NamedArtifactPathConfig(ArtifactPathConfig):
@@ -68,6 +91,84 @@ def _parse_named_artifact_entries(value: Any) -> list[NamedArtifactPathConfig]:
                 f"path, but is {describe_yaml_shape(item)}"
             )
     return entries
+
+
+#: Manifest lists whose entries are read *for tools*. Everything else a
+#: framework block declares — traces, eval sets, test cases, prompt files,
+#: policy rules, credential stubs — is read for other reasons, and a path
+#: repeated in one of those says nothing about a duplicate tool. Keying the
+#: repeat set globally let ``openai_api.test_cases`` poison ``openai_api.tools``
+#: and make a real in-file duplicate look like a repeated source (#329
+#: review 3).
+#:
+#: ``tests/test_config.py`` asserts every artifact list on the manifest model is
+#: either named here or deliberately excluded, so a new one cannot arrive
+#: unclassified.
+TOOL_PRODUCING_ARTIFACT_LISTS: frozenset[str] = frozenset(
+    {
+        "agent_configs",
+        "function_schemas",
+        "mcp_tool_inventories",
+        "python_entrypoints",
+        "tool_inventories",
+        "tools",
+        "workflows",
+    }
+)
+
+
+def _normalized_declared_path(path: str) -> str:
+    """One spelling for one file.
+
+    ``tools.json`` and ``./tools.json`` are the same artifact declared twice,
+    and comparing raw spellings reported no repeat for that pair while
+    reporting a false one for ``./tools.json`` twice (#329 review 3).
+    """
+
+    return posixpath.normpath(path.replace("\\", "/"))
+
+
+def repeated_declared_artifacts(manifest: BaseModel) -> frozenset[str]:
+    """Normalized paths a single tool-producing list names more than once.
+
+    A manifest that lists one file twice under, say, ``openai_api.tools`` is
+    always a mistake, and it is the only place the mistake is *visible*: the
+    loaders that aggregate every configured artifact into one source hand the
+    catalog two identical observations with no record of having read the file
+    twice, so the duplicate check downstream cannot tell that shape from a file
+    that genuinely defines a tool twice (#329 review). Answering from the
+    config keeps the two apart without teaching every loader to carry
+    occurrence provenance.
+
+    Counted *within* one list. Two entries in different lists are two
+    declarations of different things, and neither is a repeat of the other.
+
+    ``tool_sources`` is skipped and needs no help: each entry becomes its own
+    source, so a repeat there is already two reads.
+    """
+
+    repeated: set[str] = set()
+
+    def visit(value: Any, field_name: str) -> None:
+        if isinstance(value, BaseModel):
+            for name, item in value.__dict__.items():
+                if name != "tool_sources":
+                    visit(item, name)
+            return
+        if not isinstance(value, list):
+            return
+        counts_for_tools = field_name in TOOL_PRODUCING_ARTIFACT_LISTS
+        seen: set[str] = set()
+        for item in value:
+            if counts_for_tools and isinstance(item, ArtifactPathConfig) and item.path:
+                normalized = _normalized_declared_path(item.path)
+                if normalized in seen:
+                    repeated.add(normalized)
+                seen.add(normalized)
+            visit(item, field_name)
+
+    visit(manifest, "")
+    return frozenset(repeated)
 
 
 class ToolInventoryConfig(ArtifactPathConfig):

--- a/src/agents_shipgate/schemas/manifest/tool_sources.py
+++ b/src/agents_shipgate/schemas/manifest/tool_sources.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, model_validator
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from agents_shipgate.schemas.manifest._common import STRICT_MODEL_CONFIG
 
@@ -36,7 +38,15 @@ BUILTIN_PER_SCAN_ONLY_TOOL_SOURCE_TYPES: frozenset[str] = frozenset(
 class ToolSourceConfig(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
-    id: str
+    # The non-blank rule is stated twice on purpose, and the parity test in
+    # `tests/test_config.py` is what keeps the two from drifting. The
+    # validator below owns the *message* — it names the keys this id is
+    # joined on, which a generic constraint error cannot — while the pattern
+    # is what reaches `docs/manifest-v0.1.json`, where a consumer validating a
+    # manifest against the published schema would otherwise accept an id the
+    # runtime refuses (#329 review). `\S` is a search, so " orders " passes it
+    # and is then stripped, and "   " fails in both places.
+    id: str = Field(json_schema_extra={"pattern": r"\S"})
     # v0.20 (PR #111 review fix P1 #3): opened from a closed Literal to
     # ``str`` so manifests can reference third-party per_source adapters
     # registered via the ``agents_shipgate.adapters`` entry-point group.
@@ -62,6 +72,30 @@ class ToolSourceConfig(BaseModel):
     trust: str | None = None
     mode: str | None = None
     optional: bool = False
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def canonical_source_id(cls, value: Any) -> Any:
+        """A source id is a join key, so it is stripped and never blank.
+
+        ``tool_identity.bindings[].members[].source_id`` and
+        ``tool_inventories[].source_id`` are already stripped where they are
+        declared, and this side was not — so ``id: " orders "`` matched none
+        of them and quietly completed nothing. A blank id matches nothing at
+        all and is a manifest error, not the loader defect the duplicate-check
+        message downstream would otherwise call it (#329 review).
+        """
+
+        if not isinstance(value, str):
+            return value
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(
+                "tool_sources[].id must name the source, but is blank; it is "
+                "the key tool_inventories[].source_id and "
+                "tool_identity.bindings[].members[].source_id join on"
+            )
+        return normalized
 
     @model_validator(mode="after")
     def reject_per_scan_only_builtins(self) -> ToolSourceConfig:

--- a/tests/test_adopter_vocabulary.py
+++ b/tests/test_adopter_vocabulary.py
@@ -1,0 +1,1725 @@
+"""Adopter-facing output must not require knowing the internal identity model.
+
+Invariant 5 of the adoption walk (#327), filed as #329. The message that made
+the case was printed at someone running Agents Shipgate on their own
+repository for the first time::
+
+    Duplicate tool observation identity: source_type='google_adk_function',
+    source_id='google_adk:agent.py',
+    native_locator='agent.py#map_salesforce_account_to_sap_bp'
+
+Three internal concepts, none of them in the manifest that person wrote, and
+the one recoverable fact — a file was read twice — unstated. Fixing that one
+message is not the point; nothing tracked whether adopter-facing strings speak
+the adopter's vocabulary, so nothing stopped the next one.
+
+This file is that tracker. It enumerates the adopter-facing strings four ways,
+because no single enumeration reaches all of them:
+
+1. **Rendered gap rows.** Every ``EvidenceGap`` kind the report schema
+   declares, pushed through the real renderers — the CLI headline, the
+   ``Improve evidence:`` action text, and ``fix_task.instructions[]``. Adding
+   a gap kind without adopter-facing wording fails here.
+2. **Rendered message builders.** Every public builder in
+   ``core.source_warnings``, and the declaration scaffold, called and checked
+   as the reader sees them. The sweep table must cover the module's ``__all__``,
+   so a new builder cannot arrive unswept.
+3. **Hand-written prose, statically.** Every string literal written at an emit
+   site in the modules that produce console output, next actions, handoff
+   prose, and PR comment text — including the branches of the big diagnostic
+   resolvers, which no fixture reaches all of.
+4. **Shipped artifacts.** The adopter-facing strings in every bundled sample's
+   ``report.json`` and ``report.md``, which is what the output actually looks
+   like rather than what the code says it should.
+
+Plus three end-to-end runs, because the assembled artifact is the only thing
+that can prove the assembly did not put an identifier back: the failure #321
+reported, walked through ``scan`` and again through ``verify``, and one real
+``insufficient_evidence`` verdict whose ``agent-handoff.json``,
+``verifier.json``, and PR comment are swept as written.
+
+The rule itself, and why ``source_id`` is treated differently from
+``native_locator``, lives in :mod:`agents_shipgate.core.adopter_text`.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import get_args
+
+import pytest
+from typer.testing import CliRunner
+
+import agents_shipgate.ci.release_decision as rd
+from agents_shipgate.cli.main import app
+from agents_shipgate.cli.scan.declarations import build_declaration_scaffold
+from agents_shipgate.cli.verify.fix_task import _insufficient_evidence_remedies
+from agents_shipgate.core import source_warnings as sw
+from agents_shipgate.core.adopter_text import (
+    DUPLICATE_TOOL_IN_SOURCE,
+    INTERNAL_ONLY_TERMS,
+    internal_vocabulary,
+)
+from agents_shipgate.core.domain import Tool
+from agents_shipgate.core.evidence_actions import (
+    evidence_gap_action_text,
+    evidence_gap_headline,
+)
+from agents_shipgate.core.surface_exclusions import derived_id_kind
+from agents_shipgate.schemas.bindings import (
+    AgentBindingGraphAssessment,
+    AgentBindingIssue,
+    AgentBindingNode,
+)
+from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.report import (
+    EvidenceCoverageDecision,
+    EvidenceGap,
+    ReadinessReport,
+    ReleaseDecision,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+runner = CliRunner()
+
+
+# --- the rule is not vacuous -------------------------------------------------
+
+# Verbatim history. Each of these shipped, each sent a reader looking for a
+# field that is in no file they have, and each must stay rejected.
+HISTORICAL_VIOLATIONS = (
+    (
+        "Duplicate tool observation identity: source_type='google_adk_function', "
+        "source_id='google_adk:agent.py', "
+        "native_locator='agent.py#map_salesforce_account_to_sap_bp'"
+    ),
+    "loaded tool source has a blank source_id",
+    (
+        "Tool observation obs_v1_"
+        "3f9a1c2b8e7d45060f4b9c1e2a7d8f3b5c6e0a19d4f7b2c8e1a3d6f9b0c4e7a25"
+        " appears in multiple bindings: orders_process, orders_legacy"
+    ),
+    "process_order [tool_v2_2c9ee6aefb31] has no declared effect",
+    "Unknown adapter source_type 'acme' (install/enable the adapter, or fix a typo)",
+    "Accepted values: unique_source_id, stable_native_locator.",
+    "member source_id='orders_b', tool='process_order' matched 0 observations",
+)
+
+# Anchored spellings that must keep passing. `source_id` really is a manifest
+# key; refusing it outright would force these messages to stop naming the field
+# the reader has to edit, which is the opposite of the point.
+ANCHORED_SPELLINGS = (
+    "Add source_id='orders' to the tool_inventories entry, then rerun the scan.",
+    "Correct the member to name a configured shipgate.yaml#tool_sources[].id.",
+    "Read it from `findings[].fingerprint` in `report.json`.",
+    "Declare the exact join at shipgate.yaml#tool_identity.bindings.",
+)
+
+
+@pytest.mark.parametrize("message", HISTORICAL_VIOLATIONS)
+def test_the_rule_rejects_the_messages_it_was_written_for(message: str) -> None:
+    assert internal_vocabulary(message), message
+
+
+@pytest.mark.parametrize("message", ANCHORED_SPELLINGS)
+def test_a_manifest_key_named_with_its_surface_is_not_internal(message: str) -> None:
+    assert internal_vocabulary(message) == (), message
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("customer_agent_v1_deadbeef", id="agent-name-substring"),
+        pytest.param("my_tool_v2_deadbeef12", id="tool-name-substring"),
+        pytest.param("legacy_fp_0123456789abcdef", id="fingerprint-substring"),
+    ],
+)
+def test_an_adopter_named_identifier_is_not_a_derived_id(label: str) -> None:
+    """Agent and tool names are adopter-controlled strings (#329 review).
+
+    An unbounded search called an agent legitimately named
+    ``customer_agent_v1_deadbeef`` a derived agent id. Once that agent has an
+    evidence gap the conservation invariant refuses the subject and aborts an
+    otherwise valid scan — a vocabulary rule turning into an outage.
+    """
+
+    assert internal_vocabulary(label) == (), label
+    assert derived_id_kind(label) is None, label
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        pytest.param("agent_v1:7205d836e4b3fee257d90695", id="agent"),
+        pytest.param("tool_v2_" + "a" * 64, id="tool"),
+        pytest.param("charge_card [tool_v2_" + "b" * 64 + "]", id="tool-in-a-label"),
+        pytest.param("obs_v1_" + "c" * 64, id="observation"),
+        pytest.param("fp_f092940f62fbb012", id="fingerprint"),
+    ],
+)
+def test_the_real_shapes_are_still_refused(identifier: str) -> None:
+    """Narrowing the patterns must not stop them matching what they exist for."""
+
+    assert internal_vocabulary(identifier), identifier
+
+
+def test_an_anchor_cannot_rescue_a_field_that_exists_in_no_file() -> None:
+    """The two categories are not the same lever.
+
+    `source_id` becomes locatable when the message says which key it is.
+    `native_locator` cannot: there is no manifest key, no report field an
+    adopter is asked to read, and no file to open. Naming `shipgate.yaml`
+    beside it must not launder it.
+    """
+
+    anchored = "Set a stable native_locator in shipgate.yaml, then rerun."
+    assert "native_locator" in internal_vocabulary(anchored)
+
+
+# --- 1. every gap kind, through the real renderers ---------------------------
+
+
+def _gap_kinds() -> tuple[str, ...]:
+    return get_args(EvidenceGap.model_fields["kind"].annotation)
+
+
+def _probe_tool() -> Tool:
+    return Tool(
+        id="tool_v2_9a1c2b8e7d450612",
+        name="process_order",
+        source_type="google_adk_function",
+        source_id="google_adk:agent.py",
+        source_ref="agent.py",
+        provider="google_adk:agent.py",
+    )
+
+
+def _gaps_for_every_kind() -> list[EvidenceGap]:
+    tool = _probe_tool()
+    return [
+        rd._semantic_gap(tool, kind=kind, why="static evidence does not prove it")
+        for kind in _gap_kinds()
+    ]
+
+
+@pytest.mark.parametrize("kind", _gap_kinds())
+def test_every_gap_kind_renders_adopter_facing_text(kind: str) -> None:
+    """The three surfaces a gap reaches, each checked as it is printed.
+
+    ``evidence_gap_headline`` is the short form — the CLI ``Improve evidence:``
+    clause, the decision reason, the GitHub step summary — and it renders
+    without the gap's ``path``, so its wording has to stand alone.
+    ``evidence_gap_action_text`` and the ``fix_task`` line both carry the
+    target, which is what makes a manifest key locatable.
+    """
+
+    gap = rd._semantic_gap(
+        _probe_tool(), kind=kind, why="static evidence does not prove it"
+    )
+    headline = evidence_gap_headline(gap)
+    assert internal_vocabulary(headline) == (), headline
+    action = evidence_gap_action_text(gap)
+    assert internal_vocabulary(action) == (), action
+
+
+def test_every_gap_kind_renders_an_adopter_facing_fix_task_instruction() -> None:
+    """``fix_task.instructions[]`` is the durable form an agent repeats.
+
+    Rendered by the production function rather than reassembled here, so the
+    `accepted_values` list is checked in the sentence that actually publishes
+    it — a bare list of selector keys means nothing without the target beside
+    it, and means something exact with it.
+    """
+
+    report = ReadinessReport.model_construct(
+        tool_inventory=[],
+        source_warnings=[],
+        release_decision=ReleaseDecision.model_construct(
+            decision="insufficient_evidence",
+            reason="test",
+            evidence_coverage=EvidenceCoverageDecision.model_construct(
+                level="mixed", evidence_gaps=_gaps_for_every_kind()
+            ),
+        ),
+    )
+    instructions = _insufficient_evidence_remedies(report)
+    assert len(instructions) >= len(_gap_kinds()) - 2, instructions
+    for line in instructions:
+        assert internal_vocabulary(line) == (), line
+
+
+def test_a_binding_gap_names_the_agent_the_reader_wrote() -> None:
+    """The subject of a binding gap is a label, the way a tool's subject is.
+
+    An issue naming no tool falls back to the agent, and the fallback used to
+    be the derived id: ``samples/conductor_agent`` shipped "the agent's tool
+    binding graph is incomplete (agent_v1:7205d836…)" as the sentence under
+    its verdict. The identity still travels — in ``subject_id`` for tools, and
+    in ``binding_surface_facts`` for agents — but the sentence names the agent
+    the reader declared and the source it was read from.
+    """
+
+    graph = AgentBindingGraphAssessment(
+        root_agent_id="agent_v1:507abc67404233d2ccd1c2d1",
+        status="partial",
+        agents=[
+            AgentBindingNode(
+                agent_id="agent_v1:507abc67404233d2ccd1c2d1",
+                name="closer_agent",
+                source_id="google_adk:agent.py",
+                source_ref="agent.py",
+            )
+        ],
+        issues=[
+            AgentBindingIssue(
+                kind="partial_binding_evidence",
+                message="Google ADK toolset 'dynamic' is not statically enumerable.",
+                agent_id="agent_v1:507abc67404233d2ccd1c2d1",
+            )
+        ],
+    )
+    report = ReadinessReport.model_construct(
+        binding_surface_facts=graph, tool_catalog=[]
+    )
+    _coverage, gaps = rd._binding_coverage(report)
+    (gap,) = gaps
+    assert gap.subject == "closer_agent [google_adk:agent.py]"
+    assert internal_vocabulary(evidence_gap_headline(gap)) == ()
+
+
+def test_an_unresolved_handoff_is_not_labelled_as_the_root_agent() -> None:
+    """The gap is about the agent that is missing, not the one that is fine.
+
+    `unresolved_agent_binding` carries `agent_id=None` precisely because the
+    endpoint could not be resolved. Falling through to `graph.root_agent_id`
+    labelled `root -> missing_worker` as `root [sdk]` and propagated that name
+    into the verdict and the fix task (#329 review).
+    """
+
+    graph = AgentBindingGraphAssessment(
+        root_agent_id="agent_v1:507abc67404233d2ccd1c2d1",
+        status="partial",
+        agents=[
+            AgentBindingNode(
+                agent_id="agent_v1:507abc67404233d2ccd1c2d1",
+                name="root",
+                source_id="sdk",
+                source_ref="agents.py",
+            )
+        ],
+        issues=[
+            AgentBindingIssue(
+                kind="unresolved_agent_binding",
+                message="Binding references unresolved agent 'missing_worker'.",
+                source="shipgate.yaml",
+                source_pointer="shipgate.yaml#/agent_bindings/declarations/0/agent",
+            )
+        ],
+    )
+    report = ReadinessReport.model_construct(
+        binding_surface_facts=graph, tool_catalog=[]
+    )
+    _coverage, (gap,) = rd._binding_coverage(report)
+    assert gap.subject == "shipgate.yaml#/agent_bindings/declarations/0/agent"
+    assert "root" not in gap.subject
+    assert internal_vocabulary(evidence_gap_headline(gap)) == ()
+
+
+def _binding_graph(observations, declarations=None, sources=("a",)):
+    """A real graph, built by the production resolver.
+
+    The shapes under test are produced by `resolve_agent_binding_graph`, not by
+    hand: the previous fix was written against a constructed issue and missed
+    both of the shapes the resolver actually emits (#329 review 2).
+    """
+
+    from agents_shipgate.core.agent_bindings import resolve_agent_binding_graph
+    from agents_shipgate.core.artifacts import ArtifactBag
+    from agents_shipgate.core.domain import AgentBindingObservation, LoadedToolSource
+
+    tool = Tool(
+        id="tool_v2_a", name="lookup", source_type="sdk_function", source_id="a"
+    )
+    loaded = [
+        LoadedToolSource(
+            source_id=source_id,
+            source_type="openai_agents_sdk",
+            tools=[tool] if source_id == "a" else [],
+            binding_observations=[
+                AgentBindingObservation(**observation)
+                for observation in observations
+                if observation["source_id"] == source_id
+            ],
+        )
+        for source_id in sources
+    ]
+    manifest = AgentsShipgateManifest.model_validate(
+        {
+            "version": "0.1",
+            "project": {"name": "handoff-probe"},
+            "agent": {"name": "root", "declared_purpose": ["look things up"]},
+            "environment": {"target": "local"},
+            "tool_sources": [
+                {"id": source_id, "type": "mcp", "path": f"{source_id}.json"}
+                for source_id in sources
+            ],
+            "agent_bindings": {
+                "root": {"source_id": "a", "object": "root"},
+                **({"declarations": declarations} if declarations else {}),
+            },
+        }
+    )
+    graph, _narrowed = resolve_agent_binding_graph(
+        manifest, [tool], ArtifactBag(), loaded_sources=loaded
+    )
+    report = ReadinessReport.model_construct(
+        binding_surface_facts=graph, tool_catalog=[]
+    )
+    _coverage, gaps = rd._binding_coverage(report)
+    return graph, gaps
+
+
+def test_an_incomplete_handoff_is_not_labelled_by_its_source_agent() -> None:
+    """The edge is incomplete; the agent that declares it is not the problem.
+
+    `incomplete_handoff_graph` carries `edge.source_agent_id` — the healthy
+    referrer — so the branch that trusts `issue.agent_id` subjected the gap
+    `root [a]` (#329 review 2).
+    """
+
+    graph, gaps = _binding_graph(
+        [
+            {
+                "agent": "root",
+                "source_id": "a",
+                "source": "framework_extraction",
+                "tool_names": ["lookup"],
+                "handoff_names": ["worker"],
+                "handoffs_complete": False,
+                "source_pointer": "agents.py#L12",
+            },
+            {"agent": "worker", "source_id": "a", "source": "framework_extraction"},
+        ]
+    )
+    (issue,) = [i for i in graph.issues if i.kind == "incomplete_handoff_graph"]
+    # The producer really does carry the healthy agent, which is why a rule
+    # keyed on "has an agent_id" cannot work here.
+    assert issue.agent_id == graph.root_agent_id
+    (gap,) = [g for g in gaps if g.kind == "incomplete_handoff_graph"]
+    assert gap.subject == "agents.py#L12"
+    assert internal_vocabulary(evidence_gap_headline(gap)) == ()
+
+
+def test_an_ambiguous_handoff_target_is_not_labelled_by_its_referrer() -> None:
+    """The other shape: two agents named `worker`, so the target resolves to
+    neither — and the issue carries the declaring agent's id outright."""
+
+    graph, gaps = _binding_graph(
+        [
+            {"agent": "root", "source_id": "a", "source": "framework_extraction"},
+            {"agent": "worker", "source_id": "a", "source": "framework_extraction"},
+            {"agent": "worker", "source_id": "b", "source": "framework_extraction"},
+        ],
+        declarations=[
+            {
+                "agent": "root",
+                "complete": True,
+                "tools": [{"tool": "lookup", "source_id": "a"}],
+                "handoffs": ["worker"],
+                "reason": "reviewed wiring",
+            }
+        ],
+        sources=("a", "b"),
+    )
+    (issue,) = [i for i in graph.issues if i.kind == "unresolved_agent_binding"]
+    assert issue.agent_id, "the producer names the declaring agent"
+    (gap,) = [g for g in gaps if g.kind == "unresolved_agent_binding"]
+    assert gap.subject == "/agent_bindings/declarations/0/handoffs/0"
+    assert "root" not in gap.subject
+    assert internal_vocabulary(evidence_gap_headline(gap)) == ()
+
+
+def test_an_identity_gap_sends_the_reader_and_the_agent_to_one_place() -> None:
+    """`path` and `expects` are read by different consumers, so they must agree.
+
+    An agent routes on `next_action.path` while a human reads `expects`; the
+    two named different sections of shipgate.yaml for `incomplete_tool_identity`
+    (#329 review). Asserted together, because either one alone passes.
+    """
+
+    gap = rd._semantic_gap(
+        _probe_tool(), kind="incomplete_tool_identity", why="test"
+    )
+    assert gap.next_action.path == "shipgate.yaml#tool_sources"
+    assert "shipgate.yaml#tool_sources" in gap.next_action.expects
+    assert "tool_identity" not in gap.next_action.expects
+
+
+def test_an_unnamed_agent_never_falls_back_to_its_id() -> None:
+    """The fallback that would abort the scan it describes.
+
+    An extractor that resolves no literal ``name=`` yields a node with an
+    empty name. Returning the agent id there is not merely unreadable — the
+    conservation invariant refuses a derived id in any gap subject, so the
+    scan would raise instead of reporting.
+    """
+
+    from agents_shipgate.core.surface_exclusions import agent_subject
+
+    unnamed = AgentBindingNode(
+        agent_id="agent_v1:507abc67404233d2ccd1c2d1",
+        name="   ",
+        source_id="google_adk:agent.py",
+        source_ref="agent.py",
+    )
+    subject = agent_subject(unnamed)
+    assert subject == "agent.py"
+    assert internal_vocabulary(subject) == ()
+
+
+def test_an_unknown_agent_falls_back_to_something_readable() -> None:
+    """A fallback that returns the unreadable value defeats itself.
+
+    An issue can name an agent the graph did not record — the chain has to end
+    somewhere a reader can go, so it ends at the source pointer and then at
+    prose, never back at the id.
+    """
+
+    graph = AgentBindingGraphAssessment(
+        root_agent_id=None,
+        status="unknown",
+        agents=[],
+        issues=[
+            AgentBindingIssue(
+                kind="missing_binding_evidence",
+                message="No static binding edge was proven.",
+                agent_id="agent_v1:507abc67404233d2ccd1c2d1",
+                source_pointer="agents/closer/agent.py#L12",
+            ),
+            AgentBindingIssue(
+                kind="missing_binding_evidence",
+                message="No static binding edge was proven.",
+                agent_id="agent_v1:d1c2d1404233507abc674042",
+            ),
+        ],
+    )
+    report = ReadinessReport.model_construct(
+        binding_surface_facts=graph, tool_catalog=[]
+    )
+    _coverage, gaps = rd._binding_coverage(report)
+    assert [gap.subject for gap in gaps] == [
+        "agents/closer/agent.py#L12",
+        "agent binding graph",
+    ]
+    for gap in gaps:
+        assert internal_vocabulary(gap.subject) == ()
+
+
+# --- 2. every rendered message builder ---------------------------------------
+
+# One probe per public message builder in `core.source_warnings`. The values
+# are deliberately realistic: a synthetic id makes a vocabulary guard as
+# vacuous as it makes a shape guard.
+SOURCE_WARNING_PROBES: dict[str, str] = {
+    "adk_unresolved_tool_warning": sw.adk_unresolved_tool_warning(
+        "smart_closer", "map_salesforce_account_to_sap_bp"
+    ),
+    "invalid_tool_binding_warning": sw.invalid_tool_binding_warning(
+        "orders_process",
+        [
+            sw.unmatched_binding_member("orders_b", "process_order", 0),
+            sw.zero_observation_binding_member("orders_empty", "process_order"),
+            sw.unknown_binding_member_source("orders_typo", "process_order"),
+        ],
+    ),
+    "unmatched_binding_member": sw.unmatched_binding_member(
+        "orders_b", "process_order", 2
+    ),
+    "zero_observation_binding_member": sw.zero_observation_binding_member(
+        "orders_empty", "process_order"
+    ),
+    "unknown_binding_member_source": sw.unknown_binding_member_source(
+        "orders_typo", "process_order"
+    ),
+    "unknown_inventory_source_warning": sw.unknown_inventory_source_warning(
+        "tools/inventory.json", "orders_typo", ["orders_a", "orders_b"]
+    ),
+    "self_referential_inventory_warning": sw.self_referential_inventory_warning(
+        "tools/inventory.json"
+    ),
+    "unbound_inventory_duplicate_warning": sw.unbound_inventory_duplicate_warning(
+        "tools/inventory.json", "orders_a", ["process_order", "refund_order"]
+    ),
+    "ambiguous_inventory_merge_warning": sw.ambiguous_inventory_merge_warning(
+        "tools/inventory.json", "orders_a", ["process_order"]
+    ),
+}
+
+# Public names in `core.source_warnings` that do not write a message: the
+# grouping machinery, the decoders, and the display normalizer.
+SOURCE_WARNING_NON_MESSAGES = frozenset(
+    {
+        "SourceWarningGroup",
+        "group_source_warnings",
+        "unresolved_adk_tool_symbols",
+        "visible_skeleton",
+        "withdraw_completed_adk_tool_warnings",
+    }
+)
+
+
+def test_every_source_warning_builder_is_swept() -> None:
+    """A new warning builder cannot arrive without a probe.
+
+    The enumeration is the module's own ``__all__``, so the table cannot go
+    stale silently — which is the whole reason this is a sweep and not nine
+    separate regression tests.
+    """
+
+    published = set(sw.__all__)
+    assert SOURCE_WARNING_NON_MESSAGES <= published, (
+        "the non-message list names something core.source_warnings no longer "
+        f"publishes: {sorted(SOURCE_WARNING_NON_MESSAGES - published)}"
+    )
+    unswept = published - set(SOURCE_WARNING_PROBES) - SOURCE_WARNING_NON_MESSAGES
+    assert not unswept, (
+        "core.source_warnings publishes message builders this file does not "
+        f"sweep: {sorted(unswept)}. Add a probe to SOURCE_WARNING_PROBES, or "
+        "record it in SOURCE_WARNING_NON_MESSAGES if it writes no message."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(SOURCE_WARNING_PROBES))
+def test_source_warnings_speak_the_adopters_vocabulary(name: str) -> None:
+    message = SOURCE_WARNING_PROBES[name]
+    assert internal_vocabulary(message) == (), message
+
+
+def test_grouped_source_warnings_speak_the_adopters_vocabulary() -> None:
+    """The grouped display projection is a second renderer, with its own prose."""
+
+    raw = [
+        sw.adk_unresolved_tool_warning("smart_closer", symbol)
+        for symbol in ("map_account", "map_product")
+    ] + [
+        sw.invalid_tool_binding_warning(
+            f"bind_{index}",
+            [sw.zero_observation_binding_member("orders_empty", "process_order")],
+        )
+        for index in range(2)
+    ]
+    groups = sw.group_source_warnings(raw)
+    assert groups
+    for group in groups:
+        assert internal_vocabulary(group.message) == (), group.message
+
+
+def test_the_declaration_scaffold_speaks_the_adopters_vocabulary() -> None:
+    """The one file the scaffold writes, checked whole.
+
+    Its lines are fragments by construction — a YAML key on one line, the
+    comment naming what it accepts on another — so the assembled file is the
+    only honest unit to check.
+    """
+
+    graph = AgentBindingGraphAssessment(
+        root_agent_id=None,
+        status="unknown",
+        agents=[
+            AgentBindingNode(
+                agent_id="a1", name="AlphaAgent", source_id="adk", source_ref="agent.py"
+            )
+        ],
+        issues=[AgentBindingIssue(kind="ambiguous_root_agent", message="ambiguous")],
+    )
+    report = ReadinessReport.model_construct(binding_surface_facts=graph)
+    _coverage, binding_gaps = rd._binding_coverage(report)
+    scaffold = build_declaration_scaffold(
+        [*binding_gaps, *_gaps_for_every_kind()], agents=graph.agents
+    )
+    assert scaffold is not None
+    # The scaffold writes a *tool* id into the block for the reader to paste,
+    # which is what keeps a selector unambiguous when two tools share a name
+    # (#388). Nothing asks them to know what it is. Only that kind is
+    # forgiven: an agent id here would still be an offender, and prose about
+    # an id is refused either way.
+    assert internal_vocabulary(scaffold, given_id_kinds={"tool"}) == (), scaffold
+
+
+# --- 3. hand-written prose at the emit sites ---------------------------------
+
+# Modules whose strings are written by hand where they are emitted: console
+# output, next actions, handoff and PR prose, and the failures that abort
+# before a report exists. `cli/scan/declarations.py` is deliberately absent —
+# it emits one assembled file, swept whole above, and its per-line fragments
+# would read as violations of a rule the file satisfies.
+ADOPTER_FACING_MODULES = (
+    "ci/github_summary.py",
+    "cli/explain_finding.py",
+    "ci/release_decision.py",
+    "cli/_helpers.py",
+    "cli/_register_scan.py",
+    "cli/diagnostics.py",
+    "cli/scan/writing.py",
+    "cli/verify/fix_task.py",
+    "cli/verify/orchestrator.py",
+    "inputs/adapter_validation.py",
+    "core/agent_control.py",
+    "core/agent_control_envelope.py",
+    "core/agent_controls.py",
+    "core/agent_handoff.py",
+    "core/evidence_actions.py",
+    "core/source_warnings.py",
+    "core/tool_identity.py",
+    "report/markdown.py",
+    "report/pr_comment.py",
+    "report/summary_text.py",
+)
+
+# A string that is only an identifier is a dict key or a field name, not
+# something anyone reads. `{"native_locator": locator}` is the identity model
+# doing its job.
+_KEY_LIKE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\[\])?(\.[A-Za-z_][A-Za-z0-9_]*(\[\])?)*$")
+
+# Below this, a literal is a fragment of a sentence assembled elsewhere rather
+# than a sentence. Fragments are checked in their assembled form by the
+# rendered sweeps above; checking them here would flag ": member source_id="
+# for saying less than the message it is part of. Applies only to the terms an
+# anchor can rescue: a term from INTERNAL_ONLY_TERMS is refused at any length.
+_MIN_SENTENCE_WORDS = 5
+
+
+def _scope_chains(tree: ast.Module) -> dict[int, tuple[ast.AST, ...]]:
+    """Every node's enclosing scopes, innermost first.
+
+    Name resolution has to be lexical or the sweep launders violations across
+    unrelated functions: two ``guidance`` locals, one unanchored and one
+    naming ``shipgate.yaml``, were concatenated into every f-string that
+    interpolated either, and the unrelated anchor cleared the offender.
+    """
+
+    chains: dict[int, tuple[ast.AST, ...]] = {}
+
+    def visit(node: ast.AST, chain: tuple[ast.AST, ...]) -> None:
+        chains[id(node)] = chain
+        inner = chain
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
+            inner = (node, *chain)
+        for child in ast.iter_child_nodes(node):
+            visit(child, inner)
+
+    visit(tree, (tree,))
+    return chains
+
+
+def _render_literal(node: ast.AST, names: dict[str, list[str]]) -> str | None:
+    """The text of a string expression, with interpolations as ``{}``.
+
+    One level of local-name substitution, because a sentence assembled from a
+    variable is still one sentence to the reader: ``_inventory_remediation``
+    builds its manifest snippet into ``binding`` and interpolates it into a
+    return value that names ``shipgate.yaml``. Judging the fragment alone
+    would call an anchored message unanchored.
+    """
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue) and isinstance(
+                value.value, ast.Name
+            ):
+                parts.append(" ".join(names.get(value.value.id, ("{}",))))
+            else:
+                parts.append("{}")
+        return "".join(parts)
+    return None
+
+
+def _literal_alternatives(node: ast.AST, names: dict[str, list[str]]) -> list[str]:
+    """Every string this expression can evaluate to, kept apart.
+
+    Concatenating the two arms of a conditional is the same laundering as
+    concatenating two scopes: an anchored branch clears an unanchored one, and
+    only one of them is ever what the reader sees.
+    """
+
+    if isinstance(node, ast.IfExp):
+        return [
+            text
+            for arm in (node.body, node.orelse)
+            for text in _literal_alternatives(arm, names)
+        ]
+    rendered = _render_literal(node, names)
+    return [] if rendered is None else [rendered]
+
+
+#: Call shapes that put a string in front of a reader with no further
+#: processing: the first argument of ``typer.echo``, and the fields of the
+#: structured actions and errors. A string here is a complete message, so the
+#: fragment and dict-key exemptions below must not apply to it — a probe with
+#: ``typer.echo("native_locator")`` looked key-like and one with a four-word
+#: sentence looked like a fragment, and neither was reported (#329 review 3).
+_EMITTING_KEYWORDS = frozenset(
+    {"why", "expects", "title", "message", "reason", "recommendation", "remediation"}
+)
+_EMITTING_CALLS = frozenset({"echo", "secho"})
+
+
+def _definitely_emitted(tree: ast.Module) -> set[int]:
+    """Nodes whose string value is handed straight to a reader."""
+
+    emitted: set[int] = set()
+
+    def mark(node: ast.AST) -> None:
+        emitted.add(id(node))
+        # An `x if c else y` in an emitting position emits both arms.
+        if isinstance(node, ast.IfExp):
+            mark(node.body)
+            mark(node.orelse)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = node.func.attr if isinstance(node.func, ast.Attribute) else (
+            node.func.id if isinstance(node.func, ast.Name) else ""
+        )
+        if name in _EMITTING_CALLS and node.args:
+            mark(node.args[0])
+        for keyword in node.keywords:
+            if keyword.arg in _EMITTING_KEYWORDS:
+                mark(keyword.value)
+    return emitted
+
+
+def _emitted_strings(path: Path) -> list[tuple[int, str, bool]]:
+    """Every string written at an emit site in ``path``.
+
+    Docstrings are excluded — they are written for the person editing this
+    repository, and the identity model is exactly the right vocabulary there.
+    So are the parts inside an f-string, which are read as the whole they
+    belong to, and the right-hand sides that were substituted into one.
+    """
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    chains = _scope_chains(tree)
+    definite = _definitely_emitted(tree)
+
+    # String assignments, keyed by (owning scope, name) rather than by name,
+    # and kept in source order so a use can take the definition that reaches
+    # it rather than every definition the scope ever makes.
+    assigned: dict[tuple[int, str], list[ast.Assign]] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and _literal_alternatives(node.value, {})
+        ):
+            owner = chains[id(node)][0]
+            assigned.setdefault((id(owner), node.targets[0].id), []).append(node)
+    for bindings in assigned.values():
+        bindings.sort(key=lambda assign: (assign.lineno, assign.col_offset))
+
+    def _reaching(
+        scope_chain: tuple[ast.AST, ...], name: str, use: ast.AST
+    ) -> list[ast.Assign]:
+        """The definition of ``name`` in effect at ``use``.
+
+        Lexical, then positional: the innermost scope that binds the name, and
+        within it the last assignment above the use. Taking every assignment
+        in the scope let a later anchored definition clear an earlier
+        unanchored one that had already been interpolated (#329 review 2).
+        """
+
+        for scope in scope_chain:
+            bindings = assigned.get((id(scope), name))
+            if not bindings:
+                continue
+            line = getattr(use, "lineno", 0)
+            earlier = [b for b in bindings if b.lineno <= line]
+            # A use above every definition in its scope is a forward
+            # reference — a closure called later — so every definition is
+            # reachable and each is kept as its own alternative.
+            return [earlier[-1]] if earlier else bindings
+        return []
+
+    # Only names an f-string actually interpolates are substituted, and only
+    # those have their assignment consumed. Consuming every string assigned to
+    # a name would open the hole this whole file exists to close: a sentence
+    # built as `guidance = "…"` and passed to `NextAction(why=guidance)` is
+    # never interpolated anywhere, so it would be excluded from the sweep and
+    # checked nowhere — which is exactly how `_register_scan` used to write
+    # its recovery prose.
+    names_at: dict[int, dict[str, list[str]]] = {}
+    substituted: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        local: dict[str, list[str]] = {}
+        for value in node.values:
+            if not (
+                isinstance(value, ast.FormattedValue)
+                and isinstance(value.value, ast.Name)
+            ):
+                continue
+            bindings = _reaching(chains[id(node)], value.value.id, node)
+            if not bindings:
+                continue
+            local[value.value.id] = [
+                text
+                for assign in bindings
+                for text in _literal_alternatives(assign.value, {})
+            ]
+            for assign in bindings:
+                substituted.update(id(inner) for inner in ast.walk(assign.value))
+        if local:
+            names_at[id(node)] = local
+
+    docstrings: set[int] = set()
+    inside_fstring: set[int] = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if (
+            isinstance(
+                node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            )
+            and body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+        ):
+            docstrings.add(id(body[0].value))
+        if isinstance(node, ast.JoinedStr):
+            inside_fstring.update(id(part) for part in node.values)
+
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if id(node) in docstrings or id(node) in inside_fstring:
+            continue
+        if id(node) in substituted:
+            continue
+        local = names_at.get(id(node), {})
+        for alternatives in _cartesian(node, local):
+            found.append((node.lineno, alternatives, id(node) in definite))
+    return found
+
+
+def _cartesian(node: ast.AST, names: dict[str, list[str]]) -> list[str]:
+    """Every string ``node`` can render to, one per combination of choices.
+
+    A name bound to two alternatives — the arms of a conditional, or two
+    reachable definitions — must not be joined into one string, or either can
+    clear the other. With two such names it is not enough to vary them one at
+    a time either: specializing `left` while `right` stays joined leaves the
+    anchor from `right` in every rendering, and the one combination that
+    matters — both unanchored — is never emitted (#329 review 3).
+    """
+
+    keys = [key for key, values in names.items() if len(values) > 1]
+    if not keys:
+        return _literal_alternatives(node, names)
+    rendered: list[str] = []
+    for combination in itertools.product(*(names[key] for key in keys)):
+        chosen = {**names, **dict(zip(keys, ([v] for v in combination), strict=True))}
+        rendered.extend(_literal_alternatives(node, chosen))
+    return rendered
+
+
+def test_the_extractor_sees_a_sentence_built_through_a_variable(tmp_path) -> None:
+    """The sweep is only as good as what it can see.
+
+    A recovery sentence assigned to a local and handed to ``NextAction`` is
+    how `scan` wrote this exact copy before #329, and it is invisible to any
+    extractor that treats a named string as a fragment of something else. The
+    substitution pass has to consume *only* the names an f-string actually
+    interpolates, or the commonest shape in these modules is swept nowhere.
+    """
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        'def f():\n'
+        '    guidance = (\n'
+        '        "Inspect the source_type in the error and fix it before "\n'
+        '        "the scan can resolve anything at all."\n'
+        '    )\n'
+        '    return NextAction(kind="review", why=guidance, expects=guidance)\n',
+        encoding="utf-8",
+    )
+    found = [text for _line, text, _definite in _emitted_strings(probe)]
+    assert any("Inspect the source_type" in text for text in found), found
+    assert any(internal_vocabulary(text) for text in found)
+
+
+def test_the_extractor_resolves_a_name_in_its_own_scope(tmp_path) -> None:
+    """A name is looked up lexically, or the sweep launders across functions.
+
+    Two functions both assigning ``guidance`` — one unanchored, one naming
+    ``shipgate.yaml`` — were rendered as the concatenation of both into every
+    f-string that interpolated either, and the unrelated anchor cleared the
+    offender while both right-hand sides were marked substituted and checked
+    nowhere.
+    """
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        'def a():\n'
+        '    guidance = "Inspect source_id before proceeding anywhere else."\n'
+        '    return f"{guidance}"\n'
+        '\n'
+        'def b():\n'
+        '    guidance = "Open shipgate.yaml and correct the entry, then rerun."\n'
+        '    return f"{guidance}"\n',
+        encoding="utf-8",
+    )
+    rendered = {
+        text: internal_vocabulary(text)
+        for _line, text, _definite in _emitted_strings(probe)
+    }
+    offending = [text for text, bad in rendered.items() if bad]
+    assert len(offending) == 1, rendered
+    assert "source_id" in offending[0]
+    assert "shipgate.yaml" not in offending[0]
+
+
+def test_the_extractor_varies_every_alternative_together(tmp_path) -> None:
+    """Two names with alternatives need the product, not one at a time.
+
+    Specializing `left` while `right` stayed joined left `right`'s anchor in
+    every rendering, so all four strings passed and the one combination that
+    matters — both unanchored — was never emitted (#329 review 3).
+    """
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        'def f(flag, other):\n'
+        '    left = "Inspect source_id first." if flag else "Open shipgate.yaml now."\n'
+        '    right = "Then check source_type." if other else "Then read report.json."\n'
+        '    return f"{left} {right}"\n',
+        encoding="utf-8",
+    )
+    rendered = {
+        text: internal_vocabulary(text)
+        for _line, text, _definite in _emitted_strings(probe)
+    }
+    assert len(rendered) == 4, rendered
+    both_unanchored = [text for text, bad in rendered.items() if len(bad) == 2]
+    assert len(both_unanchored) == 1, rendered
+    assert internal_vocabulary(both_unanchored[0]) == ("source_id", "source_type")
+
+
+def test_the_extractor_reads_an_interpolated_fragment_in_its_whole(tmp_path) -> None:
+    """And the other direction, which is why the substitution exists.
+
+    ``_inventory_remediation`` builds its manifest snippet into a local and
+    interpolates it into a sentence that names ``shipgate.yaml``. Judged on
+    its own the fragment is an unanchored ``source_id``; judged as what the
+    reader sees, it is anchored.
+    """
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        'def f(source):\n'
+        '    binding = "an entry carrying `source_id: <the source above>`"\n'
+        '    return f"Reference it from shipgate.yaml as {binding}, then rerun."\n',
+        encoding="utf-8",
+    )
+    for _line, text, _definite in _emitted_strings(probe):
+        assert internal_vocabulary(text) == (), text
+
+
+#: Modules whose strings legitimately carry an identifier the reader already
+#: has, mapped to *which kind* they were given. `explain-finding` takes a
+#: fingerprint as its argument: its help shows an example of the shape to
+#: supply, and its unknown-fingerprint error echoes the value the reader just
+#: typed. Neither asks the reader to decode anything, and both name
+#: `findings[].fingerprint` in `report.json` as where the right one lives —
+#: which is what the term rules check, and they still apply here.
+#:
+#: Per kind, because a surface with a reason for one shape has no reason for
+#: the other three: a module-wide exemption forgave an agent id in
+#: `explain-finding` prose that nobody had supplied (#329 review 3).
+MODULES_WITH_GIVEN_IDS: dict[str, frozenset[str]] = {
+    "cli/explain_finding.py": frozenset({"finding"}),
+}
+
+
+@pytest.mark.parametrize("module", ADOPTER_FACING_MODULES)
+def test_emitted_prose_speaks_the_adopters_vocabulary(module: str) -> None:
+    given_ids = MODULES_WITH_GIVEN_IDS.get(module, frozenset())
+    offenders: list[str] = []
+    swept = 0
+    for lineno, text, definite in _emitted_strings(
+        REPO_ROOT / "src/agents_shipgate" / module
+    ):
+        stripped = text.strip()
+        # The two exemptions exist for strings whose emit-site is unknown: a
+        # dict key that looks like prose, a fragment assembled elsewhere.
+        # Neither can be true of a string handed straight to `typer.echo` or
+        # to a `NextAction` field, so a known emit site suspends both.
+        if not stripped or (not definite and _KEY_LIKE.match(stripped)):
+            continue
+        swept += 1
+        if definite or len(text.split()) >= _MIN_SENTENCE_WORDS:
+            hits = list(internal_vocabulary(text, given_id_kinds=given_ids))
+        else:
+            hits = [term for term in INTERNAL_ONLY_TERMS if term in text]
+        if hits:
+            offenders.append(f"{module}:{lineno} {sorted(set(hits))} :: {text!r}")
+    assert swept, f"{module} yielded no strings — the extractor stopped working"
+    assert not offenders, "\n".join(offenders)
+
+
+def test_a_real_adapter_validation_message_is_swept() -> None:
+    """The producer whose output `report.md` prints, pinned on a real message.
+
+    `report/markdown.py` renders every `validation_errors` / `runtime_errors`
+    entry under Loaded Adapters, so these strings are adopter-facing — and
+    both the producer and those two keys were missing from the sweep, so
+    `source_type 'mcp' is reserved by a built-in adapter` shipped while every
+    guard passed (#329 review 3).
+    """
+
+    from agents_shipgate.inputs.adapter_validation import (
+        validate_adapter_entry_point,
+    )
+
+    class _Colliding:
+        source_type = "mcp"
+        scope = "per_source"
+        artifact_class = None
+
+        def load(self, *args, **kwargs):  # pragma: no cover - never called
+            raise AssertionError("validation must not load")
+
+    class _EntryPoint:
+        name = "acme"
+        value = "acme.adapter:Adapter"
+        dist = None
+
+        def load(self):
+            return _Colliding()
+
+    loaded = validate_adapter_entry_point(
+        _EntryPoint(),
+        builtin_source_types={"mcp"},
+        already_registered_source_types=set(),
+    )
+    errors = loaded.info["validation_errors"]
+    assert errors, loaded.info
+    for message in errors:
+        assert internal_vocabulary(message) == (), message
+        assert "tool_sources[].type" in message
+
+
+def test_the_given_id_allowance_is_narrow_and_still_checks_the_terms() -> None:
+    """The carve-out exempts the shape, never the vocabulary.
+
+    Listing a module here would be a way to smuggle a whole file past the
+    sweep if it exempted anything else, so this pins both halves: an echoed
+    fingerprint is allowed, and a sentence about `native_locator` in the same
+    module is not.
+    """
+
+    assert set(MODULES_WITH_GIVEN_IDS) <= set(ADOPTER_FACING_MODULES)
+    echoed = (
+        "Unknown fingerprint: fp_f092940f62fbb012. No entry in "
+        "findings[].fingerprint matches it."
+    )
+    assert internal_vocabulary(echoed, given_id_kinds={"finding"}) == ()
+    assert internal_vocabulary(echoed) == ("fp_f092940f62fbb012",)
+    # The allowance is per kind: a shape nobody supplied is still an offender.
+    other_kind = "Agent agent_v1:7205d836e4b3fee257d90695 could not be resolved."
+    assert internal_vocabulary(other_kind, given_id_kinds={"finding"})
+    smuggled = "Set a stable native_locator in shipgate.yaml, then rerun."
+    assert "native_locator" in internal_vocabulary(smuggled, given_id_kinds={"finding"})
+
+
+# --- 4. what the shipped artifacts actually say ------------------------------
+
+# Keys whose values a person reads and acts on. Report internals — the tool
+# catalog, `identity_assessment`, evidence blocks — are deliberately absent:
+# they are the identity model, they are consumed by tooling, and #329 puts
+# them out of scope on purpose.
+ADOPTER_FACING_KEYS = frozenset(
+    {
+        "agent_repair_instructions",
+        "expects",
+        "human_review",
+        "instructions",
+        "message",
+        "next_action",
+        "reason",
+        "recommendation",
+        "remediation",
+        "runtime_errors",
+        "source_warnings",
+        "suggested_fixes",
+        "title",
+        "validation_errors",
+        "warnings",
+        "why",
+    }
+)
+
+
+def _adopter_strings(node: object, path: str, key: str | None = None):
+    if isinstance(node, dict):
+        for name, value in node.items():
+            yield from _adopter_strings(value, f"{path}.{name}", name)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _adopter_strings(value, f"{path}[{index}]", key)
+    elif isinstance(node, str) and key in ADOPTER_FACING_KEYS:
+        yield path, node
+
+
+SAMPLE_REPORTS = sorted(REPO_ROOT.glob("samples/*/expected/report.json"))
+SAMPLE_MARKDOWN = sorted(REPO_ROOT.glob("samples/*/expected/report.md"))
+
+
+def test_the_shipped_artifacts_are_actually_found() -> None:
+    """A glob that matches nothing parametrizes to nothing and asserts nothing.
+
+    The two sweeps below are the only check against what the output *is*
+    rather than what the code says it should be, so an empty sample set has to
+    fail rather than pass silently.
+    """
+
+    assert len(SAMPLE_REPORTS) >= 5, SAMPLE_REPORTS
+    assert len(SAMPLE_MARKDOWN) >= 5, SAMPLE_MARKDOWN
+
+
+@pytest.mark.parametrize(
+    "report_path",
+    SAMPLE_REPORTS,
+    ids=lambda path: path.parent.parent.name,
+)
+def test_sample_reports_speak_the_adopters_vocabulary(report_path: Path) -> None:
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    offenders = [
+        f"{where} {internal_vocabulary(text)} :: {text[:200]!r}"
+        for where, text in _adopter_strings(payload, "")
+        if internal_vocabulary(text)
+    ]
+    assert not offenders, "\n".join(offenders)
+
+
+@pytest.mark.parametrize(
+    "markdown_path",
+    SAMPLE_MARKDOWN,
+    ids=lambda path: path.parent.parent.name,
+)
+def test_sample_markdown_speaks_the_adopters_vocabulary(markdown_path: Path) -> None:
+    offenders = [
+        f"{markdown_path.name}:{number} {internal_vocabulary(line)} :: {line.strip()!r}"
+        for number, line in enumerate(
+            markdown_path.read_text(encoding="utf-8").splitlines(), start=1
+        )
+        if internal_vocabulary(line)
+    ]
+    assert not offenders, "\n".join(offenders)
+
+
+# --- the failure this issue was filed for, end to end ------------------------
+
+
+_DUPLICATE_ENTRYPOINT_AGENT = '''
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool
+
+
+def map_salesforce_account_to_sap_bp(account_id: str) -> dict:
+    """Map a Salesforce account onto an SAP business partner."""
+    return {"sap_bp": account_id}
+
+
+root_agent = LlmAgent(
+    name="smart_closer",
+    instruction="Close deals.",
+    tools=[FunctionTool(func=map_salesforce_account_to_sap_bp)],
+)
+'''
+
+_DUPLICATE_ENTRYPOINT_MANIFEST = """version: "0.1"
+project:
+  name: adk-duplicate-entrypoint
+agent:
+  name: smart_closer
+  declared_purpose:
+    - map salesforce records onto sap records
+environment:
+  target: local
+google_adk:
+  python_entrypoints:
+    - agent.py
+    - agent.py
+"""
+
+
+def test_a_repeated_entrypoint_is_reported_in_the_adopters_terms(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#321's failure, walked the way an adopter meets it.
+
+    Every string on the path — the console line, the envelope ``message``, the
+    ranked ``next_actions[]`` — has to be actionable without the identity
+    model, and the identity model has to still be there for a bug report.
+    """
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "agent.py").write_text(_DUPLICATE_ENTRYPOINT_AGENT, encoding="utf-8")
+    (workspace / "shipgate.yaml").write_text(
+        _DUPLICATE_ENTRYPOINT_MANIFEST, encoding="utf-8"
+    )
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "-c",
+            str(workspace / "shipgate.yaml"),
+            "--out",
+            str(tmp_path / "reports"),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 3, result.output
+
+    console = [
+        line
+        for line in result.output.splitlines()
+        if line and not line.startswith("{")
+    ]
+    assert console
+    for line in console:
+        assert internal_vocabulary(line) == (), line
+
+    envelope = json.loads(
+        next(line for line in result.output.splitlines() if line.startswith("{"))
+    )
+    assert envelope["error"] == "input_parse_error"
+    for field in (envelope["message"], envelope["next_action"]):
+        assert internal_vocabulary(field) == (), field
+    for action in envelope["next_actions"]:
+        for text in (action["why"], action["expects"]):
+            assert internal_vocabulary(text) == (), text
+
+    # Every adopter-facing failure names a file, symbol, or manifest key.
+    assert "agent.py" in envelope["message"]
+    assert "map_salesforce_account_to_sap_bp" in envelope["message"]
+    assert "shipgate.yaml" in envelope["message"]
+
+    # ...and the identity model is still on the wire, for the bug report the
+    # adopter should not have to reverse-engineer from prose.
+    details = envelope["details"]
+    assert details["failure"] == DUPLICATE_TOOL_IN_SOURCE
+    assert details["source_type"] == "google_adk_function"
+    assert details["native_locator"] == "agent.py#map_salesforce_account_to_sap_bp"
+
+
+_DYNAMIC_TOOLKIT_AGENT = '''
+from google.adk.agents import LlmAgent
+
+from .toolkit import build_tools
+
+root_agent = LlmAgent(
+    name="closer_agent",
+    instruction="Route approvals and send confirmations.",
+    tools=build_tools(),
+)
+'''
+
+_DYNAMIC_TOOLKIT_MANIFEST = """version: "0.1"
+project:
+  name: adk-dynamic-toolkit
+agent:
+  name: closer_agent
+  declared_purpose:
+    - route approvals
+environment:
+  target: local
+google_adk:
+  python_entrypoints:
+    - agent.py
+"""
+
+
+def _git_repo(workspace: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=workspace, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=workspace, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"], cwd=workspace, check=True
+    )
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=workspace, check=True)
+
+
+def test_the_handoff_and_pr_comment_of_a_real_verdict_are_swept(tmp_path: Path) -> None:
+    """The two surfaces #329 names that no static list can vouch for.
+
+    ``agent-handoff.json`` prose and PR comment text are assembled from gap
+    rows, source-warning text, and decision reasons — all covered structurally
+    above, but only an actual run proves the assembly did not put an internal
+    identifier back. A dynamic ADK toolkit is the richest cheap verdict: it
+    reaches `insufficient_evidence` with a binding gap, a source warning, and
+    a `fix_task` full of instructions.
+    """
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "agent.py").write_text(_DYNAMIC_TOOLKIT_AGENT, encoding="utf-8")
+    (workspace / "shipgate.yaml").write_text(
+        _DYNAMIC_TOOLKIT_MANIFEST, encoding="utf-8"
+    )
+    _git_repo(workspace)
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(workspace),
+            "--config",
+            str(workspace / "shipgate.yaml"),
+            "--ci-mode",
+            "advisory",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    reports = workspace / "agents-shipgate-reports"
+    report = json.loads((reports / "report.json").read_text(encoding="utf-8"))
+    # The run has to be the interesting one, or this sweeps an empty verdict.
+    assert report["release_decision"]["decision"] == "insufficient_evidence"
+    assert report["source_warnings"]
+
+    offenders: list[str] = []
+    for name in ("agent-handoff.json", "verifier.json", "report.json"):
+        payload = json.loads((reports / name).read_text(encoding="utf-8"))
+        offenders += [
+            f"{name}{where} {internal_vocabulary(text)} :: {text[:200]!r}"
+            for where, text in _adopter_strings(payload, "")
+            if internal_vocabulary(text)
+        ]
+    comment = (reports / "pr-comment.md").read_text(encoding="utf-8")
+    offenders += [
+        f"pr-comment.md:{number} {internal_vocabulary(line)} :: {line.strip()!r}"
+        for number, line in enumerate(comment.splitlines(), start=1)
+        if internal_vocabulary(line)
+    ]
+    assert not offenders, "\n".join(offenders)
+
+    # And the reader is named something they can open, not a digest.
+    instructions = json.loads(
+        (reports / "verifier.json").read_text(encoding="utf-8")
+    )["fix_task"]["instructions"]
+    assert any("closer_agent" in line for line in instructions), instructions
+
+
+_DUPLICATE_IN_ARTIFACT_TOOLS = """{"tools": [
+  {"name": "pay", "description": "pay an invoice for a customer account"},
+  {"name": "pay", "description": "pay an invoice for a customer account"}
+]}
+"""
+
+_DUPLICATE_IN_ARTIFACT_MANIFEST = """version: "0.1"
+project:
+  name: dup-mcp
+agent:
+  name: billing-agent
+  declared_purpose:
+    - pay invoices
+environment:
+  target: local
+tool_sources:
+  - id: billing
+    type: mcp
+    path: tools.json
+"""
+
+
+def test_a_duplicate_inside_an_artifact_edits_the_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other cause of the same failure, with the opposite repair.
+
+    One `tool_sources` entry whose `tools.json` defines `pay` twice is not a
+    repeated manifest entry, and the structured action carries exactly one
+    `path`. Naming the manifest here lets a consumer routing on it delete the
+    source declaration and lose coverage (#329 review), so the check reports
+    which cause it saw and the action follows it.
+    """
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "tools.json").write_text(
+        _DUPLICATE_IN_ARTIFACT_TOOLS, encoding="utf-8"
+    )
+    (workspace / "shipgate.yaml").write_text(
+        _DUPLICATE_IN_ARTIFACT_MANIFEST, encoding="utf-8"
+    )
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "-c",
+            str(workspace / "shipgate.yaml"),
+            "--out",
+            str(tmp_path / "reports"),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 3, result.output
+    envelope = json.loads(
+        next(line for line in result.output.splitlines() if line.startswith("{"))
+    )
+    assert envelope["details"]["cause"] == "duplicate_in_source_artifact"
+    (action,) = envelope["next_actions"]
+    # No artifact path is published as a routable target: a declared path has
+    # no single base — the manifest's for most sources, the entrypoint's for an
+    # inventory a framework file mounts — so it named files that did not exist
+    # (#329 review 3). The artifact is in the sentence, to grep for.
+    assert action["kind"] == "review"
+    assert action.get("path") is None
+    assert "tools.json" in action["why"]
+    assert str(workspace / "shipgate.yaml") in action["why"]
+    assert internal_vocabulary(action["why"]) == (), action["why"]
+    assert "tools.json" in envelope["message"]
+
+
+def test_a_nested_manifest_is_the_one_the_edit_action_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--workspace` discovery selects the manifest; the CLI spelling does not.
+
+    Reproducing the repeated entrypoint through `scan --workspace <repo>`
+    emitted `next_actions[0].path = "shipgate.yaml"`, so an agent following
+    the documented route would edit an unrelated trust root in its own working
+    directory (#329 review). The run records the manifest it read.
+    """
+
+    repo = tmp_path / "repo"
+    nested = repo / "services" / "billing"
+    nested.mkdir(parents=True)
+    (nested / "agent.py").write_text(_DUPLICATE_ENTRYPOINT_AGENT, encoding="utf-8")
+    (nested / "shipgate.yaml").write_text(
+        _DUPLICATE_ENTRYPOINT_MANIFEST, encoding="utf-8"
+    )
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        ["scan", "--workspace", str(repo), "--out", str(tmp_path / "reports"), "--format", "json"],
+    )
+    assert result.exit_code == 3, result.output
+    envelope = json.loads(
+        next(line for line in result.output.splitlines() if line.startswith("{"))
+    )
+    action = envelope["next_actions"][0]
+    assert action["kind"] == "edit"
+    assert Path(action["path"]) == nested / "shipgate.yaml"
+    assert envelope["details"]["manifest_path"] == str(nested / "shipgate.yaml")
+
+
+def test_verify_without_a_config_flag_still_names_the_manifest_it_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`verify` defaults `--config`, so the raw flag is `None` at the handler."""
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "agent.py").write_text(_DUPLICATE_ENTRYPOINT_AGENT, encoding="utf-8")
+    (workspace / "shipgate.yaml").write_text(
+        _DUPLICATE_ENTRYPOINT_MANIFEST, encoding="utf-8"
+    )
+    _git_repo(workspace)
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        ["verify", "--workspace", str(workspace), "--ci-mode", "advisory", "--format", "json"],
+    )
+    assert result.exit_code == 3, result.output
+    envelope = json.loads(
+        next(line for line in result.output.splitlines() if line.startswith("{"))
+    )
+    action = envelope["next_actions"][0]
+    assert Path(action["path"]) == workspace / "shipgate.yaml"
+
+
+_OPENAI_TOOLS = (
+    '[{"type": "function", "function": {"name": "pay", "description": '
+    '"pay an invoice for a customer account", "parameters": {"type": "object", '
+    '"properties": {}}}}]\n'
+)
+
+_OPENAI_REPEATED_MANIFEST = """version: "0.1"
+project:
+  name: oai-dup
+agent:
+  name: billing-agent
+  declared_purpose:
+    - pay invoices
+environment:
+  target: local
+openai_api:
+  tools:
+    - tools.json
+    - tools.json
+"""
+
+
+def test_an_aggregating_loader_still_reports_a_repeated_manifest_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`read_index` identifies the adapter batch, not the artifact read.
+
+    The OpenAI and Anthropic loaders fold every configured artifact into one
+    `LoadedToolSource`, so listing one file twice collides *inside* one read
+    and was reported as a duplicate definition — sending the reader to edit a
+    perfectly valid JSON file (#329 review 2). The manifest settles it.
+    """
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "tools.json").write_text(_OPENAI_TOOLS, encoding="utf-8")
+    (workspace / "shipgate.yaml").write_text(
+        _OPENAI_REPEATED_MANIFEST, encoding="utf-8"
+    )
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "-c",
+            str(workspace / "shipgate.yaml"),
+            "--out",
+            str(tmp_path / "reports"),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 3, result.output
+    envelope = json.loads(
+        next(line for line in result.output.splitlines() if line.startswith("{"))
+    )
+    assert envelope["details"]["cause"] == "repeated_source_entry"
+    (action,) = envelope["next_actions"]
+    assert Path(action["path"]) == workspace / "shipgate.yaml"
+
+
+def test_an_archived_head_names_the_checkout_manifest_not_the_temporary_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`verify --base/--head` scans a temporary archive that it then deletes.
+
+    `run_scan` records the manifest it read, which there is a path inside that
+    archive — so the recovery named a file that no longer existed by the time
+    anyone read it (#329 review 2).
+    """
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "agent.py").write_text(_DUPLICATE_ENTRYPOINT_AGENT, encoding="utf-8")
+    (workspace / "shipgate.yaml").write_text(
+        _DUPLICATE_ENTRYPOINT_MANIFEST, encoding="utf-8"
+    )
+    _git_repo(workspace)
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(workspace),
+            "--config",
+            str(workspace / "shipgate.yaml"),
+            "--base",
+            "HEAD",
+            "--head",
+            "HEAD",
+            "--ci-mode",
+            "advisory",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 3, result.output
+    envelope = json.loads(
+        next(line for line in result.output.splitlines() if line.startswith("{"))
+    )
+    published = Path(envelope["next_actions"][0]["path"])
+    assert published == workspace / "shipgate.yaml"
+    assert published.is_file(), "the emitted recovery names a file that still exists"
+    assert Path(envelope["details"]["manifest_path"]).is_file()
+
+
+def test_verify_routes_the_same_failure_the_same_way(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`verify` is the command an adopter runs (#327), not `scan`.
+
+    The two caught this exception separately and wrote separate recoveries, so
+    the precise route existed on one command and not the other. One resolver,
+    asserted from both ends.
+    """
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "agent.py").write_text(_DUPLICATE_ENTRYPOINT_AGENT, encoding="utf-8")
+    (workspace / "shipgate.yaml").write_text(
+        _DUPLICATE_ENTRYPOINT_MANIFEST, encoding="utf-8"
+    )
+    # `verify` reads a committed worktree; without a checkout it stops at a
+    # config error long before the failure under test.
+    _git_repo(workspace)
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(workspace),
+            "--config",
+            str(workspace / "shipgate.yaml"),
+            "--ci-mode",
+            "advisory",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 3, result.output
+
+    envelope = json.loads(
+        next(line for line in result.output.splitlines() if line.startswith("{"))
+    )
+    assert envelope["error"] == "input_parse_error"
+    assert internal_vocabulary(envelope["message"]) == (), envelope["message"]
+    (action,) = envelope["next_actions"]
+    assert action["kind"] == "edit"
+    assert "map_salesforce_account_to_sap_bp" in action["why"]
+    assert internal_vocabulary(action["why"]) == (), action["why"]
+    assert envelope["details"]["failure"] == DUPLICATE_TOOL_IN_SOURCE

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,8 +233,47 @@ tool_sources:
     result = runner.invoke(app, ["scan", "--config", str(config)])
 
     assert result.exit_code == 3
-    assert "CHANGE_ME placeholders" in result.output
-    assert "next: Edit shipgate.yaml" in result.output
+    # Named from the parsed manifest, so the route says which field still
+    # holds the placeholder rather than that one exists somewhere.
+    assert "still declares CHANGE_ME at tool_sources[0].path" in result.output
+    # The manifest the run read, not the bare filename: `--workspace` can
+    # select a nested one, and a caller-relative `shipgate.yaml` is a
+    # different file (#329 review).
+    assert f"next: Edit {config}" in result.output
+
+
+def test_a_missing_file_named_change_me_is_not_a_placeholder_manifest(tmp_path):
+    """The placeholder route is a fact about the manifest, not about the text.
+
+    A manifest with every field filled in, pointing at a file that happens to
+    be named `CHANGE_ME-tools.json`, matched a substring search of the failure
+    and was told it still contained template placeholders (#329 review 3).
+    """
+
+    config = tmp_path / "shipgate.yaml"
+    config.write_text(
+        """version: "0.1"
+project:
+  name: real-project
+agent:
+  name: support-agent
+  declared_purpose:
+    - look things up
+environment:
+  target: local
+tool_sources:
+  - id: tools
+    type: mcp
+    path: CHANGE_ME-tools.json
+""",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["scan", "--config", str(config)])
+
+    assert result.exit_code == 3
+    assert "CHANGE_ME" not in result.output.replace("CHANGE_ME-tools.json", "")
+    assert "next: Review:" in result.output
 
 
 def test_cli_agent_mode_suppresses_prose_hint(tmp_path, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -448,3 +448,142 @@ def test_inventory_entry_still_rejects_an_unknown_key(tmp_path) -> None:
 
     with pytest.raises(ConfigError):
         load_manifest(manifest_path)
+
+
+
+def test_a_blank_tool_source_id_is_a_manifest_error_not_a_loader_defect(tmp_path):
+    """`tool_sources[].id` is a join key, so blank is rejected at load.
+
+    It used to validate, reach `core/tool_identity._observations`, and be
+    reported as a defect in Agents Shipgate that the repository could not
+    repair — while the schema that accepted it was the thing at fault
+    (#329 review). A padded id is worse than blank: it validated, then matched
+    none of the `source_id` selectors that are stripped where they are
+    declared, so an inventory silently completed nothing.
+    """
+
+    from agents_shipgate.schemas.manifest import ToolSourceConfig
+
+    assert ToolSourceConfig(id=" orders ", type="mcp", path="t.json").id == "orders"
+    with pytest.raises(ValueError, match="tool_sources\\[\\].id must name the source"):
+        ToolSourceConfig(id="   ", type="mcp", path="t.json")
+
+
+@pytest.mark.parametrize(
+    ("source_id", "accepted"),
+    [
+        pytest.param("orders", True, id="plain"),
+        pytest.param(" orders ", True, id="padded"),
+        pytest.param("", False, id="empty"),
+        pytest.param("   ", False, id="whitespace-only"),
+        pytest.param("\t\n", False, id="tab-and-newline"),
+    ],
+)
+def test_the_published_schema_and_the_runtime_agree_about_source_ids(
+    source_id, accepted
+):
+    """A `field_validator` is invisible to the generated JSON Schema.
+
+    `docs/manifest-v0.1.json` is part of the manifest contract, so a consumer
+    validating against it accepted ids the runtime refuses (#329 review 2).
+    The rule is now stated in both places; this is what keeps them equal.
+    """
+
+    import jsonschema
+
+    from agents_shipgate.schemas.manifest import ToolSourceConfig
+
+    published = json.loads(
+        (Path(__file__).resolve().parent.parent / "docs" / "manifest-v0.1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    defs = published.get("$defs") or published.get("definitions") or {}
+    schema = {**defs["ToolSourceConfig"], "$defs": defs}
+    document = {"id": source_id, "type": "mcp", "path": "t.json"}
+
+    schema_accepts = True
+    try:
+        jsonschema.validate(document, schema)
+    except jsonschema.ValidationError:
+        schema_accepts = False
+
+    runtime_accepts = True
+    try:
+        ToolSourceConfig.model_validate(document)
+    except ValueError:
+        runtime_accepts = False
+
+    assert schema_accepts is accepted, source_id
+    assert runtime_accepts is accepted, source_id
+
+
+#: Artifact lists a framework block declares that are read for something other
+#: than tools. Kept explicit so a new list must be classified rather than
+#: silently inheriting either answer.
+_NON_TOOL_ARTIFACT_LISTS = frozenset(
+    {
+        "agent_traces",
+        "approval_traces",
+        "credential_stubs",
+        "data_table_schemas",
+        "eval_sets",
+        "execution_samples",
+        "high_risk_exclusions",
+        "override_logs",
+        "policy_rules",
+        "promotion_criteria",
+        "response_formats",
+        "test_cases",
+        "trace_samples",
+        "variable_stubs",
+    }
+)
+
+
+def test_every_declared_artifact_list_is_classified():
+    """A new artifact list cannot arrive unclassified.
+
+    `repeated_declared_artifacts` counts a repeat only within a *tool-producing*
+    list, because a path repeated under `openai_api.test_cases` says nothing
+    about a duplicate tool (#329 review 3). That is only true while the
+    tool-producing set is complete, so this walks the manifest model and
+    requires every artifact list to be on one side or the other.
+    """
+
+    from pydantic import BaseModel
+
+    from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+    from agents_shipgate.schemas.manifest._artifacts import (
+        TOOL_PRODUCING_ARTIFACT_LISTS,
+        ArtifactPathConfig,
+    )
+
+    def artifact_lists(model: type[BaseModel], seen: set[type]) -> set[str]:
+        if model in seen:
+            return set()
+        seen.add(model)
+        found: set[str] = set()
+        for name, field in model.model_fields.items():
+            annotation = repr(field.annotation)
+            if "ArtifactPathConfig" in annotation or "InventoryConfig" in annotation:
+                if "list[" in annotation:
+                    found.add(name)
+            for candidate in getattr(field.annotation, "__args__", ()) or ():
+                inner = getattr(candidate, "__args__", (candidate,))
+                for nested in inner:
+                    if isinstance(nested, type) and issubclass(nested, BaseModel):
+                        if not issubclass(nested, ArtifactPathConfig):
+                            found |= artifact_lists(nested, seen)
+            if isinstance(field.annotation, type) and issubclass(
+                field.annotation, BaseModel
+            ):
+                found |= artifact_lists(field.annotation, seen)
+        return found
+
+    declared = artifact_lists(AgentsShipgateManifest, set())
+    unclassified = declared - TOOL_PRODUCING_ARTIFACT_LISTS - _NON_TOOL_ARTIFACT_LISTS
+    assert not unclassified, (
+        "artifact lists on the manifest model that are neither tool-producing "
+        f"nor explicitly excluded: {sorted(unclassified)}"
+    )

--- a/tests/test_evidence_gap_ranking.py
+++ b/tests/test_evidence_gap_ranking.py
@@ -1307,15 +1307,23 @@ def test_configured_but_empty_source_still_gets_the_agent_bindings_rule():
     assert "shipgate.yaml#agent_bindings.declarations" in warning
 
 
-def test_member_naming_a_live_source_without_that_tool_keeps_plain_arithmetic():
-    """A source that produced *other* tools is neither of the two cases."""
+def test_member_naming_a_live_source_without_that_tool_repairs_the_selector():
+    """A source that produced *other* tools is neither of the two cases.
+
+    Its repair is the selector itself, so the warning says so and names where
+    the selector lives — the arithmetic alone ("matched 0 observations") named
+    an internal noun and no surface (#329).
+    """
 
     (warning,) = _catalog_warnings(
         member_source="orders_b",
         configured=[("orders_a", ["process_order"]), ("orders_b", ["ship_order"])],
     )
 
-    assert "matched 0 observations" in warning
+    # Zero matches cannot be repaired by narrowing (#329 review 2).
+    assert "matched no tool in that source" in warning
+    assert "name a tool that source exposes" in warning
+    assert "shipgate.yaml#tool_identity.bindings[].members" in warning
     assert "produced no tool observations" not in warning
     assert "no tool source with id" not in warning
 

--- a/tests/test_google_adk.py
+++ b/tests/test_google_adk.py
@@ -5,6 +5,10 @@ import yaml
 
 from agents_shipgate.checks.adk import _has_long_running_contract
 from agents_shipgate.cli.scan import inspect_sources, run_scan
+from agents_shipgate.core.adopter_text import (
+    DUPLICATE_TOOL_IN_SOURCE,
+    internal_vocabulary,
+)
 from agents_shipgate.core.artifact_models import GoogleAdkArtifacts
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.inputs.google_adk import (
@@ -445,7 +449,18 @@ google_adk:
             ci_mode="advisory",
         )
 
-    assert "Duplicate tool observation identity" in str(excinfo.value)
+    # Still fails closed — and now says so in the adopter's terms (#329): the
+    # tool, the file it came from, and the two places a duplicate can be
+    # declared. The identity triple that detected it stays in `details`.
+    message = str(excinfo.value)
+    assert "map_salesforce_account_to_sap_bp" in message
+    assert "agent.py" in message
+    assert "shipgate.yaml" in message
+    assert not internal_vocabulary(message), message
+    assert excinfo.value.details["failure"] == DUPLICATE_TOOL_IN_SOURCE
+    assert excinfo.value.details["native_locator"] == (
+        "agent.py#map_salesforce_account_to_sap_bp"
+    )
 
 
 def test_google_adk_agent_config_dynamic_toolset_findings(tmp_path):

--- a/tests/test_surface_exclusions.py
+++ b/tests/test_surface_exclusions.py
@@ -42,6 +42,10 @@ from agents_shipgate.schemas.exclusions import (
 #: id this fixture used before did not exercise the real thing.
 TOOL_ID = "tool_v2_f8e7804c48c4ce36de4c20c96f8143721961b2d79a0522532b269fdd6cb527bb"
 
+#: The agent equivalent — ``core.agent_bindings`` builds every agent id as
+#: ``agent_v1:`` plus the first 24 hex of a sha256.
+AGENT_ID = "agent_v1:7205d836e4b3fee257d90695"
+
 _MANIFEST = """
 version: "0.1"
 project: {{name: mcp-server}}
@@ -1175,7 +1179,38 @@ def test_a_raw_id_is_refused_for_a_gap_kind_the_ledger_never_joins():
         )
     )
 
-    with pytest.raises(SemanticConsistencyError, match="canonical id"):
+    with pytest.raises(SemanticConsistencyError, match="a tool .* with a derived id"):
+        _validate_exclusion_ledger(report)
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        pytest.param(AGENT_ID, id="bare"),
+        pytest.param(f"closer_agent [{AGENT_ID}]", id="wrapped-in-a-label"),
+        pytest.param("agent_v1:" + "a" * 24, id="not-in-this-graph"),
+    ],
+)
+def test_an_agent_id_is_refused_the_same_way_a_tool_id_is(subject):
+    """The other negative control: one shape is not the property (#329).
+
+    Scoping the rule to ``tool_v…`` left the identical defect standing one
+    subject kind over. A binding issue that names no tool falls back to the
+    agent, and ``samples/conductor_agent`` shipped
+    ``(agent_v1:7205d836…)`` in ``subject`` and in the decision ``reason``
+    printed under it — the exact reader-facing failure this invariant exists
+    to prevent, on a bundled sample, while the whole suite stayed green.
+    """
+
+    report = _report_with_one_possible_tool()
+    gaps = report.release_decision.evidence_coverage.evidence_gaps
+    gaps.append(
+        gaps[0].model_copy(
+            update={"kind": "missing_binding_evidence", "subject": subject}
+        )
+    )
+
+    with pytest.raises(SemanticConsistencyError, match="an agent .* with a derived id"):
         _validate_exclusion_ledger(report)
 
 
@@ -1206,5 +1241,5 @@ def test_a_canonical_id_is_refused_wherever_it_sits_in_the_label(subject):
         )
     )
 
-    with pytest.raises(SemanticConsistencyError, match="canonical id"):
+    with pytest.raises(SemanticConsistencyError, match="a tool .* with a derived id"):
         _validate_exclusion_ledger(report)

--- a/tests/test_tool_identity.py
+++ b/tests/test_tool_identity.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import pytest
 
 from agents_shipgate.cli.scan import run_scan
+from agents_shipgate.core.adopter_text import (
+    DUPLICATE_TOOL_IN_SOURCE,
+    internal_vocabulary,
+)
 from agents_shipgate.core.baseline import apply_baseline
 from agents_shipgate.core.domain import AuthInfo, LoadedToolSource, Tool
 from agents_shipgate.core.errors import InputParseError
@@ -123,6 +127,55 @@ def test_bare_name_selector_applies_nowhere_and_prevents_pass() -> None:
     )
 
 
+def test_a_tool_in_two_bindings_is_named_by_tool_and_file() -> None:
+    """One observation, two bindings: neither binding can be applied.
+
+    The warning used to open ``Tool observation obs_v1_<64 hex> appears in
+    multiple bindings`` — an identifier that is in no file the reader has,
+    naming a tool they could have opened instead (#329).
+    """
+
+    config = ToolIdentityConfig(
+        bindings=[
+            ToolIdentityBindingConfig(
+                id="orders_process",
+                provider="orders_runtime",
+                reason="same underlying order write",
+                primary={"source_id": "orders_a", "tool": "process_order"},
+                members=[
+                    {"source_id": "orders_a", "tool": "process_order"},
+                    {"source_id": "orders_b", "tool": "process_order"},
+                ],
+            ),
+            ToolIdentityBindingConfig(
+                id="orders_legacy",
+                provider="orders_legacy",
+                reason="the same observation, claimed twice",
+                primary={"source_id": "orders_a", "tool": "process_order"},
+                members=[
+                    {"source_id": "orders_a", "tool": "process_order"},
+                    {"source_id": "orders_c", "tool": "process_order"},
+                ],
+            ),
+        ]
+    )
+    _tools, warnings = build_tool_identity_catalog(
+        [
+            _source("orders_a", scope="orders:read", effect="read"),
+            _source("orders_b", scope="orders:read", effect="read"),
+            _source("orders_c", scope="orders:read", effect="read"),
+        ],
+        config,
+    )
+
+    overlap = [w for w in warnings if "claimed by more than one" in w]
+    assert len(overlap) == 1, warnings
+    assert "process_order" in overlap[0]
+    assert "'orders_legacy', 'orders_process'" in overlap[0]
+    assert "shipgate.yaml" in overlap[0] or "tool_identity.bindings" in overlap[0]
+    assert not internal_vocabulary(overlap[0]), overlap[0]
+
+
 def test_qualified_selector_resolves_exactly_one_provider() -> None:
     tools, _ = build_tool_identity_catalog(
         [
@@ -175,9 +228,49 @@ def test_duplicate_observation_tuple_is_rejected() -> None:
     try:
         build_tool_identity_catalog([duplicate], ToolIdentityConfig())
     except InputParseError as exc:
-        assert "Duplicate tool observation identity" in str(exc)
+        # The rejection is unchanged; what it says is not (#329). One read of
+        # one source produced the tool twice, so the repair is in the artifact
+        # rather than the manifest — and this fixture records no path, so the
+        # label falls back to the `tool_sources[].id` the adopter wrote.
+        assert "process_order" in str(exc)
+        assert "'orders'" in str(exc)
+        assert not internal_vocabulary(str(exc)), str(exc)
+        assert exc.details["failure"] == DUPLICATE_TOOL_IN_SOURCE
+        assert exc.details["cause"] == "duplicate_in_source_artifact"
+        assert exc.details["source_id"] == "orders"
     else:  # pragma: no cover - explicit safety assertion
         raise AssertionError("duplicate observation tuple was accepted")
+
+
+def test_only_a_field_that_names_a_file_can_name_a_file() -> None:
+    """An edit action must name a file, and most provenance fields do not.
+
+    `source_path` is the structured one. `source_ref` is accepted only when it
+    carries no `#`, because several adapters write a *locator* there
+    (`spec.yaml#/paths/~1orders/get`, `file#index`) and a filename may legally
+    contain one. `source_location` and `source_pointer` are separate optional
+    fields a third-party adapter may set without a path at all, and
+    `agent.py:12` and `/tools/0` both reached an edit action as if they were
+    files (#329 review 3).
+    """
+
+    from agents_shipgate.core.tool_identity import _source_file
+
+    def tool(**fields) -> Tool:
+        return Tool(id="t", name="x", source_type="mcp", source_id="s", **fields)
+
+    assert (
+        _source_file(tool(source_path="services/tools.json", source_ref="other#0"))
+        == "services/tools.json"
+    )
+    assert _source_file(tool(source_ref="agent.py")) == "agent.py"
+    assert (
+        _source_file(tool(source_ref="specs/orders.yaml#/paths/~1orders/post")) is None
+    )
+    assert _source_file(tool(source_ref="tools#prod.json")) is None
+    assert _source_file(tool(source_location="agent.py:12")) is None
+    assert _source_file(tool(source_pointer="/tools/0")) is None
+    assert _source_file(tool()) is None
 
 
 def test_fingerprint_v2_and_legacy_baseline_do_not_cross_providers() -> None:


### PR DESCRIPTION
Closes #329. Invariant 5 of #327.

## The reported defect

Running the tool on your own repository for the first time could produce:

```text
Duplicate tool observation identity: source_type='google_adk_function', source_id='google_adk:agent.py', native_locator='agent.py#map_salesforce_account_to_sap_bp'
```

Three internal concepts, none of them in the manifest that person wrote, two of them derived — and the one recoverable fact, that a file was listed twice under `google_adk.python_entrypoints`, is the one thing the message does not say. It now reads:

```text
Tool 'map_salesforce_account_to_sap_bp' was read twice from 'agent.py' as one tool source. Check shipgate.yaml for an entry naming 'agent.py' more than once, and check 'agent.py' itself for two tools called 'map_salesforce_account_to_sap_bp'; remove the duplicate, then re-run the scan.
```

…and the next action is an `edit` on the manifest rather than "inspect the file referenced in the error". The identity triple moves to a new `details` object on the agent-mode envelope, where a machine consumer or a bug report can still read it. #321 fixed the collision behind this failure; the message shape was a separate problem and nothing tracked it.

## The rule

Internal identity vocabulary may appear as evidence in machine-read artifacts. It may not appear in anything whose purpose is to tell a person what to do next. `report.json` evidence blocks, `tool_catalog`, `identity_assessment`, and the verification artifacts are untouched — they are the identity model and are supposed to be precise.

Two categories, because the terms are not equally unlocatable ([`core/adopter_text.py`](src/agents_shipgate/core/adopter_text.py)):

- **Refused outright** — `native_locator`, observation ids, and derived `obs_v…` / `tool_v…` / `agent_v…` / `fp_…` shapes, matched by shape rather than by the field name that carries them. There is no manifest key, no field, no file to send the reader to.
- **Refused unless anchored** — `source_id`, `source_type`, `fingerprint`. These really are keys the adopter owns (`tool_identity.bindings[].members[]` takes the first two, `tool_inventories[].source_id` and `agent_bindings.root.source_id` the first, `findings[].fingerprint` the third). Spelled with the surface they belong to they are locatable; spelled bare they are the model leaking.

Checked on *rendered* messages, not fragments: a list of selector keys is fine next to `at shipgate.yaml#tool_identity.bindings` and meaningless on its own.

## Two defects the audit found beyond the reported one

**A digest was the subject of a shipped verdict.** A binding gap whose issue names no tool falls back to the agent, and the fallback was the derived agent id — so `samples/conductor_agent` shipped `Insufficient evidence: the agent's tool binding graph is incomplete (agent_v1:7205d836…)` as the sentence under its verdict, printed again in `agent_summary.first_recommended_action.why`, the CLI `Improve evidence:` line, and the GitHub step summary. It now reads `(durable_order_agent [conductor_workflows])`. The report's conservation invariant — which already refused a raw *tool* id in a gap subject — now refuses **any** derived id: a guard scoped to one kind of identifier passes vacuously for every other one, which is exactly how this survived #404 and #408.

**`scan` and `verify` disagreed about the same failure.** Each caught `InputParseError` and wrote its own recovery, so the precise route existed on one command and not the other — the second-implementation bug class from #322. One resolver (`cli/diagnostics.input_parse_recovery`) now serves `scan`, `verify`, and the verifier assembly path, routing on the typed `details.failure` key rather than on message text, so the sentence a human reads stays free to change without breaking the machine route.

## The guard test

[`tests/test_adopter_vocabulary.py`](tests/test_adopter_vocabulary.py) enumerates the adopter-facing strings four ways, because no single enumeration reaches all of them:

1. **Every `EvidenceGap` kind** the report schema declares (30 of them), pushed through the real renderers — `evidence_gap_headline`, `evidence_gap_action_text`, and `fix_task.instructions[]`. A new gap kind without adopter-facing wording fails here.
2. **Every published message builder** in `core.source_warnings`, plus the grouped display projection and the declaration scaffold, called and checked as the reader sees them. The sweep table is checked against the module's own `__all__`, so a new builder cannot arrive unswept.
3. **Every hand-written string at an emit site** in the 18 modules that produce console output, next actions, handoff prose, and PR comment text — including the branches of the big diagnostic resolvers that no fixture reaches all of. Extracted by AST, with one level of local-name substitution so a sentence assembled from a variable is judged as the sentence; two probe tests pin the extractor in both directions, because a sweep is only as good as what it can see.
4. **The shipped sample artifacts** — the adopter-facing strings in every bundled `report.json` and `report.md`, with a non-empty assertion so an unmatched glob cannot make the sweep vacuous.

Plus three end-to-end runs: #321's failure walked through `scan` and again through `verify`, and one real `insufficient_evidence` verdict whose `agent-handoff.json`, `verifier.json`, and PR comment are swept as written. And negative controls over the exact strings that shipped, so the rule cannot pass by doing nothing.

## Other messages changed

| Where | Change |
|---|---|
| source warning, one tool in several bindings | `Tool observation obs_v1_3f9a1c…` → names the tool and the file |
| source warning, binding member resolving to the wrong count | `matched 0 observations` → `matched 0 tools in that source, not one — narrow it at shipgate.yaml#tool_identity.bindings[].members` |
| `SHIP-DIAG-UNKNOWN-ADAPTER-SOURCE-TYPE` | `Unknown adapter source_type 'acme'` → `No adapter handles tool_sources[].type 'acme' in shipgate.yaml` |
| `incomplete_tool_identity` `accepted_values` | `stable_native_locator` → `stable_source_path` |
| two loader-invariant `InputParseError`s | now say the defect is ours, and prescribe no user edit |
| `explain-finding` unknown fingerprint | now names `findings[].fingerprint` in the report it read |

## Compatibility

No version moves — `contract_version`, `report_schema_version`, `minimum_control_contract_version`, and every published schema document are unchanged. No field removed or retyped, no error kind added, no exit code moved. One additive envelope field (`details`, documented in `docs/errors.json`), one gap `subject` value change in two samples, and prose. Migration note in [`STABILITY.md`](STABILITY.md); the rule is written up for contributors in [`CONTRIBUTING.md`](CONTRIBUTING.md).

## Verification

- `ruff check .` clean; `compileall` clean; `generate_schemas.py --check` clean.
- Full suite green (`pytest -n auto`), including `test_adapter_static_only.py`.
- Sample goldens regenerated for `conductor_agent` (report.json + report.md) and `support_refund_agent` (report.json + packet.json); the diff is the subject value and nothing else.

## Deliberately out of scope

Report internals stay precise, per the issue's non-goals. Two adopter-visible spots are documented carve-outs rather than fixes: `explain-finding --help`, whose *argument* is a fingerprint and which says which field to copy it from, and the `tool_id` a declaration template pre-fills for the reader to paste — removing that would put back the same-name ambiguity #388 closed. Both are recorded in `core/adopter_text.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
