### PR TITLE
build(deps): stop Dependabot raising transitive pins past their parent's cap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,36 @@
 version: 2
+
+# The constraints/ locks are hash-pinned closures, not flat requirement lists:
+# most lines are transitive and are recorded with a `# via <parent>` comment.
+# Dependabot treats every line as independently bumpable, so it will raise a pin
+# past the cap of the parent that pulls it in. Such a PR can never go green —
+# pip fails with ResolutionImpossible at install time, before any test runs —
+# and it cannot be repaired by rebasing, only closed.
+#
+# A transitive pin should move because its parent moved. When one of these is
+# genuinely wanted, bump the parent and recompile with scripts/update_locks.py.
+
 updates:
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # `# via cyclonedx-bom`, which requires chardet<6.0,>=5.1. cyclonedx-bom
+      # 7.3.1 is the latest release overall, not merely the latest 7.x, so no
+      # release accepts chardet 6 or above. Closed #407 on this. Major updates
+      # only: 5.x movement is still legitimate, and this reopens on its own if
+      # cyclonedx-bom ever lifts the cap.
+      - dependency-name: "chardet"
+        update-types: ["version-update:semver-major"]
+      # `# via pydantic`, which pins it *exactly* rather than as a range:
+      # pydantic 2.13.4 requires pydantic-core==2.46.4, and 2.13.5 requires
+      # ==2.46.5. Any independent bump is unsatisfiable at every update type,
+      # so this one is ignored outright. Closed #382 on this.
+      - dependency-name: "pydantic-core"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-


### PR DESCRIPTION
Follow-up to closing #407 and #382. Adds the `ignore:` rules that stop both from regenerating every week.

## The pattern

`constraints/*.txt` are hash-pinned closures whose lines are mostly **transitive** — recorded with a `# via <parent>` comment. Dependabot treats every line as independently bumpable, so it raises pins above the cap of the parent that pulls them in. The result fails with `ResolutionImpossible` at install time, in roughly 20 seconds, before a single test runs. No rebase can fix it, because no release of the parent accepts the new version.

| PR | Bump | Parent | Parent's constraint |
|---|---|---|---|
| #407 | chardet 5.2.0 → 7.6.0 | cyclonedx-bom | `chardet<6.0,>=5.1` |
| #382 | pydantic-core 2.46.4 → 2.48.0 | pydantic | `pydantic-core==2.46.4` (exact) |

In both cases I checked the whole release history, not just the pinned version: cyclonedx-bom **7.3.1 is the latest release overall**, not merely the latest 7.x, and even the newest pydantic (2.13.5) only reaches `pydantic-core==2.46.5`. Neither bump is reachable from any published parent.

## The rules

- **chardet** — ignored for `version-update:semver-major` only. 5.x movement still comes through, and the bump reopens on its own if cyclonedx-bom ever lifts the cap.
- **pydantic-core** — ignored outright. An exact parent pin leaves no update type that could ever resolve.

A comment block at the top of the file records the reasoning, and points at `scripts/update_locks.py` as the correct way to move a transitive pin: bump the parent and recompile.

## Scope

`.github/dependabot.yml` only, +24/-1. The two other open Dependabot PRs are unaffected — #405 (idna) is green and independently mergeable, and #406 (uv) fails for an unrelated reason: its lockfile regeneration dropped PyPy environment markers and rewrote `pydantic` as `pydantic[email]`, which trips `scripts/verify_dependency_lock.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
