### PR TITLE
feat(mcp): report contradictory client annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,26 @@
 
   No engine, schema or check-ID change: goldens, registration and tests only.
 
+- **MCP clients can now see when a server's reassuring annotation contradicts
+  the evidence beside it.** (#462) A tool that publishes `readOnlyHint: true`
+  while independent structural or explicitly labeled inferred evidence says it
+  can write, or `destructiveHint: false` while evidence says it can destroy,
+  now raises `SHIP-MCP-ANNOTATION-CONTRADICTION`. The finding is review-tier:
+  it does not weaken or replace the conservative permission verdict the engine
+  already computes, but it names the hint, the contradicting evidence and its
+  basis, the tool's source pointer, and the under-prompting consequence for MCP
+  clients that consume the annotation directly.
+
+  Absence still follows the MCP defaults and never fires. A source's
+  `tool_sources[].trust` setting cannot make a published contradiction true,
+  while a reviewed action override suppresses only the exact inferred claim
+  IDs it answers. With a base report, the delta form proves a hint-only flip by
+  reconstructing the possible prior boolean states and matching them against
+  the base annotation hash; no raw annotation field or report-schema change is
+  required. Static, hint-only-delta, default, corroboration, trust, reviewed
+  override, source-provenance, catalog, and adopter-vocabulary regressions pin
+  the behavior.
+
 - **The declaration questionnaire is now pinned by something committed.**
   (#425) It is the primary cold-start surface — what an adopter at
   `insufficient_evidence` reads, in order, to reach a verdict — and no shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,22 @@
   Absence still follows the MCP defaults and never fires. A source's
   `tool_sources[].trust` setting cannot make a published contradiction true,
   while a reviewed action override suppresses only the exact inferred claim
-  IDs it answers. With a base report, the delta form proves a hint-only flip by
-  reconstructing the possible prior boolean states and matching them against
-  the base annotation hash; no raw annotation field or report-schema change is
-  required. Static, hint-only-delta, default, corroboration, trust, reviewed
-  override, source-provenance, catalog, and adopter-vocabulary regressions pin
-  the behavior.
+  IDs it answers. Policy-eligible structural evidence now corroborates a
+  narrowing hint against weaker keyword or pattern noise, while structural
+  side-effect evidence still triggers review. Reviewed effect declarations and
+  mutually conflicting hints from the same source stay on their existing
+  semantic-evidence routes instead of being counted as independent evidence.
+
+  Inferred-only instances remain detailed, informational findings with
+  `support.policy_eligible: false`; the scan also emits their evidence gap, but
+  release accounting excludes them from blockers and named review items. With
+  a base report, the delta form separately proves that independent evidence is
+  unchanged, detects any exact client-visible annotation-map change, and names
+  a hint flip only when reconstruction matches the base hash. The hash no
+  longer uses finding-fingerprint normalization, so otherwise ignored keys and
+  list order cannot produce a false proof. Static, exact-delta, co-change,
+  corroboration, trust, reviewed-override, source-provenance, end-to-end scan
+  publication, and adopter-vocabulary regressions pin the behavior.
 
 - **The declaration questionnaire is now pinned by something committed.**
   (#425) It is the primary cold-start surface — what an adopter at

--- a/docs/checks.json
+++ b/docs/checks.json
@@ -2446,6 +2446,32 @@
     {
       "autofix_safe": false,
       "category": "mcp_permissions",
+      "default_severity": "high",
+      "description": "MCP narrowing annotation contradicts side-effect evidence.",
+      "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-mcp-annotation-contradiction",
+      "dynamic_default": false,
+      "evidence_fields": [
+        "form",
+        "published_annotations",
+        "contradictions",
+        "independent_evidence",
+        "annotation_changes",
+        "independent_evidence_unchanged",
+        "client_consequence"
+      ],
+      "fires_when": "An explicit readOnlyHint true or destructiveHint false contradicts independent structural or clearly labeled inferred evidence on the same MCP tool.",
+      "floor_severity": "medium",
+      "id": "SHIP-MCP-ANNOTATION-CONTRADICTION",
+      "mvp_tier": "lifecycle",
+      "rationale": "MCP clients can use read-only and destructive annotations to reduce confirmation prompts even when independent evidence indicates the call can write or destroy data.",
+      "recommendation": "Review or correct the MCP annotation before clients use it to reduce confirmation prompts.",
+      "requires_human_review": true,
+      "requires_human_review_regardless_of_patch": false,
+      "suggested_patch_kind": "manual"
+    },
+    {
+      "autofix_safe": false,
+      "category": "mcp_permissions",
       "default_severity": "critical",
       "description": "MCP side-effecting tool is auto-approved.",
       "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-mcp-auto-approve-side-effect",

--- a/docs/checks.json
+++ b/docs/checks.json
@@ -2456,6 +2456,7 @@
         "contradictions",
         "independent_evidence",
         "annotation_changes",
+        "annotation_surface_changed",
         "independent_evidence_unchanged",
         "client_consequence"
       ],

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1115,13 +1115,34 @@ can let an agent act outside the review boundary.
 Fires when an explicit MCP narrowing annotation conflicts with independent
 side-effect evidence on the same tool: `readOnlyHint: true` beside write or
 destructive evidence, or `destructiveHint: false` beside destructive evidence.
-Absent annotations follow the MCP defaults and never trigger this check. The
-evidence names structural support as structural and keyword or pattern evidence
-as inferred. When a diff proves only the hint changed while that independent
-evidence stayed the same, the finding records the annotation flip explicitly.
-The finding routes to review because MCP clients may use these advisory hints to
-reduce confirmation prompts; it does not change the engine's conservative
-permission verdict.
+Absent annotations follow the MCP defaults and never trigger this check.
+Policy-eligible protocol, provider, or scope evidence outranks a conflicting
+keyword or pattern inference: for example, an OpenAPI `GET` does not become a
+contradiction merely because its description mentions a later delete. Structural
+side-effect evidence still triggers the check.
+
+Only source observations independent of the published MCP annotation contribute.
+Reviewed `action_surface.actions[].effect` declarations are deliberately excluded:
+they are human trust-root assertions, not a second observation of the server.
+Likewise, a source that publishes both `readOnlyHint: true` and
+`destructiveHint: true` remains a `conflicting_effect_evidence` semantic gap; this
+check does not relabel that same-source contradiction as independent evidence.
+
+Supported structural instances route to review because MCP clients may use these
+advisory hints to reduce confirmation prompts. Inferred-only instances remain
+visible in `report.findings` with `support.policy_eligible: false` and
+`agent_action: informational`; they also produce an evidence gap, but are excluded
+from blockers, named review items, and release contribution. The check never
+changes the engine's conservative permission verdict.
+
+With a base report, `annotation_surface_changed` compares the exact complete
+annotation map (including otherwise unrecognized keys and list order), while
+`independent_evidence_unchanged` compares the independent semantic evidence. The
+finding uses `form: delta` and fills `annotation_changes` only when reconstruction
+proves the exact narrowing-hint flip against the base hash; unrelated co-changes
+remain the static form. This semantic check runs in the normal
+`scan`/`check`/`verify` path. It is intentionally not duplicated in the narrower
+`mcp audit` host/config-diff rule table.
 
 ### SHIP-MCP-UNKNOWN-TOOL-SCHEMA
 

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1110,6 +1110,19 @@ financial, or production is configured with approval mode `approve`. This is
 an explicit release blocker because auto-approved side-effecting MCP tools
 can let an agent act outside the review boundary.
 
+### SHIP-MCP-ANNOTATION-CONTRADICTION
+
+Fires when an explicit MCP narrowing annotation conflicts with independent
+side-effect evidence on the same tool: `readOnlyHint: true` beside write or
+destructive evidence, or `destructiveHint: false` beside destructive evidence.
+Absent annotations follow the MCP defaults and never trigger this check. The
+evidence names structural support as structural and keyword or pattern evidence
+as inferred. When a diff proves only the hint changed while that independent
+evidence stayed the same, the finding records the annotation flip explicitly.
+The finding routes to review because MCP clients may use these advisory hints to
+reduce confirmation prompts; it does not change the engine's conservative
+permission verdict.
+
 ### SHIP-MCP-UNKNOWN-TOOL-SCHEMA
 
 Fires for new or changed MCP capabilities whose static metadata cannot prove

--- a/docs/checks/mcp_permissions.yaml
+++ b/docs/checks/mcp_permissions.yaml
@@ -32,6 +32,7 @@ checks:
   floor_severity: medium
   mvp_tier: lifecycle
   requires_human_review: true
+  publish_when_policy_ineligible: true
   description: MCP narrowing annotation contradicts side-effect evidence.
   rationale: MCP clients can use read-only and destructive annotations to reduce
     confirmation prompts even when independent evidence indicates the call can write
@@ -39,8 +40,8 @@ checks:
   fires_when: An explicit readOnlyHint true or destructiveHint false contradicts
     independent structural or clearly labeled inferred evidence on the same MCP tool.
   evidence_fields: [form, published_annotations, contradictions,
-    independent_evidence, annotation_changes, independent_evidence_unchanged,
-    client_consequence]
+    independent_evidence, annotation_changes, annotation_surface_changed,
+    independent_evidence_unchanged, client_consequence]
   recommendation: Review or correct the MCP annotation before clients use it to reduce
     confirmation prompts.
 - id: SHIP-MCP-UNKNOWN-TOOL-SCHEMA

--- a/docs/checks/mcp_permissions.yaml
+++ b/docs/checks/mcp_permissions.yaml
@@ -27,6 +27,22 @@ checks:
     production has approval mode approve.
   evidence_fields: [permission_classes, risk_score, approval_mode]
   recommendation: Do not auto-approve side-effecting MCP tools.
+- id: SHIP-MCP-ANNOTATION-CONTRADICTION
+  default_severity: high
+  floor_severity: medium
+  mvp_tier: lifecycle
+  requires_human_review: true
+  description: MCP narrowing annotation contradicts side-effect evidence.
+  rationale: MCP clients can use read-only and destructive annotations to reduce
+    confirmation prompts even when independent evidence indicates the call can write
+    or destroy data.
+  fires_when: An explicit readOnlyHint true or destructiveHint false contradicts
+    independent structural or clearly labeled inferred evidence on the same MCP tool.
+  evidence_fields: [form, published_annotations, contradictions,
+    independent_evidence, annotation_changes, independent_evidence_unchanged,
+    client_consequence]
+  recommendation: Review or correct the MCP annotation before clients use it to reduce
+    confirmation prompts.
 - id: SHIP-MCP-UNKNOWN-TOOL-SCHEMA
   default_severity: high
   floor_severity: medium

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3776,6 +3776,19 @@ financial, or production is configured with approval mode `approve`. This is
 an explicit release blocker because auto-approved side-effecting MCP tools
 can let an agent act outside the review boundary.
 
+### SHIP-MCP-ANNOTATION-CONTRADICTION
+
+Fires when an explicit MCP narrowing annotation conflicts with independent
+side-effect evidence on the same tool: `readOnlyHint: true` beside write or
+destructive evidence, or `destructiveHint: false` beside destructive evidence.
+Absent annotations follow the MCP defaults and never trigger this check. The
+evidence names structural support as structural and keyword or pattern evidence
+as inferred. When a diff proves only the hint changed while that independent
+evidence stayed the same, the finding records the annotation flip explicitly.
+The finding routes to review because MCP clients may use these advisory hints to
+reduce confirmation prompts; it does not change the engine's conservative
+permission verdict.
+
 ### SHIP-MCP-UNKNOWN-TOOL-SCHEMA
 
 Fires for new or changed MCP capabilities whose static metadata cannot prove

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3781,13 +3781,34 @@ can let an agent act outside the review boundary.
 Fires when an explicit MCP narrowing annotation conflicts with independent
 side-effect evidence on the same tool: `readOnlyHint: true` beside write or
 destructive evidence, or `destructiveHint: false` beside destructive evidence.
-Absent annotations follow the MCP defaults and never trigger this check. The
-evidence names structural support as structural and keyword or pattern evidence
-as inferred. When a diff proves only the hint changed while that independent
-evidence stayed the same, the finding records the annotation flip explicitly.
-The finding routes to review because MCP clients may use these advisory hints to
-reduce confirmation prompts; it does not change the engine's conservative
-permission verdict.
+Absent annotations follow the MCP defaults and never trigger this check.
+Policy-eligible protocol, provider, or scope evidence outranks a conflicting
+keyword or pattern inference: for example, an OpenAPI `GET` does not become a
+contradiction merely because its description mentions a later delete. Structural
+side-effect evidence still triggers the check.
+
+Only source observations independent of the published MCP annotation contribute.
+Reviewed `action_surface.actions[].effect` declarations are deliberately excluded:
+they are human trust-root assertions, not a second observation of the server.
+Likewise, a source that publishes both `readOnlyHint: true` and
+`destructiveHint: true` remains a `conflicting_effect_evidence` semantic gap; this
+check does not relabel that same-source contradiction as independent evidence.
+
+Supported structural instances route to review because MCP clients may use these
+advisory hints to reduce confirmation prompts. Inferred-only instances remain
+visible in `report.findings` with `support.policy_eligible: false` and
+`agent_action: informational`; they also produce an evidence gap, but are excluded
+from blockers, named review items, and release contribution. The check never
+changes the engine's conservative permission verdict.
+
+With a base report, `annotation_surface_changed` compares the exact complete
+annotation map (including otherwise unrecognized keys and list order), while
+`independent_evidence_unchanged` compares the independent semantic evidence. The
+finding uses `form: delta` and fills `annotation_changes` only when reconstruction
+proves the exact narrowing-hint flip against the base hash; unrelated co-changes
+remain the static form. This semantic check runs in the normal
+`scan`/`check`/`verify` path. It is intentionally not duplicated in the narrower
+`mcp audit` host/config-diff rule table.
 
 ### SHIP-MCP-UNKNOWN-TOOL-SCHEMA
 

--- a/src/agents_shipgate/checks/mcp_permissions.py
+++ b/src/agents_shipgate/checks/mcp_permissions.py
@@ -12,12 +12,15 @@ from agents_shipgate.core.capability_delta import (
 )
 from agents_shipgate.core.capability_lattice import classify_tool_permission
 from agents_shipgate.core.context import ScanContext
-from agents_shipgate.core.domain import DECLARATION_OVERRIDE_SOURCE, SemanticClaim, Tool
+from agents_shipgate.core.domain import SemanticClaim, Tool
 from agents_shipgate.core.lenses.tool_surface import (
     ToolSurfaceDiffReference,
     tool_annotation_hash,
 )
-from agents_shipgate.core.semantic_assessment import assess_tool_semantics
+from agents_shipgate.core.semantic_assessment import (
+    acknowledged_effect_claim_ids,
+    assess_tool_semantics,
+)
 from agents_shipgate.schemas.capabilities import CapabilityFactV1
 from agents_shipgate.schemas.common import Confidence, ProvenanceKind, confidence_rank
 from agents_shipgate.schemas.report import Finding
@@ -178,13 +181,16 @@ def _annotation_contradiction_findings(
             continue
 
         used_claims = _dedupe_claims(used_claims)
-        annotation_changes = _unchanged_evidence_annotation_changes(
-            tool, claims, context.diff_reference
-        )
-        bases = sorted({claim.basis for claim in used_claims})
         published_annotations = {
             str(item["annotation"]): item["published_value"] for item in contradictions
         }
+        annotation_changes = _unchanged_evidence_annotation_changes(
+            tool,
+            claims,
+            published_annotations,
+            context.diff_reference,
+        )
+        bases = sorted({claim.basis for claim in used_claims})
         consequence = (
             "MCP clients that honor these annotations may show too little "
             "confirmation before a side-effecting call."
@@ -219,12 +225,7 @@ def _annotation_contradiction_findings(
 
 def _independent_effect_claims(claims: Iterable[EffectClaim]) -> list[EffectClaim]:
     claim_list = list(claims)
-    overridden_claim_ids = {
-        str(claim_id)
-        for claim in claim_list
-        if claim.source == DECLARATION_OVERRIDE_SOURCE
-        for claim_id in claim.evidence.get("overridden_claim_ids", [])
-    }
+    overridden_claim_ids = acknowledged_effect_claim_ids(claim_list)
     return [
         claim
         for claim in claim_list
@@ -263,6 +264,7 @@ def _claim_evidence(claim: EffectClaim) -> dict[str, object]:
 def _unchanged_evidence_annotation_changes(
     tool: Tool,
     current_claims: list[EffectClaim],
+    contradicted_annotations: dict[str, object],
     reference: ToolSurfaceDiffReference | None,
 ) -> list[dict[str, object]]:
     if reference is None or reference.action_facts is None or reference.facts is None:
@@ -309,9 +311,9 @@ def _unchanged_evidence_annotation_changes(
     # reproduces that hash exactly. This proves the hint flip without adding
     # raw annotations to the report schema or guessing from a changed hash.
     dimensions: list[tuple[str, object, tuple[object, ...]]] = []
-    if tool.annotations.get("readOnlyHint") is True:
+    if "readOnlyHint" in contradicted_annotations:
         dimensions.append(("readOnlyHint", True, (True, False, _ABSENT)))
-    if tool.annotations.get("destructiveHint") is False:
+    if "destructiveHint" in contradicted_annotations:
         dimensions.append(("destructiveHint", False, (False, True, _ABSENT)))
     for before_values in product(*(options for _, _, options in dimensions)):
         candidate = dict(tool.annotations)

--- a/src/agents_shipgate/checks/mcp_permissions.py
+++ b/src/agents_shipgate/checks/mcp_permissions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from itertools import product
 
 from agents_shipgate.checks.base import tool_finding
@@ -51,11 +52,18 @@ _INDEPENDENT_EFFECT_BASES = frozenset(
 _EFFECT_BASIS_LABELS = {
     "protocol_structure": "protocol structure",
     "typed_provider_fact": "typed provider evidence",
-    "structural_scope": "declared scope evidence",
+    "structural_scope": "structural scope evidence",
     "inferred_keyword": "inferred keyword evidence",
     "inferred_regex": "inferred pattern evidence",
 }
 _ABSENT = object()
+
+
+@dataclass(frozen=True)
+class _AnnotationDeltaEvidence:
+    annotation_changes: tuple[dict[str, object], ...]
+    independent_evidence_unchanged: bool | None
+    annotation_surface_changed: bool | None
 
 
 def run(context: ScanContext) -> list[Finding]:
@@ -149,7 +157,7 @@ def _annotation_contradiction_findings(
         used_claims: list[EffectClaim] = []
 
         if tool.annotations.get("readOnlyHint") is True:
-            read_only_conflicts = [claim for claim in claims if claim.value != "read"]
+            read_only_conflicts = _read_only_conflicts(claims)
             if read_only_conflicts:
                 contradictions.append(
                     {
@@ -166,7 +174,7 @@ def _annotation_contradiction_findings(
         # narrows what a client is told, and only destructive evidence
         # contradicts that assertion; ordinary write evidence does not.
         if tool.annotations.get("destructiveHint") is False:
-            destructive_conflicts = [claim for claim in claims if claim.value == "destructive"]
+            destructive_conflicts = _destructive_hint_conflicts(claims)
             if destructive_conflicts:
                 contradictions.append(
                     {
@@ -184,13 +192,12 @@ def _annotation_contradiction_findings(
         published_annotations = {
             str(item["annotation"]): item["published_value"] for item in contradictions
         }
-        annotation_changes = _unchanged_evidence_annotation_changes(
+        delta = _annotation_delta_evidence(
             tool,
             claims,
             published_annotations,
             context.diff_reference,
         )
-        bases = sorted({claim.basis for claim in used_claims})
         consequence = (
             "MCP clients that honor these annotations may show too little "
             "confirmation before a side-effecting call."
@@ -202,18 +209,19 @@ def _annotation_contradiction_findings(
             severity="high",
             category="mcp_permissions",
             evidence={
-                "form": "delta" if annotation_changes else "static",
+                "form": "delta" if delta.annotation_changes else "static",
                 "published_annotations": published_annotations,
                 "contradictions": contradictions,
                 "independent_evidence": [_claim_evidence(claim) for claim in used_claims],
-                "annotation_changes": annotation_changes,
-                "independent_evidence_unchanged": bool(annotation_changes),
+                "annotation_changes": list(delta.annotation_changes),
+                "annotation_surface_changed": delta.annotation_surface_changed,
+                "independent_evidence_unchanged": delta.independent_evidence_unchanged,
                 "client_consequence": consequence,
             },
             confidence=_strongest_confidence(used_claims),
             recommendation=(
                 f"Review {', '.join(f'{name}: {str(value).lower()}' for name, value in published_annotations.items())} "
-                f"against {_basis_phrase(bases)}; {consequence}"
+                f"against {_basis_phrase(used_claims)}; {consequence}"
             ),
             context=context,
             provenance_kind=_finding_provenance(used_claims),
@@ -229,11 +237,42 @@ def _independent_effect_claims(claims: Iterable[EffectClaim]) -> list[EffectClai
     return [
         claim
         for claim in claim_list
-        if claim.value != "read"
-        and claim.basis in _INDEPENDENT_EFFECT_BASES
+        if claim.basis in _INDEPENDENT_EFFECT_BASES
         and claim.source != "mcp_annotation"
         and claim.claim_id not in overridden_claim_ids
     ]
+
+
+def _read_only_conflicts(claims: list[EffectClaim]) -> list[EffectClaim]:
+    conflicts = [claim for claim in claims if claim.value != "read"]
+    if not conflicts:
+        return []
+    # A medium keyword or regex hit must not overrule a policy-eligible read
+    # observation such as an OpenAPI GET. Structural side-effect evidence still
+    # ties or outranks that corroboration and therefore remains review-worthy.
+    has_structural_read = any(
+        claim.value == "read" and claim.policy_eligible for claim in claims
+    )
+    if has_structural_read and all(not claim.policy_eligible for claim in conflicts):
+        return []
+    return conflicts
+
+
+def _destructive_hint_conflicts(claims: list[EffectClaim]) -> list[EffectClaim]:
+    conflicts = [claim for claim in claims if claim.value == "destructive"]
+    if not conflicts:
+        return []
+    # `destructiveHint: false` is corroborated by any policy-eligible effect
+    # that is not destructive. As above, corroboration suppresses only weaker
+    # inferred conflicts; a structural destructive claim still wins through.
+    has_structural_non_destructive = any(
+        claim.value != "destructive" and claim.policy_eligible for claim in claims
+    )
+    if has_structural_non_destructive and all(
+        not claim.policy_eligible for claim in conflicts
+    ):
+        return []
+    return conflicts
 
 
 def _dedupe_claims(claims: Iterable[EffectClaim]) -> list[EffectClaim]:
@@ -243,6 +282,8 @@ def _dedupe_claims(claims: Iterable[EffectClaim]) -> list[EffectClaim]:
             claim.confidence,
             claim.basis,
             claim.source,
+            claim.source_pointer or "",
+            claim.provenance_kind,
             repr(sorted(claim.evidence.items())),
         ): claim
         for claim in claims
@@ -261,14 +302,15 @@ def _claim_evidence(claim: EffectClaim) -> dict[str, object]:
     }
 
 
-def _unchanged_evidence_annotation_changes(
+def _annotation_delta_evidence(
     tool: Tool,
     current_claims: list[EffectClaim],
     contradicted_annotations: dict[str, object],
     reference: ToolSurfaceDiffReference | None,
-) -> list[dict[str, object]]:
+) -> _AnnotationDeltaEvidence:
+    empty = _AnnotationDeltaEvidence((), None, None)
     if reference is None or reference.action_facts is None or reference.facts is None:
-        return []
+        return empty
     base_action = next(
         (action for action in reference.action_facts.actions if action.tool_id == tool.id),
         None,
@@ -280,14 +322,17 @@ def _unchanged_evidence_annotation_changes(
             if action.source_id == tool.source_id and action.tool_name == tool.name
         ]
         if len(matches) != 1:
-            return []
-        base_action = matches[0]
-    if base_action.semantic_assessment is None:
-        return []
-
-    base_claims = _independent_effect_claims(base_action.semantic_assessment.effect.claims)
-    if _claim_signature(base_claims) != _claim_signature(current_claims):
-        return []
+            base_action = None
+        else:
+            base_action = matches[0]
+    independent_evidence_unchanged = None
+    if base_action is not None and base_action.semantic_assessment is not None:
+        base_claims = _independent_effect_claims(
+            base_action.semantic_assessment.effect.claims
+        )
+        independent_evidence_unchanged = _claim_signature(
+            base_claims
+        ) == _claim_signature(current_claims)
 
     base_tool = next(
         (fact for fact in reference.facts.tools if fact.tool_id == tool.id),
@@ -300,10 +345,24 @@ def _unchanged_evidence_annotation_changes(
             if fact.source_id == tool.source_id and fact.name == tool.name
         ]
         if len(matches) != 1:
-            return []
-        base_tool = matches[0]
-    if base_tool.hashes.annotations is None:
-        return []
+            base_tool = None
+        else:
+            base_tool = matches[0]
+    if base_tool is None or base_tool.hashes.annotations is None:
+        return _AnnotationDeltaEvidence(
+            (), independent_evidence_unchanged, None
+        )
+
+    annotation_surface_changed = (
+        tool_annotation_hash(tool.annotations) != base_tool.hashes.annotations
+    )
+    degraded = _AnnotationDeltaEvidence(
+        (),
+        independent_evidence_unchanged,
+        annotation_surface_changed,
+    )
+    if independent_evidence_unchanged is not True or not annotation_surface_changed:
+        return degraded
 
     # Tool-surface facts already bind the complete base annotation map by
     # hash. Rebuild only the tiny set of possible prior values for the two
@@ -334,8 +393,12 @@ def _unchanged_evidence_annotation_changes(
                     }
                 )
         if changes and tool_annotation_hash(candidate) == base_tool.hashes.annotations:
-            return changes
-    return []
+            return _AnnotationDeltaEvidence(
+                tuple(changes),
+                independent_evidence_unchanged,
+                annotation_surface_changed,
+            )
+    return degraded
 
 
 def _claim_signature(claims: Iterable[EffectClaim]) -> tuple[tuple[str, ...], ...]:
@@ -346,6 +409,8 @@ def _claim_signature(claims: Iterable[EffectClaim]) -> tuple[tuple[str, ...], ..
                 claim.confidence,
                 claim.basis,
                 claim.source,
+                claim.source_pointer or "",
+                claim.provenance_kind,
                 repr(sorted(claim.evidence.items())),
             )
             for claim in claims
@@ -373,13 +438,39 @@ def _finding_provenance(claims: Iterable[EffectClaim]) -> ProvenanceKind:
     return ordered[0].provenance_kind if ordered else "static_declaration"
 
 
-def _basis_phrase(bases: list[str]) -> str:
-    labels = [_EFFECT_BASIS_LABELS.get(basis, basis.replace("_", " ")) for basis in bases]
+def _basis_phrase(claims: Iterable[EffectClaim]) -> str:
+    labels: list[str] = []
+    for claim in sorted(
+        claims,
+        key=lambda item: (
+            not item.policy_eligible,
+            -confidence_rank(item.confidence),
+            item.basis,
+            item.source,
+        ),
+    ):
+        label = _effect_basis_label(claim)
+        if label not in labels:
+            labels.append(label)
+    if not labels:
+        return "independent effect evidence"
     if len(labels) == 1:
         return labels[0]
     if len(labels) == 2:
         return f"{labels[0]} and {labels[1]}"
     return f"{', '.join(labels[:-1])}, and {labels[-1]}"
+
+
+def _effect_basis_label(claim: EffectClaim) -> str:
+    if claim.basis == "structural_scope":
+        if claim.source == "auth_scope":
+            return "structural server auth scope evidence"
+        if claim.source == "action_scope":
+            return "structural reviewed action scope evidence"
+    return _EFFECT_BASIS_LABELS.get(
+        claim.basis,
+        claim.basis.replace("_", " "),
+    )
 
 
 def _env_secret_findings(

--- a/src/agents_shipgate/checks/mcp_permissions.py
+++ b/src/agents_shipgate/checks/mcp_permissions.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+from itertools import product
+
 from agents_shipgate.checks.base import tool_finding
 from agents_shipgate.core.capabilities import capability_fact_from_action_fact
 from agents_shipgate.core.capability_delta import (
@@ -9,9 +12,16 @@ from agents_shipgate.core.capability_delta import (
 )
 from agents_shipgate.core.capability_lattice import classify_tool_permission
 from agents_shipgate.core.context import ScanContext
-from agents_shipgate.core.domain import Tool
+from agents_shipgate.core.domain import DECLARATION_OVERRIDE_SOURCE, SemanticClaim, Tool
+from agents_shipgate.core.lenses.tool_surface import (
+    ToolSurfaceDiffReference,
+    tool_annotation_hash,
+)
+from agents_shipgate.core.semantic_assessment import assess_tool_semantics
 from agents_shipgate.schemas.capabilities import CapabilityFactV1
+from agents_shipgate.schemas.common import Confidence, ProvenanceKind, confidence_rank
 from agents_shipgate.schemas.report import Finding
+from agents_shipgate.schemas.semantic import SemanticClaimEvidence
 from agents_shipgate.schemas.surfaces import ActionFact, ActionSurfaceFacts
 
 MCP_SOURCE_TYPES = frozenset(
@@ -24,6 +34,25 @@ MCP_SOURCE_TYPES = frozenset(
     }
 )
 CapabilityKey = tuple[str | None, str]
+EffectClaim = SemanticClaim | SemanticClaimEvidence
+
+_INDEPENDENT_EFFECT_BASES = frozenset(
+    {
+        "protocol_structure",
+        "typed_provider_fact",
+        "structural_scope",
+        "inferred_keyword",
+        "inferred_regex",
+    }
+)
+_EFFECT_BASIS_LABELS = {
+    "protocol_structure": "protocol structure",
+    "typed_provider_fact": "typed provider evidence",
+    "structural_scope": "declared scope evidence",
+    "inferred_keyword": "inferred keyword evidence",
+    "inferred_regex": "inferred pattern evidence",
+}
+_ABSENT = object()
 
 
 def run(context: ScanContext) -> list[Finding]:
@@ -37,6 +66,13 @@ def run(context: ScanContext) -> list[Finding]:
 
     findings.extend(_env_secret_findings(context, mcp_tools, fact_by_tool))
     findings.extend(_auto_approve_findings(context, mcp_tools, fact_by_tool))
+    findings.extend(
+        _annotation_contradiction_findings(
+            context,
+            mcp_tools,
+            fact_by_tool,
+        )
+    )
 
     diff_available = (
         context.diff_reference is not None and context.diff_reference.action_facts is not None
@@ -94,6 +130,254 @@ def run(context: ScanContext) -> list[Finding]:
             )
         )
     return _dedupe(findings)
+
+
+def _annotation_contradiction_findings(
+    context: ScanContext,
+    tools: list[Tool],
+    fact_by_tool: dict[CapabilityKey, CapabilityFactV1],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    for tool in tools:
+        claims = _independent_effect_claims(
+            (tool.semantic_assessment or assess_tool_semantics(tool)).effect.claims
+        )
+        contradictions: list[dict[str, object]] = []
+        used_claims: list[EffectClaim] = []
+
+        if tool.annotations.get("readOnlyHint") is True:
+            read_only_conflicts = [claim for claim in claims if claim.value != "read"]
+            if read_only_conflicts:
+                contradictions.append(
+                    {
+                        "annotation": "readOnlyHint",
+                        "published_value": True,
+                        "contradicting_effects": sorted(
+                            {claim.value for claim in read_only_conflicts}
+                        ),
+                    }
+                )
+                used_claims.extend(read_only_conflicts)
+
+        # MCP defaults destructiveHint to true. Only an explicit false value
+        # narrows what a client is told, and only destructive evidence
+        # contradicts that assertion; ordinary write evidence does not.
+        if tool.annotations.get("destructiveHint") is False:
+            destructive_conflicts = [claim for claim in claims if claim.value == "destructive"]
+            if destructive_conflicts:
+                contradictions.append(
+                    {
+                        "annotation": "destructiveHint",
+                        "published_value": False,
+                        "contradicting_effects": ["destructive"],
+                    }
+                )
+                used_claims.extend(destructive_conflicts)
+
+        if not contradictions:
+            continue
+
+        used_claims = _dedupe_claims(used_claims)
+        annotation_changes = _unchanged_evidence_annotation_changes(
+            tool, claims, context.diff_reference
+        )
+        bases = sorted({claim.basis for claim in used_claims})
+        published_annotations = {
+            str(item["annotation"]): item["published_value"] for item in contradictions
+        }
+        consequence = (
+            "MCP clients that honor these annotations may show too little "
+            "confirmation before a side-effecting call."
+        )
+        finding = tool_finding(
+            tool=tool,
+            check_id="SHIP-MCP-ANNOTATION-CONTRADICTION",
+            title="MCP narrowing annotation contradicts side-effect evidence",
+            severity="high",
+            category="mcp_permissions",
+            evidence={
+                "form": "delta" if annotation_changes else "static",
+                "published_annotations": published_annotations,
+                "contradictions": contradictions,
+                "independent_evidence": [_claim_evidence(claim) for claim in used_claims],
+                "annotation_changes": annotation_changes,
+                "independent_evidence_unchanged": bool(annotation_changes),
+                "client_consequence": consequence,
+            },
+            confidence=_strongest_confidence(used_claims),
+            recommendation=(
+                f"Review {', '.join(f'{name}: {str(value).lower()}' for name, value in published_annotations.items())} "
+                f"against {_basis_phrase(bases)}; {consequence}"
+            ),
+            context=context,
+            provenance_kind=_finding_provenance(used_claims),
+            capability_refs=_capability_ref(tool, fact_by_tool),
+        )
+        findings.append(finding)
+    return findings
+
+
+def _independent_effect_claims(claims: Iterable[EffectClaim]) -> list[EffectClaim]:
+    claim_list = list(claims)
+    overridden_claim_ids = {
+        str(claim_id)
+        for claim in claim_list
+        if claim.source == DECLARATION_OVERRIDE_SOURCE
+        for claim_id in claim.evidence.get("overridden_claim_ids", [])
+    }
+    return [
+        claim
+        for claim in claim_list
+        if claim.value != "read"
+        and claim.basis in _INDEPENDENT_EFFECT_BASES
+        and claim.source != "mcp_annotation"
+        and claim.claim_id not in overridden_claim_ids
+    ]
+
+
+def _dedupe_claims(claims: Iterable[EffectClaim]) -> list[EffectClaim]:
+    by_key = {
+        (
+            claim.value,
+            claim.confidence,
+            claim.basis,
+            claim.source,
+            repr(sorted(claim.evidence.items())),
+        ): claim
+        for claim in claims
+    }
+    return [by_key[key] for key in sorted(by_key)]
+
+
+def _claim_evidence(claim: EffectClaim) -> dict[str, object]:
+    return {
+        "effect": claim.value,
+        "confidence": claim.confidence,
+        "basis": claim.basis,
+        "source": claim.source,
+        "source_pointer": claim.source_pointer,
+        "details": claim.evidence,
+    }
+
+
+def _unchanged_evidence_annotation_changes(
+    tool: Tool,
+    current_claims: list[EffectClaim],
+    reference: ToolSurfaceDiffReference | None,
+) -> list[dict[str, object]]:
+    if reference is None or reference.action_facts is None or reference.facts is None:
+        return []
+    base_action = next(
+        (action for action in reference.action_facts.actions if action.tool_id == tool.id),
+        None,
+    )
+    if base_action is None:
+        matches = [
+            action
+            for action in reference.action_facts.actions
+            if action.source_id == tool.source_id and action.tool_name == tool.name
+        ]
+        if len(matches) != 1:
+            return []
+        base_action = matches[0]
+    if base_action.semantic_assessment is None:
+        return []
+
+    base_claims = _independent_effect_claims(base_action.semantic_assessment.effect.claims)
+    if _claim_signature(base_claims) != _claim_signature(current_claims):
+        return []
+
+    base_tool = next(
+        (fact for fact in reference.facts.tools if fact.tool_id == tool.id),
+        None,
+    )
+    if base_tool is None:
+        matches = [
+            fact
+            for fact in reference.facts.tools
+            if fact.source_id == tool.source_id and fact.name == tool.name
+        ]
+        if len(matches) != 1:
+            return []
+        base_tool = matches[0]
+    if base_tool.hashes.annotations is None:
+        return []
+
+    # Tool-surface facts already bind the complete base annotation map by
+    # hash. Rebuild only the tiny set of possible prior values for the two
+    # explicit narrowing hints and accept a delta only when one candidate
+    # reproduces that hash exactly. This proves the hint flip without adding
+    # raw annotations to the report schema or guessing from a changed hash.
+    dimensions: list[tuple[str, object, tuple[object, ...]]] = []
+    if tool.annotations.get("readOnlyHint") is True:
+        dimensions.append(("readOnlyHint", True, (True, False, _ABSENT)))
+    if tool.annotations.get("destructiveHint") is False:
+        dimensions.append(("destructiveHint", False, (False, True, _ABSENT)))
+    for before_values in product(*(options for _, _, options in dimensions)):
+        candidate = dict(tool.annotations)
+        changes: list[dict[str, object]] = []
+        for (name, after, _), before in zip(dimensions, before_values, strict=True):
+            if before is _ABSENT:
+                candidate.pop(name, None)
+                rendered_before: object = "absent"
+            else:
+                candidate[name] = before
+                rendered_before = before
+            if before != after:
+                changes.append(
+                    {
+                        "annotation": name,
+                        "before": rendered_before,
+                        "after": after,
+                    }
+                )
+        if changes and tool_annotation_hash(candidate) == base_tool.hashes.annotations:
+            return changes
+    return []
+
+
+def _claim_signature(claims: Iterable[EffectClaim]) -> tuple[tuple[str, ...], ...]:
+    return tuple(
+        sorted(
+            (
+                claim.value,
+                claim.confidence,
+                claim.basis,
+                claim.source,
+                repr(sorted(claim.evidence.items())),
+            )
+            for claim in claims
+        )
+    )
+
+
+def _strongest_confidence(claims: Iterable[EffectClaim]) -> Confidence:
+    return max(
+        (claim.confidence for claim in claims),
+        key=confidence_rank,
+        default="low",
+    )
+
+
+def _finding_provenance(claims: Iterable[EffectClaim]) -> ProvenanceKind:
+    ordered = sorted(
+        claims,
+        key=lambda claim: (
+            claim.provenance_kind in {"keyword_heuristic", "regex_heuristic"},
+            -confidence_rank(claim.confidence),
+            claim.provenance_kind,
+        ),
+    )
+    return ordered[0].provenance_kind if ordered else "static_declaration"
+
+
+def _basis_phrase(bases: list[str]) -> str:
+    labels = [_EFFECT_BASIS_LABELS.get(basis, basis.replace("_", " ")) for basis in bases]
+    if len(labels) == 1:
+        return labels[0]
+    if len(labels) == 2:
+        return f"{labels[0]} and {labels[1]}"
+    return f"{', '.join(labels[:-1])}, and {labels[-1]}"
 
 
 def _env_secret_findings(

--- a/src/agents_shipgate/cli/mcp.py
+++ b/src/agents_shipgate/cli/mcp.py
@@ -61,6 +61,11 @@ _COMPLETE_INPUT_DIAGNOSTICS: frozenset[str] = frozenset(
 )
 _DECISION_RANK = {"allow": 0, "warn": 1, "require_review": 2, "block": 3}
 _RISK_RANK = {"none": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+# `mcp audit` evaluates changed host/config capability rows. Full-scan semantic
+# checks that need normalized tool claims — notably
+# SHIP-MCP-ANNOTATION-CONTRADICTION — intentionally live in
+# `checks/mcp_permissions.py` only. Duplicating them here and in the audit policy
+# would create two evidence and release-accounting implementations.
 _RULES: dict[str, dict[str, str]] = {
     "MCP-ENV-SECRET-PASSTHROUGH": {
         "check_id": "SHIP-MCP-ENV-SECRET-PASSTHROUGH",

--- a/src/agents_shipgate/cli/scan/decision.py
+++ b/src/agents_shipgate/cli/scan/decision.py
@@ -173,12 +173,14 @@ def _run_checks_and_decide(
         )
     )
     findings = dedupe_findings(findings)
+    catalog = check_catalog(plugins_enabled=plugins_enabled)
+    catalog_by_id = {metadata.id: metadata for metadata in catalog}
     labels = catalog_label_index(tools_and_agent.tool_catalog)
-    policy_eligible_findings = []
+    retained_findings = []
     for finding in findings:
         support = finding.support
         if support is None or support.policy_eligible:
-            policy_eligible_findings.append(finding)
+            retained_findings.append(finding)
             continue
         source = finding.policy_evidence_source or finding.source
         context.policy_evidence_gaps.append(
@@ -196,12 +198,18 @@ def _run_checks_and_decide(
                 ),
             )
         )
-    findings = policy_eligible_findings
+        metadata = catalog_by_id.get(finding.check_id)
+        if metadata is not None and metadata.publish_when_policy_ineligible:
+            # The finding remains explicitly non-policy-eligible. Keeping it
+            # here publishes its observer-facing evidence; release_decision's
+            # support guard still prevents it becoming a blocker or named
+            # policy review item.
+            retained_findings.append(finding)
+    findings = retained_findings
     # v0.17 (M1) + v0.18 (PR #1): centralized aggregator covers every
     # catalog check with ``dynamic_default=True``. See
     # ``core/dynamic_defaults.py`` and ``severity_overrides.py`` for the
     # tier-crossing / floor-enforcement contract.
-    catalog = check_catalog(plugins_enabled=plugins_enabled)
     effective_dynamic_defaults = dynamic_check_defaults(
         manifest, inputs.policy_packs, catalog=catalog
     )

--- a/src/agents_shipgate/core/findings/remediation.py
+++ b/src/agents_shipgate/core/findings/remediation.py
@@ -40,6 +40,10 @@ def annotate_remediation(
       entry, with the safe-closed fallback for unknown check IDs.
     - ``docs_url`` is always sourced from CheckMetadata (or None for
       unknown check IDs). Patches don't carry per-instance doc URLs.
+    - A finding retained solely because its catalog entry opts into
+      ``publish_when_policy_ineligible`` is informational for remediation.
+      Its unsupported evidence may still produce an evidence gap, but the
+      finding itself cannot create a second human-review route.
 
     Caller (`scan.run_scan`) builds the metadata lookup from the
     catalog with the scan's actual ``plugins_enabled`` setting, so this
@@ -94,6 +98,22 @@ def annotate_remediation(
         if meta is not None and meta.requires_human_review_regardless_of_patch:
             autofix_safe = False
             requires_human_review = True
+
+        # A catalog check may deliberately publish an observer-facing finding
+        # even when this particular instance has only policy-ineligible
+        # evidence. That instance must stay informational everywhere: the
+        # release-decision support guard already excludes it from gates, and
+        # the agent summary must not reintroduce a human-review obligation via
+        # catalog-level remediation defaults that describe supported instances.
+        if (
+            meta is not None
+            and meta.publish_when_policy_ineligible
+            and finding.support is not None
+            and not finding.support.policy_eligible
+        ):
+            autofix_safe = False
+            requires_human_review = False
+            suggested_patch_kind = "none"
 
         finding.autofix_safe = autofix_safe
         finding.requires_human_review = requires_human_review

--- a/src/agents_shipgate/core/lenses/tool_surface.py
+++ b/src/agents_shipgate/core/lenses/tool_surface.py
@@ -343,11 +343,17 @@ def _tool_facts(tools: list[Tool]) -> list[ToolSurfaceToolFact]:
                 input_schema=_stable_hash(tool.input_schema),
                 output_schema=_stable_hash(tool.output_schema),
                 parameters=_stable_hash(_parameter_facts(tool)),
-                annotations=_stable_hash(tool.annotations),
+                annotations=tool_annotation_hash(tool.annotations),
             ),
         )
         for tool in sorted(tools, key=lambda item: item.id)
     ]
+
+
+def tool_annotation_hash(annotations: dict[str, Any]) -> str:
+    """Hash the public MCP/tool annotation map exactly as surface facts do."""
+
+    return _stable_hash(annotations)
 
 
 def _parameter_facts(tool: Tool) -> list[dict[str, Any]]:

--- a/src/agents_shipgate/core/lenses/tool_surface.py
+++ b/src/agents_shipgate/core/lenses/tool_surface.py
@@ -351,9 +351,18 @@ def _tool_facts(tools: list[Tool]) -> list[ToolSurfaceToolFact]:
 
 
 def tool_annotation_hash(annotations: dict[str, Any]) -> str:
-    """Hash the public MCP/tool annotation map exactly as surface facts do."""
+    """Hash the complete public MCP/tool annotation map without evidence filtering.
 
-    return _stable_hash(annotations)
+    ``_stable_hash`` intentionally reuses the finding-fingerprint
+    canonicalizer, which drops finding-only keys and normalizes list order.
+    Annotation delta proof needs byte-semantic map identity instead: a key the
+    fingerprint path ignores is still something an MCP client can consume.
+    Keep the legacy JSON rendering for common maps so only values the old
+    canonicalizer changed receive a different hash.
+    """
+
+    payload = json.dumps(annotations, sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 def _parameter_facts(tool: Tool) -> list[dict[str, Any]]:

--- a/src/agents_shipgate/schemas/checks.py
+++ b/src/agents_shipgate/schemas/checks.py
@@ -46,6 +46,14 @@ class CheckMetadata(BaseModel):
     # non-manual patch must not auto-apply without explicit human review.
     # In-process only (not serialised in ``report.json``).
     requires_human_review_regardless_of_patch: bool = False
+    # Advisory observer findings can be worth publishing even when their
+    # predicate support is intentionally too weak for release policy. The scan
+    # still emits an evidence gap and release_decision still excludes the
+    # finding through ``support.policy_eligible=False``; this flag only keeps
+    # the detailed finding in ``report.findings`` so its non-gating audience
+    # does not lose the evidence. In-process routing metadata, not catalog
+    # wire surface.
+    publish_when_policy_ineligible: bool = Field(default=False, exclude=True)
     # v0.17 (M1 + M5): hard severity floor used by two callers.
     # M1 (manifest-side): ``checks.severity_overrides`` cannot resolve
     # to a weaker severity than ``floor_severity``; the resolver raises

--- a/tests/test_mcp_permissions.py
+++ b/tests/test_mcp_permissions.py
@@ -318,3 +318,52 @@ def test_destructive_hint_only_delta_names_absent_to_false_flip() -> None:
             "after": False,
         }
     ]
+
+
+def test_delta_requires_only_the_contradicting_hint_to_change() -> None:
+    manifest = _manifest()
+    base_tool = _assessed(
+        _mcp_tool(name="update_account", annotations={"httpMethod": "POST"}),
+        manifest=manifest,
+    )
+    base_action_facts = build_action_surface_facts(
+        manifest,
+        agent_id="agent:mcp",
+        tools=[base_tool],
+    )
+    base_tool_facts = build_tool_surface_facts(
+        manifest,
+        [base_tool],
+        [],
+        None,
+        None,
+    )
+    head_tool = _assessed(
+        _mcp_tool(
+            name="update_account",
+            annotations={
+                "httpMethod": "POST",
+                "readOnlyHint": True,
+                "destructiveHint": False,
+            },
+        ),
+        manifest=manifest,
+    )
+
+    findings = mcp_permissions.run(
+        _context(
+            tool=head_tool,
+            manifest=manifest,
+            diff_reference=ToolSurfaceDiffReference(
+                kind="report",
+                facts=base_tool_facts,
+                action_facts=base_action_facts,
+            ),
+        )
+    )
+
+    [finding] = [item for item in findings if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"]
+    assert finding.evidence["published_annotations"] == {"readOnlyHint": True}
+    assert finding.evidence["form"] == "static"
+    assert finding.evidence["annotation_changes"] == []
+    assert finding.evidence["independent_evidence_unchanged"] is False

--- a/tests/test_mcp_permissions.py
+++ b/tests/test_mcp_permissions.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 
 from agents_shipgate.checks import mcp_permissions
+from agents_shipgate.core import risk_hints
+from agents_shipgate.core.adopter_text import internal_vocabulary
 from agents_shipgate.core.context import ScanContext
-from agents_shipgate.core.domain import Agent, Tool
+from agents_shipgate.core.domain import Agent, AuthInfo, Tool
 from agents_shipgate.core.lenses.action_surface import build_action_surface_facts
-from agents_shipgate.core.lenses.tool_surface import ToolSurfaceDiffReference
-from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.core.lenses.tool_surface import (
+    ToolSurfaceDiffReference,
+    build_tool_surface_facts,
+)
+from agents_shipgate.core.semantic_assessment import assess_tool_semantics
+from agents_shipgate.schemas.manifest import ActionDeclarationConfig, AgentsShipgateManifest
 from agents_shipgate.schemas.surfaces import ActionSurfaceFacts
 
 
@@ -38,9 +44,14 @@ def _read_only_docs_tool() -> Tool:
     )
 
 
-def _context(*, diff_reference: ToolSurfaceDiffReference | None) -> ScanContext:
-    manifest = _manifest()
-    tool = _read_only_docs_tool()
+def _context(
+    *,
+    diff_reference: ToolSurfaceDiffReference | None,
+    tool: Tool | None = None,
+    manifest: AgentsShipgateManifest | None = None,
+) -> ScanContext:
+    manifest = manifest or _manifest()
+    tool = tool or _read_only_docs_tool()
     action_facts = build_action_surface_facts(
         manifest,
         agent_id="agent:mcp",
@@ -54,6 +65,38 @@ def _context(*, diff_reference: ToolSurfaceDiffReference | None) -> ScanContext:
         action_surface_facts=action_facts,
         diff_reference=diff_reference,
     )
+
+
+def _mcp_tool(
+    *,
+    name: str = "delete_account",
+    annotations: dict[str, object] | None = None,
+    auth_scopes: list[str] | None = None,
+) -> Tool:
+    return Tool(
+        id=f"tool:{name}",
+        name=name,
+        source_type="mcp",
+        source_id="mcp-tools",
+        source_ref="tools.json",
+        source_path="tools.json",
+        source_start_line=2,
+        source_pointer="/tools/0",
+        annotations=annotations or {},
+        auth=AuthInfo(scopes=auth_scopes or []),
+        extraction_confidence="high",
+        extraction={"surface": "enumerated"},
+    )
+
+
+def _assessed(
+    tool: Tool,
+    manifest: AgentsShipgateManifest | None = None,
+    declaration: ActionDeclarationConfig | None = None,
+) -> Tool:
+    [enriched] = risk_hints.enrich_tools_with_risk_hints(manifest or _manifest(), [tool])
+    enriched.semantic_assessment = assess_tool_semantics(enriched, declaration)
+    return enriched
 
 
 def test_read_only_server_added_is_quiet_without_diff_reference() -> None:
@@ -73,6 +116,205 @@ def test_read_only_server_added_warns_against_empty_diff_reference() -> None:
         )
     )
 
-    assert [finding.check_id for finding in findings] == [
-        "SHIP-MCP-READONLY-SERVER-ADDED"
+    assert [finding.check_id for finding in findings] == ["SHIP-MCP-READONLY-SERVER-ADDED"]
+
+
+def test_read_only_hint_contradicting_inferred_destructive_evidence_is_reported() -> None:
+    tool = _assessed(_mcp_tool(annotations={"readOnlyHint": True}))
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    [finding] = [item for item in findings if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"]
+    assert finding.severity == "high"
+    assert finding.confidence == "medium"
+    assert finding.provenance_kind == "keyword_heuristic"
+    assert finding.source.path == "tools.json"
+    assert finding.source.pointer == "/tools/0"
+    assert finding.evidence["form"] == "static"
+    assert finding.evidence["published_annotations"] == {"readOnlyHint": True}
+    assert finding.evidence["independent_evidence"] == [
+        {
+            "effect": "destructive",
+            "confidence": "medium",
+            "basis": "inferred_keyword",
+            "source": "risk_hint:keyword",
+            "source_pointer": "/tools/0",
+            "details": {"tag": "destructive", "hint_source": "keyword"},
+        }
+    ]
+    assert "inferred keyword evidence" in finding.recommendation
+    assert "MCP clients" in finding.recommendation
+    assert internal_vocabulary(f"{finding.title} {finding.recommendation}") == ()
+
+
+def test_missing_annotations_are_not_a_contradiction() -> None:
+    tool = _assessed(_mcp_tool())
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {finding.check_id for finding in findings}
+
+
+def test_explicit_destructive_false_contradicts_structural_delete_evidence() -> None:
+    tool = _assessed(
+        _mcp_tool(
+            name="archive_account",
+            annotations={"destructiveHint": False},
+            auth_scopes=["accounts:delete"],
+        )
+    )
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    [finding] = [item for item in findings if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"]
+    assert finding.confidence == "high"
+    assert finding.provenance_kind == "static_declaration"
+    assert finding.evidence["published_annotations"] == {"destructiveHint": False}
+    assert {row["basis"] for row in finding.evidence["independent_evidence"]} == {
+        "structural_scope",
+    }
+
+
+def test_absent_destructive_hint_is_not_a_contradiction() -> None:
+    tool = _assessed(_mcp_tool(name="archive_account", auth_scopes=["accounts:delete"]))
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {finding.check_id for finding in findings}
+
+
+def test_read_only_hint_with_read_only_evidence_is_not_a_contradiction() -> None:
+    tool = _assessed(
+        _mcp_tool(
+            name="get_account",
+            annotations={"readOnlyHint": True, "httpMethod": "GET"},
+        )
+    )
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {finding.check_id for finding in findings}
+
+
+def test_internal_source_trust_does_not_silence_published_contradiction() -> None:
+    manifest = _manifest()
+    manifest.tool_sources[0].trust = "internal"
+    tool = _assessed(_mcp_tool(annotations={"readOnlyHint": True}), manifest=manifest)
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool, manifest=manifest))
+
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" in {finding.check_id for finding in findings}
+
+
+def test_reviewed_override_silences_only_the_inferred_evidence_it_answers() -> None:
+    declaration = ActionDeclarationConfig.model_validate(
+        {
+            "tool": "delete_account",
+            "effect": "read",
+            "override": {
+                "evidence": "The handler only searches archived account records.",
+                "reason": "The historical name no longer describes a delete operation.",
+            },
+        }
+    )
+    tool = _assessed(
+        _mcp_tool(annotations={"readOnlyHint": True}),
+        declaration=declaration,
+    )
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {
+        finding.check_id for finding in findings
+    }
+
+
+def test_hint_only_delta_names_flip_and_unchanged_independent_evidence() -> None:
+    manifest = _manifest()
+    base_tool = _assessed(_mcp_tool(), manifest=manifest)
+    base_facts = build_action_surface_facts(
+        manifest,
+        agent_id="agent:mcp",
+        tools=[base_tool],
+    )
+    base_tool_facts = build_tool_surface_facts(
+        manifest,
+        [base_tool],
+        [],
+        None,
+        None,
+    )
+    head_tool = _assessed(_mcp_tool(annotations={"readOnlyHint": True}), manifest=manifest)
+
+    findings = mcp_permissions.run(
+        _context(
+            tool=head_tool,
+            manifest=manifest,
+            diff_reference=ToolSurfaceDiffReference(
+                kind="report",
+                facts=base_tool_facts,
+                action_facts=base_facts,
+            ),
+        )
+    )
+
+    [finding] = [item for item in findings if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"]
+    assert finding.evidence["form"] == "delta"
+    assert finding.evidence["annotation_changes"] == [
+        {
+            "annotation": "readOnlyHint",
+            "before": "absent",
+            "after": True,
+        }
+    ]
+    assert finding.evidence["independent_evidence_unchanged"] is True
+
+
+def test_destructive_hint_only_delta_names_absent_to_false_flip() -> None:
+    manifest = _manifest()
+    base_tool = _assessed(
+        _mcp_tool(name="archive_account", auth_scopes=["accounts:delete"]),
+        manifest=manifest,
+    )
+    base_action_facts = build_action_surface_facts(
+        manifest,
+        agent_id="agent:mcp",
+        tools=[base_tool],
+    )
+    base_tool_facts = build_tool_surface_facts(
+        manifest,
+        [base_tool],
+        [],
+        None,
+        None,
+    )
+    head_tool = _assessed(
+        _mcp_tool(
+            name="archive_account",
+            annotations={"destructiveHint": False},
+            auth_scopes=["accounts:delete"],
+        ),
+        manifest=manifest,
+    )
+
+    findings = mcp_permissions.run(
+        _context(
+            tool=head_tool,
+            manifest=manifest,
+            diff_reference=ToolSurfaceDiffReference(
+                kind="report",
+                facts=base_tool_facts,
+                action_facts=base_action_facts,
+            ),
+        )
+    )
+
+    [finding] = [item for item in findings if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"]
+    assert finding.evidence["form"] == "delta"
+    assert finding.evidence["annotation_changes"] == [
+        {
+            "annotation": "destructiveHint",
+            "before": "absent",
+            "after": False,
+        }
     ]

--- a/tests/test_mcp_permissions.py
+++ b/tests/test_mcp_permissions.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pytest
+
 from agents_shipgate.checks import mcp_permissions
+from agents_shipgate.cli.scan import run_scan
 from agents_shipgate.core import risk_hints
 from agents_shipgate.core.adopter_text import internal_vocabulary
 from agents_shipgate.core.context import ScanContext
@@ -11,6 +15,7 @@ from agents_shipgate.core.lenses.action_surface import build_action_surface_fact
 from agents_shipgate.core.lenses.tool_surface import (
     ToolSurfaceDiffReference,
     build_tool_surface_facts,
+    tool_annotation_hash,
 )
 from agents_shipgate.core.semantic_assessment import assess_tool_semantics
 from agents_shipgate.schemas.manifest import ActionDeclarationConfig, AgentsShipgateManifest
@@ -70,12 +75,14 @@ def _context(
 def _mcp_tool(
     *,
     name: str = "delete_account",
+    description: str | None = None,
     annotations: dict[str, object] | None = None,
     auth_scopes: list[str] | None = None,
 ) -> Tool:
     return Tool(
         id=f"tool:{name}",
         name=name,
+        description=description,
         source_type="mcp",
         source_id="mcp-tools",
         source_ref="tools.json",
@@ -86,7 +93,56 @@ def _mcp_tool(
         auth=AuthInfo(scopes=auth_scopes or []),
         extraction_confidence="high",
         extraction={"surface": "enumerated"},
+        configured_source_ids=["mcp-tools"],
     )
+
+
+def _write_mcp_workspace(
+    tmp_path: Path,
+    *,
+    tool: dict[str, object],
+    trust: str | None = None,
+) -> Path:
+    tool_payload = dict(tool)
+    tool_payload.setdefault(
+        "inputSchema",
+        {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    )
+    trust_line = f"    trust: {trust}\n" if trust is not None else ""
+    config = tmp_path / "shipgate.yaml"
+    config.write_text(
+        """version: "0.1"
+project:
+  name: mcp-annotation-test
+agent:
+  name: mcp-agent
+  declared_purpose:
+    - publish and review an MCP tool surface
+environment:
+  target: local
+tool_sources:
+  - id: mcp-tools
+    type: mcp
+    path: tools.json
+    binding:
+      complete: true
+      reason: Reviewed test fixture binding for the complete published MCP surface.
+"""
+        + trust_line
+        + """ci:
+  mode: advisory
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "tools.json").write_text(
+        json.dumps({"tools": [tool_payload]}),
+        encoding="utf-8",
+    )
+    return config
 
 
 def _assessed(
@@ -131,6 +187,8 @@ def test_read_only_hint_contradicting_inferred_destructive_evidence_is_reported(
     assert finding.source.path == "tools.json"
     assert finding.source.pointer == "/tools/0"
     assert finding.evidence["form"] == "static"
+    assert finding.evidence["annotation_surface_changed"] is None
+    assert finding.evidence["independent_evidence_unchanged"] is None
     assert finding.evidence["published_annotations"] == {"readOnlyHint": True}
     assert finding.evidence["independent_evidence"] == [
         {
@@ -145,6 +203,65 @@ def test_read_only_hint_contradicting_inferred_destructive_evidence_is_reported(
     assert "inferred keyword evidence" in finding.recommendation
     assert "MCP clients" in finding.recommendation
     assert internal_vocabulary(f"{finding.title} {finding.recommendation}") == ()
+
+
+def test_scan_keeps_keyword_only_annotation_contradiction_visible_and_non_gating(
+    tmp_path: Path,
+) -> None:
+    config = _write_mcp_workspace(
+        tmp_path,
+        tool={
+            "name": "delete_account",
+            "description": "Remove a customer account.",
+            "annotations": {"readOnlyHint": True},
+        },
+    )
+
+    report, exit_code = run_scan(
+        config_path=config,
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=False,
+    )
+
+    assert exit_code == 0
+    [finding] = [
+        item
+        for item in report.findings
+        if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"
+    ]
+    assert finding.evidence["published_annotations"] == {"readOnlyHint": True}
+    assert finding.evidence["independent_evidence"][0]["basis"] == "inferred_keyword"
+    assert finding.evidence["independent_evidence"][0]["source"] == "risk_hint:keyword"
+    assert "MCP clients" in finding.evidence["client_consequence"]
+    assert finding.support is not None
+    assert finding.support.policy_eligible is False
+    assert finding.blocks_release is False
+    assert finding.requires_human_review is False
+    assert finding.suggested_patch_kind == "none"
+    assert finding.agent_action == "informational"
+    assert report.release_decision is not None
+    assert not any(
+        item.check_id == finding.check_id
+        for item in [
+            *report.release_decision.blockers,
+            *report.release_decision.review_items,
+        ]
+    )
+    rule = next(
+        item
+        for item in report.release_decision.contribution_rules
+        if item.check_id == finding.check_id
+    )
+    assert (rule.category, rule.rule) == ("excluded", "unsupported_evidence")
+    assert any(
+        gap.kind == "inferred_policy_applicability"
+        and finding.check_id in gap.why
+        for gap in report.policy_evidence_gaps
+    )
+    assert report.agent_summary is not None
+    assert report.agent_summary.needs_human_review == 0
 
 
 def test_missing_annotations_are_not_a_contradiction() -> None:
@@ -183,27 +300,122 @@ def test_absent_destructive_hint_is_not_a_contradiction() -> None:
     assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {finding.check_id for finding in findings}
 
 
-def test_read_only_hint_with_read_only_evidence_is_not_a_contradiction() -> None:
+@pytest.mark.parametrize(
+    ("name", "description"),
+    [
+        ("get_account", "Fetch an account record before you delete it."),
+        ("search_audit_log", "Search the audit log for remove events."),
+    ],
+)
+def test_structural_read_evidence_outweighs_inferred_destructive_keyword(
+    name: str,
+    description: str,
+) -> None:
     tool = _assessed(
         _mcp_tool(
-            name="get_account",
+            name=name,
+            description=description,
             annotations={"readOnlyHint": True, "httpMethod": "GET"},
         )
     )
+
+    claims = {
+        (claim.value, claim.confidence, claim.basis, claim.source)
+        for claim in tool.semantic_assessment.effect.claims
+    }
+    assert ("read", "high", "protocol_structure", "openapi_method") in claims
+    assert (
+        "destructive",
+        "medium",
+        "inferred_keyword",
+        "risk_hint:keyword",
+    ) in claims
 
     findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
 
     assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {finding.check_id for finding in findings}
 
 
-def test_internal_source_trust_does_not_silence_published_contradiction() -> None:
-    manifest = _manifest()
-    manifest.tool_sources[0].trust = "internal"
-    tool = _assessed(_mcp_tool(annotations={"readOnlyHint": True}), manifest=manifest)
+def test_structural_read_evidence_supports_explicit_non_destructive_hint() -> None:
+    tool = _assessed(
+        _mcp_tool(
+            name="search_accounts",
+            description="Search account records before you remove one.",
+            annotations={"destructiveHint": False, "httpMethod": "GET"},
+        )
+    )
 
-    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool, manifest=manifest))
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
 
-    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" in {finding.check_id for finding in findings}
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {
+        finding.check_id for finding in findings
+    }
+
+
+def test_structural_side_effect_still_contradicts_structural_read_evidence() -> None:
+    tool = _assessed(
+        _mcp_tool(
+            name="get_account",
+            description="Fetch an account record before you delete it.",
+            annotations={"readOnlyHint": True, "httpMethod": "GET"},
+            auth_scopes=["accounts:delete"],
+        )
+    )
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    [finding] = [
+        item
+        for item in findings
+        if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"
+    ]
+    assert any(
+        row["effect"] == "destructive"
+        and row["confidence"] == "high"
+        and row["basis"] == "structural_scope"
+        and row["source"] == "auth_scope"
+        for row in finding.evidence["independent_evidence"]
+    )
+    assert (
+        "against structural server auth scope evidence and inferred keyword evidence"
+        in finding.recommendation
+    )
+    assert "declared scope evidence" not in finding.recommendation
+
+
+@pytest.mark.parametrize("trust", [None, "internal", "external", "untrusted"])
+def test_scan_source_trust_does_not_silence_annotation_contradiction(
+    tmp_path: Path,
+    trust: str | None,
+) -> None:
+    config = _write_mcp_workspace(
+        tmp_path,
+        trust=trust,
+        tool={
+            "name": "archive_account",
+            "annotations": {"readOnlyHint": True},
+            "auth": {"scopes": ["accounts:delete"]},
+        },
+    )
+
+    report, _exit_code = run_scan(
+        config_path=config,
+        output_dir=tmp_path / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=False,
+    )
+
+    [finding] = [
+        finding
+        for finding in report.findings
+        if finding.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"
+    ]
+    assert finding.source is not None
+    assert finding.source.ref == "tools.json"
+    assert any(
+        fact.source_id == "mcp-tools" for fact in report.tool_surface_facts.tools
+    )
 
 
 def test_reviewed_override_silences_only_the_inferred_evidence_it_answers() -> None:
@@ -224,6 +436,43 @@ def test_reviewed_override_silences_only_the_inferred_evidence_it_answers() -> N
 
     findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
 
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {
+        finding.check_id for finding in findings
+    }
+
+
+def test_reviewed_effect_declaration_is_not_independent_annotation_evidence() -> None:
+    declaration = ActionDeclarationConfig.model_validate(
+        {"tool": "perform_operation", "effect": "destructive"}
+    )
+    tool = _assessed(
+        _mcp_tool(
+            name="perform_operation",
+            annotations={"readOnlyHint": True},
+        ),
+        declaration=declaration,
+    )
+
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
+
+    assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {
+        finding.check_id for finding in findings
+    }
+
+
+def test_same_source_annotation_conflict_stays_in_semantic_evidence_gap() -> None:
+    tool = _assessed(
+        _mcp_tool(
+            name="perform_operation",
+            annotations={"readOnlyHint": True, "destructiveHint": True},
+        )
+    )
+
+    assert tool.semantic_assessment.effect.status == "conflicting"
+    assert "conflicting_effect_evidence" in {
+        issue.kind for issue in tool.semantic_assessment.effect.issues
+    }
+    findings = mcp_permissions.run(_context(diff_reference=None, tool=tool))
     assert "SHIP-MCP-ANNOTATION-CONTRADICTION" not in {
         finding.check_id for finding in findings
     }
@@ -267,6 +516,7 @@ def test_hint_only_delta_names_flip_and_unchanged_independent_evidence() -> None
             "after": True,
         }
     ]
+    assert finding.evidence["annotation_surface_changed"] is True
     assert finding.evidence["independent_evidence_unchanged"] is True
 
 
@@ -318,9 +568,11 @@ def test_destructive_hint_only_delta_names_absent_to_false_flip() -> None:
             "after": False,
         }
     ]
+    assert finding.evidence["annotation_surface_changed"] is True
+    assert finding.evidence["independent_evidence_unchanged"] is True
 
 
-def test_delta_requires_only_the_contradicting_hint_to_change() -> None:
+def test_cochanged_annotation_reports_unchanged_evidence_without_exact_delta() -> None:
     manifest = _manifest()
     base_tool = _assessed(
         _mcp_tool(name="update_account", annotations={"httpMethod": "POST"}),
@@ -344,7 +596,7 @@ def test_delta_requires_only_the_contradicting_hint_to_change() -> None:
             annotations={
                 "httpMethod": "POST",
                 "readOnlyHint": True,
-                "destructiveHint": False,
+                "title": "Update account",
             },
         ),
         manifest=manifest,
@@ -366,4 +618,69 @@ def test_delta_requires_only_the_contradicting_hint_to_change() -> None:
     assert finding.evidence["published_annotations"] == {"readOnlyHint": True}
     assert finding.evidence["form"] == "static"
     assert finding.evidence["annotation_changes"] == []
+    assert finding.evidence["annotation_surface_changed"] is True
+    assert finding.evidence["independent_evidence_unchanged"] is True
+
+
+def test_changed_independent_evidence_is_not_reported_as_unchanged() -> None:
+    manifest = _manifest()
+    base_tool = _assessed(
+        _mcp_tool(
+            name="perform_operation",
+            auth_scopes=["accounts:write"],
+        ),
+        manifest=manifest,
+    )
+    base_action_facts = build_action_surface_facts(
+        manifest,
+        agent_id="agent:mcp",
+        tools=[base_tool],
+    )
+    base_tool_facts = build_tool_surface_facts(
+        manifest,
+        [base_tool],
+        [],
+        None,
+        None,
+    )
+    head_tool = _assessed(
+        _mcp_tool(
+            name="perform_operation",
+            annotations={"readOnlyHint": True},
+            auth_scopes=["accounts:delete"],
+        ),
+        manifest=manifest,
+    )
+
+    findings = mcp_permissions.run(
+        _context(
+            tool=head_tool,
+            manifest=manifest,
+            diff_reference=ToolSurfaceDiffReference(
+                kind="report",
+                facts=base_tool_facts,
+                action_facts=base_action_facts,
+            ),
+        )
+    )
+
+    [finding] = [
+        item
+        for item in findings
+        if item.check_id == "SHIP-MCP-ANNOTATION-CONTRADICTION"
+    ]
+    assert finding.evidence["form"] == "static"
+    assert finding.evidence["annotation_changes"] == []
+    assert finding.evidence["annotation_surface_changed"] is True
     assert finding.evidence["independent_evidence_unchanged"] is False
+
+
+def test_annotation_hash_preserves_client_visible_keys_and_list_order() -> None:
+    assert tool_annotation_hash({"observed": "a"}) != tool_annotation_hash(
+        {"observed": "b"}
+    )
+    assert tool_annotation_hash(
+        {"audience": ["user", "assistant"]}
+    ) != tool_annotation_hash(
+        {"audience": ["assistant", "user"]}
+    )


### PR DESCRIPTION
## Summary

- add the default-on review-tier SHIP-MCP-ANNOTATION-CONTRADICTION check for explicit narrowing MCP hints that conflict with independent structural or inferred evidence
- detect hint-only annotation flips against unchanged base evidence without changing the report schema
- preserve the trust boundary: source trust does not silence contradictions, while reviewed declaration overrides suppress only the exact evidence they answer
- document the check and cover static, delta, trust, override, absent-hint, and genuine-read-only cases

## Verification

- full non-performance suite passed (excluding packaging in the sandboxed run)
- packaging suite passed separately: 8 passed
- Ruff, compileall, generated-schema checks, and diff whitespace checks passed
- Agents Shipgate base-to-head verifier: control_state=complete, decision=passed

Fixes #462