### PR TITLE
fix(semantics): a reviewed risk tag refines the row it sits in, it does not contradict it (#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,15 +35,47 @@
   annotations, a source's own scopes, and typed provider facts keep
   contradicting a weaker declaration exactly as before.
 
+  **The repair names the whole `risk_tags` value, not the additions.**
+  `risk_tags` is one key, so a published block naming it replaces it. Naming
+  only the newly uncovered category asked a reviewer whose row already read
+  `risk_tags: [financial_write]` to delete the tag covering the financial
+  reading, and the next scan reopened the row asking for it back — the same
+  defect, in the case the repair itself creates. The declared list is now
+  carried verbatim on the declared-effect claim (it cannot be rebuilt from the
+  tag claims: `read_only`, `network_access`, and `customer_data` map to no
+  positive effect and produce none), and `EffectRepair.added_risk_tags` carries
+  what changed so the sentence and the value cannot disagree.
+
   **The gate verdict this moves.** `effect: read` + `risk_tags: [destructive]`
   goes from blocking to pass-eligible. It is not a downgrade: the action still
   resolves to `destructive`, the destructive claim is still policy-eligible,
-  and the two spellings now produce byte-identical gate answers — the same
-  decision and the same findings as declaring the effect outright. The P0
-  canary that pinned the old outcome
+  and beside `effect: read` — which obliges nothing — the two spellings publish
+  identical action and capability facts and reach the same decision and
+  findings. Beside a *positive* effect they are not interchangeable, and the
+  contract now says so: a tag **adds** its category, so
+  `effect: external_communication` with a financial tag owes confirmation as
+  well as approval, audit, and idempotency, where `effect: financial_write`
+  alone does not. The P0 canary that pinned the old outcome
   (`manual_financial_tag_cannot_downgrade_to_read`) is replaced in its slot by
   the boundary the fix draws, `declared_delete_scope_cannot_downgrade_to_read`,
   and the property it guarded is asserted in its new form beside it.
+
+  **A read claim no longer synthesizes a `read_only` tag** ([#461]). The action
+  fact unions a risk tag for every policy-eligible effect claim, and `read` is
+  not a category — it is the assertion that none apply. A row declaring
+  `effect: read` beside `risk_tags: [financial_write]` therefore published
+  `read_only` on a `financial_write` action, and `derive_side_effect` reads
+  that tag as positive evidence: `reversibility: reversible`, the one thing
+  that helper's own docstring says a declared read must not buy. Pre-existing,
+  and folded in here because this change is what moves the wrong fact into a
+  report that can pass. Actions with that spelling lose the `read_only` entry
+  from their published `risk_tags`, so a stored lock covering one shows a
+  single `risk_changed` / `narrowed` row on the first scan after upgrading —
+  the safe direction, and correct: the action stops claiming to be read-only.
+  Carrying the declared tag list on the declared-effect claim likewise moves
+  that claim's `evidence` and `claim_id` for rows declaring both an `effect`
+  and `risk_tags`; an `evidence_hash`-only change is classified `evidence_only`
+  by design and carries no direction.
 
   **Two more sites read the manifest as the source, found reviewing this
   change.** The manifest reaches the effect dimension by two routes — the
@@ -65,6 +97,8 @@
   Both now ask one predicate, `is_manifest_owned_effect_claim`, promoted from
   the private helper `_source_read_conflict` already used so a fourth site
   cannot spell it a fifth way.
+
+  [#461]: https://github.com/ThreeMoonsLab/agents-shipgate/issues/461
 
 - **The declaration continuation: a drafted proposal can now reach the person
   it was drafted for.** (#429 review) `apply-patches --kinds declare_action`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,27 @@
   the boundary the fix draws, `declared_delete_scope_cannot_downgrade_to_read`,
   and the property it guarded is asserted in its new form beside it.
 
+  **Two more sites read the manifest as the source, found reviewing this
+  change.** The manifest reaches the effect dimension by two routes — the
+  action row, named by `DECLARATION_CLAIM_SOURCES`, and `risk_overrides.tags`,
+  which arrives as `risk_hint:manual` carrying a `reviewed_declaration` basis
+  and no declaration source. Two comparisons excluded the first only:
+
+  - `SHIP-ACTION-EFFECT-DOWNGRADE-DECLARED` derives "the effect Shipgate
+    inferred" from the claims that are not the manifest's. A reviewed
+    `risk_overrides.tags: [destructive]` beside a source that says only `write`
+    was reported as Shipgate's own inference, in a recommendation telling the
+    reviewer to declare the value they had already written.
+  - `declaration_below_inferred_evidence` names the evidence that *agrees* with
+    the declaration, in a sentence that says "source evidence agrees with the
+    declaration" in so many words. A `risk_overrides.tags` entry matching the
+    declared effect was named there — the manifest confirming itself, which the
+    comment above that filter already forbade.
+
+  Both now ask one predicate, `is_manifest_owned_effect_claim`, promoted from
+  the private helper `_source_read_conflict` already used so a fourth site
+  cannot spell it a fifth way.
+
 - **The declaration continuation: a drafted proposal can now reach the person
   it was drafted for.** (#429 review) `apply-patches --kinds declare_action`
   writes into `shipgate.yaml`, which is the trust root — so the control that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## Unreleased
 
+- **A reviewed risk tag is the manifest refining its own row, not source
+  evidence contradicting it.** (#424) `declaration_below_inferred_evidence`
+  publishes two routes, and the second is the one the row names: *"add
+  `action_surface.actions[].risk_tags: [X]` so the X controls apply to this
+  action"*. Applying it exactly as instructed replaced the review-tier row with
+  a **blocking** `conflicting_effect_evidence` whose message blamed the
+  reviewer's own manifest — the published next step could not close the row it
+  was printed on. Measured over every declared effect against every one-, two-,
+  and three-observation combination: 281 of the 390 pairs that take the tag
+  route. First-time adoption was never affected; a proposal always raises the
+  effect or names a covering set, so only the post-declaration repair was
+  broken, and it was broken exactly where the two published rank tables
+  disagree — the case the two-route design exists for.
+
+  Two branches of the resolver disagreed about what a reviewed `risk_tags`
+  entry is. `claims_above_declared_effect` treats it as **covering**,
+  deliberately: a declared tag is policy-eligible, so it both accounts for the
+  observation and makes that category's built-in controls apply. The
+  `contradictory` filter ran first and read the same claim as source evidence
+  outranking the declaration. It now excludes the two spellings of "declare
+  this category as reviewed" — the action row's `risk_tags` and the
+  `risk_overrides.tags` hint that says it once for a whole selector. This is
+  the same class already fixed one branch over in `_source_read_conflict`.
+
+  **Deliberately narrow.** The exclusion is *not* `_is_manifest_owned`
+  wholesale. That predicate also covers `action_scope`, and a declared
+  permission list is a different kind of statement: #417 made a declared
+  `crm.delete` grant bound the action's effect, so excluding it would re-open
+  that fail-open. A declared tag refines the effect the same person wrote; a
+  declared grant asserts an independent fact that bounds it. Protocol
+  annotations, a source's own scopes, and typed provider facts keep
+  contradicting a weaker declaration exactly as before.
+
+  **The gate verdict this moves.** `effect: read` + `risk_tags: [destructive]`
+  goes from blocking to pass-eligible. It is not a downgrade: the action still
+  resolves to `destructive`, the destructive claim is still policy-eligible,
+  and the two spellings now produce byte-identical gate answers — the same
+  decision and the same findings as declaring the effect outright. The P0
+  canary that pinned the old outcome
+  (`manual_financial_tag_cannot_downgrade_to_read`) is replaced in its slot by
+  the boundary the fix draws, `declared_delete_scope_cannot_downgrade_to_read`,
+  and the property it guarded is asserted in its new form beside it.
+
 - **The declaration continuation: a drafted proposal can now reach the person
   it was drafted for.** (#429 review) `apply-patches --kinds declare_action`
   writes into `shipgate.yaml`, which is the trust root — so the control that

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -826,6 +826,23 @@ never count as agreeing evidence for itself. Manual positive risk tags may escal
 but cannot prove read-only safety or independently close an effect gap. Setting
 inherited approval or safeguards from `true` to `false` emits
 `SHIP-ACTION-CONTROL-DOWNGRADE`.
+
+A reviewed `risk_tags` entry — and the `risk_overrides.tags` entry that says
+the same thing once for a whole selector — is the manifest **refining** the row
+it sits in, never source evidence contradicting it. Declaring
+`risk_tags: [destructive]` beside `effect: read` accounts for a destructive
+observation *and* makes the destructive controls apply, so it reaches the same
+gate answer as declaring `effect: destructive` outright. It is not a downgrade
+and it is not a conflict, which is what makes the second route out of
+`declaration_below_inferred_evidence` — "add `risk_tags: [X]` so the X controls
+apply to this action" — an edit that closes the row it is printed on.
+
+A declared `scopes` grant is a different kind of statement and keeps its
+blocking behaviour: it asserts an independent fact about what the action is
+permitted to do, so a write-verb grant beside a weaker `effect` stays
+`conflicting_effect_evidence`. So does anything the source itself supplies —
+protocol annotations, the source's own scopes, a typed provider fact.
+
 ### Pinning an answer to its evidence
 
 Declarations are matched by name, so without a pin a year-old `effect: write`

--- a/docs/manifest-v0.1.md
+++ b/docs/manifest-v0.1.md
@@ -831,11 +831,19 @@ A reviewed `risk_tags` entry — and the `risk_overrides.tags` entry that says
 the same thing once for a whole selector — is the manifest **refining** the row
 it sits in, never source evidence contradicting it. Declaring
 `risk_tags: [destructive]` beside `effect: read` accounts for a destructive
-observation *and* makes the destructive controls apply, so it reaches the same
-gate answer as declaring `effect: destructive` outright. It is not a downgrade
+observation *and* makes the destructive controls apply. It is not a downgrade
 and it is not a conflict, which is what makes the second route out of
-`declaration_below_inferred_evidence` — "add `risk_tags: [X]` so the X controls
+`declaration_below_inferred_evidence` — "set `risk_tags: [X]` so the X controls
 apply to this action" — an edit that closes the row it is printed on.
+
+A tag **adds** a category to the declared effect rather than replacing it, so
+the obligations of both stand. Beside `effect: read`, which obliges nothing,
+that is the same answer as declaring the category as the effect; beside a
+positive effect it is not — `effect: external_communication` with a financial
+tag owes confirmation as well as approval, audit, and idempotency, where
+`effect: financial_write` alone owes no confirmation. The row's own repair
+therefore names the **whole** intended `risk_tags` value, existing entries
+included: `risk_tags` is one key, and a block naming it replaces it.
 
 A declared `scopes` grant is a different kind of statement and keeps its
 blocking behaviour: it asserts an independent fact about what the action is

--- a/docs/passed-verdict-contract.md
+++ b/docs/passed-verdict-contract.md
@@ -156,8 +156,13 @@ human review, not an executable Patch.
 A declaration may freely escalate past the evidence. Declaring an effect
 **weaker** than one the scan inferred raises
 `declaration_below_inferred_evidence` (v0.36+) and the action is not
-pass-eligible until a reviewer raises `effect` or acknowledges the difference
-with `actions[].override` (`evidence` + `reason`). An acknowledged override is
+pass-eligible until a reviewer accounts for the observation or acknowledges the
+difference with `actions[].override` (`evidence` + `reason`). Accounting for it
+is one edit, and the row names which: raise `effect` where one value covers
+every uncovered reading, otherwise name the uncovered categories as reviewed
+`actions[].risk_tags` — a declared tag is policy-eligible, so it accounts for
+the reading *and* applies that category's controls, reaching the same gate
+answer as declaring the effect outright. An acknowledged override is
 accepted and the action is pass-eligible again, but it is counted as a semantic
 review concern — like `unscoped` and `ambient` authority, it keeps human review
 mandatory, so a run carrying one is never `passed`.

--- a/docs/passed-verdict-contract.md
+++ b/docs/passed-verdict-contract.md
@@ -161,8 +161,13 @@ difference with `actions[].override` (`evidence` + `reason`). Accounting for it
 is one edit, and the row names which: raise `effect` where one value covers
 every uncovered reading, otherwise name the uncovered categories as reviewed
 `actions[].risk_tags` — a declared tag is policy-eligible, so it accounts for
-the reading *and* applies that category's controls, reaching the same gate
-answer as declaring the effect outright. An acknowledged override is
+the reading *and* applies that category's controls. A tag **adds** its category
+to the effect already declared; it does not replace it, and the obligations of
+both stand. Raising `effect` instead answers the row with a single category and
+drops whatever the previous value obliged, so the two edits are not
+interchangeable: `effect: external_communication` plus a financial tag owes
+confirmation as well as approval, audit, and idempotency, where
+`effect: financial_write` alone does not owe confirmation. An acknowledged override is
 accepted and the action is pass-eligible again, but it is counted as a semantic
 review concern — like `unscoped` and `ambient` authority, it keeps human review
 mandatory, so a run carrying one is never `passed`.

--- a/src/agents_shipgate/core/domain.py
+++ b/src/agents_shipgate/core/domain.py
@@ -56,6 +56,25 @@ DECLARATION_CLAIM_SOURCES = frozenset(
     }
 )
 
+#: The two spellings of "this risk category is reviewed and applies here" —
+#: the action row's ``risk_tags`` and the ``risk_overrides.tags`` hint, which
+#: says the same thing once for a whole selector. Both are policy-eligible, so
+#: both make that category's built-in controls apply; neither is a second
+#: opinion about the action, and neither may be read as *source* evidence
+#: contradicting the ``effect`` the same person wrote (#424).
+#:
+#: Deliberately narrower than :data:`DECLARATION_CLAIM_SOURCES`, which also
+#: covers ``action_scope``. A declared permission list is a different kind of
+#: statement: a declared ``crm.delete`` grant asserts an independent fact that
+#: bounds the action's effect (#417), so it must keep contradicting a weaker
+#: declaration.
+REVIEWED_RISK_TAG_CLAIM_SOURCES = frozenset(
+    {
+        "action_risk_tag_declaration",
+        "risk_hint:manual",
+    }
+)
+
 #: Claim source for ``tool_sources[].authority`` — one reviewed authority for
 #: every action a source contributes (#410 increment 3). A separate spelling
 #: from ``DECLARED_EFFECT_SOURCE`` because an audit reading the claims has to

--- a/src/agents_shipgate/core/lenses/action_surface.py
+++ b/src/agents_shipgate/core/lenses/action_surface.py
@@ -25,7 +25,6 @@ from agents_shipgate.core.control_packs import (
     resolve_control_pack,
 )
 from agents_shipgate.core.domain import (
-    DECLARATION_CLAIM_SOURCES,
     Action,
     Scope,
     Tool,
@@ -47,6 +46,7 @@ from agents_shipgate.core.semantic_assessment import (
     acknowledged_effect_claim_ids,
     assess_tool_semantics,
     declaration_covers,
+    is_manifest_owned_effect_claim,
     resolve_action_scopes,
 )
 from agents_shipgate.core.surface_exclusions import (
@@ -1036,10 +1036,19 @@ def _declaration_downgrade_findings(
             # source bound without a second semantic evaluation.
             if action_assessment is None:
                 action_assessment = assess_tool_semantics(tool, declaration)
+            # Every claim a human wrote into the manifest, by *both* routes it
+            # reaches this dimension by — the action row (its ``effect``,
+            # ``risk_tags``, ``scopes``, and ``override``) and the
+            # ``risk_overrides.tags`` hint, which carries a
+            # ``reviewed_declaration`` basis rather than a declaration source.
+            # Excluding only the first named the reviewer's own
+            # ``risk_overrides`` tag as "the effect Shipgate inferred", in a
+            # recommendation telling them to declare what they had already
+            # written (#424 review).
             source_effects = [
                 claim.value
                 for claim in action_assessment.effect.claims
-                if claim.source not in DECLARATION_CLAIM_SOURCES
+                if not is_manifest_owned_effect_claim(claim)
                 and claim.value in ACTION_EFFECT_RANK
             ]
             source_effect = max(

--- a/src/agents_shipgate/core/lenses/action_surface.py
+++ b/src/agents_shipgate/core/lenses/action_surface.py
@@ -588,10 +588,21 @@ def build_action(
         for claim in semantic_assessment.effect.claims
         if claim.policy_eligible and claim.value in ACTION_EFFECT_RANK
     }
+    # Every category the reviewed surface establishes gets its tag, so the
+    # controls it obliges are visible in the row. ``read`` is excluded because
+    # it is not a category: it is the assertion that none of them apply, and
+    # ``semantic_effects`` is a *union* — a row declaring ``effect: read``
+    # beside ``risk_tags: [financial_write]`` contributes both. Mapping the
+    # ``read`` member synthesized a ``read_only`` tag on a ``financial_write``
+    # action, and ``derive_side_effect`` reads that tag as positive evidence,
+    # publishing ``reversibility: reversible`` for it — the one thing that
+    # helper's own docstring says a declared read must not buy (#461). The
+    # conservative effect below still contributes ``read_only`` where the
+    # action really does resolve to ``read``.
     risk_tag_values = sorted(
         set(risk_tag_values)
         | {_risk_tag_for_effect(effect)}
-        | {_risk_tag_for_effect(value) for value in semantic_effects}
+        | {_risk_tag_for_effect(value) for value in semantic_effects if value != "read"}
     )
     approval = _approval_fact(manifest, tool, declaration)
     safeguards = _safeguards_fact(manifest, tool, declaration)

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -17,6 +17,7 @@ from agents_shipgate.core.domain import (
     DECLARED_EFFECT_SOURCE,
     DECLARED_SOURCE_AUTHORITY_SOURCE,
     ENVIRONMENT_TEMPLATE_AUTHORITY_SOURCE,
+    REVIEWED_RISK_TAG_CLAIM_SOURCES,
     SURFACE_ENUMERATED,
     AuthorityMode,
     AuthoritySemanticAssessment,
@@ -504,8 +505,7 @@ def _assess_effect(
         authoritative.extend(
             claim
             for claim in claims
-            if claim.source in {"risk_hint:manual", "action_risk_tag_declaration"}
-            and claim.value != "read"
+            if claim.source in REVIEWED_RISK_TAG_CLAIM_SOURCES and claim.value != "read"
         )
     declared = [
         claim for claim in authoritative if claim.source == DECLARED_EFFECT_SOURCE
@@ -560,12 +560,32 @@ def _assess_effect(
     below_sources: list[str] = []
     if declaration is not None and declaration.effect is not None:
         declared_rank = _EFFECT_RANK[declaration.effect]
-        # Unchanged: policy-eligible evidence outranking the declaration is a
-        # blocking conflict, and no override may acknowledge it away.
+        # Unchanged: policy-eligible *source* evidence outranking the
+        # declaration is a blocking conflict, and no override may acknowledge
+        # it away.
+        #
+        # #424 — but a reviewed risk tag is not source evidence. The row this
+        # branch pre-empts publishes exactly one non-raise route: "add
+        # ``risk_tags: [X]`` so the X controls apply to this action". Reading
+        # that tag back as evidence contradicting the ``effect`` beside it
+        # turned the published repair into a *blocking* conflict whose message
+        # blamed the reviewer's own manifest — 281 of the 390 declared/observed
+        # pairs that take the tag route could not close the row they were
+        # printed on. :func:`claims_above_declared_effect` had already decided
+        # the other way one branch over, and ``_source_read_conflict`` was
+        # fixed for the same reason; this branch never got the treatment.
+        #
+        # Narrow on purpose: only the two spellings of "declare this category
+        # as reviewed" are excluded, never ``_is_manifest_owned`` wholesale.
+        # That predicate also covers ``action_scope``, and #417 deliberately
+        # made a declared ``crm.delete`` grant bound the action's effect — a
+        # grant asserts an independent fact, a tag refines the effect the same
+        # person wrote.
         contradictory = [
             claim
             for claim in [*structural, *inferred]
             if claim.policy_eligible
+            and claim.source not in REVIEWED_RISK_TAG_CLAIM_SOURCES
             and _EFFECT_RANK[_as_effect(claim.value)] > declared_rank
         ]
         if not contradictory:

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -300,6 +300,22 @@ def _assess_effect(
                 "reviewed_declaration",
                 "action_surface_declaration",
                 f"action_surface.actions[tool={tool.name!r}].effect",
+                # The reviewed tag list *verbatim*, because a repair that
+                # publishes ``risk_tags`` publishes the whole value of that key
+                # and has to be able to write back what is already there. It
+                # cannot be rebuilt from the tag claims below: three members of
+                # the vocabulary — ``read_only``, ``network_access`` and
+                # ``customer_data`` — map to no positive effect and produce no
+                # claim, so a list rebuilt from claims would drop what a
+                # reviewer wrote (#424 review).
+                #
+                # Recorded on this claim rather than a new assessment field
+                # because this branch is the exact condition under which the
+                # repair can be published: no declared ``effect``, no
+                # ``declaration_below_inferred_evidence`` row.
+                {"declared_risk_tags": list(declaration.risk_tags)}
+                if declaration.risk_tags
+                else None,
             )
         )
     if declaration is not None:
@@ -1035,6 +1051,14 @@ def effect_repair(effect: EffectSemanticAssessment) -> EffectRepair:
     policy-eligible evidence, so it both accounts for the observation *and*
     makes that category's built-in controls apply, which is the outcome the
     uncovered obligation was asking for.
+
+    A third way it could not close its own row, and the reason ``risk_tags``
+    is the *whole* list rather than the additions: ``risk_tags`` is one YAML
+    key, so a template naming it replaces it. Publishing ``[destructive]`` for
+    a row already reading ``risk_tags: [financial_write]`` asked the reviewer
+    to delete the tag covering the financial reading, and the next scan
+    reopened the row asking for it back (#424 review). ``added_risk_tags``
+    carries what changed, so the sentence and the value cannot disagree.
     """
 
     declared = next(
@@ -1065,17 +1089,35 @@ def effect_repair(effect: EffectSemanticAssessment) -> EffectRepair:
             instruction=f"Raise action_surface.actions[].effect to {target!r}",
             effect=target,
         )
-    tags = [value for value in uncovered if value in _ACTION_RISK_TAG_VALUES]
-    if not tags:  # pragma: no cover - every non-read effect has a matching tag
+    added = [value for value in uncovered if value in _ACTION_RISK_TAG_VALUES]
+    if not added:  # pragma: no cover - every non-read effect has a matching tag
         return EffectRepair(kind="raise_effect", instruction=_GENERIC_RAISE)
-    rendered = ", ".join(tags)
+    # The whole list, not just the new part. ``risk_tags`` is one YAML key, so
+    # a template naming it replaces it: publishing ``[destructive]`` for a row
+    # that already reads ``risk_tags: [financial_write]`` asked the reviewer to
+    # delete the tag that was covering the financial reading, and the next scan
+    # reopened the row asking for it back — the #424 defect surviving in the
+    # case #424's own repair created (#424 review).
+    #
+    # Declared tags keep the reviewer's own spelling and order:
+    # ``financial_action`` and ``financial_write`` are one category under two
+    # names, and rewriting one to the other is a change nobody asked for.
+    declared_tags = [
+        str(tag)
+        for tag in (declared.evidence.get("declared_risk_tags") or [])
+        if isinstance(tag, str)
+    ]
+    declared_effects = {_TAG_EFFECTS.get(tag) for tag in declared_tags}
+    tags = [*declared_tags, *(value for value in added if value not in declared_effects)]
+    rendered_added = ", ".join(added)
     return EffectRepair(
         kind="declare_risk_tags",
         instruction=(
-            f"Add action_surface.actions[].risk_tags: [{rendered}] so the "
-            f"{rendered} controls apply to this action"
+            f"Set action_surface.actions[].risk_tags: [{', '.join(tags)}] so the "
+            f"{rendered_added} controls apply to this action"
         ),
         risk_tags=tuple(tags),
+        added_risk_tags=tuple(added),
     )
 
 
@@ -1126,7 +1168,16 @@ class EffectRepair:
     kind: Literal["raise_effect", "declare_risk_tags"]
     instruction: str
     effect: ActionEffect | None = None
+    #: The **complete** value to write to ``risk_tags`` — every tag the row
+    #: already declares, plus the categories this repair adds. A template
+    #: carrying only the additions replaces the key it is merged into, so on an
+    #: already-tagged action the published repair dropped a covering tag and
+    #: reopened the same row on the next scan (#424 review).
     risk_tags: tuple[str, ...] = ()
+    #: The categories being added, which is what the instruction's "so the X
+    #: controls apply" clause names and what ``accepted_values`` publishes.
+    #: Equal to :attr:`risk_tags` when the row declared none.
+    added_risk_tags: tuple[str, ...] = ()
 
 
 #: Evidence bases that state a *default* rather than an observation of the

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -576,7 +576,8 @@ def _assess_effect(
         # fixed for the same reason; this branch never got the treatment.
         #
         # Narrow on purpose: only the two spellings of "declare this category
-        # as reviewed" are excluded, never ``_is_manifest_owned`` wholesale.
+        # as reviewed" are excluded, never ``is_manifest_owned_effect_claim``
+        # wholesale.
         # That predicate also covers ``action_scope``, and #417 deliberately
         # made a declared ``crm.delete`` grant bound the action's effect — a
         # grant asserts an independent fact, a tag refines the effect the same
@@ -600,13 +601,20 @@ def _assess_effect(
                 {claim.source for claim in below_declared if claim.value == below_effect}
             )
             # What the source says *for* the declared value, so the row can
-            # state both readings. Never the manifest row's own restatements
-            # of itself — a declaration confirming itself is not evidence.
+            # state both readings. Never the manifest's own restatements of
+            # itself — a declaration confirming itself is not evidence, and
+            # the sentence this feeds says "source evidence agrees with the
+            # declaration" in so many words.
+            #
+            # By both routes the manifest reaches this dimension, not just the
+            # action row: a reviewed ``risk_overrides.tags`` entry matching the
+            # declared effect was named to the reviewer as the *source*
+            # agreeing with them (#424 review).
             corroborating = [
                 claim
                 for claim in claims
                 if claim.policy_eligible
-                and claim.source not in DECLARATION_CLAIM_SOURCES
+                and not is_manifest_owned_effect_claim(claim)
                 and claim.value == declaration.effect
             ]
             # An acknowledged override is itself reviewed evidence: it records
@@ -848,8 +856,8 @@ def _assess_effect(
     )
 
 
-def _is_manifest_owned(claim: SemanticClaim) -> bool:
-    """True when a human wrote this claim into the manifest.
+def is_manifest_owned_effect_claim(claim: SemanticClaim) -> bool:
+    """True when a human wrote this effect claim into the manifest.
 
     Two tests, because the manifest reaches the effect dimension by two routes
     that carry different bases:
@@ -867,6 +875,15 @@ def _is_manifest_owned(claim: SemanticClaim) -> bool:
     *source* evidence: a reviewed ``risk_overrides`` tag of ``code_execution``
     on a tool published with ``readOnlyHint: true`` was reported as the source
     contradicting itself, and no declaration could clear it.
+
+    Public because the same question is asked outside this module.
+    ``SHIP-ACTION-EFFECT-DOWNGRADE-DECLARED`` names "the effect Shipgate
+    inferred", and it derived that bound by excluding
+    :data:`DECLARATION_CLAIM_SOURCES` alone — the first route only. A reviewed
+    ``risk_overrides.tags`` entry of ``destructive`` beside a source that says
+    only ``write`` was therefore quoted back to the reviewer as Shipgate's own
+    inference, in a recommendation telling them to declare the value they had
+    already written (#424 review).
     """
 
     return (
@@ -901,7 +918,7 @@ def _source_read_conflict(structural: Sequence[SemanticClaim]) -> tuple[bool, bo
     high = [
         claim
         for claim in structural
-        if claim.confidence == "high" and not _is_manifest_owned(claim)
+        if claim.confidence == "high" and not is_manifest_owned_effect_claim(claim)
     ]
     return (
         any(claim.value == "read" for claim in high),
@@ -2309,4 +2326,5 @@ __all__ = [
     "claims_above_declared_effect",
     "EffectRepair",
     "effect_repair",
+    "is_manifest_owned_effect_claim",
 ]

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -576,12 +576,11 @@ def _assess_effect(
         # fixed for the same reason; this branch never got the treatment.
         #
         # Narrow on purpose: only the two spellings of "declare this category
-        # as reviewed" are excluded, never ``is_manifest_owned_effect_claim``
-        # wholesale.
-        # That predicate also covers ``action_scope``, and #417 deliberately
-        # made a declared ``crm.delete`` grant bound the action's effect — a
-        # grant asserts an independent fact, a tag refines the effect the same
-        # person wrote.
+        # as reviewed" are excluded, never every manifest-owned claim. That
+        # wider set covers ``action_scope`` too, and #417 deliberately made a
+        # declared ``crm.delete`` grant bound the action's effect — a grant
+        # asserts an independent fact, a tag refines the effect the same person
+        # wrote.
         contradictory = [
             claim
             for claim in [*structural, *inferred]

--- a/tests/test_action_surface_diff.py
+++ b/tests/test_action_surface_diff.py
@@ -1257,6 +1257,65 @@ def test_action_declaration_effect_downgrade_blocks_release(monkeypatch):
     assert finding.evidence["declared_effect"] == "read"
 
 
+def test_the_downgrade_row_never_quotes_the_reviewers_own_tag_back_at_them():
+    """An inferred effect has to be something this scan actually inferred.
+
+    The manifest reaches the effect dimension by two routes: the action row —
+    `DECLARATION_CLAIM_SOURCES` — and `risk_overrides.tags`, which arrives as
+    `risk_hint:manual` carrying a `reviewed_declaration` basis and no
+    declaration source. This bound excluded the first only, so a reviewed
+    `risk_overrides` tag of `destructive` on a tool whose source says `write`
+    was reported as Shipgate's own inference, in a recommendation telling the
+    reviewer to declare the value they had already written (#424 review).
+    """
+
+    manifest = _manifest(
+        {
+            "action_surface": {
+                "actions": [{"tool": "create_ticket", "effect": "read"}]
+            }
+        }
+    )
+    tool = Tool(
+        id="tool:create_ticket",
+        name="create_ticket",
+        source_type="openapi",
+        source_id="support-api",
+        annotations={"httpMethod": "POST", "path": "/tickets"},
+        extraction_confidence="high",
+        # Exactly what `_apply_manual_override` writes for a
+        # `risk_overrides.tags` entry.
+        risk_hints=[
+            ToolRiskHint(
+                tag="destructive",
+                source="manual",
+                confidence="high",
+                basis="reviewed_declaration",
+            )
+        ],
+    )
+    tools = attach_semantic_assessments(
+        [tool],
+        {tool.id: manifest.action_surface.actions[0]},
+    )
+    findings = evaluate_action_surface_policies(
+        manifest,
+        build_action_surface_facts(
+            manifest, agent_id="agent:action-test/agent", tools=tools
+        ),
+        ActionSurfaceDiff(),
+        agent_id="agent:action-test/agent",
+        tools=tools,
+    )
+
+    finding = next(
+        item for item in findings if item.check_id == "SHIP-ACTION-EFFECT-DOWNGRADE-DECLARED"
+    )
+    # `POST` is what the source said; `destructive` is what the reviewer said.
+    assert finding.evidence["inferred_effect"] == "write"
+    assert "destructive" not in finding.recommendation
+
+
 def test_scan_diff_from_prior_report_does_not_launder_financial_keyword_into_blocker(
     tmp_path,
 ):

--- a/tests/test_declaration_questionnaire.py
+++ b/tests/test_declaration_questionnaire.py
@@ -655,8 +655,9 @@ def _rendered_gaps(tmp_path: Path, *, tools: list[dict], actions: list[dict]):
     return report, report.release_decision.evidence_coverage.evidence_gaps
 
 
+@pytest.mark.parametrize("already_declared", [[], ["financial_write"]])
 def test_pasting_the_published_tag_block_closes_the_row_end_to_end(
-    tmp_path: Path,
+    tmp_path: Path, already_declared: list[str]
 ) -> None:
     """The §E walk that found #424, as a scan the reader actually performs.
 
@@ -666,14 +667,20 @@ def test_pasting_the_published_tag_block_closes_the_row_end_to_end(
     own repair came back as a *blocking* `conflicting_effect_evidence` — and
     where the pin has to survive it, since a template that re-opens
     `declaration_drift` on the next scan has not closed anything either.
+
+    Parametrized over a row that already carries a covering tag, because
+    `risk_tags` is one YAML key and pasting replaces it. A template naming only
+    the newly uncovered category deleted the tag that was covering the
+    financial reading, and the next scan reopened the row asking for it back —
+    the same defect, in the case the repair itself creates (#424 review).
     """
 
     tools = [
         {
-            "name": "purge_and_notify_customers",
+            "name": "refund_and_purge_customer",
             "description": (
-                "Delete the customer record permanently and email the customer "
-                "about it."
+                "Issue a refund payment to the customer and permanently delete "
+                "their account record."
             ),
             "inputSchema": {
                 "type": "object",
@@ -683,11 +690,13 @@ def test_pasting_the_published_tag_block_closes_the_row_end_to_end(
             },
         }
     ]
-    declared = {
-        "tool": "purge_and_notify_customers",
+    declared: dict = {
+        "tool": "refund_and_purge_customer",
         "effect": "external_communication",
         "authority": {"mode": "none"},
     }
+    if already_declared:
+        declared["risk_tags"] = list(already_declared)
 
     def _scan(actions: list[dict], where: Path):
         where.mkdir()
@@ -708,24 +717,34 @@ def test_pasting_the_published_tag_block_closes_the_row_end_to_end(
         if item.kind == "declaration_below_inferred_evidence"
     )
     template = dict(gap.next_action.declaration_template or {})
-    assert template["risk_tags"] == ["destructive"]
+    # The whole value of the key, not the additions: the same list either way,
+    # so a reviewer who already answered half the question keeps that half.
+    assert template["risk_tags"] == ["financial_write", "destructive"]
     # `override` is the row's *other* route, offered in the same block; a
     # reviewer taking the first one does not also write an acknowledgement.
     template.pop("override", None)
-    merged = {**declared, **{
-        key: value
-        for key, value in template.items()
-        if key not in {"tool_id", "source_id"}
-    }}
+    # Pasted the way a merge instruction is pasted: each key it names replaces
+    # the key it lands on. Unioning here instead would test the reader's
+    # goodwill rather than the block.
+    merged = {
+        **declared,
+        **{
+            key: value
+            for key, value in template.items()
+            if key not in {"tool_id", "source_id"}
+        },
+    }
 
     answered = _scan([merged], tmp_path / "after")
     coverage = answered.release_decision.evidence_coverage
 
     assert [item.kind for item in coverage.evidence_gaps] == []
     questions = coverage.semantic_coverage.declaration_questions
-    assert questions.open == 0 and questions.answered == questions.total
-    # Closed by *applying* both categories' controls, not by silencing either.
+    assert questions.open == 0
+    assert questions.answered == questions.total
+    # Closed by *applying* every category's controls, not by silencing any.
     active = {finding.check_id for finding in answered.findings}
+    assert "SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING" in active
     assert "SHIP-ACTION-DESTRUCTIVE-ROLLBACK-MISSING" in active
     assert "SHIP-ACTION-EXTERNAL-COMMUNICATION-AUDIT-MISSING" in active
 

--- a/tests/test_declaration_questionnaire.py
+++ b/tests/test_declaration_questionnaire.py
@@ -491,52 +491,83 @@ def test_the_answerable_kinds_are_real_gap_kinds_and_belong_to_one_dimension() -
 _PIN = "<CURRENT_PIN>"
 
 
-#: One reachable configuration per answerable kind, with the declaration that
-#: is supposed to close it. `conflicting_effect_evidence` appears twice on
-#: purpose: it is raised about two different surfaces, and only one of them is
-#: a question a declaration can answer.
-_ROUND_TRIP_CASES: dict[str, tuple[dict, dict, dict]] = {
-    # kind: (tool kwargs, declaration that raised it or {}, the answer)
+#: Every reachable configuration whose row a declaration is supposed to close,
+#: grouped by kind. `conflicting_effect_evidence` appears twice on purpose: it
+#: is raised about two different surfaces, and only one of them is a question a
+#: declaration can answer.
+#:
+#: A kind carries more than one case when its row publishes more than one
+#: route out. `declaration_below_inferred_evidence` publishes two — raise the
+#: effect, or name the categories as reviewed `risk_tags` — and only the first
+#: was walked, so the second could swap the row for a *blocking*
+#: `conflicting_effect_evidence` and nothing here noticed (#424).
+_ROUND_TRIP_CASES: dict[str, tuple[tuple[dict, dict, dict], ...]] = {
+    # kind: ((tool kwargs, declaration that raised it or {}, the answer), ...)
     "missing_effect_evidence": (
-        {"source_type": "mcp", "annotations": {"mcp_server": True}},
-        {},
-        {"effect": "write"},
+        (
+            {"source_type": "mcp", "annotations": {"mcp_server": True}},
+            {},
+            {"effect": "write"},
+        ),
     ),
     "inferred_effect_only": (
-        {"risk_hints": "external_communication"},
-        {},
-        {"effect": "external_communication"},
+        (
+            {"risk_hints": "external_communication"},
+            {},
+            {"effect": "external_communication"},
+        ),
     ),
     "declaration_below_inferred_evidence": (
-        {"risk_hints": "external_communication"},
-        {"effect": "read"},
-        {"effect": "external_communication"},
+        # The `raise_effect` route.
+        (
+            {"risk_hints": "external_communication"},
+            {"effect": "read"},
+            {"effect": "external_communication"},
+        ),
+        # The `declare_risk_tags` route. No single effect covers both
+        # `destructive` and `external_communication` under both rank tables, so
+        # the row's own instruction is to name the uncovered category as a
+        # reviewed tag — the exact edit #424 found could not close the row it
+        # was printed on.
+        (
+            {"risk_hints": ("destructive", "external_communication")},
+            {"effect": "external_communication"},
+            {"effect": "external_communication", "risk_tags": ["destructive"]},
+        ),
     ),
     "conflicting_effect_evidence": (
-        {"annotations": {"httpMethod": "POST"}},
-        {"effect": "read"},
-        {"effect": "write"},
+        (
+            {"annotations": {"httpMethod": "POST"}},
+            {"effect": "read"},
+            {"effect": "write"},
+        ),
     ),
     "missing_authority_evidence": (
-        {},
-        {},
-        {"authority": {"mode": "none"}},
+        (
+            {},
+            {},
+            {"authority": {"mode": "none"}},
+        ),
     ),
     "conflicting_authority_evidence": (
-        {"auth": {"type": "oauth2", "scopes": ["a:write"]}},
-        {"authority": {"mode": "none"}},
-        {
-            "scopes": ["a:write"],
-            "authority": {"mode": "scoped", "auth_type": "oauth2"},
-        },
+        (
+            {"auth": {"type": "oauth2", "scopes": ["a:write"]}},
+            {"authority": {"mode": "none"}},
+            {
+                "scopes": ["a:write"],
+                "authority": {"mode": "scoped", "auth_type": "oauth2"},
+            },
+        ),
     ),
     # A pinned declaration whose pin names evidence this scan does not read.
     # The answer is the same declaration re-confirmed against what it reads
     # now — the one-line edit the row asks for (#410 §E).
     "declaration_drift": (
-        {"risk_hints": "external_communication"},
-        {"effect": "external_communication", "basis": "confirmed:0"},
-        {"effect": "external_communication", "basis": _PIN},
+        (
+            {"risk_hints": "external_communication"},
+            {"effect": "external_communication", "basis": "confirmed:0"},
+            {"effect": "external_communication", "basis": _PIN},
+        ),
     ),
 }
 
@@ -568,35 +599,46 @@ def test_every_answerable_kind_has_an_answer_that_closes_it() -> None:
         "a kind was added to ANSWERABLE_ISSUE_KINDS with no round-trip case"
     )
 
-    for kind, (tool_kwargs, raising, answer) in _ROUND_TRIP_CASES.items():
+    for kind, cases in _ROUND_TRIP_CASES.items():
         dimension = dimension_of[kind]
-        hint = tool_kwargs.pop("risk_hints", None) if "risk_hints" in tool_kwargs else None
-        tool = _observing(hint, **tool_kwargs) if hint else _tool(**tool_kwargs)
-        raised = assess_tool_semantics(
-            tool,
-            ActionDeclarationConfig.model_validate({"tool": "send_email", **raising})
-            if raising
-            else None,
-        )
-        assert kind in {issue.kind for issue in _dim_issues(raised, dimension)}, (
-            f"{kind}: the fixture no longer raises it"
-        )
+        for tool_kwargs, raising, answer in cases:
+            tool_kwargs = dict(tool_kwargs)
+            hints = tool_kwargs.pop("risk_hints", None)
+            if isinstance(hints, str):
+                hints = (hints,)
+            tool = _observing(*hints, **tool_kwargs) if hints else _tool(**tool_kwargs)
+            raised = assess_tool_semantics(
+                tool,
+                ActionDeclarationConfig.model_validate({"tool": "send_email", **raising})
+                if raising
+                else None,
+            )
+            assert kind in {issue.kind for issue in _dim_issues(raised, dimension)}, (
+                f"{kind}: the fixture no longer raises it"
+            )
 
-        answered = assess_tool_semantics(
-            tool,
-            ActionDeclarationConfig.model_validate(
-                {"tool": "send_email", **_with_pin(answer, tool)}
-            ),
-        )
-        tool.semantic_assessment = answered
-        questions = {
-            (question.dimension, question.answered)
-            for question in declaration_questions([tool])
-        }
-        assert (dimension, False) not in questions, (
-            f"{kind}: applying {answer} left the {dimension} question open — "
-            "the counter advertises a finish line this answer cannot reach"
-        )
+            answered = assess_tool_semantics(
+                tool,
+                ActionDeclarationConfig.model_validate(
+                    {"tool": "send_email", **_with_pin(answer, tool)}
+                ),
+            )
+            tool.semantic_assessment = answered
+            questions = {
+                (question.dimension, question.answered)
+                for question in declaration_questions([tool])
+            }
+            assert (dimension, False) not in questions, (
+                f"{kind}: applying {answer} left the {dimension} question open — "
+                "the counter advertises a finish line this answer cannot reach"
+            )
+            # And it must not have traded the row for a different one: the
+            # published route has to leave the dimension clean, not swap a
+            # review-tier row for a blocking conflict (#424).
+            assert not _dim_issues(answered, dimension), (
+                f"{kind}: applying {answer} replaced the row with "
+                f"{sorted(issue.kind for issue in _dim_issues(answered, dimension))}"
+            )
 
 
 def _rendered_gaps(tmp_path: Path, *, tools: list[dict], actions: list[dict]):
@@ -611,6 +653,81 @@ def _rendered_gaps(tmp_path: Path, *, tools: list[dict], actions: list[dict]):
     )
     assert report.release_decision is not None
     return report, report.release_decision.evidence_coverage.evidence_gaps
+
+
+def test_pasting_the_published_tag_block_closes_the_row_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """The §E walk that found #424, as a scan the reader actually performs.
+
+    The unit round-trip proves the resolver agrees with itself. This proves the
+    thing a reviewer does: take the block the row publishes, paste it into the
+    action it names, rescan. That is where the defect was visible — the row's
+    own repair came back as a *blocking* `conflicting_effect_evidence` — and
+    where the pin has to survive it, since a template that re-opens
+    `declaration_drift` on the next scan has not closed anything either.
+    """
+
+    tools = [
+        {
+            "name": "purge_and_notify_customers",
+            "description": (
+                "Delete the customer record permanently and email the customer "
+                "about it."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {"id": {"type": "string"}},
+                "required": ["id"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    declared = {
+        "tool": "purge_and_notify_customers",
+        "effect": "external_communication",
+        "authority": {"mode": "none"},
+    }
+
+    def _scan(actions: list[dict], where: Path):
+        where.mkdir()
+        report, _ = run_scan(
+            config_path=_mcp_workspace(where, tools=tools, actions=actions),
+            output_dir=where / "out",
+            formats=["json"],
+            ci_mode="advisory",
+            packet_enabled=False,
+        )
+        assert report.release_decision is not None
+        return report
+
+    raised = _scan([dict(declared)], tmp_path / "before")
+    gap = next(
+        item
+        for item in raised.release_decision.evidence_coverage.evidence_gaps
+        if item.kind == "declaration_below_inferred_evidence"
+    )
+    template = dict(gap.next_action.declaration_template or {})
+    assert template["risk_tags"] == ["destructive"]
+    # `override` is the row's *other* route, offered in the same block; a
+    # reviewer taking the first one does not also write an acknowledgement.
+    template.pop("override", None)
+    merged = {**declared, **{
+        key: value
+        for key, value in template.items()
+        if key not in {"tool_id", "source_id"}
+    }}
+
+    answered = _scan([merged], tmp_path / "after")
+    coverage = answered.release_decision.evidence_coverage
+
+    assert [item.kind for item in coverage.evidence_gaps] == []
+    questions = coverage.semantic_coverage.declaration_questions
+    assert questions.open == 0 and questions.answered == questions.total
+    # Closed by *applying* both categories' controls, not by silencing either.
+    active = {finding.check_id for finding in answered.findings}
+    assert "SHIP-ACTION-DESTRUCTIVE-ROLLBACK-MISSING" in active
+    assert "SHIP-ACTION-EXTERNAL-COMMUNICATION-AUDIT-MISSING" in active
 
 
 def test_a_source_owned_row_points_at_the_source_it_names(tmp_path: Path) -> None:

--- a/tests/test_declaration_questionnaire.py
+++ b/tests/test_declaration_questionnaire.py
@@ -492,9 +492,9 @@ _PIN = "<CURRENT_PIN>"
 
 
 #: Every reachable configuration whose row a declaration is supposed to close,
-#: grouped by kind. `conflicting_effect_evidence` appears twice on purpose: it
-#: is raised about two different surfaces, and only one of them is a question a
-#: declaration can answer.
+#: grouped by kind. `conflicting_effect_evidence` carries the manifest-owned
+#: surface only: it is also raised about a source that contradicts itself, and
+#: that one is not a question any declaration can answer.
 #:
 #: A kind carries more than one case when its row publishes more than one
 #: route out. `declaration_below_inferred_evidence` publishes two — raise the

--- a/tests/test_effect_coverage.py
+++ b/tests/test_effect_coverage.py
@@ -512,6 +512,44 @@ def test_the_row_never_names_the_manifest_as_the_source_agreeing_with_it() -> No
     assert "source evidence agrees with the declaration (openapi_method)" in corroborated
 
 
+def test_only_the_manifest_can_write_a_reviewed_risk_hint() -> None:
+    """The trust premise the exclusion rests on, pinned.
+
+    Excluding `risk_hint:manual` from the source-evidence comparison is only
+    safe because tool-published content cannot produce one. Two things make
+    that true and both are one edit away from not being: `_validated_hint_basis`
+    grants the `reviewed_declaration` basis to no other hint source, and no
+    adapter writes a hint with that basis or that source. Adapters read
+    untrusted files; if one could emit either, a server could describe itself
+    into a claim the resolver stops reading as its own.
+    """
+
+    from agents_shipgate.core.semantic_assessment import _validated_hint_basis
+
+    tool = _tool()
+    for source in ("mcp_annotation", "openapi_method", "keyword", "n8n_static", "name"):
+        hint = ToolRiskHint(
+            tag="destructive",
+            source=source,
+            confidence="high",
+            basis="reviewed_declaration",
+        )
+        assert _validated_hint_basis(tool, hint, None) == "unknown", (
+            f"{source} was granted the reviewed basis"
+        )
+
+    adapters = _REPO_ROOT / "src" / "agents_shipgate" / "inputs"
+    offenders = [
+        str(path.relative_to(_REPO_ROOT))
+        for path in sorted(adapters.rglob("*.py"))
+        if "reviewed_declaration" in (text := path.read_text(encoding="utf-8"))
+        or '"manual"' in text
+    ]
+    assert not offenders, (
+        "an adapter can now write a reviewed risk hint: " + ", ".join(offenders)
+    )
+
+
 @pytest.mark.parametrize(
     ("tool_updates", "declaration_updates"),
     [

--- a/tests/test_effect_coverage.py
+++ b/tests/test_effect_coverage.py
@@ -238,12 +238,20 @@ def test_the_published_repair_closes_the_row_it_is_printed_on() -> None:
     """Exhaustive: apply what the row advertises and the row must be gone.
 
     A published next step that cannot change the answer is the recurring defect
-    here. Two ways the single-value instruction failed: it named the strongest
-    observation and left a second one uncovered, and it fell through to
-    "declare the ``write`` controls" for an effect that obliges none.
+    here. Three ways the instruction failed: it named the strongest observation
+    and left a second one uncovered; it fell through to "declare the ``write``
+    controls" for an effect that obliges none; and — checking only that the row
+    itself disappeared — the ``declare_risk_tags`` route swapped a review-tier
+    row for a *blocking* ``conflicting_effect_evidence`` on 281 of the 390
+    declared/observed pairs that take it (#424).
 
-    This walks every declared effect against every one- and two-observation
-    combination, applies the repair the row publishes, and re-resolves.
+    So "closed" is the whole effect dimension being clean, not the absence of
+    one kind. A repair that trades one finding for a worse one has not closed
+    anything.
+
+    This walks every declared effect against every one-, two-, and
+    three-observation combination, applies the repair the row publishes, and
+    re-resolves.
     """
 
     import itertools
@@ -273,8 +281,9 @@ def test_the_published_repair_closes_the_row_it_is_printed_on() -> None:
         )
 
     unclosed: list[str] = []
+    routes: set[str] = set()
     exercised = 0
-    for count in (1, 2):
+    for count in (1, 2, 3):
         for effects in itertools.combinations(sorted(tags), count):
             tool = observed(effects)
             for declared in _EFFECTS:
@@ -290,21 +299,26 @@ def test_the_published_repair_closes_the_row_it_is_printed_on() -> None:
                     continue
                 exercised += 1
                 repair = effect_repair(assessment.effect)
+                routes.add(repair.kind)
                 repaired = dict(base)
                 if repair.kind == "raise_effect":
                     repaired["effect"] = repair.effect
                 else:
                     repaired["risk_tags"] = list(repair.risk_tags)
-                _, after = _issue_kinds(
+                repaired_assessment, after = _issue_kinds(
                     tool, ActionDeclarationConfig.model_validate(repaired)
                 )
-                if "declaration_below_inferred_evidence" in after:
+                if after or not repaired_assessment.pass_eligible:
                     unclosed.append(
                         f"declared={declared} observed={effects} "
-                        f"repair={repair.kind}:{repair.effect or repair.risk_tags}"
+                        f"repair={repair.kind}:{repair.effect or repair.risk_tags} "
+                        f"-> {sorted(after) or 'not pass-eligible'}"
                     )
 
     assert exercised > 100, "the matrix stopped exercising the rule"
+    assert routes == {"raise_effect", "declare_risk_tags"}, (
+        f"the matrix stopped walking both published routes: {sorted(routes)}"
+    )
     assert not unclosed, "\n".join(unclosed)
 
 
@@ -330,6 +344,152 @@ def test_a_repair_never_drops_the_reading_the_reviewer_declared() -> None:
 
     assert repair.kind == "declare_risk_tags"
     assert repair.effect is None
+
+
+# --------------------------------------------------------------------------
+# A reviewed risk tag is not source evidence (#424)
+# --------------------------------------------------------------------------
+
+
+def _policy_eligible_effects(assessment) -> set[str]:
+    """What `_control_effects` unions — the categories whose controls apply.
+
+    Asserted here rather than through the lens because it is the same set by
+    construction, and a repair that closes the row by making the observation
+    *disappear* would look identical to one that closes it by making the
+    category's controls apply. Only the second is a repair.
+    """
+
+    return {
+        claim.value
+        for claim in assessment.effect.claims
+        if claim.policy_eligible and claim.value in ACTION_EFFECT_RANK
+    }
+
+
+def test_the_tag_route_closes_the_row_it_is_printed_on() -> None:
+    """The issue's own reproduction, applied verbatim.
+
+    `declaration_below_inferred_evidence` publishes two routes, and the second
+    names the row's own repair: add the uncovered category as a reviewed
+    `risk_tags` entry. Reading that entry back as *source* evidence made the
+    edit produce a blocking `conflicting_effect_evidence` whose message blamed
+    the reviewer's own manifest — a published next step that could not close
+    the row it was printed on.
+    """
+
+    tool = _tool(
+        risk_hints=[
+            ToolRiskHint(
+                tag="external_write",
+                source="keyword",
+                confidence="medium",
+                basis="inferred_keyword",
+            ),
+            ToolRiskHint(
+                tag="destructive",
+                source="keyword",
+                confidence="medium",
+                basis="inferred_keyword",
+            ),
+        ]
+    )
+    raised, kinds = _issue_kinds(tool, _declaration(effect="external_communication"))
+    assert kinds == {"declaration_below_inferred_evidence"}
+
+    repair = effect_repair(raised.effect)
+    assert repair.kind == "declare_risk_tags"
+    assert repair.risk_tags == ("destructive",)
+
+    repaired, after = _issue_kinds(
+        tool,
+        _declaration(
+            effect="external_communication", risk_tags=list(repair.risk_tags)
+        ),
+    )
+    assert after == set()
+    assert repaired.pass_eligible is True
+    # And it closed by *applying* the destructive controls, not by silencing
+    # the observation: the declared tag is policy-eligible evidence.
+    assert "destructive" in _policy_eligible_effects(repaired)
+    assert repaired.conservative_effect == "destructive"
+
+
+def test_the_other_spelling_of_a_reviewed_tag_reads_the_same_way() -> None:
+    """`risk_overrides.tags` says the same thing once for a whole selector.
+
+    It reaches the effect dimension as `risk_hint:manual` with basis
+    `reviewed_declaration` rather than through the action row, so a fix scoped
+    to the action row alone would leave the sibling surface contradicting the
+    declaration beside it.
+    """
+
+    tool = _tool(
+        risk_hints=[
+            ToolRiskHint(
+                tag="external_write",
+                source="name",
+                confidence="medium",
+                basis="inferred_keyword",
+            ),
+            # Exactly what `_apply_manual_override` writes for a
+            # `risk_overrides.tags` entry.
+            ToolRiskHint(
+                tag="destructive",
+                source="manual",
+                confidence="high",
+                basis="reviewed_declaration",
+            ),
+        ]
+    )
+    assessment, kinds = _issue_kinds(
+        tool, _declaration(effect="external_communication")
+    )
+
+    assert kinds == set()
+    assert assessment.pass_eligible is True
+    assert "destructive" in _policy_eligible_effects(assessment)
+
+
+@pytest.mark.parametrize(
+    ("tool_updates", "declaration_updates"),
+    [
+        # A source annotation the server published.
+        ({"annotations": {"httpMethod": "POST"}}, {}),
+        # A permission list the source itself carries.
+        ({"auth": {"type": "oauth2", "scopes": ["crm:write"]}}, {}),
+        # A permission list the *manifest* declares. #417 deliberately made a
+        # declared `crm.delete` grant bound the action's effect, so this one
+        # must keep contradicting a weaker declaration even though it is
+        # manifest-owned — which is why the exclusion is the two risk-tag
+        # spellings and never `_is_manifest_owned` wholesale.
+        (
+            {},
+            {
+                "scopes": ["crm.delete"],
+                "authority": {"mode": "scoped", "auth_type": "oauth2"},
+            },
+        ),
+    ],
+)
+def test_a_declared_tag_never_launders_away_evidence_it_does_not_own(
+    tool_updates: dict, declaration_updates: dict
+) -> None:
+    """Negative control: the exclusion is scoped to reviewed risk tags.
+
+    Adding `risk_tags: [destructive]` accounts for the *heuristic* reading of
+    the same category. It may not answer a claim the reviewer did not write —
+    protocol structure, a source's own scopes, or a declared grant.
+    """
+
+    for risk_tags in ([], ["destructive"]):
+        _, kinds = _issue_kinds(
+            _tool(**tool_updates),
+            _declaration(effect="read", risk_tags=risk_tags, **declaration_updates),
+        )
+        assert "conflicting_effect_evidence" in kinds, (
+            f"risk_tags={risk_tags} silenced evidence it does not own"
+        )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_effect_coverage.py
+++ b/tests/test_effect_coverage.py
@@ -451,6 +451,67 @@ def test_the_other_spelling_of_a_reviewed_tag_reads_the_same_way() -> None:
     assert "destructive" in _policy_eligible_effects(assessment)
 
 
+def test_the_row_never_names_the_manifest_as_the_source_agreeing_with_it() -> None:
+    """A row saying the source agrees has to mean the source.
+
+    The row states both readings so an override is one line to write, and the
+    corroboration half says, in so many words, that *source* evidence agrees.
+    The filter behind it excluded the action row only, so a reviewed
+    `risk_overrides.tags` entry matching the declared effect was named to the
+    reviewer as the source agreeing with them — the manifest confirming itself,
+    which the comment above that filter already forbids (#424 review).
+    """
+
+    tool = _tool(
+        risk_hints=[
+            ToolRiskHint(
+                tag="financial_action",
+                source="name",
+                confidence="medium",
+                basis="inferred_keyword",
+            ),
+            # `risk_overrides.tags: [external_write]` — the same value the
+            # declaration below states.
+            ToolRiskHint(
+                tag="external_write",
+                source="manual",
+                confidence="high",
+                basis="reviewed_declaration",
+            ),
+        ]
+    )
+    assessment, _ = _issue_kinds(tool, _declaration(effect="external_communication"))
+    message = next(
+        item.message
+        for item in assessment.effect.issues
+        if item.kind == "declaration_below_inferred_evidence"
+    )
+
+    assert "source evidence agrees" not in message
+    assert "risk_hint:manual" not in message
+    # Negative control: a claim the source really did publish still corroborates.
+    annotated, _ = _issue_kinds(
+        _tool(
+            annotations={"httpMethod": "POST"},
+            risk_hints=[
+                ToolRiskHint(
+                    tag="financial_action",
+                    source="name",
+                    confidence="medium",
+                    basis="inferred_keyword",
+                )
+            ],
+        ),
+        _declaration(effect="write"),
+    )
+    corroborated = next(
+        item.message
+        for item in annotated.effect.issues
+        if item.kind == "declaration_below_inferred_evidence"
+    )
+    assert "source evidence agrees with the declaration (openapi_method)" in corroborated
+
+
 @pytest.mark.parametrize(
     ("tool_updates", "declaration_updates"),
     [

--- a/tests/test_effect_coverage.py
+++ b/tests/test_effect_coverage.py
@@ -283,39 +283,52 @@ def test_the_published_repair_closes_the_row_it_is_printed_on() -> None:
     unclosed: list[str] = []
     routes: set[str] = set()
     exercised = 0
+    seeded = 0
     for count in (1, 2, 3):
         for effects in itertools.combinations(sorted(tags), count):
             tool = observed(effects)
-            for declared in _EFFECTS:
-                base = {
-                    "tool": "send_email",
-                    "effect": declared,
-                    "authority": {"mode": "none"},
-                }
-                assessment, kinds = _issue_kinds(
-                    tool, ActionDeclarationConfig.model_validate(base)
-                )
-                if "declaration_below_inferred_evidence" not in kinds:
-                    continue
-                exercised += 1
-                repair = effect_repair(assessment.effect)
-                routes.add(repair.kind)
-                repaired = dict(base)
-                if repair.kind == "raise_effect":
-                    repaired["effect"] = repair.effect
-                else:
-                    repaired["risk_tags"] = list(repair.risk_tags)
-                repaired_assessment, after = _issue_kinds(
-                    tool, ActionDeclarationConfig.model_validate(repaired)
-                )
-                if after or not repaired_assessment.pass_eligible:
-                    unclosed.append(
-                        f"declared={declared} observed={effects} "
-                        f"repair={repair.kind}:{repair.effect or repair.risk_tags} "
-                        f"-> {sorted(after) or 'not pass-eligible'}"
+            # Rows that already carry a reviewed tag as well as bare ones.
+            # `risk_tags` is one key, so applying the repair replaces it: a
+            # repair naming only the new category deleted a covering tag and
+            # reopened the row on the next scan (#424 review). The seed is a
+            # category the tool really does read, so it covers something.
+            for seed in ((), (effects[0],)):
+                for declared in _EFFECTS:
+                    base: dict = {
+                        "tool": "send_email",
+                        "effect": declared,
+                        "authority": {"mode": "none"},
+                    }
+                    if seed:
+                        base["risk_tags"] = list(seed)
+                    assessment, kinds = _issue_kinds(
+                        tool, ActionDeclarationConfig.model_validate(base)
                     )
+                    if "declaration_below_inferred_evidence" not in kinds:
+                        continue
+                    exercised += 1
+                    seeded += bool(seed)
+                    repair = effect_repair(assessment.effect)
+                    routes.add(repair.kind)
+                    repaired = dict(base)
+                    if repair.kind == "raise_effect":
+                        repaired["effect"] = repair.effect
+                    else:
+                        # Replaced, not unioned: that is what pasting a block
+                        # that names the key does.
+                        repaired["risk_tags"] = list(repair.risk_tags)
+                    repaired_assessment, after = _issue_kinds(
+                        tool, ActionDeclarationConfig.model_validate(repaired)
+                    )
+                    if after or not repaired_assessment.pass_eligible:
+                        unclosed.append(
+                            f"declared={declared} observed={effects} seed={seed} "
+                            f"repair={repair.kind}:{repair.effect or repair.risk_tags} "
+                            f"-> {sorted(after) or 'not pass-eligible'}"
+                        )
 
     assert exercised > 100, "the matrix stopped exercising the rule"
+    assert seeded > 50, "the matrix stopped exercising already-tagged rows"
     assert routes == {"raise_effect", "declare_risk_tags"}, (
         f"the matrix stopped walking both published routes: {sorted(routes)}"
     )

--- a/tests/test_evidence_backed_pass.py
+++ b/tests/test_evidence_backed_pass.py
@@ -402,15 +402,128 @@ def test_manual_positive_action_tag_cannot_hide_behind_read_effect(
     )
 
 
-def test_a_declared_tag_obliges_exactly_what_declaring_the_effect_would(
+def _without_claims(value):
+    """The same fact with its provenance record removed.
+
+    The two spellings are genuinely different reviewed statements, so their
+    claim lists must differ — that is the audit trail saying *where* each
+    answer was written. Everything else a scan publishes about the action is
+    supposed to be the same, and that is what this strips down to.
+    """
+
+    if isinstance(value, dict):
+        return {
+            key: _without_claims(item)
+            for key, item in value.items()
+            if key != "claims"
+        }
+    if isinstance(value, list):
+        return [_without_claims(item) for item in value]
+    return value
+
+
+def test_a_tag_on_a_read_row_publishes_what_declaring_the_effect_publishes(
     tmp_path: Path,
 ) -> None:
-    """The two spellings have to land on the same gate answer.
+    """`effect: read` + a tag is now pass-eligible, so it must publish the truth.
 
-    `effect: read` + `risk_tags: [financial_write]` is now pass-eligible where
-    it used to be a blocking conflict (#424), so the thing worth proving is
-    that nothing was laundered: the controls the tag obliges are the controls
-    `effect: financial_write` obliges, and the same absence blocks either way.
+    Comparing the decision and the check IDs is not enough: a false *fact* can
+    ride into a passing artifact without changing either. This spelling emitted
+    a synthesized `read_only` risk tag beside the positive one, which
+    `derive_side_effect` reads as evidence — publishing `reversibility:
+    reversible` for a `financial_write` action, and diverging action and
+    capability facts from the direct declaration (#461, folded in on review
+    because this PR is what moves the wrong claim into a report that can pass).
+
+    Facts are compared rather than diffs: equal facts are equal against every
+    base, so this is the stronger statement.
+
+    Scoped to `effect: read` on purpose — see
+    `test_a_tag_unions_obligations_with_the_declared_effect` for why the
+    equivalence is not general.
+    """
+
+    controls = [
+        ("approval", {"required": True}),
+        ("safeguards", {"audit_log": True, "idempotency": True}),
+    ]
+    counter = itertools.count()
+
+    def _scan(action: dict[str, object]):
+        root = tmp_path / f"case{next(counter)}"
+        root.mkdir()
+        report, _ = run_scan(
+            config_path=_write_project(
+                root, tools=[_tool("settle_order")], actions=[action]
+            ),
+            output_dir=root / "reports",
+            formats=["json"],
+            ci_mode="advisory",
+            packet_enabled=False,
+        )
+        assert report.release_decision is not None
+        return report
+
+    def _spellings(**extra: object):
+        base: dict[str, object] = {
+            "tool": "settle_order",
+            "authority": {"mode": "none"},
+            **extra,
+        }
+        return (
+            _scan({**base, "effect": "read", "risk_tags": ["financial_write"]}),
+            _scan({**base, "effect": "financial_write"}),
+        )
+
+    for reports in (_spellings(controls=controls), _spellings()):
+        tagged, declared = reports
+        gates = [
+            (
+                report.release_decision.decision,
+                frozenset(finding.check_id for finding in report.findings),
+            )
+            for report in reports
+        ]
+        assert gates[0] == gates[1]
+
+        facts = [
+            (
+                _without_claims(report.action_surface_facts.model_dump(mode="json")),
+                _without_claims(
+                    [fact.model_dump(mode="json") for fact in report.capability_facts]
+                ),
+            )
+            for report in reports
+        ]
+        assert facts[0] == facts[1]
+
+        # And the provenance really was the only difference: the claim lists
+        # say where each answer was written, and they are not the same.
+        assert (
+            tagged.action_surface_facts.actions[0].semantic_assessment.effect.claims
+            != declared.action_surface_facts.actions[0].semantic_assessment.effect.claims
+        )
+
+    # The controls were the whole gate difference: without them both spellings
+    # block on the same missing financial-write control.
+    bare, _ = _spellings()
+    assert bare.release_decision.decision == "blocked"
+    assert any(
+        finding.check_id == "SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING"
+        for finding in bare.findings
+    )
+
+
+def test_a_tag_unions_obligations_with_the_declared_effect(tmp_path: Path) -> None:
+    """A tag adds a category; it does not replace the one already declared.
+
+    The `effect: read` equivalence above holds because `read` obliges nothing.
+    Beside a positive effect the two spellings are not the same statement:
+    `external_communication` + a financial tag owes confirmation *and* audit
+    *and* approval *and* idempotency, while `effect: financial_write` alone
+    drops the confirmation the outward communication required. Stating the
+    equivalence generally would have sent a reviewer to replace an effect and
+    lose a category (#424 review).
     """
 
     controls = [
@@ -420,7 +533,7 @@ def test_a_declared_tag_obliges_exactly_what_declaring_the_effect_would(
     counter = itertools.count()
 
     def _gate(action: dict[str, object]) -> tuple[str, frozenset[str]]:
-        root = tmp_path / f"case{next(counter)}"
+        root = tmp_path / f"union{next(counter)}"
         root.mkdir()
         report, _ = run_scan(
             config_path=_write_project(
@@ -436,27 +549,31 @@ def test_a_declared_tag_obliges_exactly_what_declaring_the_effect_would(
             finding.check_id for finding in report.findings
         )
 
-    def _spellings(**extra: object) -> tuple[tuple[str, frozenset[str]], ...]:
-        base: dict[str, object] = {
+    tagged = _gate(
+        {
             "tool": "settle_order",
+            "effect": "external_communication",
+            "risk_tags": ["financial_write"],
             "authority": {"mode": "none"},
-            **extra,
+            "controls": controls,
         }
-        return (
-            _gate({**base, "effect": "read", "risk_tags": ["financial_write"]}),
-            _gate({**base, "effect": "financial_write"}),
-        )
+    )
+    replaced = _gate(
+        {
+            "tool": "settle_order",
+            "effect": "financial_write",
+            "authority": {"mode": "none"},
+            "controls": controls,
+        }
+    )
 
-    controlled_tag, controlled_effect = _spellings(controls=controls)
-    bare_tag, bare_effect = _spellings()
-
-    assert controlled_tag == controlled_effect
-    assert bare_tag == bare_effect
-    # And the controls were the whole difference: without them both spellings
-    # block on the same missing financial-write control.
-    assert "SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING" not in controlled_tag[1]
-    assert bare_tag[0] == "blocked"
-    assert "SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING" in bare_tag[1]
+    assert tagged != replaced
+    assert tagged[0] == "blocked"
+    assert "SHIP-POLICY-CONFIRMATION-MISSING" in tagged[1]
+    assert "SHIP-ACTION-EXTERNAL-COMMUNICATION-AUDIT-MISSING" in tagged[1]
+    # Replacing the effect drops the category the row had already declared.
+    assert replaced[0] != "blocked"
+    assert "SHIP-POLICY-CONFIRMATION-MISSING" not in replaced[1]
 
 
 def test_suppression_cannot_waive_mandatory_destructive_control(

--- a/tests/test_evidence_backed_pass.py
+++ b/tests/test_evidence_backed_pass.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import json
 from pathlib import Path
 
@@ -361,6 +362,17 @@ def test_control_union_preserves_financial_and_destructive_claims(
 def test_manual_positive_action_tag_cannot_hide_behind_read_effect(
     tmp_path: Path,
 ) -> None:
+    """A declared tag applies its category's controls; it does not soften.
+
+    The tag used to be reported as `conflicting_effect_evidence` — the
+    manifest read as contradicting itself — which is the #424 defect: the
+    same reading made the `declare_risk_tags` repair unable to close the row
+    that published it. What must hold is that the tag cannot *hide* anything,
+    and the stronger form of that is what the gate now says: the
+    financial-write controls apply, they are missing, and the run is blocked
+    for that reason rather than for the shape of the manifest.
+    """
+
     config = _write_project(
         tmp_path,
         tools=[_tool("settle_order")],
@@ -383,11 +395,68 @@ def test_manual_positive_action_tag_cannot_hide_behind_read_effect(
     )
 
     assert report.release_decision is not None
-    assert report.release_decision.decision != "passed"
+    assert report.release_decision.decision == "blocked"
     assert any(
-        gap.kind == "conflicting_effect_evidence"
-        for gap in report.release_decision.evidence_coverage.evidence_gaps
+        finding.check_id == "SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING"
+        for finding in report.findings
     )
+
+
+def test_a_declared_tag_obliges_exactly_what_declaring_the_effect_would(
+    tmp_path: Path,
+) -> None:
+    """The two spellings have to land on the same gate answer.
+
+    `effect: read` + `risk_tags: [financial_write]` is now pass-eligible where
+    it used to be a blocking conflict (#424), so the thing worth proving is
+    that nothing was laundered: the controls the tag obliges are the controls
+    `effect: financial_write` obliges, and the same absence blocks either way.
+    """
+
+    controls = [
+        ("approval", {"required": True}),
+        ("safeguards", {"audit_log": True, "idempotency": True}),
+    ]
+    counter = itertools.count()
+
+    def _gate(action: dict[str, object]) -> tuple[str, frozenset[str]]:
+        root = tmp_path / f"case{next(counter)}"
+        root.mkdir()
+        report, _ = run_scan(
+            config_path=_write_project(
+                root, tools=[_tool("settle_order")], actions=[action]
+            ),
+            output_dir=root / "reports",
+            formats=["json"],
+            ci_mode="advisory",
+            packet_enabled=False,
+        )
+        assert report.release_decision is not None
+        return report.release_decision.decision, frozenset(
+            finding.check_id for finding in report.findings
+        )
+
+    def _spellings(**extra: object) -> tuple[tuple[str, frozenset[str]], ...]:
+        base: dict[str, object] = {
+            "tool": "settle_order",
+            "authority": {"mode": "none"},
+            **extra,
+        }
+        return (
+            _gate({**base, "effect": "read", "risk_tags": ["financial_write"]}),
+            _gate({**base, "effect": "financial_write"}),
+        )
+
+    controlled_tag, controlled_effect = _spellings(controls=controls)
+    bare_tag, bare_effect = _spellings()
+
+    assert controlled_tag == controlled_effect
+    assert bare_tag == bare_effect
+    # And the controls were the whole difference: without them both spellings
+    # block on the same missing financial-write control.
+    assert "SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING" not in controlled_tag[1]
+    assert bare_tag[0] == "blocked"
+    assert "SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING" in bare_tag[1]
 
 
 def test_suppression_cannot_waive_mandatory_destructive_control(

--- a/tests/test_p0_safety_canaries.py
+++ b/tests/test_p0_safety_canaries.py
@@ -1368,9 +1368,9 @@ def test_a_reviewed_tag_transitions_the_action_instead_of_blocking_it() -> None:
     `effect: read` + `risk_tags: [financial_action]` used to be a blocking
     `conflicting_effect_evidence`. It is now pass-eligible — and the reason
     that is not an evasion is asserted here rather than assumed: the action
-    resolves to `financial_write`, the financial-write claim is policy-eligible
-    (so `_control_effects` applies that category's controls), and read is not
-    what anything downstream reads.
+    resolves to `financial_write`, which is the effect every downstream
+    consumer reads, and the financial-write claim is policy-eligible, which is
+    what makes `_control_effects` apply that category's controls.
     """
 
     assessment = assess_tool_semantics(

--- a/tests/test_p0_safety_canaries.py
+++ b/tests/test_p0_safety_canaries.py
@@ -357,19 +357,34 @@ CONTRADICTION_EVASION_CASES = [
         authority_mode="none",
         effect_issues=frozenset({"conflicting_effect_evidence"}),
     ),
+    # #424 retired this slot's previous occupant,
+    # `manual_financial_tag_cannot_downgrade_to_read`. A declared
+    # `risk_tags: [financial_action]` beside `effect: read` is the manifest
+    # refining its own row, not contradicting it — and reading it as a
+    # contradiction is what left the `declare_risk_tags` repair unable to close
+    # the row that published it. The property that canary guarded is unchanged
+    # and asserted, in its post-#424 form, by
+    # `test_a_reviewed_tag_transitions_the_action_instead_of_blocking_it`.
+    #
+    # The slot now holds the boundary that fix draws. A declared *scope* is a
+    # different kind of statement: #417 made a declared `billing.delete` grant
+    # bound the action's effect, so it must keep contradicting a weaker
+    # declaration even though the same human wrote both lines. The tag rides
+    # along to prove it cannot launder the grant.
     SemanticCanary(
         "contradiction_evasion",
-        "manual_financial_tag_cannot_downgrade_to_read",
+        "declared_delete_scope_cannot_downgrade_to_read",
         declaration={
             "tool": "process_order",
             "effect": "read",
             "risk_tags": ["financial_action"],
-            "authority": {"mode": "none"},
+            "scopes": ["billing.delete"],
+            "authority": {"mode": "scoped", "auth_type": "oauth2"},
         },
         effect_status="conflicting",
-        effect="financial_write",
+        effect="destructive",
         authority_status="declared",
-        authority_mode="none",
+        authority_mode="scoped",
         effect_issues=frozenset({"conflicting_effect_evidence"}),
     ),
     SemanticCanary(
@@ -1345,6 +1360,37 @@ def test_p0_robustness_metamorphic_canary(case: RobustnessCanary) -> None:
         assert assessment.effect.status == "protocol_default"
         assert assessment.conservative_effect == "write"
         assert assessment.pass_eligible is False
+
+
+def test_a_reviewed_tag_transitions_the_action_instead_of_blocking_it() -> None:
+    """The retired canary's property, in the form #424 left it.
+
+    `effect: read` + `risk_tags: [financial_action]` used to be a blocking
+    `conflicting_effect_evidence`. It is now pass-eligible — and the reason
+    that is not an evasion is asserted here rather than assumed: the action
+    resolves to `financial_write`, the financial-write claim is policy-eligible
+    (so `_control_effects` applies that category's controls), and read is not
+    what anything downstream reads.
+    """
+
+    assessment = assess_tool_semantics(
+        _semantic_tool(),
+        ActionDeclarationConfig.model_validate(
+            {
+                "tool": "process_order",
+                "effect": "read",
+                "risk_tags": ["financial_action"],
+                "authority": {"mode": "none"},
+            }
+        ),
+    )
+
+    assert assessment.conservative_effect == "financial_write"
+    assert "financial_write" in {
+        claim.value for claim in assessment.effect.claims if claim.policy_eligible
+    }
+    assert assessment.pass_eligible is True
+    assert not assessment.effect.issues
 
 
 def test_p0_safety_canary_catalog_has_exact_planned_shape() -> None:


### PR DESCRIPTION
## Summary

- Fixes #424: the `declare_risk_tags` repair `declaration_below_inferred_evidence` publishes could not close the row it was printed on. Applying the row's own instruction verbatim replaced a review-tier row with a **blocking** `conflicting_effect_evidence` whose message blamed the reviewer's own manifest.
- Two branches of `_assess_effect` disagreed about what a reviewed `risk_tags` entry is. `claims_above_declared_effect` treats it as **covering**, deliberately and with a docstring saying so — a declared tag is policy-eligible, so it accounts for the observation *and* applies that category's built-in controls. The `contradictory` filter ran first and read the same claim as source evidence outranking the declaration.
- `contradictory` now excludes the two spellings of "declare this category as reviewed": `action_risk_tag_declaration` (the action row) and `risk_hint:manual` (`risk_overrides.tags`). They are named once as `REVIEWED_RISK_TAG_CLAIM_SOURCES` in `core/domain.py` and shared with the one other site that had the pair spelled inline.
- Same class already fixed one branch over in `_source_read_conflict`, for the same reason and with the same wording in its docstring. This branch never got the treatment.

### Blast radius, measured

Every declared effect × every one-, two-, and three-observation combination, applying the repair the engine publishes and re-resolving:

| route | exercised | did not close their row (before) | after |
|---|---:|---:|---:|
| `raise_effect` | 301 | 0 | 0 |
| `declare_risk_tags` | 390 | **281** | 0 |

First-time adoption was never affected — `propose_effect_declaration` always raises the effect or names a covering set. Only the post-declaration repair was broken, and only where the two published rank tables disagree, which is the case the two-route design exists for.

### Deliberately narrow

Not `_is_manifest_owned` wholesale. That predicate also covers `action_scope`, and #417 deliberately made a declared `crm.delete` grant bound the action's effect; excluding it would re-open that fail-open, and worse — the scope claim is policy-eligible, so it would then *cover itself* and raise nothing at all.

A declared tag refines the effect the same person wrote. A declared grant asserts an independent fact that bounds it. Protocol annotations, a source's own scopes, and typed provider facts keep contradicting a weaker declaration exactly as before — `test_a_declared_tag_never_launders_away_evidence_it_does_not_own` is the negative control, and it passes both before and after the fix.

### The gate verdict this moves

`effect: read` + `risk_tags: [destructive]` goes from **blocking** to **pass-eligible**. The issue asked for this to get its own adversarial pass; here is what that pass established:

- `conservative_effect` still resolves to `destructive`, the destructive claim is still policy-eligible, so `_control_effects` still applies the destructive controls.
- The two spellings now reach **identical** gate answers — same decision, same finding set — with and without the controls. Asserted in `test_a_declared_tag_obliges_exactly_what_declaring_the_effect_would`.
- Uncontrolled, `effect: read` + `risk_tags: [financial_write]` is `blocked` on `SHIP-ACTION-FINANCIAL-WRITE-CONTROL-MISSING` rather than on the shape of the manifest — a better answer to the same question.

**One P0 canary changed.** `manual_financial_tag_cannot_downgrade_to_read` encoded the old outcome; the `contradiction_evasion` category asserts `pass_eligible is False` for every case in it, and this case is no longer an evasion. Its slot is filled by the boundary the fix draws — `declared_delete_scope_cannot_downgrade_to_read`, which carries the same risk tag *plus* a declared `billing.delete` grant and stays blocking — so the catalog keeps its planned shape (64 cases, 12 in `contradiction_evasion`). The property the retired canary guarded is asserted in its post-#424 form by `test_a_reviewed_tag_transitions_the_action_instead_of_blocking_it`, in the same file.

### Guards

The issue's suggested guard, plus what it took to make it bite:

- `test_the_published_repair_closes_the_row_it_is_printed_on` — extended to three-observation combinations, now asserts **both** routes are exercised, and requires the whole effect dimension clean *and* pass-eligible rather than the absence of one kind. The old assertion is why the class shipped: the sweep already ran and already passed while the repair was swapping the row for a blocking conflict.
- `test_every_answerable_kind_has_an_answer_that_closes_it` — `_ROUND_TRIP_CASES` now holds a tuple of cases per kind so a kind that publishes two routes gets both walked, and each answer must leave the dimension clean.
- `test_pasting_the_published_tag_block_closes_the_row_end_to_end` — a real scan: raise the row, take the `next_action.declaration_template` it publishes, merge it into the action it names, rescan. Gaps empty, questions answered, the `basis` pin survives, and both categories' controls are what the run now reports.
- `test_the_tag_route_closes_the_row_it_is_printed_on` / `test_the_other_spelling_of_a_reviewed_tag_reads_the_same_way` — the issue's own reproduction and its `risk_overrides.tags` sibling.

Every new or strengthened guard was confirmed to fail with the fix reverted.

## Review round 1

Reviewing this change found the **same missing second route at two more comparisons**, both fixed here. The manifest reaches the effect dimension by two routes — the action row (`DECLARATION_CLAIM_SOURCES`) and `risk_overrides.tags`, which arrives as `risk_hint:manual` carrying a `reviewed_declaration` basis and *no* declaration source. Each of these excluded the first only:

1. **`SHIP-ACTION-EFFECT-DOWNGRADE-DECLARED` quoted the reviewer back at themselves.** It derives "the effect Shipgate inferred" by excluding the manifest's own claims. A reviewed `risk_overrides.tags: [destructive]` beside a source that says only `write` produced `inferred_effect: destructive` and the recommendation *"Set ... effect ... to destructive"* — telling the reviewer to declare the value they had already written. Now reports `write`, which is what the source said. Guard: `test_the_downgrade_row_never_quotes_the_reviewers_own_tag_back_at_them`.

2. **The row said the source agreed with a declaration when only the manifest did.** `declaration_below_inferred_evidence` appends *"; source evidence agrees with the declaration (…)"*, and a `risk_overrides.tags` entry matching the declared effect was named there — the manifest confirming itself, which the comment directly above that filter already forbade. Guard: `test_the_row_never_names_the_manifest_as_the_source_agreeing_with_it`, with a negative control proving `openapi_method` still corroborates.

`_is_manifest_owned` is promoted to `is_manifest_owned_effect_claim` and both sites ask it, so a fourth site cannot spell it a fifth way.

**Trust premise, now pinned.** Excluding `risk_hint:manual` from a source-evidence comparison is only safe because tool-published content cannot produce one. Two things make that true — `_validated_hint_basis` grants the `reviewed_declaration` basis to no other hint source, and no adapter writes that basis or a `"manual"` source — and neither was asserted anywhere, including by `_source_read_conflict`, which has relied on the same argument unstated since it was written. `test_only_the_manifest_can_write_a_reviewed_risk_hint` asserts both.

### Filed rather than folded in

Two findings from the same pass are out of scope and filed:

- **#460** — `effect_readings` counts a `risk_overrides` tag as something the scan *observed*. Same class, but excluding it moves the `basis` pin for every tool a `risk_overrides` selector touches and could weaken `propose_effect_declaration`. Both want their own adversarial pass.
- **#461** — a declared `effect: read` beside a positive risk tag publishes `reversibility: reversible` for a `financial_write` action, because `build_action` maps the policy-eligible `read` claim to a `read_only` tag. Pre-existing and byte-identical on `main` (verified), but this PR moves the wrong claim from reports that were blocked anyway into reports that can pass.

## Review round 2

All three findings reproduced first, then fixed. Both P1s were production defects, not test gaps.

1. **The tag repair still could not close its row on an already-tagged action.** `risk_tags` is one YAML key, so a block naming it replaces it — and the repair named only the newly uncovered category. A row reading `risk_tags: [financial_write]` was asked to delete the tag covering the financial reading, and the next scan reopened the row asking for it back: the #424 defect surviving in the case #424's own repair creates. `EffectRepair.risk_tags` is now the **complete value to write**, with `added_risk_tags` carrying what changed so the instruction and the value come from one place. The declared list is taken *verbatim* from a new `declared_risk_tags` entry on the declared-effect claim — it cannot be rebuilt from the tag claims, because `read_only`, `network_access` and `customer_data` map to no positive effect and produce none, the same lossiness the `declaration_drift` branch already refuses to guess through. Guard: the end-to-end paste test is parametrized over `already_declared` and still merges shallowly, the way a merge instruction is actually pasted.

2. **[#461](https://github.com/ThreeMoonsLab/agents-shipgate/issues/461) folded in rather than deferred.** `build_action` unions a risk tag for every policy-eligible effect claim, and `read` is not a category — it is the assertion that none apply. `effect: read` beside `risk_tags: [financial_write]` synthesized `read_only` on a `financial_write` action, and `derive_side_effect` reads that tag as positive evidence: `reversibility: reversible`, which that helper's own docstring says a declared read must not buy. Deferring was the wrong call, because this branch is what moves the wrong fact into an artifact that can pass. The equivalence guard now compares whole action and capability facts (equal facts are equal against every base — stronger than comparing two diffs) and separately asserts the claim lists still *differ*, so a flattened audit trail cannot pass as agreement.

3. **The contract overstated the equivalence.** A tag *adds* its category to the declared effect; raising the effect replaces it and drops whatever the old value obliged. `effect: external_communication` + a financial tag with approval/audit/idempotency is blocked on the missing confirmation, where `effect: financial_write` with the same controls is not. `docs/passed-verdict-contract.md`, `docs/manifest-v0.1.md` and the changelog now say the tag applies its category's controls *in addition*, with that example; the equivalence claim survives only where it is true — beside `effect: read`, which obliges nothing — and its test is renamed and scoped to that, with `test_a_tag_unions_obligations_with_the_declared_effect` as the negative control.

**Upgrade notes**, both in the changelog: an action spelled `effect: read` + a positive tag loses the `read_only` entry from its published `risk_tags`, so a stored lock shows one `risk_changed` / `narrowed` row on the first scan after upgrading — the safe direction, and correct. Carrying the declared tag list moves the declared-effect claim's `evidence` and `claim_id` for rows declaring both an `effect` and `risk_tags`; an `evidence_hash`-only change is classified `evidence_only` by design and carries no direction.

Round-1 finding [#460](https://github.com/ThreeMoonsLab/agents-shipgate/issues/460) stays filed — it moves the `basis` pin and changes what `propose_effect_declaration` must account for, which is a separate decision.

## Type

- [x] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- `python -m pytest tests/ -n auto` — full suite green (exit 0).
- `python -m ruff check .`, `python -m compileall -q src tests`, `python scripts/generate_schemas.py --check` — all clean.
- Self-dogfood: `shipgate verify --config shipgate-self.yaml --base origin/main --head HEAD` then `shipgate agent control` → `control_state: complete`, `decision: passed`.
- Each new/strengthened guard re-run with `src/agents_shipgate/core/{semantic_assessment,domain}.py` reverted to `main`, to confirm it fails without the fix.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — no check IDs added, removed, or renamed.
- [x] Report/schema changes are additive or documented in `STABILITY.md` — no schema change. No report field, gap kind, or check ID is added or removed; `report_schema_version` is unchanged. What changes is which of two already-published gap kinds a given manifest raises, documented in `CHANGELOG.md`, `docs/manifest-v0.1.md`, and `docs/passed-verdict-contract.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
