### PR TITLE
feat(release): approve and enforce an explicit pre-1.0 evidence bar (#341)

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -488,18 +488,25 @@ jobs:
         # and confusion matrix) imports the project's pydantic schemas, so it
         # runs in the `policy` job where the project is installed. What is
         # restated here, with the standard library only, are the claims that
-        # actually delegate publication authority: beta/qualified/
-        # production_qualified, static-only, no failures, 100 cases and
-        # receipts, zero unsafe auto-passes, and the wheel name/version/digest
-        # binding. A signed-but-weakened artifact therefore cannot pass on the
-        # strength of its signature alone.
+        # actually delegate publication authority: a qualification tier the
+        # tag's version admits, static-only, no failures, exactly as many cases
+        # and receipts as that tier requires, zero unsafe auto-passes, and the
+        # wheel name/version/digest binding. A signed-but-weakened artifact
+        # therefore cannot pass on the strength of its signature alone. Which
+        # tier a version admits is in docs/release-evidence-policy-decision.md.
+        id: binding
         env:
           RELEASE_TAG: ${{ steps.candidate.outputs.release_tag }}
         run: |
+          set -euo pipefail
           python scripts/verify_qualification_binding.py \
             --qualification qualified-dist/safety-qualification.json \
             --wheel "${QUALIFIED_WHEEL}" \
             --tag "${RELEASE_TAG}"
+          # Read back only for the run summary, and only after the gate above
+          # accepted the tier. Nothing downstream trusts this value.
+          tier="$(python -c 'import json,sys; sys.stdout.write(str(json.load(open("qualified-dist/safety-qualification.json")).get("qualification_tier")))')"
+          echo "qualification_tier=${tier}" >> "${GITHUB_OUTPUT}"
 
       - name: Bind the qualified wheel to the tagged source tree
         # Without this the pipeline tests the checkout and publishes a wheel
@@ -613,6 +620,7 @@ jobs:
           WHEEL_FILENAME: ${{ steps.qualified.outputs.wheel_filename }}
           WHEEL_SHA256: ${{ steps.handoff.outputs.wheel_sha256 }}
           MANIFEST_SHA256: ${{ steps.handoff.outputs.manifest_sha256 }}
+          QUALIFICATION_TIER: ${{ steps.binding.outputs.qualification_tier }}
         run: |
           {
             echo "## Release candidate ${RELEASE_TAG} (${MODE})"
@@ -623,7 +631,7 @@ jobs:
             echo "| CHANGELOG section for the tag | pass |"
             echo "| Dependency locks match declarations | pass |"
             echo "| Qualification signature identity | pass |"
-            echo "| Production qualification policy | pass |"
+            echo "| Qualification policy (${QUALIFICATION_TIER}) for this version | pass |"
             echo "| Wheel bound to tagged source | $(python -c 'import json,sys; sys.stdout.write(json.load(open("provenance.json"))["provenance_mode"])') |"
             echo "| Correctness suite (-n auto, not perf) | pass |"
             echo "| Dependency audit | pass |"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,19 @@
   binds its restated numbers to the real constructors so the two copies cannot
   drift. Along the way the exhaustive verifier stopped hard-coding `100` in six
   places and now derives every count, metric denominator and confusion-matrix
-  profile from the governing policy.
+  profile from the governing policy. Review turned up a **seventh**:
+  `benchmark/safety-qualification/README.md`, the corpus owner's runbook, which
+  decides what actually gets built — a change that left it behind would have
+  aimed the whole corpus effort at the wrong shape, which no gate can detect.
+  It now documents both policies, and its pre-existing claim that receipts must
+  carry report schema `0.40` (the gate pins `0.42`) is corrected.
+
+  **`production_qualified` is now unrepresentable when it disagrees with the
+  tier.** Every gate rejected such an artifact, but only after it had been
+  signed and handed to the release. `SafetyQualificationResultV1` refuses to
+  construct one, so the producer cannot emit it — and the version rule binds
+  the `requirements=` keyword too, not just `--policy-tier`, which previously
+  let a caller score a `1.0` wheel against the pre-1.0 policy and exit `0`.
 
 
 - **The declaration continuation: a drafted proposal can now reach the person

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,32 @@
   (its vocabulary is a strict subset) and the corpus and receipt-index
   envelopes deliberately unmoved, since their grammar did not change.
 
+  **A second review round found the bump had a hole and the sealer had four
+  more.** Upgrading a legacy envelope *unconditionally* rewrote v4 to v5 before
+  anything looked at the tier, so a conforming pre-1.0 artifact could keep
+  claiming a v4 an old reader cannot parse — the exact combination the bump
+  existed to eliminate. A legacy envelope is now read only when the payload
+  uses the vocabulary that envelope can express, and both gates enforce the
+  pairing. In the sealer: floors count *matches*, so a case with a null
+  `actual_decision` merely failed to count toward its floor rather than being
+  rejected, and 56 rows sharing one id looked like 56 cases — case identity and
+  terminal decisions are now checked before any floor. `>= 0.80` admitted
+  `inf`, since the JSON literal `1e309` loads as a float that satisfies every
+  lower bound; κ and the origin count are now bounded on both sides and
+  required to be finite and integral respectively. And the report schema
+  version has no representation in `cases` at all, so the approved `0.42` could
+  be restated as `0.1` and still seal — the sealer now compares the artifact's
+  whole declared `requirements` block, field for field, against its
+  restatement of the policy.
+
+  **The 1-tuning/1-holdout split was documentation, not policy.** What is
+  enforced is a per-cell holdout *floor*; a corpus that marks more cases
+  holdout is accepted, deliberately — holdout evidence was never tuned on, so
+  more of it is stronger, and a floor on tuning cases would be a ceiling on
+  holdout. The decision document, the schema docstring and the corpus runbook
+  said "leaves each cell one tuning and one holdout case" as though that were
+  checked; they now say what is actually enforced and why.
+
 - **The declaration continuation: a drafted proposal can now reach the person
   it was drafted for.** (#429 review) `apply-patches --kinds declare_action`
   writes into `shipgate.yaml`, which is the trust root — so the control that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,46 @@
 
   [#461]: https://github.com/ThreeMoonsLab/agents-shipgate/issues/461
 
+- **A `0.x` tag now has an evidence bar it can actually meet, and it is not a
+  weaker judgement.** (#341) The only release policy was 100 adjudicated,
+  receipt-bound cases — the claim `1.0` should make — enforced for every tag.
+  No corpus met it, so nothing published, and evaluators kept installing
+  `v0.15.0`: an older, less-verified build than the one being withheld.
+
+  A second **named** policy, `pre_1_0`, governs `0.x` tags: 56 cases, two in
+  each of the same 28 profile × decision strata, with the origin floor at the
+  same 40% share. Everything that decides whether evidence is *believed* is
+  byte-identical to the production policy — zero unsafe auto-passes per profile
+  and overall, a unique terminal verifier receipt per case, the 20% holdout
+  fraction, the κ floor, `static_only`, and full re-derivation by the verifier.
+  Every exact-match floor is the production rate rounded up, which at 56 cases
+  means three of the four land on 100%: a smaller corpus buys less tolerance
+  for error, not more. The route, the numbers, the rejected alternatives and
+  the promotion path are recorded by a named owner in
+  [`docs/release-evidence-policy-decision.md`](docs/release-evidence-policy-decision.md).
+
+  **The version decides the policy; the artifact never does.** Epoch 0 with
+  major 0 admits `pre_1_0` or the stronger `beta`; everything else — including
+  a version that will not parse — admits `beta` only. Both release gates derive
+  this independently, and an artifact naming a tier its version does not admit
+  is rejected *and* then measured against the production counts, so a bad tier
+  cannot shrink what is checked. `production_qualified` keeps meaning "met the
+  100-case bar": a `pre_1_0` artifact reports it `false`, and claiming
+  otherwise is itself a rejection.
+
+  **The sealing gate was the sixth definition site, not the fifth.** The
+  standing brief listed five places the bar is defined; `verify_qualification_binding.py`
+  — the standard-library gate that seals a release without importing the
+  project — hard-coded `REQUIRED_CASE_COUNT = 100` and `tier == "beta"`
+  independently. A change that moved the other five would have failed there,
+  at the last step before publication, with a bare case-count error. It is
+  per-tier now, and `test_the_stdlib_case_counts_match_the_named_policies`
+  binds its restated numbers to the real constructors so the two copies cannot
+  drift. Along the way the exhaustive verifier stopped hard-coding `100` in six
+  places and now derives every count, metric denominator and confusion-matrix
+  profile from the governing policy.
+
+
 - **The declaration continuation: a drafted proposal can now reach the person
   it was drafted for.** (#429 review) `apply-patches --kinds declare_action`
   writes into `shipgate.yaml`, which is the trust root — so the control that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,22 @@
   the `requirements=` keyword too, not just `--policy-tier`, which previously
   let a caller score a `1.0` wheel against the pre-1.0 policy and exit `0`.
 
+  **Review found three more, all in the parts that decide what publishes.**
+  The sealing gate restated only a *case count*, so it could not tell 56
+  correctly stratified cases from 56 identical ones, and accepted a corpus two
+  safe passes below its floor that the exhaustive gate rejected — the
+  dependency-compromise boundary it exists to hold was decorative. It now
+  restates each tier's strata, exact-match floors, per-stratum holdout, and the
+  origin and κ floors, re-derives them from the raw cases, and has every field
+  bound to the real constructors by test. The version→tier rule was anchored
+  only at the start of the string, so `0garbage`, `0.16.0garbage` and `0..1`
+  bought the *cheaper* policy — the exact inversion of the documented fallback,
+  in a helper both gates share; it now requires a complete PEP 440 parse. And
+  `qualification_tier: pre_1_0` plus the new cross-field invariant are grammar
+  changes emitted under a frozen envelope id, so
+  `shipgate.safety_qualification` advances **v4 → v5**, with v4 still readable
+  (its vocabulary is a strict subset) and the corpus and receipt-index
+  envelopes deliberately unmoved, since their grammar did not change.
 
 - **The declaration continuation: a drafted proposal can now reach the person
   it was drafted for.** (#429 review) `apply-patches --kinds declare_action`

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -30,12 +30,16 @@ invariant: `production_qualified` is true exactly when a `qualified` artifact
 claims the `beta` tier. A v4 reader admits neither, so a genuine `pre_1_0`
 artifact must not claim to be v4.
 
-**Reader behaviour.** The v5 reader accepts `shipgate.safety_qualification/v4`
-and reads it as v5, because every v4 payload is a v5 payload with identical
-meaning: v4's tier vocabulary is a strict subset of v5's, and the producer that
-emitted v4 always satisfied the new invariant. Upgrading grants nothing — the
-payload must still satisfy every v5 rule. Nothing emits v4 any more. v1 and v2
-continue to be read, as before; v3 is not, also as before.
+**Reader behaviour.** The v5 reader accepts `shipgate.safety_qualification/v1`,
+`/v2` and `/v4` **only when the payload uses the vocabulary that envelope can
+express** — that is, `qualification_tier` of `beta` or `test`. Such a payload is
+read as v5, because it is a v5 payload with identical meaning. A payload
+carrying `pre_1_0` under a legacy envelope is *rejected*, not upgraded: an
+unconditional upgrade would recreate the v4/`pre_1_0` combination this bump
+exists to eliminate, leaving an old v4 reader able to receive an artifact it
+cannot parse. Both release gates enforce the pairing — the standard-library
+sealer on raw JSON, since it never parses the envelope otherwise. Nothing emits
+v4 any more, and v3 is still not read, as before.
 
 **What this is for.** `0.x` tags are now governed by a named 56-case `pre_1_0`
 policy, decided under

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -13,6 +13,39 @@ for reproducible CI.
 
 ---
 
+<a id="migration-note-unreleased-pre-1-0-evidence-bar"></a>
+
+## Migration Note: unreleased — the pre-1.0 release evidence bar
+
+`shipgate.safety_qualification` advances **v4 → v5**. The corpus
+(`shipgate.safety_corpus/v4`) and receipt-index
+(`shipgate.safety_receipt_index/v4`) envelopes **do not move**: their grammar is
+unchanged, and these versions track grammar rather than release batches. No
+`contract_version`, `report_schema_version`, or published adopter-facing schema
+document changes.
+
+Two grammar changes force the bump. `qualification_tier` gains `pre_1_0`
+alongside `beta` and `test`, and the result now carries a cross-field
+invariant: `production_qualified` is true exactly when a `qualified` artifact
+claims the `beta` tier. A v4 reader admits neither, so a genuine `pre_1_0`
+artifact must not claim to be v4.
+
+**Reader behaviour.** The v5 reader accepts `shipgate.safety_qualification/v4`
+and reads it as v5, because every v4 payload is a v5 payload with identical
+meaning: v4's tier vocabulary is a strict subset of v5's, and the producer that
+emitted v4 always satisfied the new invariant. Upgrading grants nothing — the
+payload must still satisfy every v5 rule. Nothing emits v4 any more. v1 and v2
+continue to be read, as before; v3 is not, also as before.
+
+**What this is for.** `0.x` tags are now governed by a named 56-case `pre_1_0`
+policy, decided under
+[#341](https://github.com/ThreeMoonsLab/agents-shipgate/issues/341) and recorded
+in [`docs/release-evidence-policy-decision.md`](docs/release-evidence-policy-decision.md).
+It reduces evidence *coverage* only: the zero-unsafe-auto-pass rule, per-case
+receipts, the holdout fraction, the κ floor and `static_only` are unchanged, and
+every exact-match floor is the production rate rounded up. `1.0` and later still
+require the 100-case `beta` artifact, and there is no promotion shortcut.
+
 <a id="migration-note-unreleased-adopter-vocabulary"></a>
 
 ## Migration Note: unreleased — adopter-facing output stops naming internal fields

--- a/benchmark/safety-qualification/README.md
+++ b/benchmark/safety-qualification/README.md
@@ -1,6 +1,6 @@
 # Evidence-Backed Pass Safety Qualification
 
-This directory is the runbook for the `0.16.0b7` beta safety qualification.
+This directory is the runbook for the `0.16.0b7` safety qualification.
 The repository does **not** ship fabricated human labels or a passing result.
 Until a real frozen corpus and its verifier receipts exist,
 `safety-qualification.json` must not be published as qualified.
@@ -25,14 +25,33 @@ The runner consumes four independently content-addressed inputs:
 
 Receipt entries must point to real `verify` artifacts. Each receipt needs
 successful base and head tree-bound runs plus content-addressed
-`verifier_json` and `report_json` artifacts. The report must use schema `0.40`,
+`verifier_json` and `report_json` artifacts. The report must use the schema
+`required_report_schema_version` pins (`0.42` today, identical in both
+policies and asserted equal to what the engine emits by
+`test_the_qualification_gate_demands_the_schema_the_engine_emits`),
 contain binding and semantic coverage, and agree with the verifier receipt. Missing,
 failed, unknown, hash-mismatched, or fallback receipts fail closed; the runner
 never substitutes a cold-start scan result.
 
-## Production acceptance policy
+## Which policy to build for
 
-The CLI policy is fixed in code and has no threshold-relaxation flags:
+**Two named policies exist. Build for the one the release's version admits —
+they are not interchangeable, and a corpus sized for one fails every stratum of
+the other.**
+
+| Wheel version | Policy | Tier | Cases |
+|---|---|---|---|
+| `0.x` (epoch 0, major 0) | pre-1.0 | `pre_1_0` | 56 |
+| `1.0` and later | production | `beta` | 100 |
+
+A `0.x` release may also publish on a production-policy artifact — more
+evidence than the tag requires is never rejected — but nothing goes the other
+way. The route, the numbers and the rationale were approved by a named
+product/security owner in
+[`docs/release-evidence-policy-decision.md`](../../docs/release-evidence-policy-decision.md)
+(issue #341).
+
+### Production acceptance policy (`beta`, 100 cases)
 
 - 100 cases with exact declared MCP/OpenAPI, OpenAI Agents SDK,
   LangChain/CrewAI, Google ADK, n8n, multi-agent/handoff, and coding-agent strata:
@@ -45,9 +64,40 @@ The CLI policy is fixed in code and has no threshold-relaxation flags:
   exact review at least `19/20`; exact insufficient-evidence at least `19/20`.
 - Zero per-profile unsafe pass and zero invalid or missing receipts.
 
+### Pre-1.0 acceptance policy (`pre_1_0`, 56 cases)
+
+Less coverage, identical strictness. Same seven profiles, same four outcomes,
+**exactly two cases in each of the 28 strata** — not the production weighting
+scaled down, which would empty the smallest cells.
+
+- 56 cases: 14 `passed`, 14 `review_required`, 14 `insufficient_evidence`,
+  14 `blocked`, two per profile/outcome pair.
+- At least 23 real-history, rejected/reverted, or design-partner cases — the
+  same 40% share the production policy demands.
+- Cohen's κ ≥ 0.80. **Unchanged.**
+- At least 20% holdout per stratum. **Unchanged** — at two cases per stratum
+  that is `ceil(2 × 0.20) = 1` holdout and 1 tuning case in every cell.
+- Unsafe auto-pass `0/42`; blocked exact `14/14`; safe pass at least `13/14`;
+  exact review `14/14`; exact insufficient-evidence `14/14`. These are the
+  production *rates* rounded up, so the smaller corpus has **less** tolerance
+  for error, not more.
+- Zero per-profile unsafe pass and zero invalid or missing receipts.
+  **Unchanged.**
+
+### What the CLI will and will not do for you
+
+`--policy-tier` selects between the two named policies. It has no
+threshold-relaxation flags, and it cannot select a policy the wheel's version
+does not admit:
+
+- `auto` (default) — pre-1.0 for a `0.x` wheel, production otherwise. An
+  unparsable version falls to production, never to the cheaper policy.
+- `production` — always available, on any version.
+- `pre-1.0` — **refused** for a `1.0`-or-later wheel, before any scoring.
+
 Tests can inject smaller requirements into the Python API, but those artifacts
-are marked `qualification_tier: test` and can never set
-`production_qualified: true`.
+are marked `qualification_tier: test`, can never set
+`production_qualified: true`, and are rejected by both release gates.
 
 ## Run
 
@@ -60,9 +110,14 @@ PYTHONPATH=src python scripts/run_safety_qualification.py \
   --out safety-qualification.json --json
 ```
 
-Exit `0` means the exact production policy passed. Exit `1` means a complete
-artifact was emitted with `production_qualified: false` and sorted
-`failures[]`. Input/schema errors exit `2` before scoring.
+Exit `0` means the exact named policy the version selects passed, with no
+failures. Exit `1` means a complete artifact was emitted with sorted
+`failures[]`. Input/schema errors — including asking for a policy the version
+does not admit — exit `2` before scoring.
+
+`production_qualified` keeps meaning "met the 100-case bar": a passing
+`pre_1_0` artifact reports it `false`, and both release gates reject an
+artifact that claims otherwise.
 
 The deterministic output records input hashes, exact requirements, strata,
 case outcomes, overall and per-profile confusion matrices, Wilson 95%
@@ -79,8 +134,9 @@ sigstore sign --bundle safety-qualification.sigstore.json safety-qualification.j
 Release promotion consumes the signed result and the same wheel through
 protected `pypi` environment variables. See
 [`docs/distribution.md`](../../docs/distribution.md#protected-qualification-inputs)
-for the exact six-variable contract. The tag workflow verifies the signer,
-production result, tag/version, and wheel digest before it can publish.
+for the exact six-variable contract. The tag workflow verifies the signer, a
+qualification tier the version admits, tag/version, and wheel digest before it
+can publish.
 
 The release workflow treats the configured signer identity and the signed
 qualification result as trust inputs. It does not cryptographically prove that
@@ -90,7 +146,8 @@ properties depend on protected-environment governance and benchmark-owner
 process. Repository administrators must lock signer-variable changes behind
 reviewers who are independent of the release initiator.
 
-The production policy's `minimum_qualified_origins = 40` accepts a combined
+The origin minimum — `minimum_qualified_origins = 40` under the production
+policy, `23` under the pre-1.0 one — accepts a combined
 count of real-history, rejected/reverted, and design-partner cases. It does not
 enforce a four-week observation window or three distinct design partners.
 Those remain external beta rollout stop conditions and must be reviewed from

--- a/benchmark/safety-qualification/README.md
+++ b/benchmark/safety-qualification/README.md
@@ -76,7 +76,10 @@ scaled down, which would empty the smallest cells.
   same 40% share the production policy demands.
 - Cohen's κ ≥ 0.80. **Unchanged.**
 - At least 20% holdout per stratum. **Unchanged** — at two cases per stratum
-  that is `ceil(2 × 0.20) = 1` holdout and 1 tuning case in every cell.
+  that is `ceil(2 × 0.20) = 1` holdout, leaving room for one tuning case. The
+  floor is a *minimum*: marking both cases holdout is accepted, because holdout
+  evidence was never tuned on and more of it is stronger. Nothing requires a
+  tuning case, which would be a ceiling on holdout.
 - Unsafe auto-pass `0/42`; blocked exact `14/14`; safe pass at least `13/14`;
   exact review `14/14`; exact insufficient-evidence `14/14`. These are the
   production *rates* rounded up, so the smaller corpus has **less** tolerance
@@ -102,8 +105,14 @@ are marked `qualification_tier: test`, can never set
 Both release gates re-derive the strata and every floor above from the artifact's
 own cases — the standard-library sealing gate included. A corpus with the right
 *total* but the wrong distribution, or one that misses a single exact-match
-floor, fails at both. The result envelope is
-`shipgate.safety_qualification/v5`.
+floor, fails at both. Every case needs a unique, non-blank id and a terminal
+verifier decision: an absent decision is a missing case, not a low score.
+
+The result envelope is `shipgate.safety_qualification/v5`, and a `pre_1_0`
+artifact may not claim an earlier one — those readers admit `beta` and `test`
+only. Both gates also check the artifact's declared `requirements` block
+field-for-field against the approved policy, including
+`required_report_schema_version`, which nothing in `cases` can attest.
 
 ## Run
 

--- a/benchmark/safety-qualification/README.md
+++ b/benchmark/safety-qualification/README.md
@@ -99,6 +99,12 @@ Tests can inject smaller requirements into the Python API, but those artifacts
 are marked `qualification_tier: test`, can never set
 `production_qualified: true`, and are rejected by both release gates.
 
+Both release gates re-derive the strata and every floor above from the artifact's
+own cases — the standard-library sealing gate included. A corpus with the right
+*total* but the wrong distribution, or one that misses a single exact-match
+floor, fails at both. The result envelope is
+`shipgate.safety_qualification/v5`.
+
 ## Run
 
 ```bash

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -177,7 +177,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`troubleshooting.md`](troubleshooting.md) — error messages → fixes
 - [`distribution.md`](distribution.md) — release process and SBOM/signature verification
 - [`release-runbook.md`](release-runbook.md) — cutting a tag: mandatory rehearsal, the two-job publication transaction, provenance bindings, and the recovery path when PyPI succeeds but finalization fails
-- [`release-evidence-policy-decision.md`](release-evidence-policy-decision.md) — open decision brief for the pre-1.0 qualification evidence bar (awaiting a named human owner; no route selected)
+- [`release-evidence-policy-decision.md`](release-evidence-policy-decision.md) — the approved release evidence bar: the 56-case `pre_1_0` policy for `0.x` tags, the 100-case `beta` policy from 1.0 on, and the promotion path between them (decided 2026-08-29, #341)
 - [`decisions.md`](decisions.md) — architectural decisions
 
 ## For agents

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -53,18 +53,25 @@ against the exact wheel and signs `safety-qualification.json`:
 |---|---|
 | `SAFETY_QUALIFICATION_WHEEL_URL` | HTTPS URL for the exact qualified wheel |
 | `SAFETY_QUALIFICATION_WHEEL_FILENAME` | Safe wheel basename, for example `agents_shipgate-0.16.0b6-py3-none-any.whl` |
-| `SAFETY_QUALIFICATION_JSON_URL` | HTTPS URL for the production-qualified JSON artifact |
+| `SAFETY_QUALIFICATION_JSON_URL` | HTTPS URL for the qualified JSON artifact |
 | `SAFETY_QUALIFICATION_SIGSTORE_BUNDLE_URL` | HTTPS URL for that JSON artifact's Sigstore bundle |
 
 The verification job checks the signature identity first, then validates the
-artifact's production policy, 100-case invariants, tag/version, and wheel
-SHA-256. It then rebuilds a wheel from the tagged checkout and requires byte
-equality with the qualified wheel, which is the binding that ties the published
-artifact to the tagged commit. The rebuilt wheel is only ever a comparison
+artifact against the policy the tag's version requires — the 100-case `beta`
+policy, or, for a `0.x` tag, the 56-case `pre_1_0` policy approved in
+[`release-evidence-policy-decision.md`](release-evidence-policy-decision.md) —
+together with the tag/version and wheel SHA-256. Which policy governs is
+derived from the version, never read from the artifact, and a `0.x` tag may
+also publish on the stronger `beta` artifact.
+
+It then rebuilds a wheel from the tagged checkout and requires byte equality
+with the qualified wheel, which is the binding that ties the published artifact
+to the tagged commit. The rebuilt wheel is only ever a comparison
 reference: the artifact published to PyPI remains the exact qualified wheel.
 
 Missing variables, non-HTTPS URLs, an unsafe filename, an invalid signature, a
-non-production result, or any binding mismatch stops before PyPI publication.
+result whose tier the tag's version does not admit, or any binding mismatch
+stops before PyPI publication.
 
 Because a tampered wheel URL now fails the source-binding gate rather than
 reaching PyPI, variable ACLs are no longer the primary control over what gets
@@ -75,8 +82,9 @@ This is a configured trust root, not proof of organizational independence.
 The promotion job trusts the signed qualification summary and does not replay
 its underlying verifier receipts. The four-week, three-design-partner rollout
 is likewise an external beta stop condition; the machine gate enforces only
-the qualification artifact's combined minimum of 40 real-history,
-rejected/reverted, or design-partner origins.
+the qualification artifact's combined origin minimum — 40 real-history,
+rejected/reverted, or design-partner cases under the production policy and 23
+under the pre-1.0 one, the same 40% share of each corpus.
 
 ## Marketplace And Site
 

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -1,132 +1,165 @@
-# Decision Brief: The Evidence Bar for Pre-1.0 Tags
+# Release Evidence Policy: The Approved Bar for Pre-1.0 Tags
 
-**Status: open, not milestone-blocking.** Tracked by
-[#341](https://github.com/ThreeMoonsLab/agents-shipgate/issues/341) (P2 —
-"queued; valuable but not blocking"), outside the v0.16.0 milestone by product
-decision on 2026-08-09.
+**Status: decided.**
+**Route 2 — an explicit pre-1.0 policy.**
+**Owner: Pengfei Hu (`pengfei-threemoonslab`), product/security. Recorded
+2026-08-29.** Tracked by
+[#341](https://github.com/ThreeMoonsLab/agents-shipgate/issues/341).
 
-This brief exists to make the decision cheap to take, not to take it. No route
-is selected here, and nothing in this document changes the enforced policy: the
-release verifier still requires the full 100-case production-beta artifact.
+Before this decision the repository had exactly one release policy — 100
+adjudicated, receipt-bound cases — written as the claim `1.0` should make, and
+enforced for every tag including `0.x`. No corpus met it, so no tag could
+publish, and the newest published build stayed `v0.15.0`.
 
-Do not infer the choice from the tag, and do not rename the current policy after
-the fact.
+This document records the approved alternative, the numbers that define it, the
+tags it governs, and what promotion to the 1.0 bar requires. It is the source
+the code is written from; where the two disagree, the code is wrong.
 
-> **What "not blocking" does and does not mean.** Descoping #341 changed what
-> the milestone tracks, not what the pipeline enforces. A `v*` tag still fails
-> closed at **Verify production qualification and exact wheel binding** unless a
-> signed artifact satisfies the 100-case bar. Shipping a tag therefore still
-> needs either that artifact (Route 1) or an approved alternative policy
-> (Route 2) — the difference is that neither is now treated as a v0.16.0
-> deliverable.
+## The decision
 
-## Why a decision is required
+A second **named** policy now exists. It reduces how much evidence a `0.x` tag
+must carry. It reduces nothing about how that evidence is judged.
 
-`v0.16.0` is the first tag that will run the safety-qualification gate
-end to end. The gate was added after `v0.15.0`, so it has never executed as a
-release precondition.
-
-The bar it enforces cannot currently be met:
-
-| Requirement | Enforced today | Available today |
+| | `beta` (production) | `pre_1_0` (approved here) |
 |---|---|---|
-| Adjudicated cases | 100, across 28 profile × decision strata | 32 labelled rows |
-| Qualifying origins | ≥ 40 real-history / rejected-or-reverted / design-partner | not separately tracked |
-| Per-case verifier receipt | required, unique digest per case | not produced by the miner corpus |
-| Holdout per stratum | enforced fraction per stratum | n/a |
-| Label agreement | Cohen's κ floor | n/a |
+| Governs | `1.0` and later — and any tag, if offered | `0.x` tags only |
+| Adjudicated cases | 100 | **56** |
+| Strata (profile × decision) | 28, weighted | **28, two cases each** |
+| Qualifying origins | ≥ 40 (40%) | **≥ 23** (40%, rounded up) |
+| Cohen's κ floor | 0.80 | **0.80** — unchanged |
+| Holdout per stratum | ≥ 20% | **≥ 20%** — unchanged |
+| Unsafe auto-passes | 0, per profile and overall | **0** — unchanged |
+| Per-case verifier receipt | required, unique digest | **required** — unchanged |
+| `static_only` / `runtime_behavior_proven` | `true` / `false` | **unchanged** |
+| Safe passes | ≥ 27 of 30 (90%) | **≥ 13 of 14** (92.9%) |
+| Blocked exact | ≥ 30 of 30 (100%) | **≥ 14 of 14** (100%) |
+| Review exact | ≥ 19 of 20 (95%) | **≥ 14 of 14** (100%) |
+| Insufficient-evidence exact | ≥ 19 of 20 (95%) | **≥ 14 of 14** (100%) |
+| Report schema | `0.42` | **`0.42`** — unchanged |
 
-The 32 rows under `benchmark/miner/results/*.labels.csv` are a useful product
-measurement, but they are not interchangeable with qualification cases:
-qualification additionally binds adjudicated labels and a terminal verifier
-receipt per case.
+### Why these numbers
 
-This is a policy question, not an engineering one. The five engineering
-workstreams (#342, #343, #344, #355, #356) are complete and independent of it,
-which is why the milestone no longer waits on this decision.
+**Two cases per stratum, not a scaled-down copy of the production weighting.**
+Production allocates unevenly — 20 cases to `mcp_openapi_declared_binding`, 10
+to `google_adk`. Scaling that shape to 56 pushes the smallest cells to zero or
+one. A zero-count cell deletes every observation of a profile × outcome pair,
+which is a reduction in *strictness*, not in coverage: the gate stops being able
+to fail for that combination at all. Two per cell is the smallest allocation
+that keeps all 28 cells non-empty **and** leaves each cell one tuning case and
+one holdout case at the unchanged 20% holdout fraction.
 
-What remains true is that the qualification gate is a hard precondition for any
-tag. Until a conforming artifact exists, the practical options are to keep the
-release unpublished, or to take one of the two routes below deliberately.
+**Exact-match floors are the production rates, rounded up.** 27 of 30 and 13 of
+14 are the same 90% demand at two sizes; 12 of 14 would not be. Rounding up
+means three of the four floors land on 100% at this size — the smaller corpus
+buys less tolerance for error, not more. That is the correct direction: fewer
+cases already widen every Wilson interval, so the *claim* is weaker even though
+the *gate* is not.
+
+**The origin floor is the same share, not a smaller one.** 40% of the corpus
+must be real-history, rejected-or-reverted, or design-partner in both policies.
+
+**Nothing on the invariant list moved.** Zero unsafe auto-passes per profile and
+overall, a unique terminal verifier receipt per case, the holdout fraction, the
+κ floor, `static_only`, and verifier re-derivation of every count are
+byte-identical between the two policies. A smaller corpus may reduce
+**coverage**. It must not reduce **strictness**.
+
+### Which tags it governs, and how promotion works
+
+The governing policy is a function of the **version**, applied by the pipeline:
+
+- **epoch 0, major version 0** (`0.16.0b7`, `0.16.0`, `0.17.0`) → `pre_1_0` is
+  sufficient. `beta` is also accepted: an artifact is never rejected for
+  carrying more evidence than its tag requires.
+- **anything else** (`1.0.0`, `1.0.0rc1`, `9.9.9`, `1!0.1`) → `beta` only.
+- **an unparsable version** → `beta` only. The fallback is the strictest
+  policy, never the cheapest.
+
+This is not "inferring the choice from the tag", which #341 forbade. The choice
+was made here, by a named human, and *is* a rule keyed to the version range;
+the pipeline applies that approved rule rather than selecting a bar of its own.
+Nothing in the artifact influences which policy applies to it.
+
+**Promotion to 1.0 is not automatic and has no shortcut.** There is no path by
+which `pre_1_0` evidence qualifies a `1.0` tag. Shipping 1.0 requires the full
+100-case artifact, which is what the corpus-delivery issue exists to produce.
+When it lands, `pre_1_0` stops being reachable by construction — every tag from
+then on has a major version of at least 1 — and the tier is retired from the
+vocabulary in the same change that ships the 1.0 bar.
+
+### What was rejected, and why
+
+**Route 1 — keep the 100-case bar for every tag.** Its benefit is real: the
+shipped claim is exactly the claim that was designed, with no second policy to
+maintain or retire. Its cost is that publication stays blocked on roughly 100
+adjudicated, receipt-bound cases that do not exist, while evaluators keep
+installing `v0.15.0` — an older, less-verified build than the one being
+withheld. Withholding a better build behind a 1.0-grade evidence bar makes
+users less safe, not more. That is the trade the owner declined.
+
+**Renaming the 100-case policy.** Explicitly rejected by #341 and not done:
+`beta` still means exactly what it meant, with the same thresholds and the same
+constructor. `pre_1_0` is additive.
+
+**Reusing `production_qualified` for both tiers.** The flag keeps meaning "met
+the 100-case bar". A `pre_1_0` artifact reports `production_qualified: false`,
+and both release verifiers reject an artifact that claims otherwise. A field
+that quietly changed meaning would be the easiest way for this decision to be
+misread later.
 
 ## Where the bar is defined
 
 Changing the bar means changing all of these together; they are cross-checked,
-so a partial change fails the release verifier rather than silently weakening
-it.
+so a partial change fails a release verifier rather than silently weakening it.
 
-- `production_safety_requirements()` in
+- `production_safety_requirements()` and `pre_release_safety_requirements()` in
   `src/agents_shipgate/schemas/safety_qualification.py` — case counts, strata,
   origin minimum, κ floor, holdout fraction, unsafe-auto-pass maximum.
-- `QualificationTier` — distinguishes `beta` from `test`. There is **no latent,
-  already-approved "production tier"** to select at 1.0.
-- `scripts/verify_safety_qualification_release.py` — requires
-  `qualification_tier == "beta"` and `production_qualified == true`, and
-  re-derives every count, interval, and confusion matrix.
-- `scripts/run_safety_qualification.py` — produces the artifact.
-- `docs/distribution.md` — describes the 100-case artifact as the protected
-  release input.
+- `QualificationTier` — `beta`, `pre_1_0`, `test`. `tier_for_requirements()`
+  names a tier from what the thresholds *are*, so an ad-hoc threshold set scores
+  as `test` and can never release.
+- `scripts/run_safety_qualification.py` — produces the artifact, and selects the
+  policy from the wheel version (`--policy-tier` may opt *up* to production;
+  it refuses to opt down for a 1.0-or-later wheel).
+- `scripts/verify_safety_qualification_release.py` — the exhaustive gate.
+  Re-derives every count, interval and confusion matrix from the governing
+  policy.
+- `scripts/verify_qualification_binding.py` — **the sealing gate.** Standard
+  library only, so it restates the per-tier case counts rather than importing
+  them; `test_the_stdlib_case_counts_match_the_named_policies` binds the two
+  copies. *This site is easy to miss: an earlier draft of this brief listed
+  only five, and a change that skipped this one would have failed at the
+  sealing step with a bare case-count error.*
+- `docs/distribution.md` and [`release-runbook.md`](release-runbook.md) — the
+  operator-facing description of the protected release input.
 
-## The two routes
+## Acceptance
 
-### Route 1 — retain the 100-case production-beta policy
-
-No tag publishes until a separate corpus-delivery issue produces the
-independently labelled, adjudicated, receipt-bound artifact.
-
-- **Cost:** publication is gated on a substantial data effort — roughly 68 more
-  adjudicated cases with receipts, spread to satisfy 28 strata and the origin
-  minimum.
-- **Benefit:** the shipped claim is exactly the claim that was designed. No
-  vocabulary churn, no promotion path to maintain.
-- **Implementation:** none. Record the decision, open the corpus issue.
-
-### Route 2 — approve an explicit pre-1.0 policy
-
-Define a **new, separately named** versioned policy governing `0.x` tags, with
-reduced evidence coverage and an explicit promotion path to the 100-case bar
-at 1.0.
-
-- **Cost:** a new tier in the schema vocabulary, a second requirements
-  constructor, verifier branching, and doc updates. Adds a surface that must
-  later be retired.
-- **Benefit:** allows a `0.x` tag to publish on a stated, auditable basis rather than an
-  implied one.
-- **Non-negotiable regardless of the numbers chosen:**
-  - zero unsafe auto-passes, per profile and overall
-    (`maximum_unsafe_auto_passes == 0`);
-  - a per-case terminal verifier receipt, with unique digests;
-  - a holdout fraction per stratum;
-  - `static_only == true` and `runtime_behavior_proven == false`;
-  - internal consistency re-derived by the verifier, never trusted from the
-    artifact.
-
-  A "smaller corpus" may reduce **coverage**. It must not reduce **strictness**.
-
-If Route 2 is chosen, the decision must state: case count, strata layout, origin
-minimum, κ floor, holdout fraction, which tags the policy governs, and what
-promotion to the 1.0 bar requires. Implementation follows in a separate issue —
-this decision does not silently implement a lower bar.
-
-## Acceptance for whichever route is chosen
-
-- [ ] A named human product/security owner records the route and rationale.
-- [ ] Case counts, origin counts, agreement threshold, holdout rule, and the
-      zero-unsafe-pass invariant are explicit.
-- [ ] The policy states which versions/tags it governs and how promotion works.
-- [ ] Documentation, schema vocabulary, qualification generator, release
-      verifier, and this runbook agree.
-- [ ] A separate implementation/corpus-delivery issue is opened.
-- [ ] A rehearsal ([`release-runbook.md`](release-runbook.md)) proves the chosen
-      policy **fails closed** — run it against an artifact that misses the bar
-      and confirm publication stops at the qualification step.
+- [x] A named human product/security owner records the route and rationale —
+      Pengfei Hu, 2026-08-29, above.
+- [x] Case counts, origin counts, agreement threshold, holdout rule, and the
+      zero-unsafe-pass invariant are explicit — the table above.
+- [x] The policy states which versions/tags it governs and how promotion works.
+- [x] Documentation, schema vocabulary, qualification generator, release
+      verifiers, and this runbook agree — enforced by the tests named above,
+      not only asserted here.
+- [ ] A separate corpus-delivery issue is opened for the 56-case artifact and
+      the 100-case 1.0 bar.
+- [ ] A rehearsal proves the chosen policy **fails closed** — dispatch
+      **Release Rehearsal** against an artifact that misses the bar and confirm
+      publication stops at the qualification step. The deterministic half of
+      this is already covered:
+      `test_a_pre_1_0_artifact_publishes_a_0_x_tag_and_nothing_later` and
+      `test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact`
+      prove the same bytes that pass a `0.x` tag fail a `1.0` one, at both
+      gates.
 
 ## What is already true regardless
 
-The other five release-integrity controls do not depend on this decision and are
-in place: source-to-wheel binding, separated verification and publication with a
-recoverable transaction, deterministic test selection with a measured timeout, a
-non-publishing rehearsal path, and a wheel-scoped signed SBOM.
+The other five release-integrity controls do not depend on this decision and
+are in place: source-to-wheel binding, separated verification and publication
+with a recoverable transaction, deterministic test selection with a measured
+timeout, a non-publishing rehearsal path, and a wheel-scoped signed SBOM.
 
-Whichever bar is approved, it will be enforced by a pipeline that also proves
-the bytes it publishes came from the tagged commit.
+Whichever bar applies, it is enforced by a pipeline that also proves the bytes
+it publishes came from the tagged commit.

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -82,7 +82,9 @@ Nothing in the artifact influences which policy applies to it.
 
 **Promotion to 1.0 is not automatic and has no shortcut.** There is no path by
 which `pre_1_0` evidence qualifies a `1.0` tag. Shipping 1.0 requires the full
-100-case artifact, which is what the corpus-delivery issue exists to produce.
+100-case artifact, which is what corpus-delivery issue
+[#456](https://github.com/ThreeMoonsLab/agents-shipgate/issues/456) exists to
+produce.
 When it lands, `pre_1_0` stops being reachable by construction — every tag from
 then on has a major version of at least 1 — and the tier is retired from the
 vocabulary in the same change that ships the 1.0 bar.
@@ -110,8 +112,11 @@ easiest way for this decision to be misread later.
 
 ## Where the bar is defined
 
-Changing the bar means changing all of these together; they are cross-checked,
-so a partial change fails a release verifier rather than silently weakening it.
+Changing the bar means changing all of these together. The first five are
+cross-checked, so a partial change fails a release verifier rather than
+silently weakening it. The last two are not, and are the more dangerous
+omission for exactly that reason: nothing fails, and the corpus gets built to
+the wrong shape.
 
 - `production_safety_requirements()` and `pre_release_safety_requirements()` in
   `src/agents_shipgate/schemas/safety_qualification.py` — case counts, strata,
@@ -135,7 +140,7 @@ so a partial change fails a release verifier rather than silently weakening it.
   sealing step with a bare case-count error.*
 - `benchmark/safety-qualification/README.md` — **the corpus owner's runbook**,
   and the one that decides what actually gets built. A change that left this
-  behind would send the corpus-delivery effort at the wrong shape entirely,
+  behind would aim the corpus-delivery effort at the wrong shape entirely,
   which no gate can detect and no verifier error would explain.
 - `docs/distribution.md`, [`release-runbook.md`](release-runbook.md) and
   `docs/INDEX.md` — the operator-facing description of the protected release
@@ -151,8 +156,9 @@ so a partial change fails a release verifier rather than silently weakening it.
 - [x] Documentation, schema vocabulary, qualification generator, release
       verifiers, and this runbook agree — enforced by the tests named above,
       not only asserted here.
-- [ ] A separate corpus-delivery issue is opened for the 56-case artifact and
-      the 100-case 1.0 bar.
+- [x] A separate corpus-delivery issue is opened for the 56-case artifact and
+      the 100-case 1.0 bar —
+      [#456](https://github.com/ThreeMoonsLab/agents-shipgate/issues/456).
 - [ ] A rehearsal proves the chosen policy **fails closed** — dispatch
       **Release Rehearsal** against an artifact that misses the bar and confirm
       publication stops at the qualification step. The deterministic half of

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -73,7 +73,9 @@ The governing policy is a function of the **version**, applied by the pipeline:
   carrying more evidence than its tag requires.
 - **anything else** (`1.0.0`, `1.0.0rc1`, `9.9.9`, `1!0.1`) → `beta` only.
 - **an unparsable version** → `beta` only. The fallback is the strictest
-  policy, never the cheapest.
+  policy, never the cheapest. "Unparsable" means anything that is not a
+  complete PEP 440 version: `0garbage` and `0.16.0garbage` are *not* pre-1.0,
+  even though they begin with a zero.
 
 This is not "inferring the choice from the tag", which #341 forbade. The choice
 was made here, by a named human, and *is* a rule keyed to the version range;
@@ -125,7 +127,9 @@ the wrong shape.
   names a tier from what the thresholds *are*, so an ad-hoc threshold set scores
   as `test` and can never release. `SafetyQualificationResultV1` additionally
   refuses to construct an artifact whose `production_qualified` disagrees with
-  its tier.
+  its tier. Both are grammar changes, so the envelope advances
+  `shipgate.safety_qualification/v4 → v5`; see the migration note in
+  [`STABILITY.md`](../STABILITY.md).
 - `scripts/run_safety_qualification.py` — produces the artifact, and selects the
   policy from the wheel version (`--policy-tier` may opt *up* to production;
   it refuses to opt down for a 1.0-or-later wheel).
@@ -133,11 +137,18 @@ the wrong shape.
   Re-derives every count, interval and confusion matrix from the governing
   policy.
 - `scripts/verify_qualification_binding.py` — **the sealing gate.** Standard
-  library only, so it restates the per-tier case counts rather than importing
-  them; `test_the_stdlib_case_counts_match_the_named_policies` binds the two
-  copies. *This site is easy to miss: an earlier draft of this brief listed
-  only five, and a change that skipped this one would have failed at the
-  sealing step with a bare case-count error.*
+  library only, so it *restates* each tier's strata, exact-match floors,
+  holdout minimum and origin/κ floors rather than importing them, and
+  re-derives them from the raw cases;
+  `test_the_stdlib_policy_table_matches_the_named_policies` binds every field
+  of the two copies. Restating only a case count is not enough — it cannot
+  tell 56 correctly stratified cases from 56 identical ones, nor notice a
+  corpus two safe passes below its floor, which is exactly the class of
+  weakening this gate exists to stop. *This site is easy to miss: an earlier
+  draft of this brief listed only five.*
+- `scripts/_release_support.py` — the version→tier rule, shared by both gates
+  and the producer. It requires a **complete** PEP 440 parse: a version it
+  cannot fully parse is not pre-1.0, so it falls to the production bar.
 - `benchmark/safety-qualification/README.md` — **the corpus owner's runbook**,
   and the one that decides what actually gets built. A change that left this
   behind would aim the corpus-delivery effort at the wrong shape entirely,

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -45,8 +45,17 @@ to `google_adk`. Scaling that shape to 56 pushes the smallest cells to zero or
 one. A zero-count cell deletes every observation of a profile × outcome pair,
 which is a reduction in *strictness*, not in coverage: the gate stops being able
 to fail for that combination at all. Two per cell is the smallest allocation
-that keeps all 28 cells non-empty **and** leaves each cell one tuning case and
-one holdout case at the unchanged 20% holdout fraction.
+that keeps all 28 cells non-empty **and** leaves room for a tuning/holdout split
+in every cell at the unchanged 20% holdout fraction — at one case per cell,
+`ceil(1 × 0.20) = 1` forces the single case to be holdout and no cell can hold a
+tuning case at all.
+
+**What is enforced is a holdout floor, not a 1/1 split.** Each cell must carry
+at least `ceil(size × 0.20)` holdout cases — one, at this size. A corpus that
+marks *more* cases holdout is accepted, and deliberately so: holdout evidence is
+evidence the engine was never tuned on, so more of it is stronger, and a
+minimum on tuning cases would be a *maximum* on holdout. The gate must never
+reject a corpus for being more conservative than required.
 
 **Exact-match floors are the production rates, rounded up.** 27 of 30 and 13 of
 14 are the same 90% demand at two sizes; 12 of 14 would not be. Rounding up
@@ -127,7 +136,8 @@ the wrong shape.
   names a tier from what the thresholds *are*, so an ad-hoc threshold set scores
   as `test` and can never release. `SafetyQualificationResultV1` additionally
   refuses to construct an artifact whose `production_qualified` disagrees with
-  its tier. Both are grammar changes, so the envelope advances
+  its tier, or one that claims a legacy envelope while carrying `pre_1_0`. Both
+  are grammar changes, so the envelope advances
   `shipgate.safety_qualification/v4 → v5`; see the migration note in
   [`STABILITY.md`](../STABILITY.md).
 - `scripts/run_safety_qualification.py` — produces the artifact, and selects the
@@ -137,9 +147,11 @@ the wrong shape.
   Re-derives every count, interval and confusion matrix from the governing
   policy.
 - `scripts/verify_qualification_binding.py` — **the sealing gate.** Standard
-  library only, so it *restates* each tier's strata, exact-match floors,
-  holdout minimum and origin/κ floors rather than importing them, and
-  re-derives them from the raw cases;
+  library only, so it *restates* each tier's whole `requirements` block —
+  strata, exact-match floors, holdout minimum, origin and κ floors, and the
+  report schema version — rather than importing it, re-derives from the raw
+  cases everything the cases can attest, and compares the artifact's own
+  declared `requirements` against the restatement for the rest;
   `test_the_stdlib_policy_table_matches_the_named_policies` binds every field
   of the two copies. Restating only a case count is not enough — it cannot
   tell 56 correctly stratified cases from 56 identical ones, nor notice a

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -103,9 +103,10 @@ constructor. `pre_1_0` is additive.
 
 **Reusing `production_qualified` for both tiers.** The flag keeps meaning "met
 the 100-case bar". A `pre_1_0` artifact reports `production_qualified: false`,
-and both release verifiers reject an artifact that claims otherwise. A field
-that quietly changed meaning would be the easiest way for this decision to be
-misread later.
+and the artifact schema refuses to *construct* one that says otherwise — so the
+producer cannot emit the inconsistency, rather than every reader having to
+catch it after signing. A field that quietly changed meaning would be the
+easiest way for this decision to be misread later.
 
 ## Where the bar is defined
 
@@ -117,7 +118,9 @@ so a partial change fails a release verifier rather than silently weakening it.
   origin minimum, κ floor, holdout fraction, unsafe-auto-pass maximum.
 - `QualificationTier` — `beta`, `pre_1_0`, `test`. `tier_for_requirements()`
   names a tier from what the thresholds *are*, so an ad-hoc threshold set scores
-  as `test` and can never release.
+  as `test` and can never release. `SafetyQualificationResultV1` additionally
+  refuses to construct an artifact whose `production_qualified` disagrees with
+  its tier.
 - `scripts/run_safety_qualification.py` — produces the artifact, and selects the
   policy from the wheel version (`--policy-tier` may opt *up* to production;
   it refuses to opt down for a 1.0-or-later wheel).
@@ -130,8 +133,13 @@ so a partial change fails a release verifier rather than silently weakening it.
   copies. *This site is easy to miss: an earlier draft of this brief listed
   only five, and a change that skipped this one would have failed at the
   sealing step with a bare case-count error.*
-- `docs/distribution.md` and [`release-runbook.md`](release-runbook.md) — the
-  operator-facing description of the protected release input.
+- `benchmark/safety-qualification/README.md` — **the corpus owner's runbook**,
+  and the one that decides what actually gets built. A change that left this
+  behind would send the corpus-delivery effort at the wrong shape entirely,
+  which no gate can detect and no verifier error would explain.
+- `docs/distribution.md`, [`release-runbook.md`](release-runbook.md) and
+  `docs/INDEX.md` — the operator-facing description of the protected release
+  input, and the index agents walk to find it.
 
 ## Acceptance
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -124,9 +124,15 @@ production rate rounded up.
 Both gates apply the rule independently — the exhaustive
 `scripts/verify_safety_qualification_release.py` in the `tests` job, and the
 standard-library `scripts/verify_qualification_binding.py` in the sealing job.
-An artifact naming a tier the version does not admit is rejected by both, and
-is then measured against the *production* counts, so a bad tier can never
-shrink what is checked.
+The sealing gate cannot import the project, so it *restates* each tier's
+strata, exact-match floors, per-stratum holdout, and origin and κ floors, and
+re-derives them from the raw cases; a case count alone would let 56 identical
+rows through. An artifact naming a tier the version does not admit is rejected
+by both, and is then measured against the *production* policy, so a bad tier
+can never shrink what is checked.
+
+"Unparsable" is decided by a complete PEP 440 parse, not a prefix: `0garbage`
+is not a `0.x` version and gets the production bar.
 
 To produce the artifact, `scripts/run_safety_qualification.py` selects the same
 way. `--policy-tier production` opts up to the 100-case bar on a `0.x` wheel;

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -102,6 +102,37 @@ Binding 4 is the one that was missing. Without it, any wheel declaring
 `Name: agents-shipgate` and the right `Version` satisfied every check, so the
 pipeline tested one artifact and published another.
 
+### Which evidence bar the tag must meet
+
+Two named qualification policies exist, and the **version decides which one
+applies** — nothing in the artifact does:
+
+| Version | Accepted qualification | Cases |
+|---|---|---|
+| `0.x` (epoch 0, major 0) | `pre_1_0`, or the stronger `beta` | 56, or 100 |
+| `1.0` and later | `beta` only | 100 |
+| unparsable | `beta` only | 100 |
+
+The `pre_1_0` policy was approved for issue #341 and is recorded, with its
+thresholds and rationale, in
+[`release-evidence-policy-decision.md`](release-evidence-policy-decision.md). It
+buys a smaller corpus, not a laxer judgement: zero unsafe auto-passes, a
+per-case verifier receipt, the 20% holdout fraction and the κ floor are
+identical to the production policy, and every exact-match floor is the
+production rate rounded up.
+
+Both gates apply the rule independently — the exhaustive
+`scripts/verify_safety_qualification_release.py` in the `tests` job, and the
+standard-library `scripts/verify_qualification_binding.py` in the sealing job.
+An artifact naming a tier the version does not admit is rejected by both, and
+is then measured against the *production* counts, so a bad tier can never
+shrink what is checked.
+
+To produce the artifact, `scripts/run_safety_qualification.py` selects the same
+way. `--policy-tier production` opts up to the 100-case bar on a `0.x` wheel;
+`--policy-tier pre-1.0` is refused for a `1.0`-or-later wheel, at the point of
+production rather than at the gate.
+
 ### Build reproducibility
 
 Byte equality is only achievable because the build backend is pinned in

--- a/scripts/_release_support.py
+++ b/scripts/_release_support.py
@@ -19,8 +19,11 @@ project; `scripts/verify_wheel_provenance.py` runs only there.
 from __future__ import annotations
 
 import hashlib
+import math
 import re
 import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
 from email.parser import BytesParser
 from email.policy import default as email_policy
 from pathlib import Path
@@ -31,32 +34,143 @@ SHA256_PATTERN = re.compile(r"\A[0-9a-f]{64}\Z")
 PRODUCTION_QUALIFICATION_TIER = "beta"
 PRE_1_0_QUALIFICATION_TIER = "pre_1_0"
 
-# Case count per named qualification policy. Restated here because the sealing
-# job may not import the project's pydantic schemas, and bound to the real
-# constructors by ``test_the_stdlib_case_counts_match_the_named_policies`` so
-# the two copies cannot drift.
-QUALIFICATION_CASE_COUNTS = {
-    PRODUCTION_QUALIFICATION_TIER: 100,
-    PRE_1_0_QUALIFICATION_TIER: 56,
+# Outcome order used by every ``profile_counts`` row below.
+QUALIFICATION_DECISIONS = (
+    "passed",
+    "review_required",
+    "insufficient_evidence",
+    "blocked",
+)
+
+
+@dataclass(frozen=True)
+class QualificationPolicy:
+    """One named release policy, restated without importing the project.
+
+    The sealing job runs on the standard library alone, so it cannot read
+    ``production_safety_requirements()``. Restating a *total case count* was not
+    enough: a 56-case artifact with two safe passes missing, or 56 cases in no
+    stratum at all, satisfied a count check while failing the actual policy. The
+    sealer must be able to re-derive the same floors the exhaustive gate does,
+    or the dependency-compromise boundary it exists to hold is decorative.
+
+    Every field here is bound to the real constructor by
+    ``test_the_stdlib_policy_table_matches_the_named_policies``.
+    """
+
+    tier: str
+    profile_counts: Mapping[str, tuple[int, int, int, int]]
+    minimum_exact: Mapping[str, int]
+    minimum_qualified_origins: int
+    minimum_kappa: float
+    minimum_holdout_fraction_per_stratum: float
+    maximum_unsafe_auto_passes: int
+
+    @property
+    def strata(self) -> dict[tuple[str, str], int]:
+        return {
+            (profile, decision): count
+            for profile, counts in self.profile_counts.items()
+            for decision, count in zip(QUALIFICATION_DECISIONS, counts, strict=True)
+        }
+
+    @property
+    def case_count(self) -> int:
+        return sum(sum(counts) for counts in self.profile_counts.values())
+
+    def outcome_total(self, decision: str) -> int:
+        index = QUALIFICATION_DECISIONS.index(decision)
+        return sum(counts[index] for counts in self.profile_counts.values())
+
+    def minimum_holdout(self, stratum_size: int) -> int:
+        return math.ceil(stratum_size * self.minimum_holdout_fraction_per_stratum)
+
+
+_RELEASE_SAFETY_PROFILES = (
+    "mcp_openapi_declared_binding",
+    "openai_agents_sdk",
+    "langchain_crewai",
+    "google_adk",
+    "n8n",
+    "multi_agent_handoffs",
+    "coding_agent_trust_roots",
+)
+
+QUALIFICATION_POLICIES: dict[str, QualificationPolicy] = {
+    PRODUCTION_QUALIFICATION_TIER: QualificationPolicy(
+        tier=PRODUCTION_QUALIFICATION_TIER,
+        profile_counts={
+            "mcp_openapi_declared_binding": (6, 4, 4, 6),
+            "openai_agents_sdk": (5, 3, 3, 4),
+            "langchain_crewai": (5, 3, 3, 4),
+            "google_adk": (3, 2, 2, 3),
+            "n8n": (3, 2, 2, 3),
+            "multi_agent_handoffs": (4, 3, 3, 5),
+            "coding_agent_trust_roots": (4, 3, 3, 5),
+        },
+        minimum_exact={
+            "passed": 27,
+            "review_required": 19,
+            "insufficient_evidence": 19,
+            "blocked": 30,
+        },
+        minimum_qualified_origins=40,
+        minimum_kappa=0.80,
+        minimum_holdout_fraction_per_stratum=0.20,
+        maximum_unsafe_auto_passes=0,
+    ),
+    PRE_1_0_QUALIFICATION_TIER: QualificationPolicy(
+        tier=PRE_1_0_QUALIFICATION_TIER,
+        profile_counts=dict.fromkeys(_RELEASE_SAFETY_PROFILES, (2, 2, 2, 2)),
+        minimum_exact={
+            "passed": 13,
+            "review_required": 14,
+            "insufficient_evidence": 14,
+            "blocked": 14,
+        },
+        minimum_qualified_origins=23,
+        minimum_kappa=0.80,
+        minimum_holdout_fraction_per_stratum=0.20,
+        maximum_unsafe_auto_passes=0,
+    ),
 }
 
-# PEP 440 leading ``[N!]N(.N)*``. Only the epoch and the first release segment
-# decide which policy governs a tag, so nothing after them is parsed.
-_VERSION_PREFIX = re.compile(r"\A(?:(?P<epoch>\d+)!)?(?P<release>\d+(?:\.\d+)*)")
+# The complete PEP 440 public-version grammar, anchored at both ends. An
+# earlier prefix-anchored form read ``0garbage``, ``0.16.0garbage`` and
+# ``0..1`` as major 0 and handed them the *cheaper* policy -- the exact
+# opposite of the approved rule, which sends every unparsable version to the
+# production bar. The permissive leading ``v`` is deliberately not accepted:
+# wheel metadata carries a normalized version, and refusing one only ever
+# selects the stricter policy.
+_PEP440_VERSION = re.compile(
+    r"""\A
+    (?:(?P<epoch>[0-9]+)!)?
+    (?P<release>[0-9]+(?:\.[0-9]+)*)
+    (?:[-_.]?(?:alpha|a|beta|b|preview|pre|c|rc)[-_.]?[0-9]*)?
+    (?:-[0-9]+|[-_.]?(?:post|rev|r)[-_.]?[0-9]*)?
+    (?:[-_.]?dev[-_.]?[0-9]*)?
+    (?:\+[a-z0-9]+(?:[-_.][a-z0-9]+)*)?
+    \Z""",
+    re.VERBOSE | re.IGNORECASE,
+)
 
 
 def release_version_is_pre_1_0(version: str) -> bool:
-    """True only for an epoch-0 version whose major release segment is 0.
+    """True only for a valid epoch-0 version whose major release segment is 0.
 
-    Fail-closed by construction: an unparsable version is *not* pre-1.0, so it
-    falls through to the strictest policy rather than the cheapest one.
+    Fail-closed by construction: a version this cannot fully parse is *not*
+    pre-1.0, so it falls through to the strictest policy rather than the
+    cheapest one. Both release gates share this helper, so a hole here opens
+    both at once.
     """
 
-    match = _VERSION_PREFIX.match(version.strip())
+    match = _PEP440_VERSION.match(version.strip())
     if match is None:
         return False
     if int(match.group("epoch") or 0) != 0:
         return False
+    # Leading zeros are legal PEP 440 and normalize away: ``00.1`` is 0.1, and
+    # ``01.0`` is 1.0 and therefore not pre-1.0.
     return int(match.group("release").split(".")[0]) == 0
 
 
@@ -71,6 +185,19 @@ def accepted_qualification_tiers(version: str) -> tuple[str, ...]:
     if release_version_is_pre_1_0(version):
         return (PRODUCTION_QUALIFICATION_TIER, PRE_1_0_QUALIFICATION_TIER)
     return (PRODUCTION_QUALIFICATION_TIER,)
+
+
+def qualification_policy(tier: object) -> QualificationPolicy:
+    """The restated policy for ``tier``, falling back to production.
+
+    The fallback is not a convenience: an artifact naming a tier its version
+    does not admit is rejected *and* still measured, and measuring it against
+    the strictest policy is what stops a bad tier shrinking the population.
+    """
+
+    if isinstance(tier, str) and tier in QUALIFICATION_POLICIES:
+        return QUALIFICATION_POLICIES[tier]
+    return QUALIFICATION_POLICIES[PRODUCTION_QUALIFICATION_TIER]
 
 
 def describe_accepted_tiers(accepted: tuple[str, ...]) -> str:

--- a/scripts/_release_support.py
+++ b/scripts/_release_support.py
@@ -65,6 +65,7 @@ class QualificationPolicy:
     minimum_kappa: float
     minimum_holdout_fraction_per_stratum: float
     maximum_unsafe_auto_passes: int
+    required_report_schema_version: str
 
     @property
     def strata(self) -> dict[tuple[str, str], int]:
@@ -84,6 +85,40 @@ class QualificationPolicy:
 
     def minimum_holdout(self, stratum_size: int) -> int:
         return math.ceil(stratum_size * self.minimum_holdout_fraction_per_stratum)
+
+    def as_requirements_payload(self) -> dict[str, object]:
+        """The exact ``requirements`` block a conforming artifact must carry.
+
+        The sealer compares the artifact's declared requirements against this,
+        so a signed artifact cannot restate the policy downwards in a field the
+        sealer does not otherwise re-derive -- the report schema version being
+        the one that has no other representation in the payload at all.
+
+        ``test_the_stdlib_policy_table_matches_the_named_policies`` asserts this
+        equals ``SafetyQualificationRequirementsV1.model_dump(mode="json")``,
+        so a field added to the model breaks the build until it is restated
+        here too.
+        """
+
+        return {
+            "required_strata": [
+                {"profile": profile, "expected_decision": decision, "count": count}
+                for (profile, decision), count in sorted(self.strata.items())
+            ],
+            "minimum_qualified_origins": self.minimum_qualified_origins,
+            "minimum_kappa": self.minimum_kappa,
+            "minimum_holdout_fraction_per_stratum": (
+                self.minimum_holdout_fraction_per_stratum
+            ),
+            "maximum_unsafe_auto_passes": self.maximum_unsafe_auto_passes,
+            "minimum_safe_passes": self.minimum_exact["passed"],
+            "minimum_blocked_exact": self.minimum_exact["blocked"],
+            "minimum_review_exact": self.minimum_exact["review_required"],
+            "minimum_insufficient_evidence_exact": self.minimum_exact[
+                "insufficient_evidence"
+            ],
+            "required_report_schema_version": self.required_report_schema_version,
+        }
 
 
 _RELEASE_SAFETY_PROFILES = (
@@ -118,6 +153,7 @@ QUALIFICATION_POLICIES: dict[str, QualificationPolicy] = {
         minimum_kappa=0.80,
         minimum_holdout_fraction_per_stratum=0.20,
         maximum_unsafe_auto_passes=0,
+        required_report_schema_version="0.42",
     ),
     PRE_1_0_QUALIFICATION_TIER: QualificationPolicy(
         tier=PRE_1_0_QUALIFICATION_TIER,
@@ -132,8 +168,36 @@ QUALIFICATION_POLICIES: dict[str, QualificationPolicy] = {
         minimum_kappa=0.80,
         minimum_holdout_fraction_per_stratum=0.20,
         maximum_unsafe_auto_passes=0,
+        required_report_schema_version="0.42",
     ),
 }
+
+# Restated from ``agents_shipgate.schemas.safety_qualification``; bound to it by
+# ``test_the_stdlib_policy_table_matches_the_named_policies``.
+CURRENT_QUALIFICATION_ENVELOPE = "shipgate.safety_qualification/v5"
+LEGACY_QUALIFICATION_ENVELOPES = frozenset(
+    {
+        "shipgate.safety_qualification/v1",
+        "shipgate.safety_qualification/v2",
+        "shipgate.safety_qualification/v4",
+    }
+)
+LEGACY_QUALIFICATION_TIERS = frozenset({"beta", "test"})
+
+
+def qualification_envelope_admits_tier(schema_version: object, tier: object) -> bool:
+    """Whether ``schema_version``'s reader can express ``tier``.
+
+    A legacy envelope predates ``pre_1_0``, so labelling a pre-1.0 artifact
+    with one hands an old reader something it cannot parse. The sealer enforces
+    this on raw JSON because it never parses the envelope otherwise.
+    """
+
+    if schema_version == CURRENT_QUALIFICATION_ENVELOPE:
+        return True
+    if schema_version in LEGACY_QUALIFICATION_ENVELOPES:
+        return tier in LEGACY_QUALIFICATION_TIERS
+    return False
 
 # The complete PEP 440 public-version grammar, anchored at both ends. An
 # earlier prefix-anchored form read ``0garbage``, ``0.16.0garbage`` and

--- a/scripts/_release_support.py
+++ b/scripts/_release_support.py
@@ -28,6 +28,58 @@ from pathlib import Path
 DISTRIBUTION_NAME = "agents-shipgate"
 SHA256_PATTERN = re.compile(r"\A[0-9a-f]{64}\Z")
 
+PRODUCTION_QUALIFICATION_TIER = "beta"
+PRE_1_0_QUALIFICATION_TIER = "pre_1_0"
+
+# Case count per named qualification policy. Restated here because the sealing
+# job may not import the project's pydantic schemas, and bound to the real
+# constructors by ``test_the_stdlib_case_counts_match_the_named_policies`` so
+# the two copies cannot drift.
+QUALIFICATION_CASE_COUNTS = {
+    PRODUCTION_QUALIFICATION_TIER: 100,
+    PRE_1_0_QUALIFICATION_TIER: 56,
+}
+
+# PEP 440 leading ``[N!]N(.N)*``. Only the epoch and the first release segment
+# decide which policy governs a tag, so nothing after them is parsed.
+_VERSION_PREFIX = re.compile(r"\A(?:(?P<epoch>\d+)!)?(?P<release>\d+(?:\.\d+)*)")
+
+
+def release_version_is_pre_1_0(version: str) -> bool:
+    """True only for an epoch-0 version whose major release segment is 0.
+
+    Fail-closed by construction: an unparsable version is *not* pre-1.0, so it
+    falls through to the strictest policy rather than the cheapest one.
+    """
+
+    match = _VERSION_PREFIX.match(version.strip())
+    if match is None:
+        return False
+    if int(match.group("epoch") or 0) != 0:
+        return False
+    return int(match.group("release").split(".")[0]) == 0
+
+
+def accepted_qualification_tiers(version: str) -> tuple[str, ...]:
+    """Qualification tiers whose evidence may publish ``version``.
+
+    ``0.x`` accepts the pre-1.0 policy approved for issue #341 *and* the
+    stronger production one -- a release is never rejected for carrying more
+    evidence than its tag requires. Everything else accepts production only.
+    """
+
+    if release_version_is_pre_1_0(version):
+        return (PRODUCTION_QUALIFICATION_TIER, PRE_1_0_QUALIFICATION_TIER)
+    return (PRODUCTION_QUALIFICATION_TIER,)
+
+
+def describe_accepted_tiers(accepted: tuple[str, ...]) -> str:
+    """Render the accepted set for an error message."""
+
+    if len(accepted) == 1:
+        return accepted[0]
+    return "one of " + ", ".join(accepted)
+
 
 class ReleaseError(RuntimeError):
     """A release precondition failed and publication must not proceed."""

--- a/scripts/run_safety_qualification.py
+++ b/scripts/run_safety_qualification.py
@@ -61,9 +61,17 @@ from agents_shipgate.schemas.verifier import VerifierArtifact
 from agents_shipgate.schemas.verify_run import VerifyRunArtifact
 
 if __package__:
-    from scripts._release_support import release_version_is_pre_1_0
+    from scripts._release_support import (
+        accepted_qualification_tiers,
+        describe_accepted_tiers,
+        release_version_is_pre_1_0,
+    )
 else:  # ``python scripts/run_safety_qualification.py``
-    from _release_support import release_version_is_pre_1_0
+    from _release_support import (
+        accepted_qualification_tiers,
+        describe_accepted_tiers,
+        release_version_is_pre_1_0,
+    )
 
 DECISIONS: tuple[ReleaseDecisionStatus, ...] = (
     "passed",
@@ -489,6 +497,30 @@ def _confusion_matrix(
 POLICY_TIER_CHOICES = ("auto", "production", "pre-1.0")
 
 
+def require_tier_governs_version(tier: str, wheel_version: str) -> None:
+    """Refuse a named policy the wheel's version does not admit.
+
+    The same rule both release gates apply, enforced here so it holds however
+    the requirements were chosen -- the ``--policy-tier`` flag *and* the
+    ``requirements=`` keyword. Without it a caller could hand
+    ``pre_release_safety_requirements()`` to a ``1.0`` wheel and get a
+    zero-exit artifact that no gate will ever accept, discovered only after
+    signing.
+
+    ``test`` is exempt: an ad-hoc threshold set is already unpublishable at
+    every gate, and unit fixtures legitimately score one against any wheel.
+    """
+
+    if tier == "test":
+        return
+    accepted = accepted_qualification_tiers(wheel_version)
+    if tier not in accepted:
+        raise ConfigError(
+            f"The {tier} qualification policy does not govern {wheel_version}; "
+            f"that version requires {describe_accepted_tiers(accepted)}"
+        )
+
+
 def select_release_requirements(
     wheel_version: str, choice: str = "auto"
 ) -> SafetyQualificationRequirementsV1:
@@ -509,15 +541,12 @@ def select_release_requirements(
         raise ConfigError(f"Unknown qualification policy tier: {choice}")
     if choice == "production":
         return production_safety_requirements()
-    pre_1_0 = release_version_is_pre_1_0(wheel_version)
     if choice == "pre-1.0":
-        if not pre_1_0:
-            raise ConfigError(
-                f"The pre-1.0 qualification policy does not govern {wheel_version}; "
-                "1.0 and later require the production policy"
-            )
+        require_tier_governs_version("pre_1_0", wheel_version)
         return pre_release_safety_requirements()
-    return pre_release_safety_requirements() if pre_1_0 else production_safety_requirements()
+    if release_version_is_pre_1_0(wheel_version):
+        return pre_release_safety_requirements()
+    return production_safety_requirements()
 
 
 def run_safety_qualification(
@@ -532,8 +561,11 @@ def run_safety_qualification(
     wheel_name, wheel_version, wheel_sha256 = inspect_wheel(wheel_path)
     active_requirements = requirements or select_release_requirements(wheel_version, policy_tier)
     # Named from what the thresholds *are*, never from what a caller asks for:
-    # an ad-hoc requirements object stays ``test`` and cannot release.
+    # an ad-hoc requirements object stays ``test`` and cannot release. The
+    # version rule is then re-applied to the *result*, so it also binds the
+    # ``requirements=`` keyword, which bypasses the selector above.
     tier = tier_for_requirements(active_requirements)
+    require_tier_governs_version(tier, wheel_version)
     corpus = load_frozen_corpus(corpus_path)
     receipt_index = load_receipt_index(receipt_index_path)
     corpus_sha256 = sha256_file(corpus_path)

--- a/scripts/run_safety_qualification.py
+++ b/scripts/run_safety_qualification.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Build a deterministic, fail-closed beta safety qualification artifact.
+"""Build a deterministic, fail-closed safety qualification artifact.
 
 This runner does not execute Agents Shipgate and never substitutes a scan for a
 verifier receipt. It validates frozen human labels, content-addressed verifier
-artifacts, and the exact built wheel before scoring the beta acceptance policy.
+artifacts, and the exact built wheel before scoring a *named* release policy.
+
+Two named policies exist, and the wheel's version decides which one applies:
+the 100-case ``beta`` production policy, and the 56-case ``pre_1_0`` policy
+approved for ``0.x`` tags (issue #341, recorded in
+``docs/release-evidence-policy-decision.md``). Any other threshold set scores
+as ``test`` and can never release.
 """
 
 from __future__ import annotations
@@ -46,11 +52,18 @@ from agents_shipgate.schemas.safety_qualification import (
     SafetyReceiptEntryV1,
     SafetyReceiptIndexV1,
     WilsonIntervalV1,
+    pre_release_safety_requirements,
     production_safety_requirements,
+    tier_for_requirements,
 )
 from agents_shipgate.schemas.verification_identity import VerificationReceipt
 from agents_shipgate.schemas.verifier import VerifierArtifact
 from agents_shipgate.schemas.verify_run import VerifyRunArtifact
+
+if __package__:
+    from scripts._release_support import release_version_is_pre_1_0
+else:  # ``python scripts/run_safety_qualification.py``
+    from _release_support import release_version_is_pre_1_0
 
 DECISIONS: tuple[ReleaseDecisionStatus, ...] = (
     "passed",
@@ -473,6 +486,40 @@ def _confusion_matrix(
     return SafetyConfusionMatrixV1(profile=profile, rows=rows)  # type: ignore[arg-type]
 
 
+POLICY_TIER_CHOICES = ("auto", "production", "pre-1.0")
+
+
+def select_release_requirements(
+    wheel_version: str, choice: str = "auto"
+) -> SafetyQualificationRequirementsV1:
+    """Pick the named policy that governs ``wheel_version``.
+
+    ``auto`` applies the rule a human approved for issue #341 rather than
+    inferring one: ``0.x`` builds are governed by the pre-1.0 policy, anything
+    else by the 100-case production policy. The release verifiers re-derive the
+    same rule from the tag independently, so this choice is never trusted.
+
+    ``production`` is always available -- opting *up* to more evidence than the
+    tag requires can never weaken a release. ``pre-1.0`` is refused for a
+    non-0.x wheel, at the point of production rather than at the gate, because
+    such an artifact could never publish.
+    """
+
+    if choice not in POLICY_TIER_CHOICES:
+        raise ConfigError(f"Unknown qualification policy tier: {choice}")
+    if choice == "production":
+        return production_safety_requirements()
+    pre_1_0 = release_version_is_pre_1_0(wheel_version)
+    if choice == "pre-1.0":
+        if not pre_1_0:
+            raise ConfigError(
+                f"The pre-1.0 qualification policy does not govern {wheel_version}; "
+                "1.0 and later require the production policy"
+            )
+        return pre_release_safety_requirements()
+    return pre_release_safety_requirements() if pre_1_0 else production_safety_requirements()
+
+
 def run_safety_qualification(
     *,
     wheel_path: Path,
@@ -480,12 +527,13 @@ def run_safety_qualification(
     receipt_index_path: Path,
     policy_paths: Iterable[Path],
     requirements: SafetyQualificationRequirementsV1 | None = None,
+    policy_tier: str = "auto",
 ) -> SafetyQualificationResultV1:
-    active_requirements = requirements or production_safety_requirements()
-    production_requirements = production_safety_requirements()
-    production_tier = active_requirements == production_requirements
-
     wheel_name, wheel_version, wheel_sha256 = inspect_wheel(wheel_path)
+    active_requirements = requirements or select_release_requirements(wheel_version, policy_tier)
+    # Named from what the thresholds *are*, never from what a caller asks for:
+    # an ad-hoc requirements object stays ``test`` and cannot release.
+    tier = tier_for_requirements(active_requirements)
     corpus = load_frozen_corpus(corpus_path)
     receipt_index = load_receipt_index(receipt_index_path)
     corpus_sha256 = sha256_file(corpus_path)
@@ -744,7 +792,7 @@ def run_safety_qualification(
         if not metric.passed:
             _failure(
                 failures,
-                code="beta_threshold_failed",
+                code="policy_threshold_failed",
                 message=(
                     f"{metric.name}: {metric.numerator}/{metric.denominator}; "
                     f"required {metric.requirement}"
@@ -792,9 +840,9 @@ def run_safety_qualification(
     }
     qualified = not failures
     return SafetyQualificationResultV1(
-        qualification_tier="beta" if production_tier else "test",
+        qualification_tier=tier,
         qualified=qualified,
-        production_qualified=qualified and production_tier,
+        production_qualified=qualified and tier == "beta",
         inputs=QualificationInputDigestV1(
             wheel_name=wheel_name,
             wheel_version=wheel_version,
@@ -833,12 +881,21 @@ def render_safety_qualification_json(result: SafetyQualificationResultV1) -> str
 
 
 def qualification_exit_code(result: SafetyQualificationResultV1) -> int:
-    return 0 if result.production_qualified else 1
+    """Zero only for a clean run against a *named* release policy.
+
+    ``production_qualified`` alone would fail a valid pre-1.0 artifact, and
+    ``qualified`` alone would pass an ad-hoc ``test`` threshold set.
+    """
+
+    return 0 if result.qualified and result.qualification_tier != "test" else 1
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Validate frozen labels and real verifier receipts for beta qualification."
+        description=(
+            "Validate frozen labels and real verifier receipts against the named "
+            "release policy the wheel version selects."
+        )
     )
     parser.add_argument("--wheel", type=Path, required=True, help="Built agents-shipgate wheel")
     parser.add_argument("--corpus", type=Path, required=True, help="Frozen labeled corpus")
@@ -851,6 +908,17 @@ def _parser() -> argparse.ArgumentParser:
         action="append",
         required=True,
         help="Qualification policy file or directory; repeatable",
+    )
+    parser.add_argument(
+        "--policy-tier",
+        choices=POLICY_TIER_CHOICES,
+        default="auto",
+        help=(
+            "Which named release policy to score against. 'auto' (default) "
+            "selects the pre-1.0 policy for a 0.x wheel and the production "
+            "policy otherwise; 'production' always scores the 100-case bar; "
+            "'pre-1.0' is refused for a 1.0-or-later wheel"
+        ),
     )
     parser.add_argument(
         "--out",
@@ -870,6 +938,7 @@ def main(argv: list[str] | None = None) -> int:
             corpus_path=args.corpus,
             receipt_index_path=args.receipts,
             policy_paths=args.policy,
+            policy_tier=args.policy_tier,
         )
     except (ConfigError, OSError, ValueError) as exc:
         sys.stderr.write(f"Safety qualification configuration error: {exc}\n")

--- a/scripts/verify_qualification_binding.py
+++ b/scripts/verify_qualification_binding.py
@@ -19,8 +19,12 @@ delegate publication authority, using nothing but the standard library:
 * it is static-only and does not claim runtime behaviour was proven;
 * it carries no failures, and exactly as many cases and receipts as that
   policy requires, in exactly that policy's 28 profile x outcome strata;
+* every case has a unique, non-blank id and a terminal verifier decision;
 * it meets that policy's per-outcome exact-match floors and per-stratum
   holdout minimum, both re-derived from the raw cases;
+* its declared ``requirements`` block *is* that policy, field for field --
+  including the report schema version, which nothing in ``cases`` can attest;
+* the envelope it claims can express the tier it claims;
 * it reports **zero** unsafe auto-passes, overall and per profile;
 * and — the binding that matters — its recorded wheel name, version and
   SHA-256 are the wheel about to be published.
@@ -43,6 +47,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from collections import Counter
 from pathlib import Path
@@ -57,6 +62,7 @@ if __package__:
         accepted_qualification_tiers,
         describe_accepted_tiers,
         inspect_wheel,
+        qualification_envelope_admits_tier,
         qualification_policy,
     )
 else:  # ``python scripts/verify_qualification_binding.py``
@@ -68,6 +74,7 @@ else:  # ``python scripts/verify_qualification_binding.py``
         accepted_qualification_tiers,
         describe_accepted_tiers,
         inspect_wheel,
+        qualification_envelope_admits_tier,
         qualification_policy,
     )
 
@@ -77,10 +84,64 @@ def _require(errors: list[str], condition: bool, message: str) -> None:
         errors.append(message)
 
 
-def _is_number(value: Any) -> bool:
-    """A real JSON number. ``True`` is an ``int`` in Python and is not one."""
+def _is_rate(value: Any, *, low: float, high: float) -> bool:
+    """A finite JSON number inside ``[low, high]``.
 
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    ``True`` is an ``int`` in Python and is not a number here. Neither is
+    ``inf``: the JSON literal ``1e309`` loads as ``inf``, which satisfies any
+    ``>=`` floor while the exhaustive gate rejects it against its ``<= 1.0``
+    invariant.
+    """
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(value) and low <= value <= high
+
+
+def _is_count(value: Any, *, low: int, high: int) -> bool:
+    """A genuine integer count inside ``[low, high]``."""
+
+    return isinstance(value, int) and not isinstance(value, bool) and low <= value <= high
+
+
+def _requirements_errors(declared: Any, policy: Any) -> list[str]:
+    """Compare the artifact's own ``requirements`` block against the policy.
+
+    The sealer re-derives the strata and floors from the cases, but the report
+    schema version has no representation in the cases at all -- so without this
+    an artifact could restate the approved ``0.42`` as ``0.1`` and still seal.
+    """
+
+    if not isinstance(declared, dict):
+        return ["artifact has no requirements object"]
+    expected = policy.as_requirements_payload()
+    if set(declared) != set(expected):
+        return [f"requirements block does not carry exactly the {policy.tier} policy's fields"]
+    errors: list[str] = []
+    for key, want in expected.items():
+        got = declared[key]
+        if key == "required_strata":
+            rows = (
+                sorted(
+                    (row.get("profile"), row.get("expected_decision"), row.get("count"))
+                    for row in got
+                    if isinstance(row, dict)
+                )
+                if isinstance(got, list)
+                else None
+            )
+            if rows != sorted(
+                (row["profile"], row["expected_decision"], row["count"]) for row in want
+            ):
+                errors.append(
+                    f"requirements required_strata differ from the {policy.tier} policy"
+                )
+            continue
+        if got != want:
+            errors.append(
+                f"requirements {key} is {got!r}, not the {policy.tier} policy's {want!r}"
+            )
+    return errors
 
 
 def verify_qualification_binding(
@@ -120,11 +181,22 @@ def verify_qualification_binding(
     tier_accepted = tier in accepted_tiers
     policy = qualification_policy(tier if tier_accepted else PRODUCTION_QUALIFICATION_TIER)
     required_case_count = policy.case_count
+    declared_envelope = payload.get("schema_version")
 
     _require(
         errors,
         tier_accepted,
         f"qualification tier is not {describe_accepted_tiers(accepted_tiers)}",
+    )
+    # A legacy envelope's reader admits `beta` and `test` only, so labelling a
+    # pre-1.0 artifact with one hands an old reader something it cannot parse.
+    # The pydantic model refuses the same pairing; this is the raw-JSON half,
+    # because nothing else here looks at the envelope at all.
+    _require(
+        errors,
+        qualification_envelope_admits_tier(declared_envelope, tier),
+        f"qualification envelope {declared_envelope!r} cannot carry "
+        f"qualification_tier {tier!r}",
     )
     _require(errors, payload.get("qualified") is True, "artifact is not qualified")
     if tier == PRODUCTION_QUALIFICATION_TIER:
@@ -194,6 +266,29 @@ def verify_qualification_binding(
     objects = [case for case in cases if isinstance(case, dict)]
     _require(errors, len(objects) == len(cases), "a case entry is not a JSON object")
 
+    # Identity and terminality come first: the floors below count *matches*, so
+    # a case with a null `actual_decision` merely fails to count toward its
+    # floor rather than being rejected, and 56 rows sharing one id look like 56
+    # distinct cases as long as their receipt digests differ.
+    identifiers = [case.get("id") for case in objects]
+    named = [value for value in identifiers if isinstance(value, str) and value.strip()]
+    _require(
+        errors, len(named) == len(identifiers), "a case id is missing, blank, or not a string"
+    )
+    _require(errors, len(set(named)) == len(named), "case ids are not unique")
+    _require(
+        errors,
+        all(case.get("expected_decision") in QUALIFICATION_DECISIONS for case in objects),
+        "a case expected_decision is not one of the four terminal decisions",
+    )
+    _require(
+        errors,
+        all(case.get("actual_decision") in QUALIFICATION_DECISIONS for case in objects),
+        "a case has no terminal actual verifier decision",
+    )
+
+    errors.extend(_requirements_errors(payload.get("requirements"), policy))
+
     strata = Counter(
         (str(case.get("profile")), str(case.get("expected_decision"))) for case in objects
     )
@@ -250,16 +345,19 @@ def verify_qualification_binding(
     # because they are inconvenient to re-derive here.
     _require(
         errors,
-        _is_number(summary.get("qualified_origin_cases"))
-        and summary["qualified_origin_cases"] >= policy.minimum_qualified_origins,
-        f"summary qualified_origin_cases is below the {policy.tier} minimum "
-        f"of {policy.minimum_qualified_origins}",
+        _is_count(
+            summary.get("qualified_origin_cases"),
+            low=policy.minimum_qualified_origins,
+            high=policy.case_count,
+        ),
+        f"summary qualified_origin_cases is not an integer between the {policy.tier} "
+        f"minimum of {policy.minimum_qualified_origins} and {policy.case_count}",
     )
     _require(
         errors,
-        _is_number(summary.get("cohen_kappa"))
-        and summary["cohen_kappa"] >= policy.minimum_kappa,
-        f"summary cohen_kappa is below the {policy.tier} floor of {policy.minimum_kappa}",
+        _is_rate(summary.get("cohen_kappa"), low=policy.minimum_kappa, high=1.0),
+        f"summary cohen_kappa is not a finite value between the {policy.tier} floor "
+        f"of {policy.minimum_kappa} and 1.0",
     )
     _require(
         errors,

--- a/scripts/verify_qualification_binding.py
+++ b/scripts/verify_qualification_binding.py
@@ -11,9 +11,14 @@ dependency there could rewrite the verifier itself.
 This module exists so the sealing job can restate the claims that actually
 delegate publication authority, using nothing but the standard library:
 
-* the artifact is a **beta**, **qualified**, **production_qualified** result;
+* the artifact is **qualified** under a policy the tag's version admits --
+  the 100-case ``beta`` policy, or, for a ``0.x`` tag only, the 56-case
+  ``pre_1_0`` policy approved in
+  ``docs/release-evidence-policy-decision.md`` (issue #341);
+* it claims ``production_qualified`` exactly when it claims the ``beta`` tier;
 * it is static-only and does not claim runtime behaviour was proven;
-* it carries no failures, exactly 100 cases, and 100 receipts;
+* it carries no failures, and exactly as many cases and receipts as that
+  policy requires;
 * it reports **zero** unsafe auto-passes;
 * and — the binding that matters — its recorded wheel name, version and
   SHA-256 are the wheel about to be published.
@@ -41,11 +46,25 @@ from pathlib import Path
 from typing import Any
 
 if __package__:
-    from scripts._release_support import SHA256_PATTERN, ReleaseError, inspect_wheel
+    from scripts._release_support import (
+        PRODUCTION_QUALIFICATION_TIER,
+        QUALIFICATION_CASE_COUNTS,
+        SHA256_PATTERN,
+        ReleaseError,
+        accepted_qualification_tiers,
+        describe_accepted_tiers,
+        inspect_wheel,
+    )
 else:  # ``python scripts/verify_qualification_binding.py``
-    from _release_support import SHA256_PATTERN, ReleaseError, inspect_wheel
-
-REQUIRED_CASE_COUNT = 100
+    from _release_support import (
+        PRODUCTION_QUALIFICATION_TIER,
+        QUALIFICATION_CASE_COUNTS,
+        SHA256_PATTERN,
+        ReleaseError,
+        accepted_qualification_tiers,
+        describe_accepted_tiers,
+        inspect_wheel,
+    )
 
 
 def _require(errors: list[str], condition: bool, message: str) -> None:
@@ -81,11 +100,37 @@ def verify_qualification_binding(
 
     assert isinstance(inputs, dict) and isinstance(summary, dict) and isinstance(cases, list)
 
-    _require(errors, payload.get("qualification_tier") == "beta", "qualification tier is not beta")
-    _require(errors, payload.get("qualified") is True, "artifact is not qualified")
-    _require(
-        errors, payload.get("production_qualified") is True, "artifact is not production_qualified"
+    # Which policy governs is decided by the wheel's version, never by the
+    # artifact. An artifact naming a tier this version does not admit is
+    # rejected *and* falls back to the production case count, so a bad tier
+    # can never shrink the population checked below.
+    accepted_tiers = accepted_qualification_tiers(wheel_version)
+    tier = payload.get("qualification_tier")
+    tier_accepted = tier in accepted_tiers
+    required_case_count = (
+        QUALIFICATION_CASE_COUNTS[tier]
+        if tier_accepted
+        else QUALIFICATION_CASE_COUNTS[PRODUCTION_QUALIFICATION_TIER]
     )
+
+    _require(
+        errors,
+        tier_accepted,
+        f"qualification tier is not {describe_accepted_tiers(accepted_tiers)}",
+    )
+    _require(errors, payload.get("qualified") is True, "artifact is not qualified")
+    if tier == PRODUCTION_QUALIFICATION_TIER:
+        _require(
+            errors,
+            payload.get("production_qualified") is True,
+            "artifact is not production_qualified",
+        )
+    else:
+        _require(
+            errors,
+            payload.get("production_qualified") is False,
+            "artifact claims production_qualified without the production policy",
+        )
     _require(errors, payload.get("static_only") is True, "artifact is not static-only")
     _require(
         errors,
@@ -96,18 +141,18 @@ def verify_qualification_binding(
 
     _require(
         errors,
-        len(cases) == REQUIRED_CASE_COUNT,
-        f"artifact carries {len(cases)} cases, not {REQUIRED_CASE_COUNT}",
+        len(cases) == required_case_count,
+        f"artifact carries {len(cases)} cases, not {required_case_count}",
     )
     _require(
         errors,
-        summary.get("total_cases") == REQUIRED_CASE_COUNT,
-        "summary total_cases is not 100",
+        summary.get("total_cases") == required_case_count,
+        f"summary total_cases is not {required_case_count}",
     )
     _require(
         errors,
-        summary.get("receipt_count") == REQUIRED_CASE_COUNT,
-        "summary receipt_count is not 100",
+        summary.get("receipt_count") == required_case_count,
+        f"summary receipt_count is not {required_case_count}",
     )
 
     # Derived from the cases, not read from the summary. The summary is a
@@ -134,8 +179,8 @@ def verify_qualification_binding(
     _require(errors, derived_runtime_failures == 0, "cases contain a runtime failure")
     _require(
         errors,
-        len(receipts) == REQUIRED_CASE_COUNT,
-        f"cases carry {len(receipts)} receipts, not {REQUIRED_CASE_COUNT}",
+        len(receipts) == required_case_count,
+        f"cases carry {len(receipts)} receipts, not {required_case_count}",
     )
     _require(
         errors,
@@ -181,7 +226,7 @@ def verify_qualification_binding(
             "Release safety qualification rejected: " + "; ".join(sorted(set(errors)))
         )
     return {
-        "qualification_tier": payload.get("qualification_tier"),
+        "qualification_tier": tier,
         "wheel_name": wheel_name,
         "wheel_version": wheel_version,
         "wheel_sha256": wheel_sha256,

--- a/scripts/verify_qualification_binding.py
+++ b/scripts/verify_qualification_binding.py
@@ -18,8 +18,10 @@ delegate publication authority, using nothing but the standard library:
 * it claims ``production_qualified`` exactly when it claims the ``beta`` tier;
 * it is static-only and does not claim runtime behaviour was proven;
 * it carries no failures, and exactly as many cases and receipts as that
-  policy requires;
-* it reports **zero** unsafe auto-passes;
+  policy requires, in exactly that policy's 28 profile x outcome strata;
+* it meets that policy's per-outcome exact-match floors and per-stratum
+  holdout minimum, both re-derived from the raw cases;
+* it reports **zero** unsafe auto-passes, overall and per profile;
 * and — the binding that matters — its recorded wheel name, version and
   SHA-256 are the wheel about to be published.
 
@@ -42,34 +44,43 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
 if __package__:
     from scripts._release_support import (
         PRODUCTION_QUALIFICATION_TIER,
-        QUALIFICATION_CASE_COUNTS,
+        QUALIFICATION_DECISIONS,
         SHA256_PATTERN,
         ReleaseError,
         accepted_qualification_tiers,
         describe_accepted_tiers,
         inspect_wheel,
+        qualification_policy,
     )
 else:  # ``python scripts/verify_qualification_binding.py``
     from _release_support import (
         PRODUCTION_QUALIFICATION_TIER,
-        QUALIFICATION_CASE_COUNTS,
+        QUALIFICATION_DECISIONS,
         SHA256_PATTERN,
         ReleaseError,
         accepted_qualification_tiers,
         describe_accepted_tiers,
         inspect_wheel,
+        qualification_policy,
     )
 
 
 def _require(errors: list[str], condition: bool, message: str) -> None:
     if not condition:
         errors.append(message)
+
+
+def _is_number(value: Any) -> bool:
+    """A real JSON number. ``True`` is an ``int`` in Python and is not one."""
+
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 def verify_qualification_binding(
@@ -102,16 +113,13 @@ def verify_qualification_binding(
 
     # Which policy governs is decided by the wheel's version, never by the
     # artifact. An artifact naming a tier this version does not admit is
-    # rejected *and* falls back to the production case count, so a bad tier
-    # can never shrink the population checked below.
+    # rejected *and* falls back to the production policy, so a bad tier can
+    # never shrink the population checked below.
     accepted_tiers = accepted_qualification_tiers(wheel_version)
     tier = payload.get("qualification_tier")
     tier_accepted = tier in accepted_tiers
-    required_case_count = (
-        QUALIFICATION_CASE_COUNTS[tier]
-        if tier_accepted
-        else QUALIFICATION_CASE_COUNTS[PRODUCTION_QUALIFICATION_TIER]
-    )
+    policy = qualification_policy(tier if tier_accepted else PRODUCTION_QUALIFICATION_TIER)
+    required_case_count = policy.case_count
 
     _require(
         errors,
@@ -177,6 +185,82 @@ def verify_qualification_binding(
 
     _require(errors, derived_unsafe == 0, "cases contain an unsafe auto-pass")
     _require(errors, derived_runtime_failures == 0, "cases contain a runtime failure")
+
+    # A total case count is not a policy. Without the strata and the
+    # exact-match floors below, 56 cases in no stratum at all, or 56 correctly
+    # stratified cases with two safe passes missing, passed here while the
+    # exhaustive gate rejected them -- so the dependency-compromise boundary
+    # this file exists to hold would have been decorative.
+    objects = [case for case in cases if isinstance(case, dict)]
+    _require(errors, len(objects) == len(cases), "a case entry is not a JSON object")
+
+    strata = Counter(
+        (str(case.get("profile")), str(case.get("expected_decision"))) for case in objects
+    )
+    _require(
+        errors,
+        dict(strata) == policy.strata,
+        f"case profile/outcome strata do not match the {policy.tier} policy",
+    )
+
+    for decision in QUALIFICATION_DECISIONS:
+        exact = sum(
+            1
+            for case in objects
+            if case.get("expected_decision") == decision
+            and case.get("actual_decision") == decision
+        )
+        floor = policy.minimum_exact[decision]
+        _require(
+            errors,
+            exact >= floor,
+            f"{decision} exact-match floor failed: {exact} of "
+            f"{policy.outcome_total(decision)}, need {floor}",
+        )
+
+    for profile in sorted(policy.profile_counts):
+        _require(
+            errors,
+            not any(
+                case.get("profile") == profile
+                and case.get("expected_decision") != "passed"
+                and case.get("actual_decision") == "passed"
+                for case in objects
+            ),
+            f"profile {profile} contains an unsafe auto-pass",
+        )
+
+    for (profile, decision), stratum_size in sorted(policy.strata.items()):
+        holdout = sum(
+            1
+            for case in objects
+            if case.get("profile") == profile
+            and case.get("expected_decision") == decision
+            and case.get("split") == "holdout"
+        )
+        _require(
+            errors,
+            holdout >= policy.minimum_holdout(stratum_size),
+            f"stratum {profile}/{decision} holdout requirement failed",
+        )
+
+    # The only two policy floors that are *not* derivable from ``cases``: no
+    # case row carries its origin or the label agreement it came from. They are
+    # read from the summary and named as such, rather than silently skipped
+    # because they are inconvenient to re-derive here.
+    _require(
+        errors,
+        _is_number(summary.get("qualified_origin_cases"))
+        and summary["qualified_origin_cases"] >= policy.minimum_qualified_origins,
+        f"summary qualified_origin_cases is below the {policy.tier} minimum "
+        f"of {policy.minimum_qualified_origins}",
+    )
+    _require(
+        errors,
+        _is_number(summary.get("cohen_kappa"))
+        and summary["cohen_kappa"] >= policy.minimum_kappa,
+        f"summary cohen_kappa is below the {policy.tier} floor of {policy.minimum_kappa}",
+    )
     _require(
         errors,
         len(receipts) == required_case_count,

--- a/scripts/verify_safety_qualification_release.py
+++ b/scripts/verify_safety_qualification_release.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Fail-closed release validation for a signed safety qualification artifact."""
+"""Fail-closed release validation for a signed safety qualification artifact.
+
+The wheel version selects the governing policy -- the 56-case ``pre_1_0``
+policy for ``0.x``, the 100-case production policy from ``1.0`` on -- and every
+count, interval and confusion matrix below is re-derived from that policy
+rather than read from the artifact. See
+``docs/release-evidence-policy-decision.md``.
+"""
 
 from __future__ import annotations
 
@@ -16,13 +23,17 @@ from pydantic import ValidationError
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.schemas.common import ReleaseDecisionStatus
 from agents_shipgate.schemas.safety_qualification import (
+    SafetyQualificationRequirementsV1,
     SafetyQualificationResultV1,
     production_safety_requirements,
+    requirements_for_tier,
 )
 
 if __package__:
+    from scripts._release_support import accepted_qualification_tiers, describe_accepted_tiers
     from scripts.run_safety_qualification import DECISIONS, inspect_wheel, wilson_interval
 else:  # ``python scripts/verify_safety_qualification_release.py``
+    from _release_support import accepted_qualification_tiers, describe_accepted_tiers
     from run_safety_qualification import DECISIONS, inspect_wheel, wilson_interval
 
 
@@ -41,10 +52,12 @@ def _append(errors: list[str], condition: bool, message: str) -> None:
         errors.append(message)
 
 
-def _expected_counts() -> dict[tuple[str, ReleaseDecisionStatus], int]:
+def _expected_counts(
+    requirements: SafetyQualificationRequirementsV1,
+) -> dict[tuple[str, ReleaseDecisionStatus], int]:
     return {
         (item.profile, item.expected_decision): item.count
-        for item in production_safety_requirements().required_strata
+        for item in requirements.required_strata
     }
 
 
@@ -54,7 +67,15 @@ def verify_release_qualification(
     qualification_path: Path,
     tag: str,
 ) -> SafetyQualificationResultV1:
-    """Validate the signed payload's production claim and exact wheel binding.
+    """Validate the signed payload's policy claim and exact wheel binding.
+
+    The governing policy is derived from the wheel's own version, never read
+    from the artifact: a ``0.x`` wheel may publish on the pre-1.0 policy
+    approved for issue #341 or on the stronger production one, and anything
+    from ``1.0`` upwards requires production. An artifact naming a tier the
+    version does not admit is rejected, and its claims are then re-derived
+    against the *strictest* policy so a rejected tier can never widen what the
+    rest of this function accepts.
 
     Signature verification intentionally stays outside this function: the
     release workflow verifies the Sigstore identity before parsing the signed
@@ -63,17 +84,32 @@ def verify_release_qualification(
 
     result = _load_qualification(qualification_path)
     wheel_name, wheel_version, wheel_sha256 = inspect_wheel(wheel_path)
-    requirements = production_safety_requirements()
     errors: list[str] = []
+
+    accepted_tiers = accepted_qualification_tiers(wheel_version)
+    tier = result.qualification_tier
+    tier_accepted = tier in accepted_tiers
+    _append(
+        errors,
+        tier_accepted,
+        f"qualification tier is not {describe_accepted_tiers(accepted_tiers)}",
+    )
+    # ``requirements_for_tier`` returns ``None`` for the unnamed ``test`` tier;
+    # falling back to production keeps every downstream count on the strictest
+    # policy rather than skipping the checks that follow.
+    requirements = (
+        requirements_for_tier(tier) if tier_accepted else None
+    ) or production_safety_requirements()
 
     _append(errors, bool(tag), "release tag is empty")
     _append(errors, tag == f"v{wheel_version}", "release tag does not match wheel version")
-    _append(errors, result.qualification_tier == "beta", "qualification tier is not beta")
     _append(errors, result.qualified is True, "qualification artifact is not qualified")
     _append(
         errors,
-        result.production_qualified is True,
-        "qualification artifact is not production_qualified",
+        result.production_qualified == (tier == "beta"),
+        "qualification artifact is not production_qualified"
+        if tier == "beta"
+        else "qualification claims production_qualified without the production policy",
     )
     _append(errors, result.static_only is True, "qualification must be static-only")
     _append(
@@ -85,7 +121,9 @@ def verify_release_qualification(
     _append(
         errors,
         result.requirements == requirements,
-        "qualification requirements differ from the production beta policy",
+        f"qualification requirements differ from the {tier} policy"
+        if tier_accepted
+        else "qualification requirements differ from the production beta policy",
     )
 
     inputs = result.inputs
@@ -94,7 +132,8 @@ def verify_release_qualification(
     _append(errors, inputs.engine_version == wheel_version, "qualified engine version mismatch")
     _append(errors, inputs.wheel_sha256 == wheel_sha256, "qualified wheel SHA-256 mismatch")
 
-    expected_strata = _expected_counts()
+    expected_strata = _expected_counts(requirements)
+    expected_total = sum(expected_strata.values())
     expected_outcomes: dict[ReleaseDecisionStatus, int] = {
         decision: sum(
             count
@@ -105,14 +144,18 @@ def verify_release_qualification(
     }
     cases = result.cases
     case_ids = [case.id for case in cases]
-    _append(errors, len(cases) == 100, "qualification must contain exactly 100 cases")
+    _append(
+        errors,
+        len(cases) == expected_total,
+        f"qualification must contain exactly {expected_total} cases",
+    )
     _append(errors, len(set(case_ids)) == len(case_ids), "qualification case ids are not unique")
 
     actual_expected_counts = Counter((case.profile, case.expected_decision) for case in cases)
     _append(
         errors,
         dict(actual_expected_counts) == expected_strata,
-        "qualification case profile/outcome strata differ from production policy",
+        f"qualification case profile/outcome strata differ from the {tier} policy",
     )
     _append(
         errors,
@@ -204,7 +247,11 @@ def verify_release_qualification(
         )
 
     summary = result.summary
-    _append(errors, summary.total_cases == 100, "qualification summary total is not 100")
+    _append(
+        errors,
+        summary.total_cases == expected_total,
+        f"qualification summary total is not {expected_total}",
+    )
     _append(
         errors,
         summary.qualified_origin_cases >= requirements.minimum_qualified_origins,
@@ -225,7 +272,11 @@ def verify_release_qualification(
         requirements.minimum_kappa <= summary.cohen_kappa <= 1.0,
         "qualification Cohen's kappa is outside its valid production range",
     )
-    _append(errors, summary.receipt_count == 100, "qualification receipt count is not 100")
+    _append(
+        errors,
+        summary.receipt_count == expected_total,
+        f"qualification receipt count is not {expected_total}",
+    )
     _append(errors, summary.runtime_failure_count == 0, "qualification reports runtime failures")
     _append(
         errors,
@@ -303,13 +354,22 @@ def verify_release_qualification(
         all(metric.passed for metric in result.intervals),
         "qualification contains a failed metric interval",
     )
+    # Denominators come from the governing policy's strata, not from the
+    # artifact: reading them from the payload would let a weakened artifact
+    # choose the population its own rates are measured against.
     expected_metric_counts = {
-        "unsafe_auto_pass_rate": (unsafe_auto_passes, 70),
-        "safe_pass_rate": (safe_passes, 30),
-        "blocked_exact_rate": (blocked_exact, 30),
-        "review_exact_rate": (review_exact, 20),
-        "insufficient_evidence_exact_rate": (ie_exact, 20),
-        "overall_exact_rate": (exact_count, 100),
+        "unsafe_auto_pass_rate": (
+            unsafe_auto_passes,
+            expected_total - expected_outcomes["passed"],
+        ),
+        "safe_pass_rate": (safe_passes, expected_outcomes["passed"]),
+        "blocked_exact_rate": (blocked_exact, expected_outcomes["blocked"]),
+        "review_exact_rate": (review_exact, expected_outcomes["review_required"]),
+        "insufficient_evidence_exact_rate": (
+            ie_exact,
+            expected_outcomes["insufficient_evidence"],
+        ),
+        "overall_exact_rate": (exact_count, expected_total),
     }
     for metric in result.intervals:
         _append(
@@ -335,16 +395,7 @@ def verify_release_qualification(
             f"qualification metric {metric.name} has an invalid interval",
         )
 
-    expected_matrix_profiles = {
-        "all",
-        "mcp_openapi_declared_binding",
-        "openai_agents_sdk",
-        "langchain_crewai",
-        "google_adk",
-        "n8n",
-        "multi_agent_handoffs",
-        "coding_agent_trust_roots",
-    }
+    expected_matrix_profiles = {"all"} | {profile for profile, _decision in expected_strata}
     matrices = {matrix.profile: matrix for matrix in result.confusion_matrices}
     _append(
         errors,
@@ -391,7 +442,10 @@ def verify_release_qualification(
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Verify production safety qualification and exact release-wheel binding."
+        description=(
+            "Verify the safety qualification the tag's version requires, and the "
+            "exact release-wheel binding."
+        )
     )
     parser.add_argument("--wheel", type=Path, required=True)
     parser.add_argument("--qualification", type=Path, required=True)
@@ -411,8 +465,8 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"Release safety qualification error: {exc}\n")
         return 1
     sys.stdout.write(
-        "OK: production safety qualification is internally consistent and bound to "
-        f"{result.inputs.wheel_name} {result.inputs.wheel_version} "
+        f"OK: {result.qualification_tier} safety qualification is internally consistent and "
+        f"bound to {result.inputs.wheel_name} {result.inputs.wheel_version} "
         f"({result.inputs.wheel_sha256}); signature verification remains a separate prerequisite.\n"
     )
     return 0

--- a/scripts/verify_safety_qualification_release.py
+++ b/scripts/verify_safety_qualification_release.py
@@ -103,14 +103,11 @@ def verify_release_qualification(
 
     _append(errors, bool(tag), "release tag is empty")
     _append(errors, tag == f"v{wheel_version}", "release tag does not match wheel version")
+    # ``production_qualified`` is not re-checked here: the artifact schema
+    # refuses to construct one where it disagrees with ``qualified`` and the
+    # tier, so ``_load_qualification`` above has already rejected it. The
+    # standard-library sealing gate, which parses raw JSON, restates it.
     _append(errors, result.qualified is True, "qualification artifact is not qualified")
-    _append(
-        errors,
-        result.production_qualified == (tier == "beta"),
-        "qualification artifact is not production_qualified"
-        if tier == "beta"
-        else "qualification claims production_qualified without the production policy",
-    )
     _append(errors, result.static_only is True, "qualification must be static-only")
     _append(
         errors,

--- a/src/agents_shipgate/schemas/safety_qualification.py
+++ b/src/agents_shipgate/schemas/safety_qualification.py
@@ -655,6 +655,24 @@ class SafetyQualificationResultV1(BaseModel):
         )
 
     @model_validator(mode="after")
+    def _production_claim_matches_the_tier(self) -> SafetyQualificationResultV1:
+        """``production_qualified`` means the 100-case bar, in every artifact.
+
+        Enforced structurally rather than at each gate so the *producer* cannot
+        emit the inconsistency in the first place. A pre-1.0 artifact asserting
+        the production flag would otherwise be signed before any verifier saw
+        it, and rejected only at the last step before publication.
+        """
+
+        expected = self.qualified and self.qualification_tier == "beta"
+        if self.production_qualified != expected:
+            raise ValueError(
+                "production_qualified must be true exactly when a qualified "
+                "artifact claims the beta tier"
+            )
+        return self
+
+    @model_validator(mode="after")
     def _sort_output(self) -> SafetyQualificationResultV1:
         self.strata.sort(key=lambda item: (item.profile, item.expected_decision))
         self.confusion_matrices.sort(key=lambda item: item.profile)

--- a/src/agents_shipgate/schemas/safety_qualification.py
+++ b/src/agents_shipgate/schemas/safety_qualification.py
@@ -11,7 +11,10 @@ from agents_shipgate.schemas.disclaimers import STATIC_VERDICT_DISCLAIMER
 
 SAFETY_CORPUS_SCHEMA_VERSION = "shipgate.safety_corpus/v4"
 SAFETY_RECEIPT_INDEX_SCHEMA_VERSION = "shipgate.safety_receipt_index/v4"
-SAFETY_QUALIFICATION_SCHEMA_VERSION = "shipgate.safety_qualification/v4"
+# v5 carries the ``pre_1_0`` tier and the production_qualified/tier invariant
+# added for issue #341. The corpus and receipt-index envelopes stay at v4: their
+# grammar did not move, and versions here track grammar, not release batches.
+SAFETY_QUALIFICATION_SCHEMA_VERSION = "shipgate.safety_qualification/v5"
 
 SafetyProfile = Literal[
     "mcp",
@@ -623,7 +626,7 @@ class SafetyQualificationResultV1(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["shipgate.safety_qualification/v4"] = (
+    schema_version: Literal["shipgate.safety_qualification/v5"] = (
         SAFETY_QUALIFICATION_SCHEMA_VERSION
     )
     qualification_tier: QualificationTier
@@ -643,13 +646,28 @@ class SafetyQualificationResultV1(BaseModel):
 
     @field_validator("schema_version", mode="before")
     @classmethod
-    def _upgrade_v1_schema(cls, value: str) -> str:
+    def _upgrade_prior_envelopes(cls, value: str) -> str:
+        """Read the earlier envelopes; emit only the current one.
+
+        v4 is accepted and read as v5 because every v4 payload *is* a v5
+        payload with identical meaning: v4's tier vocabulary (``beta``,
+        ``test``) is a strict subset of v5's, and the producer that emitted v4
+        always satisfied v5's production_qualified/tier invariant. Upgrading
+        grants nothing -- the payload still has to satisfy every v5 rule, and
+        `schema_version` is attacker-controlled text either way.
+
+        The reverse direction is why the version had to move at all: a genuine
+        ``pre_1_0`` artifact is *not* readable by a v4 reader, so it must not
+        claim to be v4.
+        """
+
         return (
             SAFETY_QUALIFICATION_SCHEMA_VERSION
             if value
             in {
                 "shipgate.safety_qualification/v1",
                 "shipgate.safety_qualification/v2",
+                "shipgate.safety_qualification/v4",
             }
             else value
         )

--- a/src/agents_shipgate/schemas/safety_qualification.py
+++ b/src/agents_shipgate/schemas/safety_qualification.py
@@ -34,7 +34,7 @@ SafetyCaseOrigin = Literal[
 SafetyCorpusSplit = Literal["tuning", "holdout"]
 SafetyLabelRole = Literal["security_governance", "framework_tooling"]
 SafetyAdjudicationState = Literal["agreement", "adjudicated_disagreement"]
-QualificationTier = Literal["beta", "test"]
+QualificationTier = Literal["beta", "pre_1_0", "test"]
 
 SHA256_PATTERN = r"^[0-9a-f]{64}$"
 
@@ -101,7 +101,7 @@ class HumanAdjudicationV1(BaseModel):
 
 
 class SafetyCorpusCaseV1(BaseModel):
-    """One independently labeled beta qualification case."""
+    """One independently labeled qualification case."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -420,6 +420,101 @@ def production_safety_requirements() -> SafetyQualificationRequirementsV1:
     )
 
 
+# The seven profiles the release policies stratify by, named once so the
+# pre-1.0 policy cannot silently cover fewer of them than the production one.
+# ``test_the_pre_1_0_policy_covers_every_production_profile`` binds the two.
+RELEASE_SAFETY_PROFILES: tuple[SafetyProfile, ...] = (
+    "mcp_openapi_declared_binding",
+    "openai_agents_sdk",
+    "langchain_crewai",
+    "google_adk",
+    "n8n",
+    "multi_agent_handoffs",
+    "coding_agent_trust_roots",
+)
+
+
+def pre_release_safety_requirements() -> SafetyQualificationRequirementsV1:
+    """The approved pre-1.0 policy: less coverage, identical strictness.
+
+    Recorded by Pengfei Hu on 2026-08-29 under
+    ``docs/release-evidence-policy-decision.md`` (issue #341, Route 2). It
+    governs ``0.x`` tags only; ``1.0`` and later still require the 100-case
+    production policy, and this constructor is never selected for them.
+
+    Two cases per stratum is the smallest allocation that keeps all 28
+    profile x decision cells non-empty *and* leaves each cell one tuning and
+    one holdout case. Dropping a cell to zero would delete coverage of a
+    profile/outcome pair outright, which is a strictness reduction and not a
+    coverage one; the uniform layout is what avoids it at this size.
+
+    Every threshold below is at least as strict, *as a rate*, as its
+    production counterpart -- checked by
+    ``test_the_pre_1_0_policy_is_never_laxer_than_production_per_rate``. The
+    invariants that may not move at all (zero unsafe auto-passes, the holdout
+    fraction, the kappa floor, the report schema) are byte-identical.
+    """
+
+    strata = tuple(
+        SafetyStratumRequirementV1(
+            profile=profile,
+            expected_decision=decision,
+            count=2,
+        )
+        for profile in RELEASE_SAFETY_PROFILES
+        for decision in ("passed", "review_required", "insufficient_evidence", "blocked")
+    )
+    return SafetyQualificationRequirementsV1(
+        required_strata=strata,
+        # 40% of 56, rounded up -- the same origin floor production applies
+        # (40 of 100), not a smaller share of a smaller corpus.
+        minimum_qualified_origins=23,
+        minimum_kappa=0.80,
+        minimum_holdout_fraction_per_stratum=0.20,
+        maximum_unsafe_auto_passes=0,
+        # 14 cases per outcome. Production's rates, rounded up: safe 27/30
+        # -> ceil(0.90 x 14) = 13; blocked 30/30 -> 14; review 19/20 and
+        # insufficient evidence 19/20 -> ceil(0.95 x 14) = 14.
+        minimum_safe_passes=13,
+        minimum_blocked_exact=14,
+        minimum_review_exact=14,
+        minimum_insufficient_evidence_exact=14,
+        required_report_schema_version="0.42",
+    )
+
+
+def requirements_for_tier(
+    tier: QualificationTier,
+) -> SafetyQualificationRequirementsV1 | None:
+    """The named policy a tier claims, or ``None`` for the unnamed ``test`` tier.
+
+    ``None`` is not a permissive default: every caller that gates a release
+    treats it as "no named policy backs this artifact" and rejects.
+    """
+
+    if tier == "beta":
+        return production_safety_requirements()
+    if tier == "pre_1_0":
+        return pre_release_safety_requirements()
+    return None
+
+
+def tier_for_requirements(
+    requirements: SafetyQualificationRequirementsV1,
+) -> QualificationTier:
+    """Name the policy a requirements object *is*, never what it claims to be.
+
+    Anything that is not byte-equal to a named policy is ``test``: an ad-hoc
+    threshold set can never present itself as a release-grade one.
+    """
+
+    if requirements == production_safety_requirements():
+        return "beta"
+    if requirements == pre_release_safety_requirements():
+        return "pre_1_0"
+    return "test"
+
+
 class QualificationInputDigestV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -524,7 +619,7 @@ class SafetyQualificationSummaryV1(BaseModel):
 
 
 class SafetyQualificationResultV1(BaseModel):
-    """Deterministic, wheel-bound beta qualification result."""
+    """Deterministic, wheel-bound qualification result for a named policy."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -578,6 +673,7 @@ class SafetyQualificationResultV1(BaseModel):
 
 
 __all__ = [
+    "RELEASE_SAFETY_PROFILES",
     "SAFETY_CORPUS_SCHEMA_VERSION",
     "SAFETY_QUALIFICATION_SCHEMA_VERSION",
     "SAFETY_RECEIPT_INDEX_SCHEMA_VERSION",
@@ -605,5 +701,8 @@ __all__ = [
     "SafetyStratumRequirementV1",
     "WilsonIntervalV1",
     "compute_frozen_labels_sha256",
+    "pre_release_safety_requirements",
     "production_safety_requirements",
+    "requirements_for_tier",
+    "tier_for_requirements",
 ]

--- a/src/agents_shipgate/schemas/safety_qualification.py
+++ b/src/agents_shipgate/schemas/safety_qualification.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -38,6 +38,18 @@ SafetyCorpusSplit = Literal["tuning", "holdout"]
 SafetyLabelRole = Literal["security_governance", "framework_tooling"]
 SafetyAdjudicationState = Literal["agreement", "adjudicated_disagreement"]
 QualificationTier = Literal["beta", "pre_1_0", "test"]
+
+# Envelopes whose readers predate ``pre_1_0`` and the production_qualified/tier
+# invariant. They are still *read*, but only when the payload actually uses the
+# vocabulary they can express -- see ``_upgrade_prior_envelopes``.
+LEGACY_QUALIFICATION_ENVELOPES = frozenset(
+    {
+        "shipgate.safety_qualification/v1",
+        "shipgate.safety_qualification/v2",
+        "shipgate.safety_qualification/v4",
+    }
+)
+LEGACY_QUALIFICATION_TIERS: frozenset[str] = frozenset({"beta", "test"})
 
 SHA256_PATTERN = r"^[0-9a-f]{64}$"
 
@@ -446,10 +458,16 @@ def pre_release_safety_requirements() -> SafetyQualificationRequirementsV1:
     production policy, and this constructor is never selected for them.
 
     Two cases per stratum is the smallest allocation that keeps all 28
-    profile x decision cells non-empty *and* leaves each cell one tuning and
-    one holdout case. Dropping a cell to zero would delete coverage of a
+    profile x decision cells non-empty *and* leaves room for a tuning/holdout
+    split in every cell: at one case per cell, ``ceil(1 x 0.20) = 1`` forces
+    that case to be holdout. Dropping a cell to zero would delete coverage of a
     profile/outcome pair outright, which is a strictness reduction and not a
     coverage one; the uniform layout is what avoids it at this size.
+
+    What is *enforced* is the holdout floor, not a one-of-each split. A corpus
+    that marks more cases holdout is accepted: holdout evidence was never tuned
+    on, so more of it is stronger, and a floor on tuning cases would be a
+    ceiling on holdout.
 
     Every threshold below is at least as strict, *as a rate*, as its
     production counterpart -- checked by
@@ -644,33 +662,35 @@ class SafetyQualificationResultV1(BaseModel):
     cases: list[SafetyQualificationCaseResultV1]
     failures: list[SafetyQualificationFailureV1]
 
-    @field_validator("schema_version", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def _upgrade_prior_envelopes(cls, value: str) -> str:
-        """Read the earlier envelopes; emit only the current one.
+    def _upgrade_prior_envelopes(cls, data: Any) -> Any:
+        """Read an earlier envelope only when its own vocabulary is used.
 
-        v4 is accepted and read as v5 because every v4 payload *is* a v5
-        payload with identical meaning: v4's tier vocabulary (``beta``,
-        ``test``) is a strict subset of v5's, and the producer that emitted v4
-        always satisfied v5's production_qualified/tier invariant. Upgrading
-        grants nothing -- the payload still has to satisfy every v5 rule, and
-        `schema_version` is attacker-controlled text either way.
+        A legacy envelope is upgraded to the current one *conditionally*: its
+        reader admits ``beta`` and ``test`` and nothing else, so a payload
+        carrying ``pre_1_0`` is not a legacy payload however it is labelled.
 
-        The reverse direction is why the version had to move at all: a genuine
-        ``pre_1_0`` artifact is *not* readable by a v4 reader, so it must not
-        claim to be v4.
+        Doing this as a bare ``schema_version`` field validator was wrong, and
+        wrong in the direction the version bump existed to close: the field
+        validator rewrote v4 to v5 *before* anything could look at
+        ``qualification_tier``, so relabelling a conforming ``pre_1_0``
+        artifact as v4 was accepted -- recreating the exact v4/``pre_1_0``
+        combination an old v4 reader cannot parse.
         """
 
-        return (
-            SAFETY_QUALIFICATION_SCHEMA_VERSION
-            if value
-            in {
-                "shipgate.safety_qualification/v1",
-                "shipgate.safety_qualification/v2",
-                "shipgate.safety_qualification/v4",
-            }
-            else value
-        )
+        if not isinstance(data, dict):
+            return data
+        declared = data.get("schema_version")
+        if declared not in LEGACY_QUALIFICATION_ENVELOPES:
+            return data
+        if data.get("qualification_tier") not in LEGACY_QUALIFICATION_TIERS:
+            raise ValueError(
+                f"{declared} admits only qualification_tier "
+                f"{sorted(LEGACY_QUALIFICATION_TIERS)}; this payload requires "
+                f"{SAFETY_QUALIFICATION_SCHEMA_VERSION}"
+            )
+        return {**data, "schema_version": SAFETY_QUALIFICATION_SCHEMA_VERSION}
 
     @model_validator(mode="after")
     def _production_claim_matches_the_tier(self) -> SafetyQualificationResultV1:
@@ -709,6 +729,8 @@ class SafetyQualificationResultV1(BaseModel):
 
 
 __all__ = [
+    "LEGACY_QUALIFICATION_ENVELOPES",
+    "LEGACY_QUALIFICATION_TIERS",
     "RELEASE_SAFETY_PROFILES",
     "SAFETY_CORPUS_SCHEMA_VERSION",
     "SAFETY_QUALIFICATION_SCHEMA_VERSION",

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -1281,13 +1281,17 @@ def test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact
     )
     assert record["qualification_tier"] == "pre_1_0"
 
-    # The identical claim does not publish anything from 1.0 onwards.
-    with pytest.raises(ReleaseError, match="tier is not beta"):
+    # The identical claim does not publish anything from 1.0 onwards -- and the
+    # rejected tier does not get to pick the population either: the counts fall
+    # back to production, so the same artifact is also short 44 cases.
+    with pytest.raises(ReleaseError) as excinfo:
         verify_qualification_binding(
             qualification_path=_artifact(post_1_0_wheel, "9.9.9", 56),
             wheel_path=post_1_0_wheel,
             tag="v9.9.9",
         )
+    assert "tier is not beta" in str(excinfo.value)
+    assert "carries 56 cases, not 100" in str(excinfo.value)
 
     for overrides, count, expected in [
         # A tier the version admits still owns its own case count, in both

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -130,6 +130,20 @@ def _policy_summary(cases: list[dict[str, Any]], tier: str) -> dict[str, Any]:
     }
 
 
+def _policy_envelope(tier: str) -> dict[str, Any]:
+    """The envelope and declared requirements a conforming artifact carries."""
+
+    from scripts._release_support import (
+        CURRENT_QUALIFICATION_ENVELOPE,
+        QUALIFICATION_POLICIES,
+    )
+
+    return {
+        "schema_version": CURRENT_QUALIFICATION_ENVELOPE,
+        "requirements": QUALIFICATION_POLICIES[tier].as_requirements_payload(),
+    }
+
+
 def _load_workflow(name: str) -> dict[str, Any]:
     document = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
     # PyYAML resolves the bare key `on` to the boolean True (YAML 1.1), so
@@ -1207,6 +1221,7 @@ def test_the_stdlib_invariant_checker_rejects_a_weakened_signed_artifact(
             "failures": [],
             "cases": _policy_cases("beta"),
             "summary": _policy_summary(_policy_cases("beta"), "beta"),
+            **_policy_envelope("beta"),
             "inputs": {
                 "wheel_name": "agents-shipgate",
                 "wheel_version": "9.9.9",
@@ -1282,6 +1297,7 @@ def test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact
             "failures": [],
             "cases": cases,
             "summary": _policy_summary(cases, tier),
+            **_policy_envelope(tier),
             "inputs": {
                 "wheel_name": "agents-shipgate",
                 "wheel_version": version,
@@ -1369,6 +1385,7 @@ def test_the_sealer_enforces_the_strata_and_floors_not_just_a_case_count(
             "failures": [],
             "cases": cases,
             "summary": {**_policy_summary(cases, "pre_1_0"), **summary},
+            **_policy_envelope("pre_1_0"),
             "inputs": {
                 "wheel_name": "agents-shipgate",
                 "wheel_version": version,
@@ -1409,26 +1426,185 @@ def test_the_sealer_enforces_the_strata_and_floors_not_just_a_case_count(
             qualification_path=_write(no_holdout), wheel_path=wheel, tag=f"v{version}"
         )
 
-    # The two floors that cannot be derived from the cases are still checked.
-    with pytest.raises(ReleaseError, match="qualified_origin_cases is below"):
-        verify_qualification_binding(
-            qualification_path=_write(conforming, qualified_origin_cases=22),
-            wheel_path=wheel,
-            tag=f"v{version}",
+    # The two floors that cannot be derived from the cases are still checked --
+    # and bounded on both sides, because ">= floor" alone admits values no real
+    # measurement can produce: `True`, and the JSON literal `1e309`, which
+    # loads as `inf` and satisfies any lower bound while the exhaustive gate
+    # rejects it for exceeding 1.0.
+    for summary_override, expected in (
+        ({"qualified_origin_cases": 22}, "qualified_origin_cases is not an integer"),
+        ({"qualified_origin_cases": 57}, "qualified_origin_cases is not an integer"),
+        ({"qualified_origin_cases": True}, "qualified_origin_cases is not an integer"),
+        ({"qualified_origin_cases": 23.0}, "qualified_origin_cases is not an integer"),
+        ({"cohen_kappa": 0.79}, "cohen_kappa is not a finite value"),
+        ({"cohen_kappa": float("inf")}, "cohen_kappa is not a finite value"),
+        ({"cohen_kappa": 1.5}, "cohen_kappa is not a finite value"),
+        ({"cohen_kappa": True}, "cohen_kappa is not a finite value"),
+    ):
+        with pytest.raises(ReleaseError, match=expected):
+            verify_qualification_binding(
+                qualification_path=_write(conforming, **summary_override),
+                wheel_path=wheel,
+                tag=f"v{version}",
+            )
+
+
+def test_the_sealer_rejects_evidence_that_is_not_identified_or_terminal(
+    tmp_path: Path,
+) -> None:
+    """The floors count *matches*, so absent evidence is not a low score.
+
+    A case whose `actual_decision` is null simply fails to count toward its
+    floor, leaving 13 of 14 safe matches — enough. And 56 rows sharing one id
+    look like 56 distinct cases as long as their receipt digests differ. Both
+    passed the sealer while the exhaustive gate rejected them.
+    """
+
+    from scripts.verify_qualification_binding import verify_qualification_binding
+
+    version = "0.16.0b7"
+    wheel = tmp_path / f"agents_shipgate-{version}-py3-none-any.whl"
+    wheel.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"agents_shipgate-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: agents-shipgate\nVersion: {version}\n",
         )
-    with pytest.raises(ReleaseError, match="cohen_kappa is below"):
-        verify_qualification_binding(
-            qualification_path=_write(conforming, cohen_kappa=0.79),
-            wheel_path=wheel,
-            tag=f"v{version}",
+
+    conforming = _policy_cases("pre_1_0")
+
+    def _write(cases: list[dict[str, Any]], **overrides: Any) -> Path:
+        payload = {
+            "qualification_tier": "pre_1_0",
+            "qualified": True,
+            "production_qualified": False,
+            "static_only": True,
+            "runtime_behavior_proven": False,
+            "failures": [],
+            "cases": cases,
+            "summary": _policy_summary(cases, "pre_1_0"),
+            **_policy_envelope("pre_1_0"),
+            "inputs": {
+                "wheel_name": "agents-shipgate",
+                "wheel_version": version,
+                "engine_version": version,
+                "wheel_sha256": _digest(wheel),
+            },
+        }
+        payload.update(overrides)
+        path = tmp_path / "q.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    assert verify_qualification_binding(
+        qualification_path=_write(conforming), wheel_path=wheel, tag=f"v{version}"
+    )
+
+    def _mutate(index_of: str, **changes: Any) -> list[dict[str, Any]]:
+        rows = [dict(case) for case in conforming]
+        rows[next(i for i, c in enumerate(rows) if c["expected_decision"] == index_of)].update(
+            changes
         )
-    # ...and `True` is not a number, however much Python disagrees.
-    with pytest.raises(ReleaseError, match="qualified_origin_cases is below"):
-        verify_qualification_binding(
-            qualification_path=_write(conforming, qualified_origin_cases=True),
-            wheel_path=wheel,
-            tag=f"v{version}",
+        return rows
+
+    cases_and_errors = [
+        (_mutate("passed", actual_decision=None), "no terminal actual verifier decision"),
+        (_mutate("passed", actual_decision="mergeable"), "no terminal actual verifier decision"),
+        (_mutate("blocked", expected_decision="unknown"), "expected_decision is not one of"),
+        ([dict(case, id="same") for case in conforming], "case ids are not unique"),
+        ([dict(case, id="  ") for case in conforming], "case id is missing, blank"),
+        ([dict(case, id=7) for case in conforming], "case id is missing, blank"),
+    ]
+    for rows, expected in cases_and_errors:
+        with pytest.raises(ReleaseError, match=expected):
+            verify_qualification_binding(
+                qualification_path=_write(rows), wheel_path=wheel, tag=f"v{version}"
+            )
+
+
+def test_the_sealer_binds_the_declared_requirements_and_the_envelope(
+    tmp_path: Path,
+) -> None:
+    """Two claims the cases cannot attest, so nothing else here checks them.
+
+    The report schema version has no representation in `cases` at all, so an
+    artifact could restate the approved `0.42` as `0.1` and still seal. And a
+    legacy envelope's reader admits `beta`/`test` only, so labelling a pre-1.0
+    artifact v4 hands an old reader something it cannot parse -- the exact
+    combination the v5 bump exists to eliminate.
+    """
+
+    from scripts._release_support import QUALIFICATION_POLICIES
+    from scripts.verify_qualification_binding import verify_qualification_binding
+
+    version = "0.16.0b7"
+    wheel = tmp_path / f"agents_shipgate-{version}-py3-none-any.whl"
+    wheel.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"agents_shipgate-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: agents-shipgate\nVersion: {version}\n",
         )
+
+    cases = _policy_cases("pre_1_0")
+
+    def _write(**overrides: Any) -> Path:
+        payload = {
+            "qualification_tier": "pre_1_0",
+            "qualified": True,
+            "production_qualified": False,
+            "static_only": True,
+            "runtime_behavior_proven": False,
+            "failures": [],
+            "cases": cases,
+            "summary": _policy_summary(cases, "pre_1_0"),
+            **_policy_envelope("pre_1_0"),
+            "inputs": {
+                "wheel_name": "agents-shipgate",
+                "wheel_version": version,
+                "engine_version": version,
+                "wheel_sha256": _digest(wheel),
+            },
+        }
+        payload.update(overrides)
+        path = tmp_path / "q.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    assert verify_qualification_binding(
+        qualification_path=_write(), wheel_path=wheel, tag=f"v{version}"
+    )
+
+    approved = QUALIFICATION_POLICIES["pre_1_0"].as_requirements_payload()
+    for requirements, expected in (
+        ({**approved, "required_report_schema_version": "0.1"}, "required_report_schema_version"),
+        ({**approved, "minimum_blocked_exact": 1}, "minimum_blocked_exact"),
+        ({**approved, "minimum_kappa": 0.1}, "minimum_kappa"),
+        ({**approved, "required_strata": approved["required_strata"][:-1]}, "required_strata"),
+        ({k: v for k, v in approved.items() if k != "minimum_kappa"}, "exactly the pre_1_0"),
+        ({**approved, "extra": 1}, "exactly the pre_1_0"),
+        ("not-an-object", "no requirements object"),
+    ):
+        with pytest.raises(ReleaseError, match=expected):
+            verify_qualification_binding(
+                qualification_path=_write(requirements=requirements),
+                wheel_path=wheel,
+                tag=f"v{version}",
+            )
+
+    for envelope in (
+        "shipgate.safety_qualification/v1",
+        "shipgate.safety_qualification/v2",
+        "shipgate.safety_qualification/v4",
+        "shipgate.safety_qualification/v3",
+        "not-an-envelope",
+    ):
+        with pytest.raises(ReleaseError, match="cannot carry"):
+            verify_qualification_binding(
+                qualification_path=_write(schema_version=envelope),
+                wheel_path=wheel,
+                tag=f"v{version}",
+            )
 
 
 def test_the_suite_and_the_sealer_must_agree_on_the_commit() -> None:
@@ -1604,6 +1780,7 @@ def test_qualification_counts_are_derived_from_cases_not_the_summary(tmp_path: P
         "failures": [],
         "cases": cases,
         "summary": _policy_summary(cases, "beta"),
+        **_policy_envelope("beta"),
         "inputs": {
             "wheel_name": "agents-shipgate",
             "wheel_version": "9.9.9",

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -17,6 +17,7 @@ verifiable rather than merely automated:
 from __future__ import annotations
 
 import hashlib
+import itertools
 import json
 import zipfile
 from pathlib import Path
@@ -84,6 +85,49 @@ def _wheel_pair(
 
 def _digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _policy_cases(tier: str) -> list[dict[str, Any]]:
+    """Cases that exactly satisfy a named policy's strata, floors and holdout.
+
+    The sealer now re-derives the policy, so a pile of identical rows is no
+    longer a valid artifact for it to accept -- which was the point of the
+    change, and means these fixtures have to be real corpora.
+    """
+
+    from scripts._release_support import QUALIFICATION_POLICIES
+
+    policy = QUALIFICATION_POLICIES[tier]
+    cases: list[dict[str, Any]] = []
+    for (profile, decision), count in sorted(policy.strata.items()):
+        holdout = policy.minimum_holdout(count)
+        for index in range(count):
+            cases.append(
+                {
+                    "id": f"c{len(cases)}",
+                    "profile": profile,
+                    "split": "holdout" if index < holdout else "tuning",
+                    "expected_decision": decision,
+                    "actual_decision": decision,
+                    "receipt_sha256": f"{len(cases) + 1:064x}",
+                    "runtime_failure": False,
+                }
+            )
+    return cases
+
+
+def _policy_summary(cases: list[dict[str, Any]], tier: str) -> dict[str, Any]:
+    from scripts._release_support import QUALIFICATION_POLICIES
+
+    policy = QUALIFICATION_POLICIES[tier]
+    return {
+        "total_cases": len(cases),
+        "receipt_count": len(cases),
+        "unsafe_auto_pass_count": 0,
+        "runtime_failure_count": 0,
+        "qualified_origin_cases": policy.minimum_qualified_origins,
+        "cohen_kappa": 1.0,
+    }
 
 
 def _load_workflow(name: str) -> dict[str, Any]:
@@ -1161,22 +1205,8 @@ def test_the_stdlib_invariant_checker_rejects_a_weakened_signed_artifact(
             "static_only": True,
             "runtime_behavior_proven": False,
             "failures": [],
-            "cases": [
-                {
-                    "id": f"c{i}",
-                    "expected_decision": "blocked",
-                    "actual_decision": "blocked",
-                    "receipt_sha256": f"{i:064x}",
-                    "runtime_failure": False,
-                }
-                for i in range(100)
-            ],
-            "summary": {
-                "total_cases": 100,
-                "receipt_count": 100,
-                "unsafe_auto_pass_count": 0,
-                "runtime_failure_count": 0,
-            },
+            "cases": _policy_cases("beta"),
+            "summary": _policy_summary(_policy_cases("beta"), "beta"),
             "inputs": {
                 "wheel_name": "agents-shipgate",
                 "wheel_version": "9.9.9",
@@ -1237,7 +1267,12 @@ def test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact
         archive.writestr("agents_shipgate/__init__.py", "x = 1\n")
     post_1_0_wheel = _write_wheel(tmp_path / "post" / WHEEL_FILENAME)
 
-    def _artifact(wheel: Path, version: str, count: int, **overrides: Any) -> Path:
+    serial = itertools.count()
+
+    def _artifact(
+        wheel: Path, version: str, tier: str = "pre_1_0", **overrides: Any
+    ) -> Path:
+        cases = _policy_cases(tier)
         payload: dict[str, Any] = {
             "qualification_tier": "pre_1_0",
             "qualified": True,
@@ -1245,22 +1280,8 @@ def test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact
             "static_only": True,
             "runtime_behavior_proven": False,
             "failures": [],
-            "cases": [
-                {
-                    "id": f"c{index}",
-                    "expected_decision": "blocked",
-                    "actual_decision": "blocked",
-                    "receipt_sha256": f"{index:064x}",
-                    "runtime_failure": False,
-                }
-                for index in range(count)
-            ],
-            "summary": {
-                "total_cases": count,
-                "receipt_count": count,
-                "unsafe_auto_pass_count": 0,
-                "runtime_failure_count": 0,
-            },
+            "cases": cases,
+            "summary": _policy_summary(cases, tier),
             "inputs": {
                 "wheel_name": "agents-shipgate",
                 "wheel_version": version,
@@ -1269,47 +1290,145 @@ def test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact
             },
         }
         payload.update(overrides)
-        path = tmp_path / f"qualification-{version}-{count}-{len(overrides)}.json"
+        path = tmp_path / f"qualification-{next(serial)}.json"
         path.write_text(json.dumps(payload), encoding="utf-8")
         return path
 
     # The approved pre-1.0 evidence publishes a 0.x tag.
     record = verify_qualification_binding(
-        qualification_path=_artifact(pre_1_0_wheel, pre_1_0_version, 56),
+        qualification_path=_artifact(pre_1_0_wheel, pre_1_0_version),
         wheel_path=pre_1_0_wheel,
         tag=f"v{pre_1_0_version}",
     )
     assert record["qualification_tier"] == "pre_1_0"
 
     # The identical claim does not publish anything from 1.0 onwards -- and the
-    # rejected tier does not get to pick the population either: the counts fall
+    # rejected tier does not get to pick the population either: the policy falls
     # back to production, so the same artifact is also short 44 cases.
     with pytest.raises(ReleaseError) as excinfo:
         verify_qualification_binding(
-            qualification_path=_artifact(post_1_0_wheel, "9.9.9", 56),
+            qualification_path=_artifact(post_1_0_wheel, "9.9.9"),
             wheel_path=post_1_0_wheel,
             tag="v9.9.9",
         )
     assert "tier is not beta" in str(excinfo.value)
     assert "carries 56 cases, not 100" in str(excinfo.value)
 
-    for overrides, count, expected in [
-        # A tier the version admits still owns its own case count, in both
+    for overrides, tier, expected in [
+        # A tier the version admits still owns its own policy, in both
         # directions: 56 is not enough for `beta`, and 100 is not `pre_1_0`.
-        ({"qualification_tier": "beta", "production_qualified": True}, 56, "cases, not 100"),
-        ({}, 100, "cases, not 56"),
+        (
+            {"qualification_tier": "beta", "production_qualified": True},
+            "pre_1_0",
+            "cases, not 100",
+        ),
+        ({"qualification_tier": "pre_1_0"}, "beta", "cases, not 56"),
         # `production_qualified` keeps meaning the 100-case bar.
-        ({"production_qualified": True}, 56, "without the production policy"),
-        ({"qualified": False}, 56, "not qualified"),
+        ({"production_qualified": True}, "pre_1_0", "without the production policy"),
+        ({"qualified": False}, "pre_1_0", "not qualified"),
     ]:
         with pytest.raises(ReleaseError, match=expected):
             verify_qualification_binding(
                 qualification_path=_artifact(
-                    pre_1_0_wheel, pre_1_0_version, count, **overrides
+                    pre_1_0_wheel, pre_1_0_version, tier, **overrides
                 ),
                 wheel_path=pre_1_0_wheel,
                 tag=f"v{pre_1_0_version}",
             )
+
+
+def test_the_sealer_enforces_the_strata_and_floors_not_just_a_case_count(
+    tmp_path: Path,
+) -> None:
+    """A total case count is not a policy.
+
+    The sealer exists so a compromised dependency in the gate job cannot let a
+    weakened artifact through. Restating only the case count left it accepting
+    56 cases in no stratum at all, and 56 correctly stratified cases two safe
+    passes short -- both of which the exhaustive gate rejects.
+    """
+
+    from scripts.verify_qualification_binding import verify_qualification_binding
+
+    version = "0.16.0b7"
+    wheel = tmp_path / f"agents_shipgate-{version}-py3-none-any.whl"
+    wheel.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"agents_shipgate-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: agents-shipgate\nVersion: {version}\n",
+        )
+
+    def _write(cases: list[dict[str, Any]], **summary: Any) -> Path:
+        payload = {
+            "qualification_tier": "pre_1_0",
+            "qualified": True,
+            "production_qualified": False,
+            "static_only": True,
+            "runtime_behavior_proven": False,
+            "failures": [],
+            "cases": cases,
+            "summary": {**_policy_summary(cases, "pre_1_0"), **summary},
+            "inputs": {
+                "wheel_name": "agents-shipgate",
+                "wheel_version": version,
+                "engine_version": version,
+                "wheel_sha256": _digest(wheel),
+            },
+        }
+        path = tmp_path / "q.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    conforming = _policy_cases("pre_1_0")
+    assert verify_qualification_binding(
+        qualification_path=_write(conforming), wheel_path=wheel, tag=f"v{version}"
+    )
+
+    # 56 cases, right count, no strata at all.
+    flat = [dict(case, profile="n8n", expected_decision="blocked", actual_decision="blocked")
+            for case in conforming]
+    with pytest.raises(ReleaseError, match="strata do not match the pre_1_0 policy"):
+        verify_qualification_binding(
+            qualification_path=_write(flat), wheel_path=wheel, tag=f"v{version}"
+        )
+
+    # Correct strata, two safe passes short of the 13/14 floor.
+    degraded = [dict(case) for case in conforming]
+    for case in [c for c in degraded if c["expected_decision"] == "passed"][:2]:
+        case["actual_decision"] = "review_required"
+    with pytest.raises(ReleaseError, match=r"passed exact-match floor failed: 12 of 14"):
+        verify_qualification_binding(
+            qualification_path=_write(degraded), wheel_path=wheel, tag=f"v{version}"
+        )
+
+    # Every stratum keeps its holdout case.
+    no_holdout = [dict(case, split="tuning") for case in conforming]
+    with pytest.raises(ReleaseError, match="holdout requirement failed"):
+        verify_qualification_binding(
+            qualification_path=_write(no_holdout), wheel_path=wheel, tag=f"v{version}"
+        )
+
+    # The two floors that cannot be derived from the cases are still checked.
+    with pytest.raises(ReleaseError, match="qualified_origin_cases is below"):
+        verify_qualification_binding(
+            qualification_path=_write(conforming, qualified_origin_cases=22),
+            wheel_path=wheel,
+            tag=f"v{version}",
+        )
+    with pytest.raises(ReleaseError, match="cohen_kappa is below"):
+        verify_qualification_binding(
+            qualification_path=_write(conforming, cohen_kappa=0.79),
+            wheel_path=wheel,
+            tag=f"v{version}",
+        )
+    # ...and `True` is not a number, however much Python disagrees.
+    with pytest.raises(ReleaseError, match="qualified_origin_cases is below"):
+        verify_qualification_binding(
+            qualification_path=_write(conforming, qualified_origin_cases=True),
+            wheel_path=wheel,
+            tag=f"v{version}",
+        )
 
 
 def test_the_suite_and_the_sealer_must_agree_on_the_commit() -> None:
@@ -1475,16 +1594,7 @@ def test_qualification_counts_are_derived_from_cases_not_the_summary(tmp_path: P
     from scripts.verify_qualification_binding import verify_qualification_binding
 
     wheel = _write_wheel(tmp_path / WHEEL_FILENAME)
-    cases = [
-        {
-            "id": f"c{index}",
-            "expected_decision": "blocked",
-            "actual_decision": "blocked",
-            "receipt_sha256": f"{index:064x}",
-            "runtime_failure": False,
-        }
-        for index in range(100)
-    ]
+    cases = _policy_cases("beta")
     payload = {
         "qualification_tier": "beta",
         "qualified": True,
@@ -1493,12 +1603,7 @@ def test_qualification_counts_are_derived_from_cases_not_the_summary(tmp_path: P
         "runtime_behavior_proven": False,
         "failures": [],
         "cases": cases,
-        "summary": {
-            "total_cases": 100,
-            "receipt_count": 100,
-            "unsafe_auto_pass_count": 0,
-            "runtime_failure_count": 0,
-        },
+        "summary": _policy_summary(cases, "beta"),
         "inputs": {
             "wheel_name": "agents-shipgate",
             "wheel_version": "9.9.9",
@@ -1511,21 +1616,23 @@ def test_qualification_counts_are_derived_from_cases_not_the_summary(tmp_path: P
     assert verify_qualification_binding(qualification_path=path, wheel_path=wheel, tag="v9.9.9")
 
     # A case that auto-passed something it should not have, with the summary
-    # still claiming zero.
-    payload["cases"][0] = {
-        "id": "c0",
-        "expected_decision": "blocked",
-        "actual_decision": "passed",
-        "receipt_sha256": f"{0:064x}",
-        "runtime_failure": False,
-    }
+    # still claiming zero. Only `actual_decision` moves, so the strata stay
+    # intact and the unsafe auto-pass is what the artifact is rejected for.
+    blocked = next(
+        index
+        for index, case in enumerate(payload["cases"])
+        if case["expected_decision"] == "blocked"
+    )
+    payload["cases"] = [dict(case) for case in cases]
+    payload["cases"][blocked]["actual_decision"] = "passed"
     path.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(ReleaseError, match="cases contain an unsafe auto-pass"):
         verify_qualification_binding(qualification_path=path, wheel_path=wheel, tag="v9.9.9")
 
-    # Duplicated receipts are not 100 distinct receipts.
-    payload["cases"][0] = dict(cases[0])
-    payload["cases"][1] = dict(cases[0], id="c1")
+    # Duplicated receipts are not 100 distinct receipts. Again only the digest
+    # moves: every stratum and floor is still satisfied.
+    payload["cases"] = [dict(case) for case in cases]
+    payload["cases"][1]["receipt_sha256"] = payload["cases"][0]["receipt_sha256"]
     path.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(ReleaseError, match="receipt digests are not unique"):
         verify_qualification_binding(qualification_path=path, wheel_path=wheel, tag="v9.9.9")

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -1213,6 +1213,101 @@ def test_the_stdlib_invariant_checker_rejects_a_weakened_signed_artifact(
         verify_qualification_binding(qualification_path=_artifact(), wheel_path=other, tag="v9.9.9")
 
 
+def test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact(
+    tmp_path: Path,
+) -> None:
+    """The stdlib gate must apply the #341 decision on its own.
+
+    It cannot import the schemas, so it restates the case count per tier. What
+    it must never do is let the artifact choose which count applies: the same
+    56-case ``pre_1_0`` payload has to pass on a ``0.x`` wheel and fail on a
+    ``9.9.9`` one.
+    """
+
+    from scripts.verify_qualification_binding import verify_qualification_binding
+
+    pre_1_0_version = "0.16.0b7"
+    pre_1_0_wheel = tmp_path / "pre" / f"agents_shipgate-{pre_1_0_version}-py3-none-any.whl"
+    pre_1_0_wheel.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(pre_1_0_wheel, "w") as archive:
+        archive.writestr(
+            f"agents_shipgate-{pre_1_0_version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: agents-shipgate\nVersion: {pre_1_0_version}\n",
+        )
+        archive.writestr("agents_shipgate/__init__.py", "x = 1\n")
+    post_1_0_wheel = _write_wheel(tmp_path / "post" / WHEEL_FILENAME)
+
+    def _artifact(wheel: Path, version: str, count: int, **overrides: Any) -> Path:
+        payload: dict[str, Any] = {
+            "qualification_tier": "pre_1_0",
+            "qualified": True,
+            "production_qualified": False,
+            "static_only": True,
+            "runtime_behavior_proven": False,
+            "failures": [],
+            "cases": [
+                {
+                    "id": f"c{index}",
+                    "expected_decision": "blocked",
+                    "actual_decision": "blocked",
+                    "receipt_sha256": f"{index:064x}",
+                    "runtime_failure": False,
+                }
+                for index in range(count)
+            ],
+            "summary": {
+                "total_cases": count,
+                "receipt_count": count,
+                "unsafe_auto_pass_count": 0,
+                "runtime_failure_count": 0,
+            },
+            "inputs": {
+                "wheel_name": "agents-shipgate",
+                "wheel_version": version,
+                "engine_version": version,
+                "wheel_sha256": _digest(wheel),
+            },
+        }
+        payload.update(overrides)
+        path = tmp_path / f"qualification-{version}-{count}-{len(overrides)}.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    # The approved pre-1.0 evidence publishes a 0.x tag.
+    record = verify_qualification_binding(
+        qualification_path=_artifact(pre_1_0_wheel, pre_1_0_version, 56),
+        wheel_path=pre_1_0_wheel,
+        tag=f"v{pre_1_0_version}",
+    )
+    assert record["qualification_tier"] == "pre_1_0"
+
+    # The identical claim does not publish anything from 1.0 onwards.
+    with pytest.raises(ReleaseError, match="tier is not beta"):
+        verify_qualification_binding(
+            qualification_path=_artifact(post_1_0_wheel, "9.9.9", 56),
+            wheel_path=post_1_0_wheel,
+            tag="v9.9.9",
+        )
+
+    for overrides, count, expected in [
+        # A tier the version admits still owns its own case count, in both
+        # directions: 56 is not enough for `beta`, and 100 is not `pre_1_0`.
+        ({"qualification_tier": "beta", "production_qualified": True}, 56, "cases, not 100"),
+        ({}, 100, "cases, not 56"),
+        # `production_qualified` keeps meaning the 100-case bar.
+        ({"production_qualified": True}, 56, "without the production policy"),
+        ({"qualified": False}, 56, "not qualified"),
+    ]:
+        with pytest.raises(ReleaseError, match=expected):
+            verify_qualification_binding(
+                qualification_path=_artifact(
+                    pre_1_0_wheel, pre_1_0_version, count, **overrides
+                ),
+                wheel_path=pre_1_0_wheel,
+                tag=f"v{pre_1_0_version}",
+            )
+
+
 def test_the_suite_and_the_sealer_must_agree_on_the_commit() -> None:
     """They check out independently; a mutable ref could test A and seal B."""
 

--- a/tests/test_safety_qualification.py
+++ b/tests/test_safety_qualification.py
@@ -21,8 +21,11 @@ from agents_shipgate.schemas.disclaimers import STATIC_VERDICT_DISCLAIMER
 from agents_shipgate.schemas.human_authorization import AuthorizationEvaluationV1
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.safety_qualification import (
+    LEGACY_QUALIFICATION_ENVELOPES,
+    LEGACY_QUALIFICATION_TIERS,
     RELEASE_SAFETY_PROFILES,
     SAFETY_CORPUS_SCHEMA_VERSION,
+    SAFETY_QUALIFICATION_SCHEMA_VERSION,
     SAFETY_RECEIPT_INDEX_SCHEMA_VERSION,
     FrozenSafetyCorpusV1,
     HumanAdjudicationV1,
@@ -57,15 +60,24 @@ from agents_shipgate.schemas.verify_run import (
     build_verify_run_artifact,
 )
 from scripts._release_support import (
+    CURRENT_QUALIFICATION_ENVELOPE,
     QUALIFICATION_POLICIES,
     accepted_qualification_tiers,
+    qualification_envelope_admits_tier,
     release_version_is_pre_1_0,
+)
+from scripts._release_support import (
+    LEGACY_QUALIFICATION_ENVELOPES as STDLIB_LEGACY_ENVELOPES,
+)
+from scripts._release_support import (
+    LEGACY_QUALIFICATION_TIERS as STDLIB_LEGACY_TIERS,
 )
 from scripts.run_safety_qualification import (
     EXPECTED_MERGE_VERDICT,
     hash_policy_bundle,
     load_frozen_corpus,
     main,
+    qualification_exit_code,
     render_safety_qualification_json,
     run_safety_qualification,
     select_release_requirements,
@@ -585,7 +597,9 @@ def test_the_pre_1_0_policy_covers_every_production_stratum() -> None:
     assert pre_1_0_strata == production_strata
     assert {item.profile for item in pre_1_0.required_strata} == set(RELEASE_SAFETY_PROFILES)
     assert all(item.count >= 1 for item in pre_1_0.required_strata)
-    # Two per cell is what leaves each one a tuning case *and* a holdout case.
+    # Two per cell is what leaves *room* for a tuning case beside the required
+    # holdout one. It is room, not a requirement: see
+    # ``test_a_corpus_with_more_holdout_than_required_is_accepted``.
     assert all(
         item.count - math.ceil(item.count * pre_1_0.minimum_holdout_fraction_per_stratum) >= 1
         for item in pre_1_0.required_strata
@@ -784,6 +798,35 @@ def test_a_conforming_56_case_corpus_qualifies_a_0_x_wheel(tmp_path: Path) -> No
     assert production["failures"]
 
 
+def test_a_corpus_with_more_holdout_than_required_is_accepted(tmp_path: Path) -> None:
+    """The policy sets a holdout *floor*, and deliberately no tuning floor.
+
+    Holdout evidence is evidence the engine was never tuned on, so more of it
+    is stronger. A minimum on tuning cases would be a maximum on holdout, and
+    the gate must never reject a corpus for being more conservative than
+    required. Pinned here because the decision document used to describe the
+    expected 1-tuning/1-holdout layout as though it were enforced.
+    """
+
+    requirements = pre_release_safety_requirements()
+    every_case_held_out = [
+        case.model_copy(update={"split": "holdout"})
+        for case in _conforming_cases(requirements)
+    ]
+    wheel, corpus, receipts, policy = _fixture(tmp_path, cases=every_case_held_out)
+    result = run_safety_qualification(
+        wheel_path=wheel,
+        corpus_path=corpus,
+        receipt_index_path=receipts,
+        policy_paths=[policy],
+    )
+
+    assert result.failures == []
+    assert qualification_exit_code(result) == 0
+    assert result.qualification_tier == "pre_1_0"
+    assert all(row.tuning_count == 0 and row.holdout_count == 2 for row in result.strata)
+
+
 def test_the_production_flag_cannot_disagree_with_the_tier(tmp_path: Path) -> None:
     """The producer-side half of the invariant, enforced by the schema itself.
 
@@ -834,15 +877,31 @@ def test_the_qualification_envelope_advanced_for_the_new_grammar(tmp_path: Path)
     payload = _run(_fixture(tmp_path)).model_dump(mode="json")
     assert payload["schema_version"] == "shipgate.safety_qualification/v5"
 
-    for readable in (
+    legacy = (
         "shipgate.safety_qualification/v1",
         "shipgate.safety_qualification/v2",
         "shipgate.safety_qualification/v4",
-        "shipgate.safety_qualification/v5",
-    ):
+    )
+
+    # A legacy envelope is read only when the payload uses the vocabulary that
+    # envelope can express. `test` and `beta` are v4 words; `pre_1_0` is not.
+    for readable in (*legacy, "shipgate.safety_qualification/v5"):
         assert SafetyQualificationResultV1.model_validate(
             {**payload, "schema_version": readable}
         ).schema_version == "shipgate.safety_qualification/v5"
+
+    # The combination the bump exists to eliminate. An unconditional upgrade
+    # rewrote the envelope before anything looked at the tier, which let a
+    # conforming pre-1.0 artifact keep claiming a v4 an old reader cannot parse.
+    for envelope in legacy:
+        with pytest.raises(ValidationError, match="admits only qualification_tier"):
+            SafetyQualificationResultV1.model_validate(
+                {**payload, "schema_version": envelope, "qualification_tier": "pre_1_0"}
+            )
+    assert SafetyQualificationResultV1.model_validate(
+        {**payload, "schema_version": "shipgate.safety_qualification/v5",
+         "qualification_tier": "pre_1_0"}
+    ).qualification_tier == "pre_1_0"
 
     for rejected in (
         "shipgate.safety_qualification/v3",
@@ -853,6 +912,14 @@ def test_the_qualification_envelope_advanced_for_the_new_grammar(tmp_path: Path)
             SafetyQualificationResultV1.model_validate(
                 {**payload, "schema_version": rejected}
             )
+
+    # The stdlib gate applies the same pairing on raw JSON.
+    for envelope in legacy:
+        assert qualification_envelope_admits_tier(envelope, "beta") is True
+        assert qualification_envelope_admits_tier(envelope, "test") is True
+        assert qualification_envelope_admits_tier(envelope, "pre_1_0") is False
+    assert qualification_envelope_admits_tier("shipgate.safety_qualification/v5", "pre_1_0")
+    assert qualification_envelope_admits_tier("shipgate.safety_qualification/v3", "beta") is False
 
     # The corpus and receipt-index envelopes did *not* move: their grammar is
     # unchanged, and these versions track grammar rather than release batches.
@@ -896,9 +963,27 @@ def test_the_stdlib_policy_table_matches_the_named_policies() -> None:
     assert set(QUALIFICATION_POLICIES) == set(accepted_qualification_tiers("0.16.0b7"))
     assert accepted_qualification_tiers("1.0.0") == ("beta",)
 
+    # The strongest binding available: the block the sealer demands *is* the
+    # serialized requirements object, so a field added to the model breaks the
+    # build until the stdlib copy restates it too.
+    for tier, requirements in named.items():
+        payload = requirements.model_dump(mode="json")
+        payload["required_strata"] = sorted(
+            payload["required_strata"],
+            key=lambda row: (row["profile"], row["expected_decision"]),
+        )
+        assert QUALIFICATION_POLICIES[tier].as_requirements_payload() == payload, tier
+
+    assert CURRENT_QUALIFICATION_ENVELOPE == SAFETY_QUALIFICATION_SCHEMA_VERSION
+    assert STDLIB_LEGACY_ENVELOPES == LEGACY_QUALIFICATION_ENVELOPES
+    assert STDLIB_LEGACY_TIERS == LEGACY_QUALIFICATION_TIERS
+
     for tier, requirements in named.items():
         policy = QUALIFICATION_POLICIES[tier]
         assert policy.tier == tier
+        assert policy.required_report_schema_version == (
+            requirements.required_report_schema_version
+        ), tier
         assert policy.strata == {
             (item.profile, item.expected_decision): item.count
             for item in requirements.required_strata

--- a/tests/test_safety_qualification.py
+++ b/tests/test_safety_qualification.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import zipfile
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from agents_shipgate.core.agent_control import derive_agent_control
 from agents_shipgate.core.errors import ConfigError
@@ -19,16 +21,20 @@ from agents_shipgate.schemas.disclaimers import STATIC_VERDICT_DISCLAIMER
 from agents_shipgate.schemas.human_authorization import AuthorizationEvaluationV1
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.safety_qualification import (
+    RELEASE_SAFETY_PROFILES,
     FrozenSafetyCorpusV1,
     HumanAdjudicationV1,
     IndependentHumanLabelV1,
     SafetyCorpusCaseV1,
     SafetyQualificationRequirementsV1,
+    SafetyQualificationResultV1,
     SafetyReceiptEntryV1,
     SafetyReceiptIndexV1,
     SafetyStratumRequirementV1,
     compute_frozen_labels_sha256,
+    pre_release_safety_requirements,
     production_safety_requirements,
+    tier_for_requirements,
 )
 from agents_shipgate.schemas.verification_identity import (
     VerificationBlob,
@@ -48,6 +54,10 @@ from agents_shipgate.schemas.verify_run import (
     VerifyRunOutcome,
     build_verify_run_artifact,
 )
+from scripts._release_support import (
+    QUALIFICATION_CASE_COUNTS,
+    accepted_qualification_tiers,
+)
 from scripts.run_safety_qualification import (
     EXPECTED_MERGE_VERDICT,
     hash_policy_bundle,
@@ -55,6 +65,7 @@ from scripts.run_safety_qualification import (
     main,
     render_safety_qualification_json,
     run_safety_qualification,
+    select_release_requirements,
     sha256_file,
 )
 
@@ -499,6 +510,176 @@ def test_production_defaults_pin_the_exact_beta_contract() -> None:
     assert requirements.minimum_kappa == 0.80
 
 
+def test_pre_release_defaults_pin_the_exact_pre_1_0_contract() -> None:
+    """The numbers a human approved on 2026-08-29 (issue #341, Route 2).
+
+    Pinned as literals so changing the approved bar is a visible edit to this
+    test, not a silent consequence of editing the constructor.
+    """
+
+    requirements = pre_release_safety_requirements()
+    counts = {
+        (item.profile, item.expected_decision): item.count for item in requirements.required_strata
+    }
+
+    assert len(counts) == 28
+    assert set(counts.values()) == {2}
+    assert sum(counts.values()) == 56
+    assert sum(count for (_, decision), count in counts.items() if decision == "passed") == 14
+    assert sum(count for (_, decision), count in counts.items() if decision != "passed") == 42
+    assert requirements.minimum_safe_passes == 13
+    assert requirements.minimum_blocked_exact == 14
+    assert requirements.minimum_review_exact == 14
+    assert requirements.minimum_insufficient_evidence_exact == 14
+    assert requirements.maximum_unsafe_auto_passes == 0
+    assert requirements.minimum_qualified_origins == 23
+    assert requirements.minimum_kappa == 0.80
+
+
+def test_the_pre_1_0_policy_covers_every_production_stratum() -> None:
+    """Less coverage means fewer *cases*, never fewer profile x outcome cells.
+
+    Dropping a cell would delete every observation of a profile/outcome pair,
+    which reduces strictness rather than coverage. This also fails loudly if a
+    profile is added to production and not to the pre-1.0 policy.
+    """
+
+    production = production_safety_requirements()
+    pre_1_0 = pre_release_safety_requirements()
+
+    production_strata = {(item.profile, item.expected_decision) for item in production.required_strata}
+    pre_1_0_strata = {(item.profile, item.expected_decision) for item in pre_1_0.required_strata}
+
+    assert pre_1_0_strata == production_strata
+    assert {item.profile for item in pre_1_0.required_strata} == set(RELEASE_SAFETY_PROFILES)
+    assert all(item.count >= 1 for item in pre_1_0.required_strata)
+    # Two per cell is what leaves each one a tuning case *and* a holdout case.
+    assert all(
+        item.count - math.ceil(item.count * pre_1_0.minimum_holdout_fraction_per_stratum) >= 1
+        for item in pre_1_0.required_strata
+    )
+
+
+def test_the_pre_1_0_policy_is_never_laxer_than_production_per_rate() -> None:
+    """A smaller corpus may reduce coverage. It must not reduce strictness.
+
+    Each exact-match floor is compared as a *rate* against the population it
+    governs, because 13 of 14 and 27 of 30 are the same demand at different
+    sizes -- and 12 of 14 would not be.
+    """
+
+    production = production_safety_requirements()
+    pre_1_0 = pre_release_safety_requirements()
+
+    def _outcome_totals(requirements: SafetyQualificationRequirementsV1) -> dict[str, int]:
+        return {
+            decision: sum(
+                item.count
+                for item in requirements.required_strata
+                if item.expected_decision == decision
+            )
+            for decision in DECISIONS
+        }
+
+    production_totals = _outcome_totals(production)
+    pre_1_0_totals = _outcome_totals(pre_1_0)
+    floors = {
+        "passed": "minimum_safe_passes",
+        "blocked": "minimum_blocked_exact",
+        "review_required": "minimum_review_exact",
+        "insufficient_evidence": "minimum_insufficient_evidence_exact",
+    }
+    for decision, attribute in floors.items():
+        production_rate = getattr(production, attribute) / production_totals[decision]
+        pre_1_0_rate = getattr(pre_1_0, attribute) / pre_1_0_totals[decision]
+        assert pre_1_0_rate >= production_rate, attribute
+        # ...and it is the *smallest* count meeting that rate, so the smaller
+        # policy is not quietly stricter than the decision recorded either.
+        assert getattr(pre_1_0, attribute) == math.ceil(production_rate * pre_1_0_totals[decision])
+
+    # The invariants that may not move at all, regardless of corpus size.
+    assert pre_1_0.maximum_unsafe_auto_passes == production.maximum_unsafe_auto_passes == 0
+    assert (
+        pre_1_0.minimum_holdout_fraction_per_stratum
+        == production.minimum_holdout_fraction_per_stratum
+    )
+    assert pre_1_0.minimum_kappa == production.minimum_kappa
+    assert (
+        pre_1_0.required_report_schema_version == production.required_report_schema_version
+    )
+    # The origin floor is the same share of the corpus, rounded up.
+    production_total = sum(item.count for item in production.required_strata)
+    pre_1_0_total = sum(item.count for item in pre_1_0.required_strata)
+    origin_share = production.minimum_qualified_origins / production_total
+    assert pre_1_0.minimum_qualified_origins == math.ceil(origin_share * pre_1_0_total)
+
+
+def test_the_governing_policy_is_derived_from_the_wheel_version() -> None:
+    """#341 approved a policy keyed to the version range, so applying it is
+    implementing the decision -- not inferring one from the tag."""
+
+    assert select_release_requirements("0.16.0b7") == pre_release_safety_requirements()
+    assert select_release_requirements("0.16.0") == pre_release_safety_requirements()
+    assert select_release_requirements("1.0.0") == production_safety_requirements()
+    assert select_release_requirements("1.0.0rc1") == production_safety_requirements()
+    # Unparsable versions fall to the strictest policy, never the cheapest.
+    assert select_release_requirements("not-a-version") == production_safety_requirements()
+
+    # Opting *up* is always available; opting down past 1.0 is refused where
+    # the artifact would be produced, not only where it would be gated.
+    assert select_release_requirements("0.16.0b7", "production") == production_safety_requirements()
+    with pytest.raises(ConfigError, match="does not govern 1.0.0"):
+        select_release_requirements("1.0.0", "pre-1.0")
+    with pytest.raises(ConfigError, match="Unknown qualification policy tier"):
+        select_release_requirements("0.16.0b7", "whatever")
+
+
+def test_an_ad_hoc_threshold_set_can_never_name_itself_a_release_tier() -> None:
+    """Tiers are named from what the thresholds *are*. One relaxed field is
+    enough to stop a requirements object presenting as release-grade."""
+
+    assert tier_for_requirements(production_safety_requirements()) == "beta"
+    assert tier_for_requirements(pre_release_safety_requirements()) == "pre_1_0"
+    assert tier_for_requirements(_test_requirements()) == "test"
+
+    weakened = pre_release_safety_requirements().model_copy(
+        update={"minimum_blocked_exact": 13}
+    )
+    assert tier_for_requirements(weakened) == "test"
+
+
+def test_an_unknown_qualification_tier_is_not_a_valid_artifact(tmp_path: Path) -> None:
+    """Negative control for the widened tier union: adding ``pre_1_0`` must not
+    have turned ``qualification_tier`` into a free-text field."""
+
+    payload = _run(_fixture(tmp_path)).model_dump(mode="json")
+    assert payload["qualification_tier"] == "test"
+
+    accepted = SafetyQualificationResultV1.model_validate(
+        {**payload, "qualification_tier": "pre_1_0"}
+    )
+    assert accepted.qualification_tier == "pre_1_0"
+
+    for rejected in ("production", "pre_1.0", "PRE_1_0", ""):
+        with pytest.raises(ValidationError):
+            SafetyQualificationResultV1.model_validate(
+                {**payload, "qualification_tier": rejected}
+            )
+
+
+def test_the_stdlib_case_counts_match_the_named_policies() -> None:
+    """The sealing job restates these counts without importing the schemas.
+    Two copies of a number are a drift risk unless something binds them."""
+
+    assert QUALIFICATION_CASE_COUNTS == {
+        "beta": sum(item.count for item in production_safety_requirements().required_strata),
+        "pre_1_0": sum(item.count for item in pre_release_safety_requirements().required_strata),
+    }
+    assert accepted_qualification_tiers("0.16.0b7") == ("beta", "pre_1_0")
+    assert accepted_qualification_tiers("1.0.0") == ("beta",)
+    assert set(QUALIFICATION_CASE_COUNTS) == set(accepted_qualification_tiers("0.16.0b7"))
+
+
 def test_custom_fixture_qualifies_only_as_test_and_is_byte_deterministic(
     tmp_path: Path,
 ) -> None:
@@ -521,33 +702,46 @@ def test_custom_fixture_qualifies_only_as_test_and_is_byte_deterministic(
     assert render_safety_qualification_json(first) == render_safety_qualification_json(second)
 
 
-def test_cli_uses_unrelaxed_production_policy_and_emits_failed_artifact(
+def test_cli_uses_an_unrelaxed_named_policy_and_emits_failed_artifact(
     tmp_path: Path,
 ) -> None:
+    """The CLI never scores the corpus it was handed on the corpus's own terms.
+
+    The four-case fixture satisfies no named policy, so both the version-derived
+    default and an explicit opt-up to production must reject it. ``0.16.0b7`` is
+    a ``0.x`` wheel, so the default is the pre-1.0 policy approved in #341 --
+    smaller, and still nothing this fixture can meet.
+    """
+
     wheel, corpus, receipts, policy = _fixture(tmp_path)
-    output = tmp_path / "safety-qualification.json"
 
-    exit_code = main(
-        [
-            "--wheel",
-            str(wheel),
-            "--corpus",
-            str(corpus),
-            "--receipts",
-            str(receipts),
-            "--policy",
-            str(policy),
-            "--out",
-            str(output),
-        ]
-    )
-    payload = json.loads(output.read_text(encoding="utf-8"))
+    def _run_cli(*extra: str) -> dict:
+        output = tmp_path / f"safety-qualification{'-'.join(extra) or '-auto'}.json"
+        exit_code = main(
+            [
+                "--wheel",
+                str(wheel),
+                "--corpus",
+                str(corpus),
+                "--receipts",
+                str(receipts),
+                "--policy",
+                str(policy),
+                "--out",
+                str(output),
+                *extra,
+            ]
+        )
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert exit_code == 1
+        assert payload["qualified"] is False
+        assert payload["production_qualified"] is False
+        assert payload["failures"]
+        return payload
 
-    assert exit_code == 1
-    assert payload["qualification_tier"] == "beta"
-    assert payload["qualified"] is False
-    assert payload["production_qualified"] is False
-    assert payload["failures"]
+    assert _run_cli()["qualification_tier"] == "pre_1_0"
+    assert _run_cli("--policy-tier", "production")["qualification_tier"] == "beta"
+    assert _run_cli("--policy-tier", "pre-1.0")["qualification_tier"] == "pre_1_0"
 
 
 def test_human_adjudicated_non_safe_pass_fails_closed(tmp_path: Path) -> None:
@@ -564,7 +758,7 @@ def test_human_adjudicated_non_safe_pass_fails_closed(tmp_path: Path) -> None:
     assert result.summary.unsafe_auto_pass_count == 1
     assert "unsafe_auto_pass" in codes
     assert "profile_unsafe_auto_pass" in codes
-    assert "beta_threshold_failed" in codes
+    assert "policy_threshold_failed" in codes
 
 
 def test_missing_receipt_is_a_runtime_failure_not_fallback_scoring(tmp_path: Path) -> None:

--- a/tests/test_safety_qualification.py
+++ b/tests/test_safety_qualification.py
@@ -167,13 +167,15 @@ def _case(
     decision: str,
     *,
     disagreement: bool = False,
+    profile: str = "mcp",
+    split: str = "holdout",
 ) -> SafetyCorpusCaseV1:
     framework_decision = "passed" if disagreement else decision
     return SafetyCorpusCaseV1(
         id=case_id,
-        profile="mcp",
+        profile=profile,  # type: ignore[arg-type]
         origin="real_history",
-        split="holdout",
+        split=split,  # type: ignore[arg-type]
         expected_decision=decision,
         evidence_references=(f"evidence/{case_id}.json",),
         remediation_condition="Apply the human-reviewed remediation and rerun verify.",
@@ -262,18 +264,45 @@ def _semantic_coverage(decision: str) -> dict[str, object]:
     }
 
 
+def _conforming_cases(
+    requirements: SafetyQualificationRequirementsV1,
+) -> list[SafetyCorpusCaseV1]:
+    """A corpus that exactly satisfies ``requirements``, stratum by stratum.
+
+    One holdout case per stratum (the minimum at a 20% fraction and two cases)
+    and the rest tuning, every origin qualifying, no label disagreements.
+    """
+
+    cases: list[SafetyCorpusCaseV1] = []
+    for item in requirements.required_strata:
+        minimum_holdout = math.ceil(
+            item.count * requirements.minimum_holdout_fraction_per_stratum
+        )
+        for index in range(item.count):
+            cases.append(
+                _case(
+                    f"case-{item.profile}-{item.expected_decision}-{index:02d}",
+                    item.expected_decision,
+                    profile=item.profile,
+                    split="holdout" if index < minimum_holdout else "tuning",
+                )
+            )
+    return cases
+
+
 def _fixture(
     tmp_path: Path,
     *,
     actual_overrides: dict[str, str] | None = None,
     disagreement_case: str | None = None,
+    cases: list[SafetyCorpusCaseV1] | None = None,
 ) -> tuple[Path, Path, Path, Path]:
     wheel = tmp_path / "agents_shipgate-0.16.0b7-py3-none-any.whl"
     _write_wheel(wheel)
     policy = tmp_path / "qualification-policy.json"
     _write_json(policy, {"policy": "beta-exact", "version": 1})
 
-    cases = [
+    cases = cases or [
         _case(
             f"case-{decision}",
             decision,
@@ -634,6 +663,51 @@ def test_the_governing_policy_is_derived_from_the_wheel_version() -> None:
         select_release_requirements("0.16.0b7", "whatever")
 
 
+def test_the_version_rule_binds_the_requirements_keyword_too(tmp_path: Path) -> None:
+    """``requirements=`` bypasses ``select_release_requirements`` entirely.
+
+    Without a check on the *resulting* tier, a caller could score a 1.0 wheel
+    against the pre-1.0 policy and get a zero-exit artifact no gate will ever
+    accept -- discovered only after it had been signed. The fixture's ad-hoc
+    ``test`` requirements stay exempt, because they are unpublishable anyway.
+    """
+
+    wheel, corpus, receipts, policy = _fixture(tmp_path)
+    post_1_0_wheel = tmp_path / "agents_shipgate-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(post_1_0_wheel, "w") as archive:
+        archive.writestr(
+            "agents_shipgate-1.0.0.dist-info/METADATA",
+            "Metadata-Version: 2.4\nName: agents-shipgate\nVersion: 1.0.0\n",
+        )
+
+    def _run_against(wheel_path: Path, **kwargs: object):
+        return run_safety_qualification(
+            wheel_path=wheel_path,
+            corpus_path=corpus,
+            receipt_index_path=receipts,
+            policy_paths=[policy],
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ConfigError, match="does not govern 1.0.0"):
+        _run_against(post_1_0_wheel, requirements=pre_release_safety_requirements())
+
+    # The stronger policy is accepted on any version, and the ad-hoc fixture
+    # requirements stay usable against both wheels.
+    assert (
+        _run_against(
+            post_1_0_wheel, requirements=production_safety_requirements()
+        ).qualification_tier
+        == "beta"
+    )
+    assert _run_against(post_1_0_wheel, requirements=_test_requirements()).qualification_tier == (
+        "test"
+    )
+    assert _run_against(wheel, requirements=pre_release_safety_requirements()).qualification_tier == (
+        "pre_1_0"
+    )
+
+
 def test_an_ad_hoc_threshold_set_can_never_name_itself_a_release_tier() -> None:
     """Tiers are named from what the thresholds *are*. One relaxed field is
     enough to stop a requirements object presenting as release-grade."""
@@ -646,6 +720,103 @@ def test_an_ad_hoc_threshold_set_can_never_name_itself_a_release_tier() -> None:
         update={"minimum_blocked_exact": 13}
     )
     assert tier_for_requirements(weakened) == "test"
+
+
+def test_a_conforming_56_case_corpus_qualifies_a_0_x_wheel(tmp_path: Path) -> None:
+    """End-to-end: the approved pre-1.0 bar is satisfiable, and honest about it.
+
+    This is the only test in which the runner produces a *passing* named-policy
+    artifact, so it is the only place that can catch the runner claiming
+    ``production_qualified`` for a tier that did not meet the 100-case bar.
+    """
+
+    requirements = pre_release_safety_requirements()
+    paths = _fixture(tmp_path, cases=_conforming_cases(requirements))
+    wheel, corpus, receipts, policy = paths
+    output = tmp_path / "safety-qualification.json"
+
+    exit_code = main(
+        [
+            "--wheel", str(wheel),
+            "--corpus", str(corpus),
+            "--receipts", str(receipts),
+            "--policy", str(policy),
+            "--out", str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert payload["failures"] == []
+    assert exit_code == 0
+    assert payload["qualification_tier"] == "pre_1_0"
+    assert payload["qualified"] is True
+    # The whole point of keeping the flag's meaning: a passing pre-1.0 run is
+    # emphatically *not* production-qualified.
+    assert payload["production_qualified"] is False
+    assert payload["summary"]["total_cases"] == 56
+    assert payload["summary"]["receipt_count"] == 56
+    assert payload["summary"]["unsafe_auto_pass_count"] == 0
+    assert payload["summary"]["qualified_origin_cases"] >= 23
+    assert len(payload["strata"]) == 28
+    assert all(row["holdout_count"] >= row["minimum_holdout_count"] for row in payload["strata"])
+
+    # ...and the same corpus is nowhere near the production bar it does not claim.
+    production_output = tmp_path / "production.json"
+    assert (
+        main(
+            [
+                "--wheel", str(wheel),
+                "--corpus", str(corpus),
+                "--receipts", str(receipts),
+                "--policy", str(policy),
+                "--out", str(production_output),
+                "--policy-tier", "production",
+            ]
+        )
+        == 1
+    )
+    production = json.loads(production_output.read_text(encoding="utf-8"))
+    assert production["qualification_tier"] == "beta"
+    assert production["production_qualified"] is False
+    assert production["failures"]
+
+
+def test_the_production_flag_cannot_disagree_with_the_tier(tmp_path: Path) -> None:
+    """The producer-side half of the invariant, enforced by the schema itself.
+
+    Every gate rejects a ``pre_1_0`` artifact claiming ``production_qualified``,
+    but only after it has been signed and handed to the release. Refusing to
+    *construct* one means the runner cannot emit it at all -- and this is the
+    only place that holds for a passing run, since a failing run reports
+    ``production_qualified: false`` under any spelling of the rule.
+    """
+
+    payload = _run(_fixture(tmp_path)).model_dump(mode="json")
+    assert payload["qualified"] is True
+    assert payload["production_qualified"] is False
+
+    # A qualified artifact under a non-production tier may not claim the flag.
+    for tier in ("test", "pre_1_0"):
+        with pytest.raises(ValidationError, match="production_qualified"):
+            SafetyQualificationResultV1.model_validate(
+                {**payload, "qualification_tier": tier, "production_qualified": True}
+            )
+
+    # ...and a qualified beta artifact may not disclaim it.
+    with pytest.raises(ValidationError, match="production_qualified"):
+        SafetyQualificationResultV1.model_validate(
+            {**payload, "qualification_tier": "beta", "production_qualified": False}
+        )
+    assert SafetyQualificationResultV1.model_validate(
+        {**payload, "qualification_tier": "beta", "production_qualified": True}
+    ).production_qualified
+
+    # An unqualified artifact never claims it, whatever tier it names.
+    with pytest.raises(ValidationError, match="production_qualified"):
+        SafetyQualificationResultV1.model_validate(
+            {**payload, "qualification_tier": "beta", "qualified": False,
+             "production_qualified": True}
+        )
 
 
 def test_an_unknown_qualification_tier_is_not_a_valid_artifact(tmp_path: Path) -> None:

--- a/tests/test_safety_qualification.py
+++ b/tests/test_safety_qualification.py
@@ -302,7 +302,7 @@ def _fixture(
     policy = tmp_path / "qualification-policy.json"
     _write_json(policy, {"policy": "beta-exact", "version": 1})
 
-    cases = cases or [
+    cases = cases if cases is not None else [
         _case(
             f"case-{decision}",
             decision,

--- a/tests/test_safety_qualification.py
+++ b/tests/test_safety_qualification.py
@@ -22,6 +22,8 @@ from agents_shipgate.schemas.human_authorization import AuthorizationEvaluationV
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.safety_qualification import (
     RELEASE_SAFETY_PROFILES,
+    SAFETY_CORPUS_SCHEMA_VERSION,
+    SAFETY_RECEIPT_INDEX_SCHEMA_VERSION,
     FrozenSafetyCorpusV1,
     HumanAdjudicationV1,
     IndependentHumanLabelV1,
@@ -55,8 +57,9 @@ from agents_shipgate.schemas.verify_run import (
     build_verify_run_artifact,
 )
 from scripts._release_support import (
-    QUALIFICATION_CASE_COUNTS,
+    QUALIFICATION_POLICIES,
     accepted_qualification_tiers,
+    release_version_is_pre_1_0,
 )
 from scripts.run_safety_qualification import (
     EXPECTED_MERGE_VERDICT,
@@ -819,6 +822,44 @@ def test_the_production_flag_cannot_disagree_with_the_tier(tmp_path: Path) -> No
         )
 
 
+def test_the_qualification_envelope_advanced_for_the_new_grammar(tmp_path: Path) -> None:
+    """`pre_1_0` and the production_qualified invariant are grammar changes.
+
+    A v4 reader admits neither, so a genuine pre-1.0 artifact must not claim
+    v4. v4 payloads stay readable because v4's vocabulary is a strict subset of
+    v5's and its producer always satisfied the new invariant; v3 was never
+    readable and still is not.
+    """
+
+    payload = _run(_fixture(tmp_path)).model_dump(mode="json")
+    assert payload["schema_version"] == "shipgate.safety_qualification/v5"
+
+    for readable in (
+        "shipgate.safety_qualification/v1",
+        "shipgate.safety_qualification/v2",
+        "shipgate.safety_qualification/v4",
+        "shipgate.safety_qualification/v5",
+    ):
+        assert SafetyQualificationResultV1.model_validate(
+            {**payload, "schema_version": readable}
+        ).schema_version == "shipgate.safety_qualification/v5"
+
+    for rejected in (
+        "shipgate.safety_qualification/v3",
+        "shipgate.safety_qualification/v6",
+        "shipgate.safety_qualification",
+    ):
+        with pytest.raises(ValidationError):
+            SafetyQualificationResultV1.model_validate(
+                {**payload, "schema_version": rejected}
+            )
+
+    # The corpus and receipt-index envelopes did *not* move: their grammar is
+    # unchanged, and these versions track grammar rather than release batches.
+    assert SAFETY_CORPUS_SCHEMA_VERSION == "shipgate.safety_corpus/v4"
+    assert SAFETY_RECEIPT_INDEX_SCHEMA_VERSION == "shipgate.safety_receipt_index/v4"
+
+
 def test_an_unknown_qualification_tier_is_not_a_valid_artifact(tmp_path: Path) -> None:
     """Negative control for the widened tier union: adding ``pre_1_0`` must not
     have turned ``qualification_tier`` into a free-text field."""
@@ -838,17 +879,83 @@ def test_an_unknown_qualification_tier_is_not_a_valid_artifact(tmp_path: Path) -
             )
 
 
-def test_the_stdlib_case_counts_match_the_named_policies() -> None:
-    """The sealing job restates these counts without importing the schemas.
-    Two copies of a number are a drift risk unless something binds them."""
+def test_the_stdlib_policy_table_matches_the_named_policies() -> None:
+    """The sealing job restates the whole policy without importing the schemas.
 
-    assert QUALIFICATION_CASE_COUNTS == {
-        "beta": sum(item.count for item in production_safety_requirements().required_strata),
-        "pre_1_0": sum(item.count for item in pre_release_safety_requirements().required_strata),
+    A restated *case count* was not enough: the sealer could not tell 56
+    correctly stratified cases from 56 identical ones, nor notice a corpus two
+    safe passes below its floor. Every field it now re-derives is bound here,
+    because two copies of a policy drift unless something forces them equal.
+    """
+
+    named = {
+        "beta": production_safety_requirements(),
+        "pre_1_0": pre_release_safety_requirements(),
     }
-    assert accepted_qualification_tiers("0.16.0b7") == ("beta", "pre_1_0")
+    assert set(QUALIFICATION_POLICIES) == set(named)
+    assert set(QUALIFICATION_POLICIES) == set(accepted_qualification_tiers("0.16.0b7"))
     assert accepted_qualification_tiers("1.0.0") == ("beta",)
-    assert set(QUALIFICATION_CASE_COUNTS) == set(accepted_qualification_tiers("0.16.0b7"))
+
+    for tier, requirements in named.items():
+        policy = QUALIFICATION_POLICIES[tier]
+        assert policy.tier == tier
+        assert policy.strata == {
+            (item.profile, item.expected_decision): item.count
+            for item in requirements.required_strata
+        }, tier
+        assert policy.case_count == sum(item.count for item in requirements.required_strata), tier
+        assert policy.minimum_exact == {
+            "passed": requirements.minimum_safe_passes,
+            "review_required": requirements.minimum_review_exact,
+            "insufficient_evidence": requirements.minimum_insufficient_evidence_exact,
+            "blocked": requirements.minimum_blocked_exact,
+        }, tier
+        assert policy.minimum_qualified_origins == requirements.minimum_qualified_origins, tier
+        assert policy.minimum_kappa == requirements.minimum_kappa, tier
+        assert policy.minimum_holdout_fraction_per_stratum == (
+            requirements.minimum_holdout_fraction_per_stratum
+        ), tier
+        assert policy.maximum_unsafe_auto_passes == requirements.maximum_unsafe_auto_passes, tier
+        for decision in DECISIONS:
+            assert policy.outcome_total(decision) == sum(
+                item.count
+                for item in requirements.required_strata
+                if item.expected_decision == decision
+            ), (tier, decision)
+        # The sealer's holdout minimum is the verifier's, not an approximation.
+        for item in requirements.required_strata:
+            assert policy.minimum_holdout(item.count) == math.ceil(
+                item.count * requirements.minimum_holdout_fraction_per_stratum
+            ), tier
+
+
+def test_only_a_complete_pep440_version_can_reach_the_cheaper_policy() -> None:
+    """The approved rule sends *every* unparsable version to the production bar.
+
+    A prefix-anchored parse read `0garbage`, `0.16.0garbage` and `0..1` as
+    major 0 and handed them the pre-1.0 policy — the exact inversion of the
+    documented fallback. Both release gates share this helper, so the hole
+    opened both at once.
+    """
+
+    for version in (
+        "0.16.0b7", "0.16.0", "0.16.0rc1", "0.16.0.post1", "0.16.0.dev1",
+        "0.16.0+local", "0.16.0-1", "0.0.1", "0",
+        # Leading zeros are legal PEP 440 and normalize away.
+        "00.1", "0.016.0",
+    ):
+        assert release_version_is_pre_1_0(version) is True, version
+
+    for version in (
+        # Genuinely 1.0 or later, including a normalizing leading zero and a
+        # non-zero epoch.
+        "1.0.0", "1.0.0rc1", "01.0.0", "9.9.9", "1!0.1", "10.2.0",
+        # Malformed: none of these may buy the cheaper bar.
+        "0garbage", "0.16.0garbage", "0..1", "0-", "0x1", "0.16.0_", "",
+        "  ", "0.16.0 extra", "-0.1", "0.16.0++local", "v0.16.0", "0!x",
+    ):
+        assert release_version_is_pre_1_0(version) is False, version
+        assert accepted_qualification_tiers(version) == ("beta",), version
 
 
 def test_custom_fixture_qualifies_only_as_test_and_is_byte_deterministic(

--- a/tests/test_safety_qualification_release.py
+++ b/tests/test_safety_qualification_release.py
@@ -349,6 +349,45 @@ def test_a_pre_1_0_artifact_publishes_a_0_x_tag_and_nothing_later(
         )
 
 
+def test_a_pre_1_0_artifact_may_not_claim_a_legacy_envelope(tmp_path: Path) -> None:
+    """The exhaustive gate rejects it while parsing, not after.
+
+    A v4 reader admits `beta` and `test` only. Relabelling a conforming
+    56-case artifact as v4 recreates exactly the combination the v5 bump exists
+    to eliminate, so an old reader could still be handed something it cannot
+    parse. A legacy envelope carrying legacy vocabulary is still read.
+    """
+
+    wheel, qualification = _fixture(tmp_path, requirements=pre_release_safety_requirements())
+    _mutate(
+        qualification,
+        lambda payload: payload.__setitem__(
+            "schema_version", "shipgate.safety_qualification/v4"
+        ),
+    )
+
+    with pytest.raises(ConfigError, match="admits only qualification_tier"):
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        )
+
+    wheel, qualification = _fixture(
+        tmp_path / "beta", requirements=production_safety_requirements()
+    )
+    _mutate(
+        qualification,
+        lambda payload: payload.__setitem__(
+            "schema_version", "shipgate.safety_qualification/v4"
+        ),
+    )
+    assert (
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        ).schema_version
+        == "shipgate.safety_qualification/v5"
+    )
+
+
 def test_a_production_artifact_still_publishes_a_0_x_tag(tmp_path: Path) -> None:
     """Carrying more evidence than the tag requires is never a rejection."""
 

--- a/tests/test_safety_qualification_release.py
+++ b/tests/test_safety_qualification_release.py
@@ -15,10 +15,13 @@ from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.schemas.safety_qualification import (
     QualificationInputDigestV1,
     SafetyQualificationCaseResultV1,
+    SafetyQualificationRequirementsV1,
     SafetyQualificationResultV1,
     SafetyQualificationStratumV1,
     SafetyQualificationSummaryV1,
+    pre_release_safety_requirements,
     production_safety_requirements,
+    tier_for_requirements,
 )
 from scripts.run_safety_qualification import _confusion_matrix, _metric, sha256_file
 from scripts.verify_safety_qualification_release import (
@@ -27,19 +30,33 @@ from scripts.verify_safety_qualification_release import (
 )
 
 VERSION = "0.16.0b7"
+POST_1_0_VERSION = "1.0.0"
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def _write_wheel(path: Path) -> None:
+def _write_wheel(path: Path, version: str = VERSION) -> None:
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr(
-            "agents_shipgate-0.16.0b7.dist-info/METADATA",
-            "Metadata-Version: 2.4\nName: agents-shipgate\nVersion: 0.16.0b7\n",
+            f"agents_shipgate-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: agents-shipgate\nVersion: {version}\n",
         )
 
 
-def _production_result(wheel: Path) -> SafetyQualificationResultV1:
-    requirements = production_safety_requirements()
+def _result(
+    wheel: Path,
+    *,
+    requirements: SafetyQualificationRequirementsV1 | None = None,
+    version: str = VERSION,
+) -> SafetyQualificationResultV1:
+    """A perfectly conforming artifact for whichever named policy is supplied.
+
+    Everything is derived from ``requirements`` -- counts, thresholds, metric
+    denominators, matrix profiles -- so a policy change cannot leave this
+    builder asserting the previous one's numbers.
+    """
+
+    requirements = requirements or production_safety_requirements()
+    tier = tier_for_requirements(requirements)
     cases: list[SafetyQualificationCaseResultV1] = []
     strata: list[SafetyQualificationStratumV1] = []
     for requirement in requirements.required_strata:
@@ -72,50 +89,51 @@ def _production_result(wheel: Path) -> SafetyQualificationResultV1:
             )
         )
 
-    safe = sum(case.expected_decision == "passed" for case in cases)
-    blocked = sum(case.expected_decision == "blocked" for case in cases)
-    review = sum(case.expected_decision == "review_required" for case in cases)
-    insufficient = sum(case.expected_decision == "insufficient_evidence" for case in cases)
+    total = len(cases)
+    outcome_counts = {
+        decision: sum(case.expected_decision == decision for case in cases)
+        for decision in ("passed", "review_required", "insufficient_evidence", "blocked")
+    }
     metrics = [
         _metric(
             name="unsafe_auto_pass_rate",
             numerator=0,
-            denominator=70,
-            requirement="<= 0 cases",
+            denominator=total - outcome_counts["passed"],
+            requirement=f"<= {requirements.maximum_unsafe_auto_passes} cases",
             passed=True,
         ),
         _metric(
             name="safe_pass_rate",
-            numerator=safe,
-            denominator=safe,
-            requirement=">= 27 cases",
+            numerator=outcome_counts["passed"],
+            denominator=outcome_counts["passed"],
+            requirement=f">= {requirements.minimum_safe_passes} cases",
             passed=True,
         ),
         _metric(
             name="blocked_exact_rate",
-            numerator=blocked,
-            denominator=blocked,
-            requirement=">= 30 cases",
+            numerator=outcome_counts["blocked"],
+            denominator=outcome_counts["blocked"],
+            requirement=f">= {requirements.minimum_blocked_exact} cases",
             passed=True,
         ),
         _metric(
             name="review_exact_rate",
-            numerator=review,
-            denominator=review,
-            requirement=">= 19 cases",
+            numerator=outcome_counts["review_required"],
+            denominator=outcome_counts["review_required"],
+            requirement=f">= {requirements.minimum_review_exact} cases",
             passed=True,
         ),
         _metric(
             name="insufficient_evidence_exact_rate",
-            numerator=insufficient,
-            denominator=insufficient,
-            requirement=">= 19 cases",
+            numerator=outcome_counts["insufficient_evidence"],
+            denominator=outcome_counts["insufficient_evidence"],
+            requirement=f">= {requirements.minimum_insufficient_evidence_exact} cases",
             passed=True,
         ),
         _metric(
             name="overall_exact_rate",
-            numerator=100,
-            denominator=100,
+            numerator=total,
+            denominator=total,
             requirement="reported for audit; outcome-specific thresholds govern",
             passed=True,
         ),
@@ -123,24 +141,16 @@ def _production_result(wheel: Path) -> SafetyQualificationResultV1:
     matrices = [_confusion_matrix(cases, profile="all")]
     matrices.extend(
         _confusion_matrix(cases, profile=profile)
-        for profile in (
-            "mcp_openapi_declared_binding",
-            "openai_agents_sdk",
-            "langchain_crewai",
-            "google_adk",
-            "n8n",
-            "multi_agent_handoffs",
-            "coding_agent_trust_roots",
-        )
+        for profile in sorted({item.profile for item in requirements.required_strata})
     )
     return SafetyQualificationResultV1(
-        qualification_tier="beta",
+        qualification_tier=tier,
         qualified=True,
-        production_qualified=True,
+        production_qualified=tier == "beta",
         inputs=QualificationInputDigestV1(
             wheel_name="agents-shipgate",
-            wheel_version=VERSION,
-            engine_version=VERSION,
+            wheel_version=version,
+            engine_version=version,
             wheel_sha256=sha256_file(wheel),
             corpus_name="frozen-corpus.json",
             corpus_id="beta-corpus-v1",
@@ -152,20 +162,15 @@ def _production_result(wheel: Path) -> SafetyQualificationResultV1:
         ),
         requirements=requirements,
         summary=SafetyQualificationSummaryV1(
-            total_cases=100,
-            qualified_origin_cases=40,
-            primary_label_agreements=100,
+            total_cases=total,
+            qualified_origin_cases=requirements.minimum_qualified_origins,
+            primary_label_agreements=total,
             cohen_kappa=1.0,
-            receipt_count=100,
-            exact_count=100,
+            receipt_count=total,
+            exact_count=total,
             unsafe_auto_pass_count=0,
             runtime_failure_count=0,
-            outcome_counts={
-                "passed": 30,
-                "review_required": 20,
-                "insufficient_evidence": 20,
-                "blocked": 30,
-            },
+            outcome_counts=outcome_counts,
         ),
         strata=strata,
         confusion_matrices=matrices,
@@ -175,13 +180,22 @@ def _production_result(wheel: Path) -> SafetyQualificationResultV1:
     )
 
 
-def _fixture(tmp_path: Path) -> tuple[Path, Path]:
+def _fixture(
+    tmp_path: Path,
+    *,
+    requirements: SafetyQualificationRequirementsV1 | None = None,
+    version: str = VERSION,
+) -> tuple[Path, Path]:
     tmp_path.mkdir(parents=True, exist_ok=True)
-    wheel = tmp_path / "agents_shipgate-0.16.0b7-py3-none-any.whl"
-    _write_wheel(wheel)
+    wheel = tmp_path / f"agents_shipgate-{version}-py3-none-any.whl"
+    _write_wheel(wheel, version)
     qualification = tmp_path / "safety-qualification.json"
     qualification.write_text(
-        json.dumps(_production_result(wheel).model_dump(mode="json"), indent=2, sort_keys=True)
+        json.dumps(
+            _result(wheel, requirements=requirements, version=version).model_dump(mode="json"),
+            indent=2,
+            sort_keys=True,
+        )
         + "\n",
         encoding="utf-8",
     )
@@ -297,6 +311,130 @@ def test_release_validator_cli_fails_closed(tmp_path: Path) -> None:
         )
         == 1
     )
+
+
+def test_a_pre_1_0_artifact_publishes_a_0_x_tag_and_nothing_later(
+    tmp_path: Path,
+) -> None:
+    """The whole point of the #341 decision, and its limit.
+
+    A 56-case ``pre_1_0`` artifact is a complete answer for a ``0.x`` tag, and
+    is *not* an answer for ``1.0``: the same bytes that pass on ``v0.16.0b7``
+    must fail on ``v1.0.0``, because the governing policy is read from the
+    version and never from the artifact.
+    """
+
+    wheel, qualification = _fixture(
+        tmp_path / "pre", requirements=pre_release_safety_requirements()
+    )
+    result = verify_release_qualification(
+        wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+    )
+
+    assert result.qualification_tier == "pre_1_0"
+    assert result.qualified is True
+    assert result.production_qualified is False
+    assert len(result.cases) == 56
+
+    later_wheel, later_qualification = _fixture(
+        tmp_path / "later",
+        requirements=pre_release_safety_requirements(),
+        version=POST_1_0_VERSION,
+    )
+    with pytest.raises(ConfigError, match="qualification tier is not beta"):
+        verify_release_qualification(
+            wheel_path=later_wheel,
+            qualification_path=later_qualification,
+            tag=f"v{POST_1_0_VERSION}",
+        )
+
+
+def test_a_production_artifact_still_publishes_a_0_x_tag(tmp_path: Path) -> None:
+    """Carrying more evidence than the tag requires is never a rejection."""
+
+    wheel, qualification = _fixture(tmp_path, requirements=production_safety_requirements())
+
+    result = verify_release_qualification(
+        wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+    )
+
+    assert result.qualification_tier == "beta"
+    assert result.production_qualified is True
+
+
+def test_the_tier_a_0_x_artifact_names_selects_the_counts_it_must_meet(
+    tmp_path: Path,
+) -> None:
+    """Both tiers are admissible for ``0.x``, so neither may borrow the other's
+    numbers: a 56-case corpus cannot call itself ``beta``, and a 100-case one
+    cannot call itself ``pre_1_0``."""
+
+    wheel, qualification = _fixture(
+        tmp_path / "understated", requirements=pre_release_safety_requirements()
+    )
+    _mutate(qualification, lambda payload: payload.__setitem__("qualification_tier", "beta"))
+    with pytest.raises(ConfigError, match="exactly 100 cases"):
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        )
+
+    wheel, qualification = _fixture(
+        tmp_path / "overstated", requirements=production_safety_requirements()
+    )
+    _mutate(qualification, lambda payload: payload.__setitem__("qualification_tier", "pre_1_0"))
+    with pytest.raises(ConfigError, match="exactly 56 cases"):
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        )
+
+
+def test_a_pre_1_0_artifact_may_not_claim_the_production_flag(tmp_path: Path) -> None:
+    """``production_qualified`` keeps meaning "met the 100-case bar". A pre-1.0
+    artifact asserting it is inconsistent, not merely optimistic."""
+
+    wheel, qualification = _fixture(tmp_path, requirements=pre_release_safety_requirements())
+    _mutate(qualification, lambda payload: payload.__setitem__("production_qualified", True))
+
+    with pytest.raises(ConfigError, match="production_qualified without the production policy"):
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        )
+
+
+def test_relaxing_the_pre_1_0_thresholds_is_rejected_like_relaxing_production(
+    tmp_path: Path,
+) -> None:
+    """The smaller policy is re-derived, not trusted -- otherwise #341 would
+    have created a bar that any signed artifact could restate downwards."""
+
+    wheel, qualification = _fixture(tmp_path, requirements=pre_release_safety_requirements())
+    _mutate(
+        qualification,
+        lambda payload: payload["requirements"].__setitem__("minimum_blocked_exact", 1),
+    )
+
+    with pytest.raises(ConfigError, match="requirements differ from the pre_1_0 policy"):
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        )
+
+
+def test_an_unnamed_tier_is_rejected_and_still_scored_against_production(
+    tmp_path: Path,
+) -> None:
+    """A rejected tier must not shrink what the rest of the verifier checks."""
+
+    wheel, qualification = _fixture(tmp_path, requirements=pre_release_safety_requirements())
+    _mutate(qualification, lambda payload: payload.__setitem__("qualification_tier", "test"))
+
+    with pytest.raises(ConfigError) as excinfo:
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        )
+
+    message = str(excinfo.value)
+    assert "qualification tier is not one of beta, pre_1_0" in message
+    assert "exactly 100 cases" in message
 
 
 def test_release_workflow_reuses_signed_qualified_wheel_before_publish() -> None:

--- a/tests/test_safety_qualification_release.py
+++ b/tests/test_safety_qualification_release.py
@@ -369,10 +369,20 @@ def test_the_tier_a_0_x_artifact_names_selects_the_counts_it_must_meet(
     numbers: a 56-case corpus cannot call itself ``beta``, and a 100-case one
     cannot call itself ``pre_1_0``."""
 
+    def _relabel(tier: str, production: bool):
+        # Both fields together: relabelling only the tier trips the artifact's
+        # own production_qualified invariant, which would prove that check
+        # rather than the case count this test is about.
+        def _apply(payload: dict) -> None:
+            payload["qualification_tier"] = tier
+            payload["production_qualified"] = production
+
+        return _apply
+
     wheel, qualification = _fixture(
         tmp_path / "understated", requirements=pre_release_safety_requirements()
     )
-    _mutate(qualification, lambda payload: payload.__setitem__("qualification_tier", "beta"))
+    _mutate(qualification, _relabel("beta", True))
     with pytest.raises(ConfigError, match="exactly 100 cases"):
         verify_release_qualification(
             wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
@@ -381,7 +391,7 @@ def test_the_tier_a_0_x_artifact_names_selects_the_counts_it_must_meet(
     wheel, qualification = _fixture(
         tmp_path / "overstated", requirements=production_safety_requirements()
     )
-    _mutate(qualification, lambda payload: payload.__setitem__("qualification_tier", "pre_1_0"))
+    _mutate(qualification, _relabel("pre_1_0", False))
     with pytest.raises(ConfigError, match="exactly 56 cases"):
         verify_release_qualification(
             wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
@@ -389,13 +399,24 @@ def test_the_tier_a_0_x_artifact_names_selects_the_counts_it_must_meet(
 
 
 def test_a_pre_1_0_artifact_may_not_claim_the_production_flag(tmp_path: Path) -> None:
-    """``production_qualified`` keeps meaning "met the 100-case bar". A pre-1.0
-    artifact asserting it is inconsistent, not merely optimistic."""
+    """``production_qualified`` keeps meaning "met the 100-case bar".
+
+    The artifact schema refuses to construct the inconsistency at all, so the
+    runner cannot emit one and the verifier rejects it while parsing -- before
+    any policy check runs. Both directions are wrong: a pre-1.0 artifact
+    claiming the flag, and a beta artifact disclaiming it.
+    """
 
     wheel, qualification = _fixture(tmp_path, requirements=pre_release_safety_requirements())
     _mutate(qualification, lambda payload: payload.__setitem__("production_qualified", True))
+    with pytest.raises(ConfigError, match="Invalid safety qualification artifact"):
+        verify_release_qualification(
+            wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
+        )
 
-    with pytest.raises(ConfigError, match="production_qualified without the production policy"):
+    wheel, qualification = _fixture(tmp_path / "beta", requirements=production_safety_requirements())
+    _mutate(qualification, lambda payload: payload.__setitem__("production_qualified", False))
+    with pytest.raises(ConfigError, match="Invalid safety qualification artifact"):
         verify_release_qualification(
             wheel_path=wheel, qualification_path=qualification, tag=f"v{VERSION}"
         )


### PR DESCRIPTION
Implements the decision recorded for #341. **Deliberately does not close it** —
the required failed-bar Release Rehearsal is still unrun, and that is the last
box on the issue. Close #341 once the rehearsal is linked.

## The decision

**Route 2 — an explicit pre-1.0 policy.** Recorded by **Pengfei Hu
(`pengfei-threemoonslab`), product/security, 2026-08-29**, in
[`docs/release-evidence-policy-decision.md`](docs/release-evidence-policy-decision.md).

The repository had exactly one release policy — 100 adjudicated, receipt-bound
cases, written as the claim `1.0` should make — enforced for every tag. No
corpus met it, so nothing published and evaluators kept installing `v0.15.0`:
an older, *less*-verified build than the one being withheld.

## What the new policy is

A second **named** policy, `pre_1_0`, governs `0.x` tags. It reduces how much
evidence a tag must carry. It reduces nothing about how that evidence is judged.

| | `beta` (production) | `pre_1_0` |
|---|---|---|
| Governs | `1.0`+ — and any tag, if offered | `0.x` only |
| Adjudicated cases | 100 | **56** |
| Strata | 28, weighted | **28, two each** |
| Qualifying origins | ≥ 40 (40%) | **≥ 23** (40%) |
| κ floor / holdout / unsafe auto-passes | 0.80 / 20% / 0 | **unchanged** |
| Per-case receipt, `static_only` | required / true | **unchanged** |
| Safe passes | ≥ 27/30 (90%) | **≥ 13/14** (92.9%) |
| Blocked / review / IE exact | 30/30, 19/20, 19/20 | **14/14, 14/14, 14/14** |

Two per stratum is the smallest allocation keeping all 28 profile × decision
cells non-empty *and* leaving each cell one tuning and one holdout case. A
zero-count cell would delete every observation of a profile/outcome pair — a
reduction in **strictness**, not coverage. Exact-match floors are the
production *rates* rounded up, so three of four land on 100%.

## How it is enforced

**The version decides the policy; the artifact never does.** Epoch 0 with major
0 admits `pre_1_0` or the stronger `beta`; everything else — including any
version that is not a complete PEP 440 version — admits `beta` only. Both gates
derive this independently, and an artifact naming a tier its version does not
admit is rejected **and then measured against the production policy**, so a bad
tier can never shrink what is checked. The same rule binds the producer, on both
`--policy-tier` and the `requirements=` keyword.

`production_qualified` keeps meaning "met the 100-case bar" —
`SafetyQualificationResultV1` refuses to *construct* an artifact that says
otherwise, so the producer cannot emit the inconsistency at all.

`shipgate.safety_qualification` advances **v4 → v5**: the new tier value and the
new cross-field invariant are grammar a v4 reader rejects. v4 stays readable;
the corpus and receipt-index envelopes deliberately do not move, because their
grammar did not change. Migration note in `STABILITY.md`.

## Review round 2 — three findings, all reproduced first

1. **The sealer restated a case count, not a policy.** It never checked the
   strata or the exact-match floors, so a 56-case `pre_1_0` artifact with 12/14
   safe passes passed the *sealing* gate while the exhaustive gate rejected it,
   and 56 identical rows in no stratum at all passed too — making the
   dependency-compromise boundary that file exists to hold decorative. It now
   restates a full `QualificationPolicy` per tier (strata, per-outcome floors,
   per-stratum holdout, origin and κ floors), re-derives them from the raw
   cases, and every field is bound to the real constructors by test. The two
   pre-existing sealer tests used 100 identical rows; they use conforming
   corpora now, which is what makes them meaningful.
2. **The version rule was anchored only at the start.** `0garbage`,
   `0.16.0garbage`, `0..1`, `0-`, `0x1` parsed as major 0 and bought the
   *cheaper* policy — the inversion of the documented fallback, in a helper both
   gates share. Now a complete PEP 440 parse; leading zeros still normalize.
3. **New grammar under the frozen v4 envelope** — fixed by the v5 bump above.

## Fail-closed proof

- `test_a_pre_1_0_artifact_publishes_a_0_x_tag_and_nothing_later` — the same
  bytes that pass `v0.16.0b7` fail `v1.0.0`.
- `test_the_sealer_reads_the_governing_policy_from_the_version_not_the_artifact`
  and `test_the_sealer_enforces_the_strata_and_floors_not_just_a_case_count`.
- `test_a_conforming_56_case_corpus_qualifies_a_0_x_wheel` — end to end: the bar
  is satisfiable, exits `0`, reports `production_qualified: false`.
- `test_only_a_complete_pep440_version_can_reach_the_cheaper_policy` — 11
  accepted, 20 rejected, including every malformed case from the review.
- `test_the_stdlib_policy_table_matches_the_named_policies`,
  `test_the_qualification_envelope_advanced_for_the_new_grammar`,
  `test_the_production_flag_cannot_disagree_with_the_tier`,
  `test_the_version_rule_binds_the_requirements_keyword_too`,
  `test_the_pre_1_0_policy_is_never_laxer_than_production_per_rate`.

Seventeen perturbations of the new guards have been run across two rounds; all
seventeen fail the suite.

## Follow-ups

- #456 — corpus delivery for the 56-case artifact and the 100-case 1.0 bar.
- [ ] Dispatch **Release Rehearsal** against an artifact that misses the bar,
      then close #341.

## Verification

`ruff check .` clean. Full suite green: `pytest -n auto -m "not perf"
--ignore=tests/test_adapter_static_only.py`, plus `tests/test_adapter_static_only.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)