### PR TITLE
fix(action-surface): one permission list per action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+- **One action, one permission list, with no reviewed authority either.** A
+  manifest row that listed `scopes:` and declared no `authority:` block at
+  either site turned `verify --base` into `Internal error` (exit 4) on a legal
+  manifest. The action's permissions were spelled twice and the two spellings
+  disagreed: the action lens took the row's list when it had one and the
+  source's auth scopes otherwise, while the authority dimension took the row's
+  list only where a reviewed record existed. `CapabilityFactV1` requires the
+  two to project one list, so where they disagreed, rebuilding a capability
+  fact from a serialized `ActionFact` raised — and that rebuild happens on
+  exactly one route, the MCP capability comparison against a base scan. A
+  plain `scan` never reaches it, which is why no sample and no scan-level test
+  saw this.
+
+  Declaring authority once per source closed the reviewed half of that by
+  normalizing both sites into one record. This closes the rest: one resolver
+  (`core.semantic_assessment.resolve_action_scopes`) decides an action's
+  permission list, read by the action lens and the authority dimension alike,
+  rather than teaching the capability builder to paper over a disagreement it
+  would then have to keep tolerating. Because the shared rule is the one the
+  lens already applied, no shape that resolves today resolves differently —
+  every list that moves belongs to a shape that was exit 4. A sweep over
+  source authority × declaration row now pins it, and the parity assertion
+  added with the source-level block covers the bare-`scopes` shape it had to
+  leave out.
+
+  *And a row cannot quietly shrink a grant.* Publishing the row's list on the
+  authority dimension is also what would let `scopes: [crm.read]` erase a
+  `crm.write` grant the source proves, with a `structural` status and nothing
+  raised. The subset rule a reviewed authority is held to now reads the
+  *resolved* list, so a bare `scopes:` list is held to it too and reports
+  `conflicting_authority_evidence` against `actions[].scopes`. Adding the
+  dropped scope back closes it. Broadening is still a broadening, visible to
+  the broad-scope policies as before.
+
+  Two consequences for a manifest that used the broken shape, and only for
+  those. `SHIP-AUTH-SCOPE-COVERAGE-MISSING` now sees the declared list, so a
+  row declaring `scopes: [crm.read]` against a manifest whose
+  `permissions.scopes` does not cover it raises the review item it always
+  should have — the divergence, not the check, was what kept it quiet. And
+  `authority_hash` moves with the scopes, in a capability lock, an
+  `action_surface.actions` row, or both.
+
 - **Authority follows credentials, not functions: declare it once per source.**
   Every action a tool source contributes normally runs with the same
   credential, and asking for it once per action asks the same infrastructure

--- a/docs/manifest-v0.1.json
+++ b/docs/manifest-v0.1.json
@@ -33,7 +33,7 @@
     },
     "ActionAuthorityConfig": {
       "additionalProperties": false,
-      "description": "Reviewed authority evidence for one declared action.\n\nScopes intentionally remain on ``ActionDeclarationConfig.scopes`` so\nthere is one canonical permission list in the manifest.",
+      "description": "Reviewed authority evidence for one declared action.\n\nScopes intentionally remain on ``ActionDeclarationConfig.scopes`` so\nthere is one canonical permission list in the manifest. This block is\noptional, so that list is the action's permissions with or without it;\none resolver reads it for every surface\n(``core.semantic_assessment.resolve_action_scopes``).",
       "properties": {
         "auth_type": {
           "anyOf": [

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -617,6 +617,16 @@ Authority modes are:
 authority produces `insufficient_evidence`. Global `permissions.scopes` proves
 manifest coverage only; it does not fill missing per-action authority.
 
+`actions[].scopes` is the action's permission list with or without a reviewed
+authority: a row that lists scopes and declares no `authority` at either site
+still publishes them as the action's `required_scopes` *and* as its authority
+scopes. Listing scopes is not the same as reviewing authority — such a row
+still reports `missing_authority_evidence` and cannot be pass-eligible. A
+declared list replaces the source's own scopes, so it may broaden them;
+dropping a scope a `scoped` source proves is a conflict
+(`conflicting_authority_evidence`), on this route exactly as on a reviewed
+block's.
+
 ### Authority declared once per source
 
 Authority is a fact about a deployment, not about a function: every action a

--- a/src/agents_shipgate/core/action_semantics.py
+++ b/src/agents_shipgate/core/action_semantics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from agents_shipgate.schemas.surfaces import ActionEffect
 
 ACTION_EFFECT_RANK: dict[ActionEffect, int] = {
@@ -43,6 +45,17 @@ BUILTIN_EFFECT_OBLIGATIONS: dict[ActionEffect, frozenset[str]] = {
 }
 
 
+def normalize_declared_strings(values: Iterable[str]) -> list[str]:
+    """Declared token lists as every surface compares them: stripped, deduped, sorted.
+
+    One rule for the two lists an ``action_surface.actions`` row can carry —
+    ``scopes`` and ``risk_tags`` — because comparing them is what decides
+    whether a declaration matches, broadens, or narrows.
+    """
+
+    return sorted({str(value).strip() for value in values if str(value).strip()})
+
+
 def builtin_obligations(effect: ActionEffect) -> frozenset[str]:
     """The built-in controls ``effect`` obliges — empty for effects with none."""
 
@@ -53,4 +66,5 @@ __all__ = [
     "ACTION_EFFECT_RANK",
     "BUILTIN_EFFECT_OBLIGATIONS",
     "builtin_obligations",
+    "normalize_declared_strings",
 ]

--- a/src/agents_shipgate/core/lenses/action_surface.py
+++ b/src/agents_shipgate/core/lenses/action_surface.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import unquote
 
-from agents_shipgate.core.action_semantics import ACTION_EFFECT_RANK
+from agents_shipgate.core.action_semantics import (
+    ACTION_EFFECT_RANK,
+    normalize_declared_strings,
+)
 from agents_shipgate.core.domain import (
     DECLARATION_CLAIM_SOURCES,
     Action,
@@ -2200,12 +2203,10 @@ def _annotation_bool(annotations: dict[str, Any], *keys: str) -> bool | None:
     return None
 
 
-def _normalize_strings(values: list[str]) -> list[str]:
-    return sorted({str(value).strip() for value in values if str(value).strip()})
-
-
 def _normalize_risk_tag_values(values: list[str]) -> list[str]:
-    return sorted({_RISK_TAG_MAP.get(value, value) for value in _normalize_strings(values)})
+    return sorted(
+        {_RISK_TAG_MAP.get(value, value) for value in normalize_declared_strings(values)}
+    )
 
 
 def _normalize_token(value: str) -> str:

--- a/src/agents_shipgate/core/lenses/action_surface.py
+++ b/src/agents_shipgate/core/lenses/action_surface.py
@@ -32,7 +32,7 @@ from agents_shipgate.core.semantic_assessment import (
     acknowledged_effect_claim_ids,
     assess_tool_semantics,
     declaration_covers,
-    reviewed_authority,
+    resolve_action_scopes,
 )
 from agents_shipgate.core.surface_exclusions import (
     catalog_label_index,
@@ -511,32 +511,6 @@ def _tool_source_for(
     )
 
 
-def _declared_scope_strings(
-    tool: Tool,
-    declaration: ActionDeclarationConfig | None,
-    source: ToolSourceConfig | None,
-) -> list[str]:
-    """The permission list this action is judged on, from the one resolver.
-
-    Not a second derivation: ``CapabilityFactV1`` *requires*
-    ``authority.scopes`` to equal the semantic authority's, and one of its two
-    builders reconstructs the fact from this list — so deciding it separately
-    here does not merely risk two answers, it raises a validation error on the
-    base-vs-head path the moment the two disagree. That is exactly what a draft
-    that kept a source's grant off the action did.
-
-    With no reviewed authority at either site the behaviour is unchanged: a
-    declared ``scopes`` list, else what the source published for this tool.
-    """
-
-    reviewed = reviewed_authority(tool, declaration, source)
-    if reviewed is not None:
-        return list(reviewed.scopes)
-    if declaration is not None and declaration.scopes:
-        return list(declaration.scopes)
-    return list(tool.auth.scopes)
-
-
 def build_action(
     manifest: AgentsShipgateManifest,
     *,
@@ -577,9 +551,11 @@ def build_action(
         _normalize_risk_tag_values(declaration.risk_tags) if declaration is not None else []
     )
     risk_tag_values = sorted(set(inferred_tags) | set(declared_tags))
-    # In the resolver's own precedence, because the capability standard binds
-    # this list to the semantic authority's (#410 increment 3).
-    scope_strings = _normalize_strings(_declared_scope_strings(tool, declaration, source))
+    # From the resolver itself, not a second derivation in its precedence,
+    # because the capability standard binds this list to the semantic
+    # authority's (#410 increment 3) — including the no-reviewed-record case,
+    # where a bare ``scopes:`` list used to reach only this side.
+    scope_strings = resolve_action_scopes(tool, declaration, source)
     effect = semantic_assessment.conservative_effect
     semantic_effects = {
         claim.value

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -1412,6 +1412,50 @@ def _answerable_source_id(
     return tool_source.id if tool_source is not None else None
 
 
+def resolve_action_scopes(
+    tool: Tool,
+    declaration: ActionDeclarationConfig | None,
+    tool_source: ToolSourceConfig | None = None,
+    reviewed: ReviewedAuthority | None = None,
+) -> list[str]:
+    """The one permission list this action publishes, normalized and sorted.
+
+    A reviewed authority supplies the whole record including its scopes
+    (:func:`reviewed_authority`). With none at either site the row's own
+    ``scopes:`` list stands where it lists anything, and the source's
+    published scopes otherwise. Note what that last rule is *not*: a declared
+    list replaces the source's, so this is where a row can drop a scope the
+    source proves — ``_scopes_narrow_source`` guards it, and only the
+    authority resolver can, because only it holds the source's evidence grade.
+    Listing scopes does not grade the authority either: a row with no reviewed
+    block still reports ``missing_authority_evidence``.
+
+    Every surface that publishes an action's permissions reads this function:
+    ``ActionFact.required_scopes`` (via ``build_action``) and this dimension's
+    ``scopes`` (via ``_assess_authority``), and through both,
+    ``CapabilityFactV1.authority.scopes`` — which *requires* the two to be one
+    list. A second spelling of the rule is therefore not a style question: two
+    spellings put two permission lists on one action, and ``verify --base`` —
+    the only path that rebuilds a capability fact from a serialized
+    ``ActionFact`` — raises ``internal_error`` on a legal manifest. The
+    reviewed half of that was closed with the normalized record; the bare
+    ``scopes:`` half is closed by this being the only derivation.
+    """
+
+    if reviewed is None:
+        reviewed = reviewed_authority(tool, declaration, tool_source)
+    if reviewed is not None:
+        return normalize_scopes(reviewed.scopes)
+    declared = normalize_scopes(declaration.scopes if declaration is not None else [])
+    return declared or normalize_scopes(tool.auth.scopes)
+
+
+def normalize_scopes(values: Iterable[str]) -> list[str]:
+    """Scope strings as every surface compares them: stripped, deduped, sorted."""
+
+    return sorted({str(value).strip() for value in values if str(value).strip()})
+
+
 def _assess_authority(
     tool: Tool,
     declaration: ActionDeclarationConfig | None,
@@ -1547,14 +1591,39 @@ def _assess_authority(
             if reviewed.credential_mode or reviewed.mode == "none"
             else tool.auth.credential_mode
         )
-        scopes = reviewed.scopes
     else:
         status = source_status
         mode = source_mode
         auth_type = tool.auth.type
         credential_mode = tool.auth.credential_mode
-        scopes = sorted(set(tool.auth.scopes))
-        if status == "partial":
+        # A bare ``scopes:`` list is not a reviewed authority — it names no
+        # mode, no auth type, no credential mode — but it *is* the permission
+        # list this action publishes (``resolve_action_scopes``), so this
+        # dimension publishes it too. What it must never do is silently shrink
+        # authority the source proves: with no reviewed record there is no
+        # ``_authority_declaration_conflicts`` call on this route, and nothing
+        # else compares the two lists.
+        if (
+            status == "structural"
+            and declaration is not None
+            and _scopes_narrow_source(
+                tool,
+                resolve_action_scopes(tool, declaration),
+                source_mode=source_mode,
+            )
+        ):
+            status = "conflicting"
+            mode = "unknown"
+            issues.append(
+                _issue(
+                    "conflicting_authority_evidence",
+                    "authority",
+                    "declared scopes drop scopes the source proves this action requires",
+                    DECLARED_EFFECT_SOURCE,
+                    f"action_surface.actions[tool={tool.name!r}].scopes",
+                )
+            )
+        elif status == "partial":
             issues.append(
                 _issue(
                     "partial_authority_evidence",
@@ -1580,7 +1649,7 @@ def _assess_authority(
         mode=mode,
         auth_type=auth_type,
         credential_mode=credential_mode,
-        scopes=scopes,
+        scopes=resolve_action_scopes(tool, declaration, tool_source, reviewed),
         claims=_sorted_claims(claims),
         issues=_sorted_issues(issues),
         answerable_source_id=_answerable_source_id(declaration, tool_source),
@@ -1687,13 +1756,31 @@ def _authority_declaration_conflicts(
     ):
         return True
 
-    if source_mode == "scoped":
-        source_scopes = set(tool.auth.scopes)
-        declared_scopes = set(reviewed.scopes)
-        if not source_scopes.issubset(declared_scopes):
-            return True
+    return _scopes_narrow_source(tool, reviewed.scopes, source_mode=source_mode)
 
-    return False
+
+def _scopes_narrow_source(
+    tool: Tool,
+    resolved_scopes: Iterable[str],
+    *,
+    source_mode: AuthorityMode,
+) -> bool:
+    """Does the list this action resolved to drop a scope the source proves?
+
+    Only meaningful against a source whose own authority is concrete: a
+    ``scoped`` source names the grant this action runs under, and a list that
+    is narrower has replaced that grant with a weaker claim. A superset is an
+    explicit broadening and stays visible to the broad-scope policies.
+
+    Both routes ask this question of the *resolved* list, because both replace
+    the same one: a reviewed authority at either manifest site, and a bare
+    ``scopes:`` list with no reviewed record at all.
+    """
+
+    if source_mode != "scoped":
+        return False
+    source_scopes = set(normalize_scopes(tool.auth.scopes))
+    return not source_scopes.issubset(set(normalize_scopes(resolved_scopes)))
 
 
 def _claim(

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -5,7 +5,11 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, cast, get_args
 
-from agents_shipgate.core.action_semantics import ACTION_EFFECT_RANK, builtin_obligations
+from agents_shipgate.core.action_semantics import (
+    ACTION_EFFECT_RANK,
+    builtin_obligations,
+    normalize_declared_strings,
+)
 from agents_shipgate.core.domain import (
     DECLARATION_CLAIM_SOURCES,
     DECLARATION_OVERRIDE_SOURCE,
@@ -1445,15 +1449,9 @@ def resolve_action_scopes(
     if reviewed is None:
         reviewed = reviewed_authority(tool, declaration, tool_source)
     if reviewed is not None:
-        return normalize_scopes(reviewed.scopes)
-    declared = normalize_scopes(declaration.scopes if declaration is not None else [])
-    return declared or normalize_scopes(tool.auth.scopes)
-
-
-def normalize_scopes(values: Iterable[str]) -> list[str]:
-    """Scope strings as every surface compares them: stripped, deduped, sorted."""
-
-    return sorted({str(value).strip() for value in values if str(value).strip()})
+        return normalize_declared_strings(reviewed.scopes)
+    declared = normalize_declared_strings(declaration.scopes if declaration is not None else [])
+    return declared or normalize_declared_strings(tool.auth.scopes)
 
 
 def _assess_authority(
@@ -1779,8 +1777,8 @@ def _scopes_narrow_source(
 
     if source_mode != "scoped":
         return False
-    source_scopes = set(normalize_scopes(tool.auth.scopes))
-    return not source_scopes.issubset(set(normalize_scopes(resolved_scopes)))
+    source_scopes = set(normalize_declared_strings(tool.auth.scopes))
+    return not source_scopes.issubset(set(normalize_declared_strings(resolved_scopes)))
 
 
 def _claim(

--- a/src/agents_shipgate/schemas/manifest/action_surface.py
+++ b/src/agents_shipgate/schemas/manifest/action_surface.py
@@ -144,7 +144,10 @@ class ActionAuthorityConfig(BaseModel):
     """Reviewed authority evidence for one declared action.
 
     Scopes intentionally remain on ``ActionDeclarationConfig.scopes`` so
-    there is one canonical permission list in the manifest.
+    there is one canonical permission list in the manifest. This block is
+    optional, so that list is the action's permissions with or without it;
+    one resolver reads it for every surface
+    (``core.semantic_assessment.resolve_action_scopes``).
     """
 
     model_config = STRICT_MODEL_CONFIG

--- a/tests/test_action_scope_projection.py
+++ b/tests/test_action_scope_projection.py
@@ -1,0 +1,345 @@
+"""One action, one permission list — and the route that proves it.
+
+An action's permissions were spelled twice. The action lens took the row's
+``scopes:`` list when it had one and the source's auth scopes otherwise;
+``_assess_authority`` took the row's list only where a *reviewed* authority
+record existed. The two rules agree only by luck, and
+``CapabilityFactV1._semantic_projection_is_consistent`` *requires* them to
+agree — so on the shapes where they disagreed, rebuilding a capability fact
+from a serialized ``ActionFact`` raised, and a legal manifest turned
+``verify --base`` into ``internal_error`` (exit 4).
+
+Declaring authority once per source (#410 increment 3) closed the reviewed
+half by normalizing both manifest sites into one record. What was left is
+every row that declares scopes with no reviewed authority at either site: ten
+of the twenty-eight shapes swept below raised until one resolver
+(``resolve_action_scopes``) decided both.
+
+Two things keep the whole class closed:
+
+* the sweep below, which walks every combination of source authority and
+  declaration row and asserts the two spellings resolve to one list — so
+  neither half can reopen without a failing test.
+* one real ``verify --base`` run. The invariant is enforced on exactly one
+  route: ``checks/mcp_permissions.py`` reaches
+  ``capability_fact_from_action_fact`` only when a base diff reference is
+  available. A plain ``scan`` never touches it, so no sample golden and no
+  scan-level test can see this class — it surfaces the first time someone
+  compares against a base.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.capabilities import capability_fact_from_action_fact
+from agents_shipgate.core.domain import AuthInfo, Tool, ToolParameter
+from agents_shipgate.core.lenses.action_surface import action_to_fact, build_action
+from agents_shipgate.core.semantic_assessment import assess_tool_semantics
+from agents_shipgate.schemas.manifest import (
+    ActionDeclarationConfig,
+    AgentsShipgateManifest,
+)
+
+runner = CliRunner()
+
+
+# --- the sweep -------------------------------------------------------------
+
+
+#: Source authority the tool publishes, by name.
+_SOURCES: dict[str, dict | None] = {
+    "no source auth": None,
+    "source scoped [crm.read]": {"type": "oauth2", "scopes": ["crm.read"]},
+    "source scoped [crm.read, crm.write]": {
+        "type": "oauth2",
+        "scopes": ["crm.read", "crm.write"],
+    },
+    "source auth without scopes": {"type": "oauth2", "scopes": []},
+}
+
+#: ``action_surface.actions[]`` rows, minus the ``tool`` selector. The manifest
+#: validator constrains which of these co-occur (``scoped`` requires non-empty
+#: ``scopes``; ``none``/``unscoped``/``ambient`` require empty ones), so the
+#: rows here are the ones an adopter can actually write.
+_ROWS: dict[str, dict] = {
+    "no declaration": {},
+    "bare scopes, same as source": {"scopes": ["crm.read"]},
+    "bare scopes, drops one": {"scopes": ["crm.read"]},
+    "bare scopes, adds one": {"scopes": ["crm.read", "crm.admin"]},
+    "reviewed scoped authority": {
+        "scopes": ["crm.read"],
+        "authority": {"mode": "scoped", "auth_type": "oauth2"},
+    },
+    "reviewed anonymous authority": {"authority": {"mode": "none"}},
+    "reviewed unscoped authority": {
+        "authority": {
+            "mode": "unscoped",
+            "auth_type": "oauth2",
+            "reason": "reviewed as unscoped",
+        }
+    },
+}
+
+
+def _tool(auth: dict | None) -> Tool:
+    return Tool(
+        id="t_read_thing",
+        name="read_thing",
+        description="Read a CRM record.",
+        source_type="mcp",
+        source_id="crm",
+        annotations={"readOnlyHint": True},
+        auth=AuthInfo(**auth) if auth else AuthInfo(),
+        parameters=[ToolParameter(name="id", required=True)],
+        extraction_confidence="high",
+    )
+
+
+def _manifest() -> AgentsShipgateManifest:
+    return AgentsShipgateManifest.model_validate(
+        {
+            "version": "0.1",
+            "project": {"name": "action-scope-projection"},
+            "agent": {"name": "agent", "declared_purpose": ["publish one scope list"]},
+            "environment": {"target": "local"},
+            "tool_sources": [{"id": "crm", "type": "mcp", "path": "tools.json"}],
+        }
+    )
+
+
+def test_the_action_and_its_authority_publish_one_permission_list() -> None:
+    """``required_scopes`` and ``authority.scopes`` are one list, every shape.
+
+    The assertion that matters is the third one: building the capability fact
+    from the serialized ``ActionFact`` is what ``verify --base`` does, and it
+    is what raised.
+    """
+
+    manifest = _manifest()
+    shapes = 0
+    declared_wins = 0  # the row's list replaced a different source list
+    source_stands = 0  # no row list, so the source's own scopes stand
+    for source_name, auth in _SOURCES.items():
+        for row_name, row in _ROWS.items():
+            shapes += 1
+            declaration = ActionDeclarationConfig.model_validate(
+                {"tool": "read_thing", "source_id": "crm", **row}
+            )
+            tool = _tool(auth)
+            tool.semantic_assessment = assess_tool_semantics(tool, declaration)
+            action = build_action(
+                manifest,
+                agent_id="agent",
+                tool=tool,
+                declaration=declaration,
+            )
+            fact = action_to_fact(action)
+            where = f"{source_name} + {row_name}"
+
+            required = sorted(set(fact.required_scopes))
+            assert fact.semantic_assessment is not None, where
+            published = sorted(set(fact.semantic_assessment.authority.scopes))
+            assert required == published, (
+                f"{where}: the action requires {required} while its authority "
+                f"publishes {published} — two permission lists on one action"
+            )
+            # The call `verify --base` makes. It validates the projection.
+            capability = capability_fact_from_action_fact(fact)
+            assert sorted(capability.authority.scopes) == required, where
+
+            source_scopes = sorted({scope for scope in (auth or {}).get("scopes", [])})
+            if row.get("scopes"):
+                if sorted(set(row["scopes"])) != source_scopes:
+                    declared_wins += 1
+            elif source_scopes:
+                source_stands += 1
+
+    # A sweep that never exercises either resolution branch would pass while
+    # asserting nothing, so both are counted rather than assumed.
+    assert shapes == len(_SOURCES) * len(_ROWS)
+    assert declared_wins >= 6, declared_wins
+    assert source_stands >= 4, source_stands
+
+
+# --- the guard the shared list makes necessary -----------------------------
+
+
+def test_declared_scopes_cannot_silently_drop_a_source_proven_scope() -> None:
+    """A row's list replaces the source's, so narrowing it has to be visible.
+
+    Publishing the row's list on the authority dimension is what closes the
+    divergence — and it is also what would let ``scopes: [crm.read]`` erase a
+    ``crm.write`` grant the source proves, with a ``structural`` status and no
+    issue raised. The reviewed ``authority:`` route has always refused that
+    (``_authority_declaration_conflicts``); the subset rule now reads the
+    *resolved* list, so a bare one goes through it too.
+    """
+
+    tool = _tool({"type": "oauth2", "scopes": ["crm.read", "crm.write"]})
+    narrowing = ActionDeclarationConfig.model_validate(
+        {"tool": "read_thing", "source_id": "crm", "scopes": ["crm.read"]}
+    )
+
+    narrowed = assess_tool_semantics(tool, narrowing)
+
+    assert narrowed.authority.status == "conflicting"
+    assert narrowed.authority.mode == "unknown"
+    assert [issue.kind for issue in narrowed.authority.issues] == [
+        "conflicting_authority_evidence"
+    ]
+    assert not narrowed.pass_eligible
+    # The dropped scope stays readable: the source's own claim carries it.
+    source_claims = [
+        claim for claim in narrowed.authority.claims if claim.basis == "protocol_structure"
+    ]
+    assert source_claims and source_claims[0].evidence["scopes"] == ["crm.read", "crm.write"]
+
+    # And the conflict is answerable by the row that raised it — otherwise it
+    # would be a wall, not a question.
+    restored = assess_tool_semantics(
+        tool,
+        ActionDeclarationConfig.model_validate(
+            {
+                "tool": "read_thing",
+                "source_id": "crm",
+                "scopes": ["crm.read", "crm.write"],
+            }
+        ),
+    )
+    assert restored.authority.status == "structural"
+    assert not restored.authority.issues
+
+
+def test_a_broader_declared_scope_list_is_a_broadening_not_a_conflict() -> None:
+    """Adding scopes is an explicit expansion the broad-scope policies see."""
+
+    tool = _tool({"type": "oauth2", "scopes": ["crm.read"]})
+
+    assessed = assess_tool_semantics(
+        tool,
+        ActionDeclarationConfig.model_validate(
+            {"tool": "read_thing", "source_id": "crm", "scopes": ["crm.read", "crm.admin"]}
+        ),
+    )
+
+    assert assessed.authority.status == "structural"
+    assert not assessed.authority.issues
+    assert list(assessed.authority.scopes) == ["crm.admin", "crm.read"]
+
+
+# --- the route that only a base comparison reaches -------------------------
+
+
+def _repo_declaring_only_scopes(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / ".gitignore").write_text("agents-shipgate-reports/\n", encoding="utf-8")
+    (repo / "tools.json").write_text(
+        json.dumps(
+            {
+                "tools": [
+                    {
+                        "name": "read_thing",
+                        "description": "Read a CRM record.",
+                        "annotations": {"readOnlyHint": True},
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"id": {"type": "string"}},
+                            "required": ["id"],
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    # The reported shape: a row that lists `scopes:` and nothing else. No
+    # `authority:` block, so before the fix the authority dimension published
+    # an empty list while the action required `crm.read`.
+    (repo / "shipgate.yaml").write_text(
+        """
+version: "0.1"
+project: {name: scopes-only-row}
+agent:
+  name: crm-agent
+  declared_purpose: [read crm records]
+environment: {target: local}
+tool_sources:
+  - id: crm
+    type: mcp
+    path: tools.json
+action_surface:
+  actions:
+    - tool: read_thing
+      source_id: crm
+      scopes: [crm.read]
+agent_bindings:
+  declarations:
+    - agent: root
+      complete: true
+      tools: [{tool: read_thing, source_id: crm}]
+      handoffs: []
+      reason: reviewed scopes-only fixture binding
+""".lstrip(),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+    (repo / "NOTES.md").write_text("second commit\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=repo, check=True)
+    return repo
+
+
+def test_a_row_that_declares_only_scopes_survives_verify_base(tmp_path: Path) -> None:
+    """The user-visible failure: exit 4, ``internal_error``, on a legal manifest."""
+
+    repo = _repo_declaring_only_scopes(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(repo),
+            "--config",
+            "shipgate.yaml",
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload.get("error") != "internal_error", payload
+    assert payload["base_status"] == "succeeded"
+
+    # Non-vacuity: the crash lives in the MCP capability comparison, which runs
+    # only over MCP actions present on *both* sides. A fixture whose action
+    # surface came back empty would pass this test while proving nothing.
+    base_report = json.loads(
+        (repo / "agents-shipgate-reports" / "verification-base-report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    head_report = json.loads(
+        (repo / "agents-shipgate-reports" / "report.json").read_text(encoding="utf-8")
+    )
+    for report in (base_report, head_report):
+        [action] = report["action_surface_facts"]["actions"]
+        assert action["source_type"] == "mcp"
+        assert action["required_scopes"] == ["crm.read"]
+        assert action["semantic_assessment"]["authority"]["scopes"] == ["crm.read"]

--- a/tests/test_source_authority.py
+++ b/tests/test_source_authority.py
@@ -681,12 +681,13 @@ def test_the_action_fact_and_the_assessment_publish_one_permission_list(
         _mcp_tool("send_email", "Send an email to a customer."),
         _mcp_tool("list_contacts", "List the contacts in the CRM."),
     ]
-    # Every shape where a reviewed authority exists at one of the two sites —
-    # which is all this increment governs. A bare ``scopes`` list with no
-    # ``authority`` block anywhere is deliberately absent: those two fields
-    # already disagree on ``main`` (the row's list against the source's
-    # published one), and the same builder already raises on it there. Widening
-    # this test to cover it would be asserting a fix this change does not make.
+    # Every shape a reviewed authority can take at either site, plus the one
+    # that needs none: a bare ``scopes`` list with no ``authority`` block
+    # anywhere. That last shape was deliberately absent while the two fields
+    # still disagreed on it — the row's list against the source's published
+    # one — and it is covered now that one resolver decides both
+    # (``resolve_action_scopes``); the sweep in
+    # ``tests/test_action_scope_projection.py`` walks the rest of that class.
     shapes: list[tuple[dict | None, list[dict] | None]] = [
         ({"mode": "scoped", "auth_type": "oauth2", "scopes": ["crm.read"]}, None),
         ({"mode": "none"}, None),
@@ -709,6 +710,8 @@ def test_the_action_fact_and_the_assessment_publish_one_permission_list(
                 }
             ],
         ),
+        # No reviewed authority at either site: the row's own permission list.
+        (None, [{"tool": "send_email", "source_id": "crm", "scopes": ["crm.send"]}]),
     ]
     for index, (source_authority, actions) in enumerate(shapes):
         workspace = tmp_path / f"shape_{index}"


### PR DESCRIPTION
## Summary

- **One action, one permission list.** A manifest row that listed `scopes:` and declared no `authority:` block at either site turned `verify --base` into `Internal error` (exit 4) on a legal manifest. The action's permissions were spelled twice and the two spellings disagreed: the action lens took the row's list when it had one and the source's auth scopes otherwise, while `_assess_authority` took the row's list only where a *reviewed* authority record existed. `CapabilityFactV1._semantic_projection_is_consistent` requires the two to project one list, so where they disagreed, rebuilding a capability fact from a serialized `ActionFact` raised.
- **This finishes what #417 started.** Declaring authority once per source closed the *reviewed* half of the divergence by normalizing both manifest sites into one record. What was left is every row that declares scopes with no reviewed authority at either site — 10 of the 28 shapes in the new sweep raised on current `main`.
- **The fix is one resolver, not a patched builder.** `core.semantic_assessment.resolve_action_scopes` is the single derivation, read by the action lens (replacing `_declared_scope_strings`) and by the authority dimension. The alternative — have `capability_fact_from_action_fact` read the semantic authority instead of `required_scopes` — was rejected: it keeps two permission lists on one action (one published as `required_scopes`, one as the authority evidence) and leaves the invariant asserting a guarantee the engine no longer makes.
- **A row cannot quietly shrink a grant.** Publishing the row's list on the authority dimension is also what would let `scopes: [crm.read]` erase a `crm.write` grant the source proves, with a `structural` status and nothing raised. The subset rule a reviewed authority is held to now reads the *resolved* list (`_scopes_narrow_source`), so a bare `scopes:` list is held to it too and reports `conflicting_authority_evidence` against `actions[].scopes`. Adding the dropped scope back closes it; broadening is still a broadening.
- The parity assertion added with the source-level block (`test_the_action_fact_and_the_assessment_publish_one_permission_list`) explicitly excluded the bare-`scopes` shape because it did not hold. It now covers it, and its stale carve-out comment is gone.

Pre-existing on `main` (found while reviewing the #410 increment-3 branch; reproduces on `main` both before and after #417 landed).

## Type

- [x] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [x] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run, all on the rebased tree (branch is rebased onto `6f55acc3`, the merge of #417):

- `pytest -n auto -m "not perf" --ignore=tests/test_adapter_static_only.py` — green; plus `tests/test_adapter_static_only.py` and `tests/test_latency_budget.py -m perf` as separate runs, both green. `ruff check .` clean.
- **The regression tests fail on pre-fix `src/`.** `git stash push -- src/` then re-run: all four tests in `tests/test_action_scope_projection.py` fail, including the real `verify --base` one at exit 4 with the exact `CapabilityFactV1.authority.scopes must project semantic authority` message.
- The invariant is enforced on exactly one route — `checks/mcp_permissions.py` reaches `capability_fact_from_action_fact` only when a base diff reference exists — so the new coverage is a **real `verify --base` run** over the reported shape, not a unit assertion. It also asserts both reports' action surfaces are non-empty MCP rows, because an empty action surface would pass the test while proving nothing.
- The 28-shape sweep was run against stashed `src/` to measure the 10 divergences quoted above, and again after, to confirm all 28 agree. (Clear `.git/agents-shipgate/base-scans/` before any such comparison — a cached base scan from a different build silently disables the diff and hides the crash.)

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — none added or changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — no field added, removed, or retyped; `docs/manifest-v0.1.json` moves only by one regenerated `description`

## Notes for the reviewer

- **Blast radius is smaller than "move `authority.scopes`" suggests.** The concern with this direction was churn to `authority_hash` for every repo using bare scopes. It does not happen, because the shared rule is the one the lens already applied: every shape that resolves today resolves identically, and every list that moves belongs to a shape that was exit 4. No sample golden, fixture, or test value moved — no `samples/*/shipgate.yaml` row uses a bare `scopes:` list, and `tests/test_evidence_backed_pass.py` *requires* an `authority` block, which is why this survived.
- **One adopter-visible consequence beyond the crash.** `SHIP-AUTH-SCOPE-COVERAGE-MISSING` reads the assessment's scopes, so a row declaring `scopes:` against a manifest whose `permissions.scopes` does not cover them now raises the review item it always should have. The divergence, not the check, was keeping it quiet. Called out in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
