### PR TITLE
Render cold-reader artifacts surface first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,31 @@
   multi-manifest console rows, `report.md`, GitHub step summaries, PR comments,
   and packet Markdown/HTML/PDF share that ordering. A cold run carrying any
   active block-tier content remains verdict-first, and committed-manifest
-  repositories retain their prior bytes and verdict-first order. Machine JSON,
-  schemas, contracts, and decision computation are unchanged.
+  repositories retain their prior bytes and verdict-first order. Cold reports
+  render the primary decision exactly once; adopted reports preserve the
+  pre-existing capability-consequence projection as part of their byte-stable
+  layout. Machine JSON, schemas, contracts, and decision computation are
+  unchanged.
+
+  The ordering is lossless: tool-surface and action/tool-diff detail still
+  appears below the decision. Compact packet finding lists share one bounded
+  truncation projection, write/destructive action names are capped with an
+  explicit omission count, and repository-owned names are display-encoded so
+  they cannot forge a decision line. PR comments consume the scan's exact
+  ephemeral repository context, including manifest introduction, rather than
+  re-probing or depending on report-evidence fallback.
 
   `samples/google_adk_cold_start_agent/expected/cold-report.md` is the committed
   first-contact golden: its test creates a Git repository whose agent sources
   are committed while `shipgate.yaml` is not, then byte-compares the rendered
   artifact. The same suite pins an empty repository, first-adoption verifier
-  output, packet ordering, exact-once decision rendering, the block-tier
+  output, packet ordering, cold exact-once decision rendering, the block-tier
   override, and adopted-sample byte stability.
+
+  This release covers report-backed scan and verify artifacts. `verify
+  --preview` remains a routing-only operation and produces no readiness report
+  to reorder; the local-review surface described in #326 is not implemented by
+  this change.
 
 - **The #424 repair loop is now pinned by a committed artifact.** (#424)
   `declaration_below_inferred_evidence` publishes a `declare_risk_tags` route,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **Cold-reader artifacts now lead with what the agent can do.** (#463) On a
+  repository with no committed Shipgate manifest, human output starts with the
+  root-reachable tool surface, its effect breakdown and write/destructive
+  action names; then shows a subject-grouped capability delta when one exists,
+  subject-grouped findings, and the unchanged release decision. Console,
+  multi-manifest console rows, `report.md`, GitHub step summaries, PR comments,
+  and packet Markdown/HTML/PDF share that ordering. A cold run carrying any
+  active block-tier content remains verdict-first, and committed-manifest
+  repositories retain their prior bytes and verdict-first order. Machine JSON,
+  schemas, contracts, and decision computation are unchanged.
+
+  `samples/google_adk_cold_start_agent/expected/cold-report.md` is the committed
+  first-contact golden: its test creates a Git repository whose agent sources
+  are committed while `shipgate.yaml` is not, then byte-compares the rendered
+  artifact. The same suite pins an empty repository, first-adoption verifier
+  output, packet ordering, exact-once decision rendering, the block-tier
+  override, and adopted-sample byte stability.
+
 - **The #424 repair loop is now pinned by a committed artifact.** (#424)
   `declaration_below_inferred_evidence` publishes a `declare_risk_tags` route,
   and every guard on it ran against tools built in-test — the same blind spot

--- a/samples/README.md
+++ b/samples/README.md
@@ -31,7 +31,7 @@ running a scan first:
 | [`simple_openai_api_agent`](simple_openai_api_agent/) | [`report.md`](simple_openai_api_agent/expected/report.md) | [`report.json`](simple_openai_api_agent/expected/report.json) |
 | [`simple_langchain_agent`](simple_langchain_agent/) | [`report.md`](simple_langchain_agent/expected/report.md) | [`report.json`](simple_langchain_agent/expected/report.json) |
 | [`conductor_agent`](conductor_agent/) | [`report.md`](conductor_agent/expected/report.md) | [`report.json`](conductor_agent/expected/report.json) |
-| [`google_adk_cold_start_agent`](google_adk_cold_start_agent/) | [`report.md`](google_adk_cold_start_agent/expected/report.md) | [`report.json`](google_adk_cold_start_agent/expected/report.json) |
+| [`google_adk_cold_start_agent`](google_adk_cold_start_agent/) | [`report.md`](google_adk_cold_start_agent/expected/report.md) ([cold first contact](google_adk_cold_start_agent/expected/cold-report.md)) | [`report.json`](google_adk_cold_start_agent/expected/report.json) |
 | [`declaration_repair_agent`](declaration_repair_agent/) | [`report.md`](declaration_repair_agent/expected/report.md) | [`report.json`](declaration_repair_agent/expected/report.json) |
 
 Two samples stop with **open declaration questions**, so they are the two that
@@ -43,7 +43,8 @@ edit — as a byte-compared golden. They render the two halves of that file:
   challenged authority row printed as a note. The fixture exists to pin the
   order the questions are asked in. Read the diff before regenerating it: a
   change in block *order* is a change in which question this tool asks a human
-  first.
+  first. Its own [README](google_adk_cold_start_agent/README.md) documents the
+  [cold-report regeneration procedure](google_adk_cold_start_agent/README.md#regenerating-the-cold-report).
 - [`declaration_repair_agent`](declaration_repair_agent/expected/suggested-declarations.yaml)
   is the step after, and adds the one shape the cold start has no example of: a
   declaration challenged in the **effect** dimension, whose repair is a

--- a/samples/google_adk_cold_start_agent/README.md
+++ b/samples/google_adk_cold_start_agent/README.md
@@ -6,7 +6,12 @@ nothing open — so a scan of it writes no `suggested-declarations.yaml` at all
 and no committed artifact beside it ever renders one. This fixture stops
 partway on purpose: it reaches `insufficient_evidence` with **ten open
 declaration questions**, and ships the questionnaire an adopter actually reads
-as a byte-compared golden.
+as a byte-compared golden. It also ships
+[`expected/cold-report.md`](expected/cold-report.md), rendered from a temporary
+Git repository where the agent sources are committed and `shipgate.yaml` is
+not, to pin the surface-first first-contact order from #463. The ordinary
+[`expected/report.md`](expected/report.md) remains the committed-manifest,
+verdict-first golden.
 
 For the step after this one, see
 [`declaration_repair_agent`](../declaration_repair_agent/): a manifest that has

--- a/samples/google_adk_cold_start_agent/README.md
+++ b/samples/google_adk_cold_start_agent/README.md
@@ -156,6 +156,57 @@ for name in ("report.md", "suggested-declarations.yaml"):
 PY
 ```
 
+### Regenerating the cold report
+
+`expected/cold-report.md` comes from a different repository state than the
+ordinary goldens: the agent sources are committed, while `shipgate.yaml`
+exists only in the worktree. Recreate that state in a temporary repository;
+running the ordinary recipe above cannot produce the cold-reader order.
+
+```bash
+python - <<'PY'
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from agents_shipgate.cli.scan import run_scan
+
+source = Path("samples/google_adk_cold_start_agent").resolve()
+golden = source / "expected" / "cold-report.md"
+
+with tempfile.TemporaryDirectory(prefix="shipgate-cold-golden-") as temp:
+    repo = Path(temp) / "repo"
+    shutil.copytree(source, repo, ignore=shutil.ignore_patterns("expected"))
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q")
+    git("config", "user.name", "Shipgate Golden")
+    git("config", "user.email", "shipgate@example.invalid")
+    git("add", "agent.py", "inventories", "specs")
+    git("commit", "-qm", "base without manifest")
+
+    out = repo / "reports"
+    run_scan(
+        config_path=repo / "shipgate.yaml",
+        output_dir=out,
+        formats=["markdown", "json"],
+        ci_mode="advisory",
+    )
+    golden.write_text(
+        (out / "report.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+        newline="\n",
+    )
+PY
+```
+
 Four things that look like details and are not.
 
 **Newlines are forced, not inherited.** `Path.write_text(..., encoding="utf-8")`

--- a/samples/google_adk_cold_start_agent/expected/cold-report.md
+++ b/samples/google_adk_cold_start_agent/expected/cold-report.md
@@ -1,0 +1,140 @@
+# Agents Shipgate Report
+
+Project: google-adk-cold-start-agent
+Agent: adk-ops-agent
+Target: production\_like
+
+See `packet.md` for the reviewer-shaped Release Evidence Packet.
+
+## Capability Surface
+
+Surface: 9 tools from 3 sources.
+Effects: 1 read, 7 write, 1 financial write.
+Write/destructive actions: issue\_goodwill\_refund \(financial write\), assemble\_case\_timeline \(write\), list\_case\_attachments \(write\), ops.append\_case\_note \(write\), ops.export\_case\_bundle \(write\), ops.queue\_backfill \(write\), record\_case\_outcome \(write\), update\_case\_index \(write\).
+
+## Top Findings
+
+1 finding across 1 subject, most urgent first.
+
+- adk-ops-agent \(agent-wide\) \(at shipgate.yaml\) — review \(1 medium\)
+  - medium SHIP-ADK-EVAL-COVERAGE-MISSING — Google ADK eval coverage is not declared
+    - Declare ADK eval files that cover expected responses and tool-use trajectories for this release.
+
+## Release Decision
+
+Decision: insufficient_evidence
+Reason: Insufficient evidence: a tool source has no declared authority \(adk\_ops \[tool\_source\]\). Fix at shipgate.yaml\#tool\_sources\[id='adk\_ops'\].authority. Context: 10 semantic evidence gap\(s\); scan results are not trustworthy enough to gate release.
+
+Blockers (0): none
+
+Review items (1):
+- MEDIUM SHIP-ADK-EVAL-COVERAGE-MISSING — Google ADK eval coverage is not declared
+
+Evidence coverage: static (9/9 catalog tools reachable; 10 semantic evidence gap(s); 2/9 actions pass-eligible)
+
+Baseline delta: not enabled
+
+Fail policy: ci_mode=advisory, fail_on=[none], new_findings_only=false, would_fail_ci=false (exit 0)
+
+## Summary
+
+- Critical: 0
+- High: 0
+- Medium: 1
+- Low: 0
+- Suppressed: 0
+- Status: Warnings detected (legacy; see Release Decision above)
+
+## Finding Provenance
+
+Reviewer triage signal only. Provenance kind does not change severity, release decision, fingerprints, baselines, or CI exit codes.
+
+| Provenance kind | Active findings |
+| --- | ---: |
+| `static_declaration` | 1 |
+| `ast_extraction` | 0 |
+| `keyword_heuristic` | 0 |
+| `regex_heuristic` | 0 |
+| `policy_pack` | 0 |
+| `runtime_trace` | 0 |
+
+Suppressed findings excluded: 0
+
+## Capability <-> Intent Diff
+
+Agent intent:
+
+- declared\_purpose: review support cases and route refunds (tags: financial\_action)
+- instruction\_preview: Review support cases and route refunds for approval. (tags: financial\_action)
+
+Actual capabilities:
+
+- issue\_goodwill\_refund: capability=financial\_action, risk=financial\_action, control=present
+
+Policy/control gaps:
+
+- MEDIUM control\_missing: Google ADK eval coverage is not declared.
+  Requires: Production-like framework releases should declare eval coverage.
+  Release implication: Release lacks validation evidence for production-like ADK behavior.
+
+Release implication:
+
+- Static evidence is incomplete; capability/intent analysis may miss release-relevant signal — gather deeper sources before shipping.
+
+Next validation:
+
+- High-risk tool validation case: A declared test or review scenario covers the high-risk tool path.
+
+## Recommended Next Actions
+
+- Declare ADK eval files that cover expected responses and tool-use trajectories for this release.
+
+## Capability Runtime Evidence
+
+No local runtime trace artifacts were declared for capability evidence.
+
+## Google ADK Surface Summary
+
+- Python entrypoints: 1
+- Agent config files: 0
+- Agents: 1
+- Function tools: 5
+- Long-running tools: 0
+- Toolsets: 2
+- Dynamic or unresolved toolsets: 0
+- Callbacks: 0
+- Plugins: 0
+- Eval files: 0
+
+## Findings By Category
+
+### Adk
+
+- MEDIUM: SHIP-ADK-EVAL-COVERAGE-MISSING - Google ADK eval coverage is not declared
+
+## Agent Binding Surface
+
+Status: structural
+Root agent: adk\_ops\_agent \[adk\_ops\]
+Entry points: adk\_ops\_agent \[adk\_ops\]
+Pass eligible: true
+Catalog partition: 9 reachable, 0 possible, 0 unbound
+
+## Appendix: Root-Reachable Tool Inventory
+
+| Tool | Source | Risk Tags | Risk Confidence | Auth Scopes | Owner |
+| --- | --- | --- | --- | --- | --- |
+| assemble\_case\_timeline | google\_adk\_function | \- | \- | \- | \- |
+| support.get\_update\_history | mcp | read\_only | read\_only=high | \- | \- |
+| record\_case\_outcome | google\_adk\_function | \- | \- | \- | \- |
+| ops.append\_case\_note | openapi | write | write=high | \- | \- |
+| issue\_goodwill\_refund | google\_adk\_function | financial\_action | financial\_action=high | \- | \- |
+| list\_case\_attachments | google\_adk\_function | \- | \- | \- | \- |
+| ops.queue\_backfill | mcp | \- | \- | \- | \- |
+| update\_case\_index | google\_adk\_function | \- | \- | \- | \- |
+| ops.export\_case\_bundle | mcp | \- | \- | ops:cases:read | \- |
+
+
+## Disclaimer
+
+Agents Shipgate is an advisory tool: the deterministic merge gate for AI-generated agent capability changes, run as a local-first, static Tool-Use Readiness review. It does not certify agent safety or compliance. Findings are based on static configuration, declared policies, tool schemas, and optional SDK metadata. Runtime behavior, actual tool routing, and output interpretation are not verified.

--- a/samples/google_adk_cold_start_agent/expected/cold-report.md
+++ b/samples/google_adk_cold_start_agent/expected/cold-report.md
@@ -89,9 +89,27 @@ Next validation:
 
 - Declare ADK eval files that cover expected responses and tool-use trajectories for this release.
 
+## Tool Surface Summary
+
+- Total tools: 9
+- High-risk tools: 1
+- Wildcard tools: 0
+- Missing descriptions: 0
+- Sources: google_adk_function=5, mcp=3, openapi=1
+
+## Action Surface Diff
+
+- Status: disabled - No action-surface comparison source was provided.
+- Base: none
+
 ## Capability Runtime Evidence
 
 No local runtime trace artifacts were declared for capability evidence.
+
+## Tool Surface Diff
+
+- Status: disabled - No --diff-from report or v0.3 baseline snapshot was provided.
+- Base: none
 
 ## Google ADK Surface Summary
 

--- a/src/agents_shipgate/ci/github_summary.py
+++ b/src/agents_shipgate/ci/github_summary.py
@@ -76,7 +76,7 @@ def write_github_step_summary(
         lines.append(f"Policy audit: {' · '.join(parts)}.")
     diff = report.tool_surface_diff
     action_diff = report.action_surface_diff
-    if action_diff.enabled and not surface_first:
+    if action_diff.enabled:
         lines.extend(
             [
                 "",
@@ -92,9 +92,9 @@ def write_github_step_summary(
         )
         for item in _action_diff_highlights(report):
             lines.append(f"- {item}")
-    elif action_diff.notes and not surface_first:
+    elif action_diff.notes:
         lines.extend(["", f"Action-surface diff: {action_diff.notes[0]}"])
-    if diff.enabled and not surface_first:
+    if diff.enabled:
         lines.extend(
             [
                 "",
@@ -112,7 +112,7 @@ def write_github_step_summary(
         )
         for item in _diff_highlights(report):
             lines.append(f"- {item}")
-    elif diff.notes and not surface_first:
+    elif diff.notes:
         lines.extend(["", f"Tool-surface diff: {diff.notes[0]}"])
         if (
             diff.summary.new_findings

--- a/src/agents_shipgate/ci/github_summary.py
+++ b/src/agents_shipgate/ci/github_summary.py
@@ -4,7 +4,17 @@ import os
 from pathlib import Path
 
 from agents_shipgate.core.disclaimers import STATIC_VERDICT_DISCLAIMER
+from agents_shipgate.core.findings.subject_rollup import (
+    roll_up_findings,
+    top_findings_block,
+)
 from agents_shipgate.core.privacy import sanitize_report
+from agents_shipgate.report.human_order import (
+    HumanArtifactContext,
+    capability_delta_by_subject,
+    should_render_surface_first,
+    surface_lead,
+)
 from agents_shipgate.report.markdown import _safe_markdown_text
 from agents_shipgate.report.summary_text import (
     evidence_coverage_text,
@@ -13,71 +23,25 @@ from agents_shipgate.report.summary_text import (
 from agents_shipgate.schemas.report import ReadinessReport
 
 
-def write_github_step_summary(report: ReadinessReport) -> None:
+def write_github_step_summary(
+    report: ReadinessReport,
+    *,
+    human_context: HumanArtifactContext | None = None,
+) -> None:
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
         return
     report = sanitize_report(report)
     path = Path(summary_path)
     summary = report.summary
-    decision = report.release_decision
-    agent_summary = report.agent_summary
     reviewer_summary = report.reviewer_summary
     formats = ", ".join(sorted(report.generated_reports)) or "configured"
     lines = ["## Agents Shipgate", ""]
-    if decision is not None:
-        lines.extend(
-            [
-                f"Decision: `{decision.decision}`",
-                *(
-                    [f"Summary: {_safe_markdown_text(agent_summary.headline)}"]
-                    if agent_summary
-                    else []
-                ),
-                # The reason carries repository-derived text on an evidence
-                # verdict (a gap subject is a tool name or agent id), so it
-                # gets the same Markdown escaping report.md has always
-                # applied to it. Unescaped, a crafted tool name renders as
-                # markup in the step summary (#362 review).
-                f"Reason: {_safe_markdown_text(decision.reason)}",
-                (
-                    f"Blockers: {len(decision.blockers)} · "
-                    f"Review items: {len(decision.review_items)}"
-                ),
-                f"Evidence coverage: {evidence_coverage_text(decision.evidence_coverage)}",
-            ]
-        )
-        if decision.decision == "insufficient_evidence":
-            lines.append(
-                "Improve evidence: "
-                f"{_safe_markdown_text(primary_evidence_remediation_text(decision.evidence_coverage))}"
-            )
-        if agent_summary and agent_summary.first_recommended_action:
-            lines.append(_agent_next_action_line(agent_summary.first_recommended_action))
-        fp = decision.fail_policy
-        lines.append(
-            f"Fail policy: ci_mode=`{fp.ci_mode}`, "
-            f"would_fail_ci=`{str(fp.would_fail_ci).lower()}` "
-            f"(exit `{fp.exit_code}`)"
-        )
-        lines.append(f"Static-verdict boundary: {STATIC_VERDICT_DISCLAIMER}")
-    else:
-        # Defensive fallback for older reports loaded without
-        # release_decision (e.g., baselines from <v0.8).
-        lines.extend(
-            [
-                f"Status: `{summary.status}`",
-                (
-                    f"Critical: {summary.critical_count} · "
-                    f"High: {summary.high_count} · "
-                    f"Medium: {summary.medium_count}"
-                ),
-                (
-                    "Human review: "
-                    f"{'recommended' if summary.human_review_recommended else 'not required'}"
-                ),
-            ]
-        )
+    surface_first = should_render_surface_first(report, context=human_context)
+    decision_lines = _decision_lines(report)
+    if surface_first:
+        _append_cold_reader_lead(lines, report)
+    lines.extend(decision_lines)
     if reviewer_summary and reviewer_summary.first_recommended_surface:
         surface = reviewer_summary.first_recommended_surface
         lines.append(
@@ -112,7 +76,7 @@ def write_github_step_summary(report: ReadinessReport) -> None:
         lines.append(f"Policy audit: {' · '.join(parts)}.")
     diff = report.tool_surface_diff
     action_diff = report.action_surface_diff
-    if action_diff.enabled:
+    if action_diff.enabled and not surface_first:
         lines.extend(
             [
                 "",
@@ -128,9 +92,9 @@ def write_github_step_summary(report: ReadinessReport) -> None:
         )
         for item in _action_diff_highlights(report):
             lines.append(f"- {item}")
-    elif action_diff.notes:
+    elif action_diff.notes and not surface_first:
         lines.extend(["", f"Action-surface diff: {action_diff.notes[0]}"])
-    if diff.enabled:
+    if diff.enabled and not surface_first:
         lines.extend(
             [
                 "",
@@ -148,7 +112,7 @@ def write_github_step_summary(report: ReadinessReport) -> None:
         )
         for item in _diff_highlights(report):
             lines.append(f"- {item}")
-    elif diff.notes:
+    elif diff.notes and not surface_first:
         lines.extend(["", f"Tool-surface diff: {diff.notes[0]}"])
         if (
             diff.summary.new_findings
@@ -164,6 +128,75 @@ def write_github_step_summary(report: ReadinessReport) -> None:
     lines.extend(["", f"Generated reports: {formats}.", ""])
     with path.open("a", encoding="utf-8") as handle:
         handle.write("\n".join(lines))
+
+
+def _decision_lines(report: ReadinessReport) -> list[str]:
+    summary = report.summary
+    decision = report.release_decision
+    agent_summary = report.agent_summary
+    if decision is None:
+        # Defensive fallback for older reports loaded without
+        # release_decision (e.g., baselines from <v0.8).
+        return [
+            f"Status: `{summary.status}`",
+            (
+                f"Critical: {summary.critical_count} · "
+                f"High: {summary.high_count} · "
+                f"Medium: {summary.medium_count}"
+            ),
+            (
+                "Human review: "
+                f"{'recommended' if summary.human_review_recommended else 'not required'}"
+            ),
+        ]
+    lines = [
+        f"Decision: `{decision.decision}`",
+        *([f"Summary: {_safe_markdown_text(agent_summary.headline)}"] if agent_summary else []),
+        # The reason carries repository-derived text on an evidence verdict
+        # (a gap subject is a tool name or agent id), so it gets the same
+        # Markdown escaping report.md has always applied to it.
+        f"Reason: {_safe_markdown_text(decision.reason)}",
+        (f"Blockers: {len(decision.blockers)} · Review items: {len(decision.review_items)}"),
+        f"Evidence coverage: {evidence_coverage_text(decision.evidence_coverage)}",
+    ]
+    if decision.decision == "insufficient_evidence":
+        lines.append(
+            "Improve evidence: "
+            f"{_safe_markdown_text(primary_evidence_remediation_text(decision.evidence_coverage))}"
+        )
+    if agent_summary and agent_summary.first_recommended_action:
+        lines.append(_agent_next_action_line(agent_summary.first_recommended_action))
+    fp = decision.fail_policy
+    lines.append(
+        f"Fail policy: ci_mode=`{fp.ci_mode}`, "
+        f"would_fail_ci=`{str(fp.would_fail_ci).lower()}` "
+        f"(exit `{fp.exit_code}`)"
+    )
+    lines.append(f"Static-verdict boundary: {STATIC_VERDICT_DISCLAIMER}")
+    return lines
+
+
+def _append_cold_reader_lead(lines: list[str], report: ReadinessReport) -> None:
+    lines.append("### Capability surface")
+    for line in surface_lead(report).text_lines():
+        lines.append(_safe_markdown_text(line))
+    groups = capability_delta_by_subject(report)
+    if groups:
+        lines.extend(["", "### Capability delta by subject"])
+        for group in groups:
+            lines.append(f"- `{_safe_markdown_text(group.subject)}`")
+            for change in group.changes:
+                lines.append(f"  - {_safe_markdown_text(change)}")
+    finding_lines = top_findings_block(
+        roll_up_findings(report),
+        group_limit=4,
+        row_limit=3,
+        escape=_safe_markdown_text,
+        heading="Findings by subject",
+        bullet="- ",
+        row_prefix="  - ",
+    )
+    lines.extend(["", "### Findings", *finding_lines, ""])
 
 
 def _agent_next_action_line(action) -> str:

--- a/src/agents_shipgate/cli/_helpers.py
+++ b/src/agents_shipgate/cli/_helpers.py
@@ -14,6 +14,7 @@ from agents_shipgate.cli.diagnostics import (
     diagnose_missing_manifest,
 )
 from agents_shipgate.cli.discovery import discover_manifest_paths
+from agents_shipgate.cli.scan.human_order import human_artifact_context
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.core.action_semantics import effect_phrase, join_phrases
 from agents_shipgate.core.control_packs import control_rule_summaries
@@ -25,6 +26,12 @@ from agents_shipgate.core.findings.subject_rollup import (
     top_findings_block,
 )
 from agents_shipgate.core.source_warnings import group_source_warnings
+from agents_shipgate.report.human_order import (
+    HumanArtifactContext,
+    capability_delta_by_subject,
+    should_render_surface_first,
+    surface_lead,
+)
 from agents_shipgate.report.summary_text import (
     evidence_coverage_text,
     primary_evidence_remediation_text,
@@ -415,6 +422,9 @@ def _run_multi_scan(
             # release_decision (older baselines loaded for diff, etc.).
             decision = report.release_decision
             if decision is not None:
+                context = human_artifact_context(config_path, None)
+                if should_render_surface_first(report, context=context):
+                    _print_multi_cold_reader_lead(config_path, report)
                 typer.echo(
                     f"{config_path}: {decision.decision} "
                     f"(blockers={len(decision.blockers)}, "
@@ -434,6 +444,23 @@ def _run_multi_scan(
     return exit_code
 
 
+def _print_multi_cold_reader_lead(config_path: Path, report) -> None:
+    prefix = f"{config_path}: "
+    for line in surface_lead(report).text_lines():
+        typer.echo(f"{prefix}{line}")
+    for group in capability_delta_by_subject(report):
+        typer.echo(f"{prefix}Delta — {group.subject}")
+        for change in group.changes:
+            typer.echo(f"{prefix}  - {change}")
+    for line in top_findings_block(
+        roll_up_findings(report),
+        group_limit=_CLI_SUBJECT_LIMIT,
+        row_limit=_CLI_ROW_LIMIT,
+        heading="Findings by subject",
+    ):
+        typer.echo(f"{prefix}{line}")
+
+
 def _safe_output_name(config_path: Path) -> str:
     parent = config_path.parent
     try:
@@ -447,15 +474,119 @@ def _safe_output_name(config_path: Path) -> str:
     return safe or "root"
 
 
-def _print_cli_summary(report, ci_mode: str, exit_code: int, *, verbose: bool = False) -> None:
+def _print_cli_summary(
+    report,
+    ci_mode: str,
+    exit_code: int,
+    *,
+    verbose: bool = False,
+    human_context: HumanArtifactContext | None = None,
+) -> None:
     summary = report.summary
-    decision = report.release_decision
     typer.echo(f"Agents Shipgate {__version__}")
     typer.echo("")
     typer.echo(f"Project: {report.project.get('name')}")
     typer.echo(f"Agent: {report.agent.get('name')}")
     typer.echo(f"Target: {report.environment.get('target')}")
     typer.echo("")
+    surface_first = should_render_surface_first(report, context=human_context)
+    if surface_first:
+        _print_cold_reader_lead(report)
+    _print_decision_summary(report)
+    typer.echo("")
+    typer.echo(
+        f"Counts: critical={summary.critical_count}, high={summary.high_count}, "
+        f"medium={summary.medium_count}, low={summary.low_count}, "
+        f"suppressed={summary.suppressed_count}"
+    )
+    # Which rule wanted the missing controls, named once instead of implied
+    # by N per-tool rows (#410 §F). Same projection the report section reads,
+    # so the console and report.md cannot disagree on the count.
+    control_rules = control_rule_summaries(report.findings)
+    if control_rules:
+        shown = control_rules[:_CLI_CONTROL_RULE_LIMIT]
+        parts = [
+            f"{join_phrases([effect_phrase(e) for e in row.effects])} "
+            f"({row.action_count})"
+            for row in shown
+        ]
+        hidden = len(control_rules) - len(shown)
+        if hidden:
+            noun = "rule" if hidden == 1 else "rules"
+            parts.append(f"and {hidden} more {noun}")
+        typer.echo(
+            f"Control pack: {control_rules[0].pack.id} — actions short of: "
+            f"{'; '.join(parts)}"
+        )
+    action_diff = report.action_surface_diff
+    if action_diff.enabled and not surface_first:
+        if _action_surface_has_signal(action_diff.summary):
+            typer.echo(
+                "Action-surface diff: "
+                f"+{action_diff.summary.actions_added} actions, "
+                f"-{action_diff.summary.actions_removed} actions, "
+                f"{action_diff.summary.actions_modified} modified, "
+                f"{action_diff.summary.blocking_findings} blocking finding(s)"
+            )
+        else:
+            typer.echo("Action-surface diff: no changes")
+    elif action_diff.notes and not surface_first:
+        typer.echo(f"Action-surface diff: disabled ({action_diff.notes[0]})")
+    diff = report.tool_surface_diff
+    if diff.enabled and not surface_first:
+        if _tool_surface_diff_has_changes(diff.summary):
+            typer.echo(
+                "Tool-surface diff: "
+                f"+{diff.summary.tools_added} tools, "
+                f"-{diff.summary.tools_removed} tools, "
+                f"{diff.summary.tools_changed} changed, "
+                f"{diff.summary.new_high_risk_effects} new high-risk effect(s), "
+                f"{diff.summary.controls_removed} removed control(s)"
+            )
+        else:
+            typer.echo("Tool-surface diff: no changes")
+    elif diff.notes and not surface_first:
+        typer.echo(f"Tool-surface diff: disabled ({diff.notes[0]})")
+    # Grouped by mechanism: six warnings that differ only in the symbol they
+    # name are one thing to fix. The raw count is what gates, so both numbers
+    # are printed and report.json keeps every warning (#362).
+    warning_groups = group_source_warnings(report.source_warnings)
+    if verbose:
+        typer.echo(f"Tool count: {report.tool_surface.total_tools}")
+        distinct = ""
+        if len(warning_groups) < len(report.source_warnings):
+            noun = "mechanism" if len(warning_groups) == 1 else "mechanisms"
+            distinct = f" ({len(warning_groups)} distinct {noun})"
+        typer.echo(f"Source warnings: {len(report.source_warnings)}{distinct}")
+    typer.echo("")
+    if not surface_first:
+        # Grouped by subject, not by severity (#364). Five subjects with their
+        # rows beats three rows of one check family repeated over sibling tools:
+        # the reader picks a tool to open, and severity is what it says about that
+        # tool rather than what orders the list.
+        for line in top_findings_block(
+            roll_up_findings(report),
+            group_limit=_CLI_SUBJECT_LIMIT,
+            row_limit=_CLI_ROW_LIMIT,
+        ):
+            typer.echo(line)
+        typer.echo("")
+    typer.echo("Reports:")
+    for path in report.generated_reports.values():
+        typer.echo(f"- {path}")
+    if verbose and report.source_warnings:
+        typer.echo("")
+        typer.echo("Source warnings:")
+        for group in warning_groups:
+            suffix = f" ({group.count} warnings)" if group.count > 1 else ""
+            typer.echo(f"- {group.message}{suffix}")
+    typer.echo("")
+    typer.echo(f"CI mode: {ci_mode}")
+    typer.echo(f"Exit code: {exit_code}")
+
+
+def _print_decision_summary(report) -> None:
+    decision = report.release_decision
     if decision is not None:
         typer.echo(f"Decision: {decision.decision}")
         if report.agent_summary:
@@ -500,95 +631,28 @@ def _print_cli_summary(report, ci_mode: str, exit_code: int, *, verbose: bool = 
         typer.echo(f"Static-verdict boundary: {STATIC_VERDICT_DISCLAIMER}")
     else:
         typer.echo("Decision: (not recorded)")
+
+
+def _print_cold_reader_lead(report) -> None:
+    for line in surface_lead(report).text_lines():
+        typer.echo(line)
+    groups = capability_delta_by_subject(report)
+    if groups:
+        typer.echo("")
+        typer.echo("Capability delta by subject:")
+        for group in groups:
+            typer.echo(f"- {group.subject}")
+            for change in group.changes:
+                typer.echo(f"  - {change}")
     typer.echo("")
-    typer.echo(
-        f"Counts: critical={summary.critical_count}, high={summary.high_count}, "
-        f"medium={summary.medium_count}, low={summary.low_count}, "
-        f"suppressed={summary.suppressed_count}"
-    )
-    # Which rule wanted the missing controls, named once instead of implied
-    # by N per-tool rows (#410 §F). Same projection the report section reads,
-    # so the console and report.md cannot disagree on the count.
-    control_rules = control_rule_summaries(report.findings)
-    if control_rules:
-        shown = control_rules[:_CLI_CONTROL_RULE_LIMIT]
-        parts = [
-            f"{join_phrases([effect_phrase(e) for e in row.effects])} "
-            f"({row.action_count})"
-            for row in shown
-        ]
-        hidden = len(control_rules) - len(shown)
-        if hidden:
-            noun = "rule" if hidden == 1 else "rules"
-            parts.append(f"and {hidden} more {noun}")
-        typer.echo(
-            f"Control pack: {control_rules[0].pack.id} — actions short of: "
-            f"{'; '.join(parts)}"
-        )
-    action_diff = report.action_surface_diff
-    if action_diff.enabled:
-        if _action_surface_has_signal(action_diff.summary):
-            typer.echo(
-                "Action-surface diff: "
-                f"+{action_diff.summary.actions_added} actions, "
-                f"-{action_diff.summary.actions_removed} actions, "
-                f"{action_diff.summary.actions_modified} modified, "
-                f"{action_diff.summary.blocking_findings} blocking finding(s)"
-            )
-        else:
-            typer.echo("Action-surface diff: no changes")
-    elif action_diff.notes:
-        typer.echo(f"Action-surface diff: disabled ({action_diff.notes[0]})")
-    diff = report.tool_surface_diff
-    if diff.enabled:
-        if _tool_surface_diff_has_changes(diff.summary):
-            typer.echo(
-                "Tool-surface diff: "
-                f"+{diff.summary.tools_added} tools, "
-                f"-{diff.summary.tools_removed} tools, "
-                f"{diff.summary.tools_changed} changed, "
-                f"{diff.summary.new_high_risk_effects} new high-risk effect(s), "
-                f"{diff.summary.controls_removed} removed control(s)"
-            )
-        else:
-            typer.echo("Tool-surface diff: no changes")
-    elif diff.notes:
-        typer.echo(f"Tool-surface diff: disabled ({diff.notes[0]})")
-    # Grouped by mechanism: six warnings that differ only in the symbol they
-    # name are one thing to fix. The raw count is what gates, so both numbers
-    # are printed and report.json keeps every warning (#362).
-    warning_groups = group_source_warnings(report.source_warnings)
-    if verbose:
-        typer.echo(f"Tool count: {report.tool_surface.total_tools}")
-        distinct = ""
-        if len(warning_groups) < len(report.source_warnings):
-            noun = "mechanism" if len(warning_groups) == 1 else "mechanisms"
-            distinct = f" ({len(warning_groups)} distinct {noun})"
-        typer.echo(f"Source warnings: {len(report.source_warnings)}{distinct}")
-    typer.echo("")
-    # Grouped by subject, not by severity (#364). Five subjects with their
-    # rows beats three rows of one check family repeated over sibling tools:
-    # the reader picks a tool to open, and severity is what it says about that
-    # tool rather than what orders the list.
     for line in top_findings_block(
         roll_up_findings(report),
         group_limit=_CLI_SUBJECT_LIMIT,
         row_limit=_CLI_ROW_LIMIT,
+        heading="Findings by subject",
     ):
         typer.echo(line)
     typer.echo("")
-    typer.echo("Reports:")
-    for path in report.generated_reports.values():
-        typer.echo(f"- {path}")
-    if verbose and report.source_warnings:
-        typer.echo("")
-        typer.echo("Source warnings:")
-        for group in warning_groups:
-            suffix = f" ({group.count} warnings)" if group.count > 1 else ""
-            typer.echo(f"- {group.message}{suffix}")
-    typer.echo("")
-    typer.echo(f"CI mode: {ci_mode}")
-    typer.echo(f"Exit code: {exit_code}")
 
 
 def _tool_surface_diff_has_changes(summary) -> bool:
@@ -628,4 +692,3 @@ def _action_surface_has_signal(summary) -> bool:
             summary.blocking_findings,
         )
     )
-

--- a/src/agents_shipgate/cli/_helpers.py
+++ b/src/agents_shipgate/cli/_helpers.py
@@ -14,7 +14,6 @@ from agents_shipgate.cli.diagnostics import (
     diagnose_missing_manifest,
 )
 from agents_shipgate.cli.discovery import discover_manifest_paths
-from agents_shipgate.cli.scan.human_order import human_artifact_context
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.core.action_semantics import effect_phrase, join_phrases
 from agents_shipgate.core.control_packs import control_rule_summaries
@@ -374,6 +373,7 @@ def _run_multi_scan(
         if out is not None:
             output_dir = out / _safe_output_name(config_path)
         try:
+            captured_contexts: list[HumanArtifactContext] = []
             report, scan_exit_code = run_scan(
                 config_path=config_path,
                 output_dir=output_dir,
@@ -391,7 +391,9 @@ def _run_multi_scan(
                 packet_enabled=packet_enabled,
                 packet_formats=packet_formats,
                 no_heuristics=no_heuristics,
+                human_context_callback=captured_contexts.append,
             )
+            human_context = captured_contexts[-1]
         except ConfigError as exc:
             scan_exit_code = 2
             typer.echo(f"{config_path}: config_error - {exc}", err=True)
@@ -422,8 +424,7 @@ def _run_multi_scan(
             # release_decision (older baselines loaded for diff, etc.).
             decision = report.release_decision
             if decision is not None:
-                context = human_artifact_context(config_path, None)
-                if should_render_surface_first(report, context=context):
+                if should_render_surface_first(report, context=human_context):
                     _print_multi_cold_reader_lead(config_path, report)
                 typer.echo(
                     f"{config_path}: {decision.decision} "
@@ -519,7 +520,7 @@ def _print_cli_summary(
             f"{'; '.join(parts)}"
         )
     action_diff = report.action_surface_diff
-    if action_diff.enabled and not surface_first:
+    if action_diff.enabled:
         if _action_surface_has_signal(action_diff.summary):
             typer.echo(
                 "Action-surface diff: "
@@ -530,10 +531,10 @@ def _print_cli_summary(
             )
         else:
             typer.echo("Action-surface diff: no changes")
-    elif action_diff.notes and not surface_first:
+    elif action_diff.notes:
         typer.echo(f"Action-surface diff: disabled ({action_diff.notes[0]})")
     diff = report.tool_surface_diff
-    if diff.enabled and not surface_first:
+    if diff.enabled:
         if _tool_surface_diff_has_changes(diff.summary):
             typer.echo(
                 "Tool-surface diff: "
@@ -545,7 +546,7 @@ def _print_cli_summary(
             )
         else:
             typer.echo("Tool-surface diff: no changes")
-    elif diff.notes and not surface_first:
+    elif diff.notes:
         typer.echo(f"Tool-surface diff: disabled ({diff.notes[0]})")
     # Grouped by mechanism: six warnings that differ only in the symbol they
     # name are one thing to fix. The raw count is what gates, so both numbers

--- a/src/agents_shipgate/cli/_register_scan.py
+++ b/src/agents_shipgate/cli/_register_scan.py
@@ -20,7 +20,6 @@ from agents_shipgate.cli._helpers import (
 )
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error as _emit_agent_mode_error
 from agents_shipgate.cli.diagnostics import input_parse_recovery, top_next_actions
-from agents_shipgate.cli.scan.human_order import human_artifact_context
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_controls import git_root_for
@@ -392,6 +391,7 @@ def register(app: typer.Typer) -> None:
                     }
                 )
             if len(config_paths) == 1:
+                captured_contexts = []
                 report, exit_code = run_scan(
                     config_path=config_paths[0],
                     output_dir=out,
@@ -410,7 +410,9 @@ def register(app: typer.Typer) -> None:
                     packet_formats=parsed_packet_formats,
                     no_heuristics=no_heuristics,
                     verification_context=verification_context,
+                    human_context_callback=captured_contexts.append,
                 )
+                human_context = captured_contexts[-1]
                 exit_code = _apply_strict_plugins(
                     report, exit_code, strict_plugins=strict_plugins
                 )
@@ -419,7 +421,7 @@ def register(app: typer.Typer) -> None:
                     ci_mode or "advisory",
                     exit_code,
                     verbose=verbose,
-                    human_context=human_artifact_context(config_paths[0], verification_context),
+                    human_context=human_context,
                 )
                 raise typer.Exit(exit_code)
             exit_code = _run_multi_scan(

--- a/src/agents_shipgate/cli/_register_scan.py
+++ b/src/agents_shipgate/cli/_register_scan.py
@@ -20,6 +20,7 @@ from agents_shipgate.cli._helpers import (
 )
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error as _emit_agent_mode_error
 from agents_shipgate.cli.diagnostics import input_parse_recovery, top_next_actions
+from agents_shipgate.cli.scan.human_order import human_artifact_context
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.cli.workspace_guard import require_workspace
 from agents_shipgate.core.agent_controls import git_root_for
@@ -413,7 +414,13 @@ def register(app: typer.Typer) -> None:
                 exit_code = _apply_strict_plugins(
                     report, exit_code, strict_plugins=strict_plugins
                 )
-                _print_cli_summary(report, ci_mode or "advisory", exit_code, verbose=verbose)
+                _print_cli_summary(
+                    report,
+                    ci_mode or "advisory",
+                    exit_code,
+                    verbose=verbose,
+                    human_context=human_artifact_context(config_paths[0], verification_context),
+                )
                 raise typer.Exit(exit_code)
             exit_code = _run_multi_scan(
                 config_paths=config_paths,

--- a/src/agents_shipgate/cli/scan/human_order.py
+++ b/src/agents_shipgate/cli/scan/human_order.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -62,50 +60,11 @@ def _manifest_committed_at_head(config_path: Path) -> bool | None:
         relative = config_path.resolve().relative_to(root)
     except (OSError, ValueError):
         return False
-    env = dict(os.environ)
-    env.update({"GIT_NO_LAZY_FETCH": "1", "GIT_OPTIONAL_LOCKS": "0"})
-    try:
-        head = subprocess.run(
-            [
-                "git",
-                "--no-replace-objects",
-                "-C",
-                str(root),
-                "rev-parse",
-                "--verify",
-                "--quiet",
-                "HEAD^{commit}",
-            ],
-            capture_output=True,
-            check=False,
-            env=env,
-            timeout=60,
-        )
-        if head.returncode == 1:
-            return False
-        if head.returncode != 0:
-            return None
-        result = subprocess.run(
-            [
-                "git",
-                "--no-replace-objects",
-                "-C",
-                str(root),
-                "ls-tree",
-                "-z",
-                "--full-tree",
-                "HEAD",
-                "--",
-                relative.as_posix(),
-            ],
-            capture_output=True,
-            check=False,
-            env=env,
-            timeout=60,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if result.returncode != 0:
-        return None
-    records = [record for record in result.stdout.split(b"\0") if record]
-    return any(record.partition(b"\t")[0].split()[1:2] == [b"blob"] for record in records)
+
+    # Local import avoids the ``cli.verify.__init__`` -> orchestrator -> scan
+    # cycle during module initialization.  More importantly, both probes go
+    # through verify's single audited, bounded, no-shell Git boundary rather
+    # than introducing a second process-execution surface in scan code.
+    from agents_shipgate.cli.verify.git import path_committed_at_head
+
+    return path_committed_at_head(root, relative)

--- a/src/agents_shipgate/cli/scan/human_order.py
+++ b/src/agents_shipgate/cli/scan/human_order.py
@@ -1,0 +1,111 @@
+"""Derive the ephemeral context used to order human scan artifacts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+
+from agents_shipgate.core.agent_controls import git_root_for
+from agents_shipgate.report.human_order import HumanArtifactContext
+from agents_shipgate.schemas.verification import VerificationContext
+
+_MANIFEST_COMMITTED_OVERRIDE: ContextVar[bool | None] = ContextVar(
+    "agents_shipgate_human_manifest_committed",
+    default=None,
+)
+
+
+def human_artifact_context(
+    config_path: Path,
+    verification: VerificationContext | None,
+) -> HumanArtifactContext:
+    """Facts already held by the scan/verify engine, never serialized.
+
+    ``manifest_introduced`` is the verifier's stronger, comparison-relative
+    proof.  The HEAD lookup covers a plain scan of a new local manifest.  A
+    Git error remains unknown and therefore keeps verdict-first ordering; a
+    path outside a checkout or a checkout with no HEAD cannot carry a
+    committed repository trust root and is cold by construction.
+    """
+
+    committed_override = _MANIFEST_COMMITTED_OVERRIDE.get()
+    return HumanArtifactContext(
+        manifest_committed=(
+            committed_override
+            if committed_override is not None
+            else _manifest_committed_at_head(config_path)
+        ),
+        manifest_introduced=bool(verification is not None and verification.manifest_introduced),
+    )
+
+
+@contextmanager
+def override_human_manifest_committed(value: bool | None) -> Iterator[None]:
+    """Thread/task-local provenance for a scan of an extracted commit tree."""
+
+    token = _MANIFEST_COMMITTED_OVERRIDE.set(value)
+    try:
+        yield
+    finally:
+        _MANIFEST_COMMITTED_OVERRIDE.reset(token)
+
+
+def _manifest_committed_at_head(config_path: Path) -> bool | None:
+    root = git_root_for(config_path.parent)
+    if root is None:
+        return False
+    try:
+        relative = config_path.resolve().relative_to(root)
+    except (OSError, ValueError):
+        return False
+    env = dict(os.environ)
+    env.update({"GIT_NO_LAZY_FETCH": "1", "GIT_OPTIONAL_LOCKS": "0"})
+    try:
+        head = subprocess.run(
+            [
+                "git",
+                "--no-replace-objects",
+                "-C",
+                str(root),
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "HEAD^{commit}",
+            ],
+            capture_output=True,
+            check=False,
+            env=env,
+            timeout=60,
+        )
+        if head.returncode == 1:
+            return False
+        if head.returncode != 0:
+            return None
+        result = subprocess.run(
+            [
+                "git",
+                "--no-replace-objects",
+                "-C",
+                str(root),
+                "ls-tree",
+                "-z",
+                "--full-tree",
+                "HEAD",
+                "--",
+                relative.as_posix(),
+            ],
+            capture_output=True,
+            check=False,
+            env=env,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    records = [record for record in result.stdout.split(b"\0") if record]
+    return any(record.partition(b"\t")[0].split()[1:2] == [b"blob"] for record in records)

--- a/src/agents_shipgate/cli/scan/orchestrator.py
+++ b/src/agents_shipgate/cli/scan/orchestrator.py
@@ -15,6 +15,7 @@ from agents_shipgate.schemas.verification import VerificationContext
 from .decision import _run_checks_and_decide
 from .diffs import _load_diff_references
 from .final_report import _build_final_report
+from .human_order import human_artifact_context
 from .inputs import _load_inputs
 from .output_planning import _plan_outputs
 from .prepare import _prepare_scan
@@ -230,6 +231,7 @@ def _run_scan(
             config_path=config_path,
             declared_ci=resolved.declared_ci,
         )
+    human_context = human_artifact_context(config_path, verification_context)
     with _perf.phase("write_outputs"):
         _write_outputs(
             report=report,
@@ -239,7 +241,8 @@ def _run_scan(
             manifest=resolved.manifest,
             config_path=config_path,
             packet_generated_at=packet_generated_at,
+            human_context=human_context,
         )
-    write_github_step_summary(report)
+    write_github_step_summary(report, human_context=human_context)
     assert report.release_decision is not None  # build_report always populates it
     return report, report.release_decision.fail_policy.exit_code

--- a/src/agents_shipgate/cli/scan/orchestrator.py
+++ b/src/agents_shipgate/cli/scan/orchestrator.py
@@ -8,6 +8,7 @@ from agents_shipgate.ci.github_summary import write_github_step_summary
 from agents_shipgate.cli.discovery.placeholders import manifest_placeholder_fields
 from agents_shipgate.core.capability_lock import build_capability_lock
 from agents_shipgate.core.errors import AgentsShipgateError, ConfigError
+from agents_shipgate.report.human_order import HumanArtifactContext
 from agents_shipgate.schemas.capabilities import CapabilityLockFileV1
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.verification import VerificationContext
@@ -45,13 +46,16 @@ def run_scan(
     packet_generated_at: str | None = None,
     verification_context: VerificationContext | None = None,
     capability_lock_callback: Callable[[CapabilityLockFileV1], None] | None = None,
+    human_context_callback: Callable[[HumanArtifactContext], None] | None = None,
     manifest_text: str | None = None,
 ) -> tuple[ReadinessReport, int]:
     """Run a full scan pipeline. Returns ``(report, exit_code)``.
 
     Orchestrates nine sequential phases (see the phase helpers above).
     Public signature, exit-code contract, and ``_run_id`` hash inputs
-    are stable across the v0.19 R-3 decomposition refactor.
+    are stable across the v0.19 R-3 decomposition refactor. When supplied,
+    ``human_context_callback`` is invoked exactly once after the presentation
+    context is derived; that ephemeral value is never serialized.
     """
     if deep_import:
         raise ConfigError("Deep import is intentionally deferred and is not supported.")
@@ -76,6 +80,7 @@ def run_scan(
             packet_generated_at=packet_generated_at,
             verification_context=verification_context,
             capability_lock_callback=capability_lock_callback,
+            human_context_callback=human_context_callback,
             manifest_text=manifest_text,
         )
     except AgentsShipgateError as exc:
@@ -136,6 +141,7 @@ def _run_scan(
     packet_generated_at: str | None,
     verification_context: VerificationContext | None,
     capability_lock_callback: Callable[[CapabilityLockFileV1], None] | None,
+    human_context_callback: Callable[[HumanArtifactContext], None] | None,
     manifest_text: str | None,
 ) -> tuple[ReadinessReport, int]:
     """The pipeline itself. Split from :func:`run_scan` so the manifest the
@@ -232,6 +238,8 @@ def _run_scan(
             declared_ci=resolved.declared_ci,
         )
     human_context = human_artifact_context(config_path, verification_context)
+    if human_context_callback is not None:
+        human_context_callback(human_context)
     with _perf.phase("write_outputs"):
         _write_outputs(
             report=report,

--- a/src/agents_shipgate/cli/scan/output_helpers.py
+++ b/src/agents_shipgate/cli/scan/output_helpers.py
@@ -11,6 +11,7 @@ from agents_shipgate.packet.pdf import (
     is_pdf_available,
     render_packet_pdf,
 )
+from agents_shipgate.report.human_order import ColdReaderLead, HumanArtifactContext
 from agents_shipgate.report.json_report import write_json_report
 from agents_shipgate.report.markdown import write_markdown_report
 from agents_shipgate.report.sarif import write_sarif_report
@@ -54,9 +55,15 @@ def _write_reports(
     formats: list[str],
     *,
     sanitized_payload: dict | None = None,
+    human_context: HumanArtifactContext | None = None,
 ) -> None:
     if "markdown" in formats and "markdown" in paths:
-        write_markdown_report(report, paths["markdown"], sanitize_output=False)
+        write_markdown_report(
+            report,
+            paths["markdown"],
+            sanitize_output=False,
+            human_context=human_context,
+        )
     if "json" in formats and "json" in paths:
         write_json_report(
             report,
@@ -67,16 +74,41 @@ def _write_reports(
         write_sarif_report(report, paths["sarif"])
 
 
-def _write_packet(packet, paths: dict[str, Path], packet_formats: set[str]) -> None:
+def _write_packet(
+    packet,
+    paths: dict[str, Path],
+    packet_formats: set[str],
+    *,
+    human_context: HumanArtifactContext | None = None,
+    cold_lead: ColdReaderLead | None = None,
+) -> None:
     if "md" in packet_formats and "packet_md" in paths:
-        write_packet_markdown(packet, paths["packet_md"], sanitize_output=False)
+        write_packet_markdown(
+            packet,
+            paths["packet_md"],
+            sanitize_output=False,
+            human_context=human_context,
+            cold_lead=cold_lead,
+        )
     if "json" in packet_formats and "packet_json" in paths:
         write_packet_json(packet, paths["packet_json"], sanitize_output=False)
     if "html" in packet_formats and "packet_html" in paths:
-        write_packet_html(packet, paths["packet_html"], sanitize_output=False)
+        write_packet_html(
+            packet,
+            paths["packet_html"],
+            sanitize_output=False,
+            human_context=human_context,
+            cold_lead=cold_lead,
+        )
     if "pdf" in packet_formats and "packet_pdf" in paths:
         try:
-            render_packet_pdf(packet, paths["packet_pdf"], sanitize_output=False)
+            render_packet_pdf(
+                packet,
+                paths["packet_pdf"],
+                sanitize_output=False,
+                human_context=human_context,
+                cold_lead=cold_lead,
+            )
         except PdfRendererUnavailable as exc:
             logger.warning("packet.pdf skipped: %s", exc)
 

--- a/src/agents_shipgate/cli/scan/writing.py
+++ b/src/agents_shipgate/cli/scan/writing.py
@@ -174,9 +174,7 @@ def _write_suggested_declarations(
     redacted content reaches the scaffold.
     """
 
-    anchor = generated_paths.get("json") or next(
-        iter(generated_paths.values()), None
-    )
+    anchor = generated_paths.get("json") or next(iter(generated_paths.values()), None)
     if anchor is None:
         return
     out_path = anchor.parent / SUGGESTED_DECLARATIONS_FILENAME
@@ -265,7 +263,9 @@ def _write_suggested_inventory(
     tools by (name, source_type), then unresolved symbols by name, stable
     JSON.
     """
-    anchor = generated_paths.get("json") or next(iter(generated_paths.values()), None)
+    anchor = generated_paths.get("json") or next(
+        iter(generated_paths.values()), None
+    )
     if anchor is None:
         return
     low_confidence = sorted(

--- a/src/agents_shipgate/cli/scan/writing.py
+++ b/src/agents_shipgate/cli/scan/writing.py
@@ -23,6 +23,7 @@ from agents_shipgate.core.domain import Tool
 from agents_shipgate.core.evidence_actions import yaml_scalar
 from agents_shipgate.core.privacy import sanitize_packet
 from agents_shipgate.packet.builder import build_packet
+from agents_shipgate.report.human_order import HumanArtifactContext, cold_reader_lead
 from agents_shipgate.schemas.current_control import (
     AgentActionRequiredCurrentControl,
     CurrentControlWorkspaceIdentity,
@@ -44,6 +45,7 @@ def _write_outputs(
     manifest: AgentsShipgateManifest,
     config_path: Path,
     packet_generated_at: str | None,
+    human_context: HumanArtifactContext,
 ) -> None:
     """Phase 9: write report (md/json/sarif) + packet (md/json/html/pdf).
 
@@ -77,6 +79,7 @@ def _write_outputs(
         plan.generated_paths,
         manifest.output.formats,
         sanitized_payload=public_report_payload,
+        human_context=human_context,
     )
     _write_suggested_inventory(
         sanitized_tools=sanitized.tools,
@@ -113,6 +116,8 @@ def _write_outputs(
             sanitize_packet(packet),
             plan.generated_paths,
             plan.packet_format_set,
+            human_context=human_context,
+            cold_lead=cold_reader_lead(public_report),
         )
     if owns_control:
         # A scan inventories a workspace; it never establishes merge authority.
@@ -169,7 +174,9 @@ def _write_suggested_declarations(
     redacted content reaches the scaffold.
     """
 
-    anchor = generated_paths.get("json") or next(iter(generated_paths.values()), None)
+    anchor = generated_paths.get("json") or next(
+        iter(generated_paths.values()), None
+    )
     if anchor is None:
         return
     out_path = anchor.parent / SUGGESTED_DECLARATIONS_FILENAME
@@ -258,9 +265,7 @@ def _write_suggested_inventory(
     tools by (name, source_type), then unresolved symbols by name, stable
     JSON.
     """
-    anchor = generated_paths.get("json") or next(
-        iter(generated_paths.values()), None
-    )
+    anchor = generated_paths.get("json") or next(iter(generated_paths.values()), None)
     if anchor is None:
         return
     low_confidence = sorted(

--- a/src/agents_shipgate/cli/scan/writing.py
+++ b/src/agents_shipgate/cli/scan/writing.py
@@ -23,7 +23,11 @@ from agents_shipgate.core.domain import Tool
 from agents_shipgate.core.evidence_actions import yaml_scalar
 from agents_shipgate.core.privacy import sanitize_packet
 from agents_shipgate.packet.builder import build_packet
-from agents_shipgate.report.human_order import HumanArtifactContext, cold_reader_lead
+from agents_shipgate.report.human_order import (
+    HumanArtifactContext,
+    cold_reader_lead,
+    should_render_surface_first,
+)
 from agents_shipgate.schemas.current_control import (
     AgentActionRequiredCurrentControl,
     CurrentControlWorkspaceIdentity,
@@ -112,12 +116,18 @@ def _write_outputs(
             generated_at=packet_generated_at,
             config_ref=config_path.resolve().name,
         )
+        packet_cold_lead = None
+        if (
+            plan.packet_format_set & {"md", "html", "pdf"}
+            and should_render_surface_first(public_report, context=human_context)
+        ):
+            packet_cold_lead = cold_reader_lead(public_report)
         _write_packet(
             sanitize_packet(packet),
             plan.generated_paths,
             plan.packet_format_set,
             human_context=human_context,
-            cold_lead=cold_reader_lead(public_report),
+            cold_lead=packet_cold_lead,
         )
     if owns_control:
         # A scan inventories a workspace; it never establishes merge authority.

--- a/src/agents_shipgate/cli/verify/git.py
+++ b/src/agents_shipgate/cli/verify/git.py
@@ -2226,6 +2226,47 @@ def staged_paths_under(workspace: Path, subdir: str) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip().startswith(prefix)]
 
 
+def _commit_present_at_ref(workspace: Path, ref: str) -> bool | None:
+    """Whether ``ref`` resolves to a commit, preserving Git's error state.
+
+    Unlike :func:`commit_sha`, an unborn ref is ``False`` while an operational
+    Git failure is ``None``.  Human-artifact ordering needs that distinction:
+    a repository with no first commit is cold by construction, but an
+    unreadable repository must fail closed to the established verdict-first
+    order.
+    """
+
+    _validate_ref_token(ref)
+    result = _run_git(
+        workspace,
+        [
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            f"{ref}^{{commit}}",
+        ],
+        check=False,
+    )
+    if result.returncode == 0:
+        return bool(result.stdout.strip()) or None
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def path_committed_at_head(workspace: Path, path: Path) -> bool | None:
+    """Whether ``path`` is a blob at ``HEAD``, with errors kept unknown."""
+
+    try:
+        head_present = _commit_present_at_ref(workspace, "HEAD")
+        if head_present is not True:
+            return head_present
+        return path_present_at_ref(workspace, "HEAD", path)
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
 __all__ = [
     "active_replace_refs",
     "archive_tree",
@@ -2245,6 +2286,7 @@ __all__ = [
     "git_path",
     "GitPushEndpoint",
     "merge_base_sha",
+    "path_committed_at_head",
     "path_present_at_ref",
     "read_bytes_at_ref",
     "read_file_at_ref",

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -31,6 +31,7 @@ from agents_shipgate.cli.discovery.scope import (
     resolve_change_scope,
 )
 from agents_shipgate.cli.discovery.signals import weak_marker_evidence_dirs
+from agents_shipgate.cli.scan.human_order import override_human_manifest_committed
 from agents_shipgate.cli.scan.orchestrator import run_scan
 from agents_shipgate.config.loader import load_manifest_text
 from agents_shipgate.core.agent_control import derive_agent_control
@@ -989,7 +990,14 @@ def run_verify(
                 root=head_tree_dir,
                 relative_paths=changed_files,
             )
-        with use_evaluation_date(date.fromisoformat(verification_date)):
+        # An archived head is a committed tree even though its temporary
+        # extraction directory is not itself a Git checkout. Keep that
+        # presentation-only provenance beside the scan without widening the
+        # public run_scan signature or any serialized context.
+        with (
+            use_evaluation_date(date.fromisoformat(verification_date)),
+            override_human_manifest_committed(True if archive_head else None),
+        ):
             head_snapshot_token = (
                 activate_static_input_snapshot(head_snapshot)
                 if head_snapshot is not None

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -90,6 +90,7 @@ from agents_shipgate.packet.json_packet import load_packet_json, write_packet_js
 from agents_shipgate.report.capability_lock_diff_markdown import (
     render_capability_lock_diff_markdown,
 )
+from agents_shipgate.report.human_order import HumanArtifactContext
 from agents_shipgate.report.json_report import report_json_payload
 from agents_shipgate.report.pr_comment import render_pr_comment
 from agents_shipgate.schemas.agent_control import (
@@ -811,10 +812,15 @@ def run_verify(
     head_manifest_text: str | None = None
     head_capability_lock: CapabilityLockFileV1 | None = None
     capability_lock_diff: CapabilityLockDiffV1 | None = None
+    head_human_context: HumanArtifactContext | None = None
 
     def capture_capability_lock(lock: CapabilityLockFileV1) -> None:
         nonlocal head_capability_lock
         head_capability_lock = lock
+
+    def capture_human_context(context: HumanArtifactContext) -> None:
+        nonlocal head_human_context
+        head_human_context = context
 
     external_snapshot_paths = [
         path
@@ -992,8 +998,8 @@ def run_verify(
             )
         # An archived head is a committed tree even though its temporary
         # extraction directory is not itself a Git checkout. Keep that
-        # presentation-only provenance beside the scan without widening the
-        # public run_scan signature or any serialized context.
+        # presentation-only provenance beside the scan without changing the
+        # public two-value return contract or serializing the context.
         with (
             use_evaluation_date(date.fromisoformat(verification_date)),
             override_human_manifest_committed(True if archive_head else None),
@@ -1048,6 +1054,7 @@ def run_verify(
                         in _BASE_COMPARISON_FAILURES,
                     ),
                     capability_lock_callback=capture_capability_lock,
+                    human_context_callback=capture_human_context,
                     manifest_text=(
                         head_manifest_text if archive_head else worktree_manifest_text
                     ),
@@ -1194,6 +1201,7 @@ def run_verify(
                     fail_on=fail_on,
                     pr_comment_style=pr_comment_style,
                     capability_lock_diff=capability_lock_diff,
+                    human_context=head_human_context,
                     input_root=head_input_root,
                     input_snapshot=head_snapshot,
                     diff_text=diff_text,
@@ -3902,6 +3910,7 @@ def _write_artifacts(
     fail_on: list[str] | None,
     pr_comment_style: str,
     capability_lock_diff: CapabilityLockDiffV1 | None = None,
+    human_context: HumanArtifactContext | None = None,
     input_root: Path | None = None,
     input_snapshot: StaticInputSnapshot | None = None,
     diff_text: str = "",
@@ -3939,6 +3948,7 @@ def _write_artifacts(
             report=report,
             style=pr_comment_style,
             capability_lock_diff=capability_lock_diff,
+            human_context=human_context,
         ),
         encoding="utf-8",
     )
@@ -4242,6 +4252,7 @@ def _write_artifacts(
             report=report,
             style=pr_comment_style,
             capability_lock_diff=capability_lock_diff,
+            human_context=human_context,
         ),
         encoding="utf-8",
     )

--- a/src/agents_shipgate/core/findings/subject_rollup.py
+++ b/src/agents_shipgate/core/findings/subject_rollup.py
@@ -36,10 +36,13 @@ from .constants import SEVERITY_ORDER
 
 __all__ = [
     "AGENT_WIDE_SUBJECT",
+    "ProjectedSubjectGroup",
     "SubjectGroup",
+    "TopFindingsProjection",
     "finding_line",
     "group_summary",
     "missing_items",
+    "project_top_findings",
     "roll_up_findings",
     "rollup_detail",
     "rollup_headline",
@@ -114,6 +117,23 @@ class SubjectGroup:
         """Findings paired with whether the release decision blocks on each."""
 
         return tuple(zip(self.findings, self.blocking, strict=True))
+
+
+@dataclass(frozen=True)
+class ProjectedSubjectGroup:
+    """One subject and the bounded rows a compact human surface will show."""
+
+    group: SubjectGroup
+    rows: tuple[tuple[Finding, bool], ...]
+    hidden_findings: int
+
+
+@dataclass(frozen=True)
+class TopFindingsProjection:
+    """The shared, non-negative truncation result for compact renderers."""
+
+    groups: tuple[ProjectedSubjectGroup, ...]
+    hidden_subjects: int
 
 
 def missing_items(finding: Finding) -> list[str]:
@@ -511,6 +531,40 @@ def rollup_headline(groups: Sequence[SubjectGroup]) -> str:
     return f"{_finding_count(groups)} across {_subject_count(groups)}"
 
 
+def project_top_findings(
+    groups: Sequence[SubjectGroup],
+    *,
+    group_limit: int,
+    row_limit: int,
+) -> TopFindingsProjection:
+    """Select compact subject rows once for every renderer.
+
+    Hidden counts are derived from what was actually selected rather than
+    from the configured cap.  That keeps counts non-negative for empty and
+    below-cap inputs, and prevents Markdown, HTML, and PDF packet renderers
+    from drifting apart at the truncation boundary.
+    """
+
+    bounded_group_limit = max(0, group_limit)
+    bounded_row_limit = max(0, row_limit)
+    shown_groups = tuple(groups[:bounded_group_limit])
+    projected: list[ProjectedSubjectGroup] = []
+    for group in shown_groups:
+        rows = group.rows()
+        shown_rows = tuple(rows[:bounded_row_limit])
+        projected.append(
+            ProjectedSubjectGroup(
+                group=group,
+                rows=shown_rows,
+                hidden_findings=max(0, len(rows) - len(shown_rows)),
+            )
+        )
+    return TopFindingsProjection(
+        groups=tuple(projected),
+        hidden_subjects=max(0, len(groups) - len(shown_groups)),
+    )
+
+
 def top_findings_block(
     groups: Sequence[SubjectGroup],
     *,
@@ -550,14 +604,18 @@ def top_findings_block(
     if not groups:
         lines.append(f"{bullet}none")
         return lines
-    shown = list(groups[:group_limit])
-    for group in shown:
+    projection = project_top_findings(
+        groups,
+        group_limit=group_limit,
+        row_limit=row_limit,
+    )
+    for projected in projection.groups:
+        group = projected.group
         lines.append(
             f"{bullet}{escape(group.subject + group.location)} — "
             f"{escape(group_summary(group))}"
         )
-        rows = group.rows()
-        for finding, blocks in rows[:row_limit]:
+        for finding, blocks in projected.rows:
             row = finding_line(
                 finding,
                 blocks_release=blocks,
@@ -566,14 +624,15 @@ def top_findings_block(
             lines.append(f"{row_prefix}{escape(row)}")
             for note in annotate(finding):
                 lines.append(f"{note_prefix}{escape(note)}")
-        hidden = len(rows) - row_limit
-        if hidden > 0:
+        if projected.hidden_findings > 0:
             lines.append(
-                f"{row_prefix}… and {_plural(hidden, 'more finding')} for this subject"
+                f"{row_prefix}… and "
+                f"{_plural(projected.hidden_findings, 'more finding')} for this subject"
             )
-    hidden_groups = len(groups) - len(shown)
-    if hidden_groups > 0:
-        lines.append(f"{bullet}… and {_plural(hidden_groups, 'more subject')}")
+    if projection.hidden_subjects > 0:
+        lines.append(
+            f"{bullet}… and {_plural(projection.hidden_subjects, 'more subject')}"
+        )
     return lines
 
 

--- a/src/agents_shipgate/packet/html.py
+++ b/src/agents_shipgate/packet/html.py
@@ -113,9 +113,14 @@ def render_packet_html(
     parts.append("<h1>Release Evidence Packet</h1>")
     parts.append(_render_header(packet))
     surface_first = bool(
-        cold_lead is not None and should_render_packet_surface_first(packet, context=human_context)
+        should_render_packet_surface_first(
+            packet,
+            context=human_context,
+            cold_lead=cold_lead,
+        )
     )
     if surface_first:
+        assert cold_lead is not None
         parts.append(_render_cold_surface(cold_lead))
         parts.append(_render_high_risk_surface(packet.high_risk_surface))
         parts.append(_render_cold_delta(cold_lead))

--- a/src/agents_shipgate/packet/html.py
+++ b/src/agents_shipgate/packet/html.py
@@ -18,6 +18,11 @@ from __future__ import annotations
 from html import escape
 from pathlib import Path
 
+from agents_shipgate.core.findings.subject_rollup import (
+    finding_line,
+    group_summary,
+    project_top_findings,
+)
 from agents_shipgate.core.privacy import sanitize_packet
 from agents_shipgate.core.source_warnings import group_source_warnings
 from agents_shipgate.report.human_order import (
@@ -210,21 +215,38 @@ def _render_cold_delta(lead: ColdReaderLead) -> str:
 
 def _render_cold_findings(lead: ColdReaderLead) -> str:
     parts = ["<h2>Findings by subject</h2><ul>"]
-    if not lead.finding_subjects:
+    if not lead.finding_groups:
         parts.append("<li>none</li>")
-    for subject in lead.finding_subjects[:8]:
-        parts.append(f"<li><code>{escape(subject.subject)}</code> — {escape(subject.summary)}<ul>")
-        for finding in subject.findings[:5]:
-            parts.append(f"<li>{escape(finding)}</li>")
-        hidden = len(subject.findings) - 5
-        if hidden:
-            suffix = "s" if hidden != 1 else ""
-            parts.append(f"<li>… and {hidden} more finding{suffix}</li>")
+    projection = project_top_findings(
+        lead.finding_groups,
+        group_limit=8,
+        row_limit=5,
+    )
+    for projected in projection.groups:
+        group = projected.group
+        parts.append(
+            f"<li><code>{escape(group.subject + group.location)}</code> — "
+            f"{escape(group_summary(group))}<ul>"
+        )
+        for finding, blocks in projected.rows:
+            row = finding_line(
+                finding,
+                blocks_release=blocks,
+                group_location=group.location,
+            )
+            parts.append(f"<li>{escape(row)}</li>")
+        if projected.hidden_findings > 0:
+            suffix = "s" if projected.hidden_findings != 1 else ""
+            parts.append(
+                f"<li>… and {projected.hidden_findings} more finding{suffix} "
+                "for this subject</li>"
+            )
         parts.append("</ul></li>")
-    hidden_subjects = len(lead.finding_subjects) - 8
-    if hidden_subjects:
-        suffix = "s" if hidden_subjects != 1 else ""
-        parts.append(f"<li>… and {hidden_subjects} more subject{suffix}</li>")
+    if projection.hidden_subjects > 0:
+        suffix = "s" if projection.hidden_subjects != 1 else ""
+        parts.append(
+            f"<li>… and {projection.hidden_subjects} more subject{suffix}</li>"
+        )
     parts.append("</ul>")
     return "".join(parts)
 

--- a/src/agents_shipgate/packet/html.py
+++ b/src/agents_shipgate/packet/html.py
@@ -20,6 +20,11 @@ from pathlib import Path
 
 from agents_shipgate.core.privacy import sanitize_packet
 from agents_shipgate.core.source_warnings import group_source_warnings
+from agents_shipgate.report.human_order import (
+    ColdReaderLead,
+    HumanArtifactContext,
+    should_render_packet_surface_first,
+)
 from agents_shipgate.schemas.packet import (
     ActionSurfaceDiffSection,
     ApprovalCoverageSection,
@@ -90,6 +95,8 @@ def render_packet_html(
     packet: EvidencePacket,
     *,
     sanitize_output: bool = True,
+    human_context: HumanArtifactContext | None = None,
+    cold_lead: ColdReaderLead | None = None,
 ) -> str:
     """Return the packet rendered as a self-contained HTML document."""
 
@@ -105,10 +112,19 @@ def render_packet_html(
     parts.append("</head><body>")
     parts.append("<h1>Release Evidence Packet</h1>")
     parts.append(_render_header(packet))
+    surface_first = bool(
+        cold_lead is not None and should_render_packet_surface_first(packet, context=human_context)
+    )
+    if surface_first:
+        parts.append(_render_cold_surface(cold_lead))
+        parts.append(_render_high_risk_surface(packet.high_risk_surface))
+        parts.append(_render_cold_delta(cold_lead))
+        parts.append(_render_cold_findings(cold_lead))
     parts.append(_render_release_decision(packet.release_decision))
     parts.append(_render_evidence_matrix(packet.evidence_matrix))
     parts.append(_render_capability_intent(packet.capability_intent))
-    parts.append(_render_high_risk_surface(packet.high_risk_surface))
+    if not surface_first:
+        parts.append(_render_high_risk_surface(packet.high_risk_surface))
     parts.append(_render_tool_surface_diff(packet.tool_surface_diff))
     parts.append(_render_action_surface_diff(packet.action_surface_diff))
     parts.append(_render_approval_coverage(packet.approval_coverage))
@@ -127,10 +143,17 @@ def write_packet_html(
     path: Path,
     *,
     sanitize_output: bool = True,
+    human_context: HumanArtifactContext | None = None,
+    cold_lead: ColdReaderLead | None = None,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        render_packet_html(packet, sanitize_output=sanitize_output),
+        render_packet_html(
+            packet,
+            sanitize_output=sanitize_output,
+            human_context=human_context,
+            cold_lead=cold_lead,
+        ),
         encoding="utf-8",
     )
 
@@ -157,6 +180,48 @@ def _render_header(packet: EvidencePacket) -> str:
         "Agents Shipgate scan. See §10 for what the packet does "
         "<em>not</em> prove.</p>"
     )
+
+
+def _render_cold_surface(lead: ColdReaderLead) -> str:
+    parts = ["<h2>Capability surface</h2><ul>"]
+    for line in lead.surface.text_lines():
+        parts.append(f"<li>{escape(line)}</li>")
+    parts.append("</ul>")
+    return "".join(parts)
+
+
+def _render_cold_delta(lead: ColdReaderLead) -> str:
+    if not lead.delta_subjects:
+        return ""
+    parts = ["<h2>Capability delta by subject</h2><ul>"]
+    for subject in lead.delta_subjects:
+        parts.append(f"<li><code>{escape(subject.subject)}</code><ul>")
+        for change in subject.changes:
+            parts.append(f"<li>{escape(change)}</li>")
+        parts.append("</ul></li>")
+    parts.append("</ul>")
+    return "".join(parts)
+
+
+def _render_cold_findings(lead: ColdReaderLead) -> str:
+    parts = ["<h2>Findings by subject</h2><ul>"]
+    if not lead.finding_subjects:
+        parts.append("<li>none</li>")
+    for subject in lead.finding_subjects[:8]:
+        parts.append(f"<li><code>{escape(subject.subject)}</code> — {escape(subject.summary)}<ul>")
+        for finding in subject.findings[:5]:
+            parts.append(f"<li>{escape(finding)}</li>")
+        hidden = len(subject.findings) - 5
+        if hidden:
+            suffix = "s" if hidden != 1 else ""
+            parts.append(f"<li>… and {hidden} more finding{suffix}</li>")
+        parts.append("</ul></li>")
+    hidden_subjects = len(lead.finding_subjects) - 8
+    if hidden_subjects:
+        suffix = "s" if hidden_subjects != 1 else ""
+        parts.append(f"<li>… and {hidden_subjects} more subject{suffix}</li>")
+    parts.append("</ul>")
+    return "".join(parts)
 
 
 def _heading(number: int, title: str, status: SectionStatus) -> str:

--- a/src/agents_shipgate/packet/markdown.py
+++ b/src/agents_shipgate/packet/markdown.py
@@ -18,6 +18,11 @@ from pathlib import Path
 
 from agents_shipgate.core.privacy import sanitize_packet
 from agents_shipgate.core.source_warnings import group_source_warnings
+from agents_shipgate.report.human_order import (
+    ColdReaderLead,
+    HumanArtifactContext,
+    should_render_packet_surface_first,
+)
 from agents_shipgate.report.markdown import _safe_markdown_text
 from agents_shipgate.schemas.packet import (
     ActionSurfaceDiffSection,
@@ -111,6 +116,8 @@ def render_packet_markdown(
     packet: EvidencePacket,
     *,
     sanitize_output: bool = True,
+    human_context: HumanArtifactContext | None = None,
+    cold_lead: ColdReaderLead | None = None,
 ) -> str:
     """Return the packet rendered as Markdown."""
 
@@ -118,10 +125,19 @@ def render_packet_markdown(
         packet = sanitize_packet(packet)
     lines: list[str] = []
     _append_header(lines, packet)
+    surface_first = bool(
+        cold_lead is not None and should_render_packet_surface_first(packet, context=human_context)
+    )
+    if surface_first:
+        _append_cold_surface(lines, cold_lead)
+        _append_high_risk_surface(lines, packet.high_risk_surface)
+        _append_cold_delta(lines, cold_lead)
+        _append_cold_findings(lines, cold_lead)
     _append_release_decision(lines, packet.release_decision)
     _append_evidence_matrix(lines, packet.evidence_matrix)
     _append_capability_intent(lines, packet.capability_intent)
-    _append_high_risk_surface(lines, packet.high_risk_surface)
+    if not surface_first:
+        _append_high_risk_surface(lines, packet.high_risk_surface)
     _append_tool_surface_diff(lines, packet.tool_surface_diff)
     _append_action_surface_diff(lines, packet.action_surface_diff)
     _append_approval_coverage(lines, packet.approval_coverage)
@@ -139,10 +155,17 @@ def write_packet_markdown(
     path: Path,
     *,
     sanitize_output: bool = True,
+    human_context: HumanArtifactContext | None = None,
+    cold_lead: ColdReaderLead | None = None,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        render_packet_markdown(packet, sanitize_output=sanitize_output),
+        render_packet_markdown(
+            packet,
+            sanitize_output=sanitize_output,
+            human_context=human_context,
+            cold_lead=cold_lead,
+        ),
         encoding="utf-8",
     )
 
@@ -175,6 +198,42 @@ def _append_header(lines: list[str], packet: EvidencePacket) -> None:
             "",
         ]
     )
+
+
+def _append_cold_surface(lines: list[str], lead: ColdReaderLead) -> None:
+    lines.extend(["## Capability surface", ""])
+    for line in lead.surface.text_lines():
+        lines.append(f"- {_escape(line)}")
+    lines.append("")
+
+
+def _append_cold_delta(lines: list[str], lead: ColdReaderLead) -> None:
+    if not lead.delta_subjects:
+        return
+    lines.extend(["## Capability delta by subject", ""])
+    for subject in lead.delta_subjects:
+        lines.append(f"- `{_escape(subject.subject)}`")
+        for change in subject.changes:
+            lines.append(f"  - {_escape(change)}")
+    lines.append("")
+
+
+def _append_cold_findings(lines: list[str], lead: ColdReaderLead) -> None:
+    lines.extend(["## Findings by subject", ""])
+    if not lead.finding_subjects:
+        lines.extend(["- none", ""])
+        return
+    for subject in lead.finding_subjects[:8]:
+        lines.append(f"- `{_escape(subject.subject)}` — {_escape(subject.summary)}")
+        for finding in subject.findings[:5]:
+            lines.append(f"  - {_escape(finding)}")
+        hidden = len(subject.findings) - 5
+        if hidden:
+            lines.append(f"  - … and {hidden} more finding{'s' if hidden != 1 else ''}")
+    hidden_subjects = len(lead.finding_subjects) - 8
+    if hidden_subjects:
+        lines.append(f"- … and {hidden_subjects} more subject{'s' if hidden_subjects != 1 else ''}")
+    lines.append("")
 
 
 def _section_heading(number: int, title: str, status: SectionStatus) -> str:

--- a/src/agents_shipgate/packet/markdown.py
+++ b/src/agents_shipgate/packet/markdown.py
@@ -126,9 +126,14 @@ def render_packet_markdown(
     lines: list[str] = []
     _append_header(lines, packet)
     surface_first = bool(
-        cold_lead is not None and should_render_packet_surface_first(packet, context=human_context)
+        should_render_packet_surface_first(
+            packet,
+            context=human_context,
+            cold_lead=cold_lead,
+        )
     )
     if surface_first:
+        assert cold_lead is not None
         _append_cold_surface(lines, cold_lead)
         _append_high_risk_surface(lines, packet.high_risk_surface)
         _append_cold_delta(lines, cold_lead)

--- a/src/agents_shipgate/packet/markdown.py
+++ b/src/agents_shipgate/packet/markdown.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from agents_shipgate.core.findings.subject_rollup import top_findings_block
 from agents_shipgate.core.privacy import sanitize_packet
 from agents_shipgate.core.source_warnings import group_source_warnings
 from agents_shipgate.report.human_order import (
@@ -225,19 +226,17 @@ def _append_cold_delta(lines: list[str], lead: ColdReaderLead) -> None:
 
 def _append_cold_findings(lines: list[str], lead: ColdReaderLead) -> None:
     lines.extend(["## Findings by subject", ""])
-    if not lead.finding_subjects:
-        lines.extend(["- none", ""])
-        return
-    for subject in lead.finding_subjects[:8]:
-        lines.append(f"- `{_escape(subject.subject)}` — {_escape(subject.summary)}")
-        for finding in subject.findings[:5]:
-            lines.append(f"  - {_escape(finding)}")
-        hidden = len(subject.findings) - 5
-        if hidden:
-            lines.append(f"  - … and {hidden} more finding{'s' if hidden != 1 else ''}")
-    hidden_subjects = len(lead.finding_subjects) - 8
-    if hidden_subjects:
-        lines.append(f"- … and {hidden_subjects} more subject{'s' if hidden_subjects != 1 else ''}")
+    lines.extend(
+        top_findings_block(
+            lead.finding_groups,
+            group_limit=8,
+            row_limit=5,
+            escape=_escape,
+            heading=None,
+            bullet="- ",
+            row_prefix="  - ",
+        )
+    )
     lines.append("")
 
 

--- a/src/agents_shipgate/packet/pdf.py
+++ b/src/agents_shipgate/packet/pdf.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from agents_shipgate.packet.html import render_packet_html
+from agents_shipgate.report.human_order import ColdReaderLead, HumanArtifactContext
 from agents_shipgate.schemas.packet import EvidencePacket
 
 
@@ -28,6 +29,8 @@ def render_packet_pdf(
     out_path: Path,
     *,
     sanitize_output: bool = True,
+    human_context: HumanArtifactContext | None = None,
+    cold_lead: ColdReaderLead | None = None,
 ) -> Path:
     """Render the packet as a PDF and write it to ``out_path``.
 
@@ -44,7 +47,12 @@ def render_packet_pdf(
         ) from exc
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    html_str = render_packet_html(packet, sanitize_output=sanitize_output)
+    html_str = render_packet_html(
+        packet,
+        sanitize_output=sanitize_output,
+        human_context=human_context,
+        cold_lead=cold_lead,
+    )
     HTML(string=html_str).write_pdf(str(out_path))
     return out_path
 

--- a/src/agents_shipgate/report/human_order.py
+++ b/src/agents_shipgate/report/human_order.py
@@ -1,0 +1,247 @@
+"""Human-artifact ordering for a repository's first Shipgate contact.
+
+This module is deliberately a presentation layer.  It carries no field into
+``report.json`` or ``packet.json`` and it never derives a release decision.
+The one decision rendered by every caller remains
+``report.release_decision.decision``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+
+from agents_shipgate.core.action_semantics import ACTION_EFFECT_RANK, effect_phrase
+from agents_shipgate.core.findings.subject_rollup import (
+    finding_line,
+    group_summary,
+    roll_up_findings,
+)
+from agents_shipgate.core.policy_reason_codes import is_adoption_evidence
+from agents_shipgate.schemas.capability_change import CapabilityChangeMember
+from agents_shipgate.schemas.packet import EvidencePacket
+from agents_shipgate.schemas.report import ReadinessReport
+
+
+@dataclass(frozen=True)
+class HumanArtifactContext:
+    """Ephemeral facts that affect human ordering but not machine output."""
+
+    manifest_committed: bool | None = None
+    manifest_introduced: bool = False
+    local_review: bool = False
+
+    @property
+    def is_cold(self) -> bool:
+        return bool(
+            self.manifest_committed is False or self.manifest_introduced or self.local_review
+        )
+
+
+@dataclass(frozen=True)
+class SurfaceLead:
+    tool_count: int
+    source_count: int
+    effect_counts: tuple[tuple[str, int], ...]
+    write_actions: tuple[tuple[str, str], ...]
+
+    def text_lines(self) -> list[str]:
+        source_noun = "source" if self.source_count == 1 else "sources"
+        lines = [f"Surface: {self.tool_count} tools from {self.source_count} {source_noun}."]
+        if self.effect_counts:
+            effects = ", ".join(
+                f"{count} {effect_phrase(effect)}" for effect, count in self.effect_counts
+            )
+            lines.append(f"Effects: {effects}.")
+        else:
+            lines.append("Effects: no root-reachable action effects were classified.")
+        if self.write_actions:
+            actions = ", ".join(
+                f"{name} ({effect_phrase(effect)})" for name, effect in self.write_actions
+            )
+            lines.append(f"Write/destructive actions: {actions}.")
+        else:
+            lines.append("Write/destructive actions: none.")
+        return lines
+
+
+@dataclass(frozen=True)
+class CapabilityDeltaSubject:
+    subject: str
+    changes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FindingSubject:
+    subject: str
+    summary: str
+    findings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ColdReaderLead:
+    surface: SurfaceLead
+    delta_subjects: tuple[CapabilityDeltaSubject, ...]
+    finding_subjects: tuple[FindingSubject, ...]
+
+
+def should_render_surface_first(
+    report: ReadinessReport,
+    *,
+    context: HumanArtifactContext | None = None,
+) -> bool:
+    """Whether this human artifact should lead with capability value.
+
+    A blocker, a block verdict, or even an inconsistent report that carries an
+    active block-tier finding keeps the established verdict-first order.  A
+    cold ``review_required`` run still leads with the surface: review is not a
+    block-tier result, and first-adoption verification legitimately produces
+    that shape when the introduced manifest is the review item.
+    """
+
+    decision = report.release_decision
+    if decision is None or decision.decision not in {
+        "insufficient_evidence",
+        "review_required",
+    }:
+        return False
+    if decision.blockers or any(
+        finding.blocks_release and not finding.suppressed for finding in report.findings
+    ):
+        return False
+    cold = context.is_cold if context is not None else False
+    return cold or _report_proves_manifest_introduction(report)
+
+
+def should_render_packet_surface_first(
+    packet: EvidencePacket,
+    *,
+    context: HumanArtifactContext | None,
+) -> bool:
+    """Packet equivalent using only its embedded decision substrate."""
+
+    decision = packet.release_decision
+    return bool(
+        context is not None
+        and context.is_cold
+        and decision.decision in {"insufficient_evidence", "review_required"}
+        and not decision.blockers
+    )
+
+
+def surface_lead(report: ReadinessReport) -> SurfaceLead:
+    """Project the already-recorded surface into a compact human lead."""
+
+    sources = {
+        (fact.source_type, fact.source_id or fact.provider)
+        for fact in report.tool_surface_facts.tools
+    }
+    if not sources:
+        sources = {
+            (action.source_type, action.source_id or action.provider)
+            for action in report.action_surface_facts.actions
+        }
+    if not sources:
+        sources = {(source_type, source_type) for source_type in report.tool_surface.sources}
+
+    counts = Counter(action.effect for action in report.action_surface_facts.actions)
+    effect_counts = tuple(
+        sorted(
+            counts.items(),
+            key=lambda item: (
+                ACTION_EFFECT_RANK.get(item[0], 99),
+                item[0],
+            ),
+        )
+    )
+    write_actions = tuple(
+        sorted(
+            {
+                (action.tool_name, action.effect)
+                for action in report.action_surface_facts.actions
+                if action.effect in {"write", "financial_write", "destructive"}
+            },
+            key=lambda item: (
+                -ACTION_EFFECT_RANK.get(item[1], 99),
+                item[0],
+                item[1],
+            ),
+        )
+    )
+    return SurfaceLead(
+        tool_count=report.tool_surface.total_tools,
+        source_count=len(sources),
+        effect_counts=effect_counts,
+        write_actions=write_actions,
+    )
+
+
+def capability_delta_by_subject(
+    report: ReadinessReport,
+) -> list[CapabilityDeltaSubject]:
+    """The canonical capability delta grouped by the tool it changes."""
+
+    change = report.capability_change
+    if change is None or not change.enabled:
+        return []
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for member in (
+        *change.added,
+        *change.broadened,
+        *change.narrowed,
+        *change.removed,
+    ):
+        grouped[member.tool].append(_delta_description(member))
+    return [
+        CapabilityDeltaSubject(subject=subject, changes=tuple(grouped[subject]))
+        for subject in sorted(grouped)
+    ]
+
+
+def findings_by_subject(report: ReadinessReport) -> list[FindingSubject]:
+    """The release-relevant finding projection grouped by review subject."""
+
+    subjects: list[FindingSubject] = []
+    for group in roll_up_findings(report):
+        rows = tuple(
+            finding_line(
+                finding,
+                blocks_release=blocks,
+                group_location=group.location,
+            )
+            for finding, blocks in group.rows()
+        )
+        subjects.append(
+            FindingSubject(
+                subject=f"{group.subject}{group.location}",
+                summary=group_summary(group),
+                findings=rows,
+            )
+        )
+    return subjects
+
+
+def cold_reader_lead(report: ReadinessReport) -> ColdReaderLead:
+    """One immutable projection for packet renderers with no report schema."""
+
+    return ColdReaderLead(
+        surface=surface_lead(report),
+        delta_subjects=tuple(capability_delta_by_subject(report)),
+        finding_subjects=tuple(findings_by_subject(report)),
+    )
+
+
+def _delta_description(member: CapabilityChangeMember) -> str:
+    target = member.action or member.scope or member.tool
+    detail = f"{member.direction} {member.subject_kind} {target}"
+    if member.before_scope is not None or member.after_scope is not None:
+        detail += f" ({member.before_scope or 'none'} -> {member.after_scope or 'none'})"
+    if member.release_impact not in {"none", "informational"}:
+        detail += f" — {effect_phrase(member.release_impact)}"
+    return detail
+
+
+def _report_proves_manifest_introduction(report: ReadinessReport) -> bool:
+    return any(
+        is_adoption_evidence(finding.check_id, finding.evidence) for finding in report.findings
+    )

--- a/src/agents_shipgate/report/human_order.py
+++ b/src/agents_shipgate/report/human_order.py
@@ -10,13 +10,11 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from typing import Literal
 
 from agents_shipgate.core.action_semantics import ACTION_EFFECT_RANK, effect_phrase
-from agents_shipgate.core.findings.subject_rollup import (
-    finding_line,
-    group_summary,
-    roll_up_findings,
-)
+from agents_shipgate.core.evidence_actions import display_literal
+from agents_shipgate.core.findings.subject_rollup import SubjectGroup, roll_up_findings
 from agents_shipgate.core.policy_reason_codes import is_adoption_evidence
 from agents_shipgate.schemas.capability_change import CapabilityChangeMember
 from agents_shipgate.schemas.packet import EvidencePacket
@@ -29,13 +27,13 @@ class HumanArtifactContext:
 
     manifest_committed: bool | None = None
     manifest_introduced: bool = False
-    local_review: bool = False
 
     @property
     def is_cold(self) -> bool:
-        return bool(
-            self.manifest_committed is False or self.manifest_introduced or self.local_review
-        )
+        return bool(self.manifest_committed is False or self.manifest_introduced)
+
+
+_SURFACE_WRITE_ACTION_LIMIT = 8
 
 
 @dataclass(frozen=True)
@@ -44,9 +42,10 @@ class SurfaceLead:
     source_count: int
     effect_counts: tuple[tuple[str, int], ...]
     write_actions: tuple[tuple[str, str], ...]
+    source_unit: Literal["source", "source type"] = "source"
 
     def text_lines(self) -> list[str]:
-        source_noun = "source" if self.source_count == 1 else "sources"
+        source_noun = self.source_unit if self.source_count == 1 else f"{self.source_unit}s"
         lines = [f"Surface: {self.tool_count} tools from {self.source_count} {source_noun}."]
         if self.effect_counts:
             effects = ", ".join(
@@ -57,8 +56,12 @@ class SurfaceLead:
             lines.append("Effects: no root-reachable action effects were classified.")
         if self.write_actions:
             actions = ", ".join(
-                f"{name} ({effect_phrase(effect)})" for name, effect in self.write_actions
+                f"{display_literal(name)} ({effect_phrase(effect)})"
+                for name, effect in self.write_actions[:_SURFACE_WRITE_ACTION_LIMIT]
             )
+            hidden = len(self.write_actions) - _SURFACE_WRITE_ACTION_LIMIT
+            if hidden > 0:
+                actions += f", … and {hidden} more action{'s' if hidden != 1 else ''}"
             lines.append(f"Write/destructive actions: {actions}.")
         else:
             lines.append("Write/destructive actions: none.")
@@ -72,17 +75,10 @@ class CapabilityDeltaSubject:
 
 
 @dataclass(frozen=True)
-class FindingSubject:
-    subject: str
-    summary: str
-    findings: tuple[str, ...]
-
-
-@dataclass(frozen=True)
 class ColdReaderLead:
     surface: SurfaceLead
     delta_subjects: tuple[CapabilityDeltaSubject, ...]
-    finding_subjects: tuple[FindingSubject, ...]
+    finding_groups: tuple[SubjectGroup, ...]
     has_active_block_tier: bool
 
 
@@ -140,6 +136,7 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
         (fact.source_type, fact.source_id or fact.provider)
         for fact in report.tool_surface_facts.tools
     }
+    source_unit: Literal["source", "source type"] = "source"
     if not sources:
         sources = {
             (action.source_type, action.source_id or action.provider)
@@ -147,6 +144,7 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
         }
     if not sources:
         sources = {(source_type, source_type) for source_type in report.tool_surface.sources}
+        source_unit = "source type"
 
     counts = Counter(action.effect for action in report.action_surface_facts.actions)
     effect_counts = tuple(
@@ -175,6 +173,7 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
     return SurfaceLead(
         tool_count=report.tool_surface.total_tools,
         source_count=len(sources),
+        source_unit=source_unit,
         effect_counts=effect_counts,
         write_actions=write_actions,
     )
@@ -197,32 +196,12 @@ def capability_delta_by_subject(
     ):
         grouped[member.tool].append(_delta_description(member))
     return [
-        CapabilityDeltaSubject(subject=subject, changes=tuple(grouped[subject]))
+        CapabilityDeltaSubject(
+            subject=display_literal(subject),
+            changes=tuple(grouped[subject]),
+        )
         for subject in sorted(grouped)
     ]
-
-
-def findings_by_subject(report: ReadinessReport) -> list[FindingSubject]:
-    """The release-relevant finding projection grouped by review subject."""
-
-    subjects: list[FindingSubject] = []
-    for group in roll_up_findings(report):
-        rows = tuple(
-            finding_line(
-                finding,
-                blocks_release=blocks,
-                group_location=group.location,
-            )
-            for finding, blocks in group.rows()
-        )
-        subjects.append(
-            FindingSubject(
-                subject=f"{group.subject}{group.location}",
-                summary=group_summary(group),
-                findings=rows,
-            )
-        )
-    return subjects
 
 
 def cold_reader_lead(report: ReadinessReport) -> ColdReaderLead:
@@ -231,7 +210,7 @@ def cold_reader_lead(report: ReadinessReport) -> ColdReaderLead:
     return ColdReaderLead(
         surface=surface_lead(report),
         delta_subjects=tuple(capability_delta_by_subject(report)),
-        finding_subjects=tuple(findings_by_subject(report)),
+        finding_groups=tuple(roll_up_findings(report)),
         has_active_block_tier=any(
             finding.blocks_release and not finding.suppressed
             for finding in report.findings
@@ -240,10 +219,12 @@ def cold_reader_lead(report: ReadinessReport) -> ColdReaderLead:
 
 
 def _delta_description(member: CapabilityChangeMember) -> str:
-    target = member.action or member.scope or member.tool
+    target = display_literal(member.action or member.scope or member.tool)
     detail = f"{member.direction} {member.subject_kind} {target}"
     if member.before_scope is not None or member.after_scope is not None:
-        detail += f" ({member.before_scope or 'none'} -> {member.after_scope or 'none'})"
+        before = display_literal(member.before_scope or "none")
+        after = display_literal(member.after_scope or "none")
+        detail += f" ({before} -> {after})"
     if member.release_impact not in {"none", "informational"}:
         detail += f" — {effect_phrase(member.release_impact)}"
     return detail

--- a/src/agents_shipgate/report/human_order.py
+++ b/src/agents_shipgate/report/human_order.py
@@ -83,6 +83,7 @@ class ColdReaderLead:
     surface: SurfaceLead
     delta_subjects: tuple[CapabilityDeltaSubject, ...]
     finding_subjects: tuple[FindingSubject, ...]
+    has_active_block_tier: bool
 
 
 def should_render_surface_first(
@@ -117,15 +118,18 @@ def should_render_packet_surface_first(
     packet: EvidencePacket,
     *,
     context: HumanArtifactContext | None,
+    cold_lead: ColdReaderLead | None,
 ) -> bool:
-    """Packet equivalent using only its embedded decision substrate."""
+    """Packet equivalent using its decision and report-derived cold lead."""
 
     decision = packet.release_decision
     return bool(
         context is not None
+        and cold_lead is not None
         and context.is_cold
         and decision.decision in {"insufficient_evidence", "review_required"}
         and not decision.blockers
+        and not cold_lead.has_active_block_tier
     )
 
 
@@ -228,6 +232,10 @@ def cold_reader_lead(report: ReadinessReport) -> ColdReaderLead:
         surface=surface_lead(report),
         delta_subjects=tuple(capability_delta_by_subject(report)),
         finding_subjects=tuple(findings_by_subject(report)),
+        has_active_block_tier=any(
+            finding.blocks_release and not finding.suppressed
+            for finding in report.findings
+        ),
     )
 
 

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -163,7 +163,7 @@ def render_markdown_report(
     _append_capability_intent_diff(
         lines,
         report,
-        include_decision=not surface_first,
+        include_legacy_consequence_decision=not surface_first,
     )
     _append_baseline(lines, report)
     _append_recommended_actions(lines, report.recommended_actions)
@@ -172,12 +172,10 @@ def render_markdown_report(
     _append_loaded_policy_packs(lines, report)
     _append_loaded_plugins(lines, report)
     _append_loaded_adapters(lines, report)
-    if not surface_first:
-        _append_tool_surface(lines, report)
-        _append_action_surface_diff(lines, report)
+    _append_tool_surface(lines, report)
+    _append_action_surface_diff(lines, report)
     _append_capability_runtime_evidence(lines, report)
-    if not surface_first:
-        _append_tool_surface_diff(lines, report)
+    _append_tool_surface_diff(lines, report)
     _append_api_surface(lines, report)
     _append_frameworks(lines, report)
     _append_codex_plugin_surface(lines, report)
@@ -415,7 +413,7 @@ def _append_capability_intent_diff(
     lines: list[str],
     report: ReadinessReport,
     *,
-    include_decision: bool = True,
+    include_legacy_consequence_decision: bool = True,
 ) -> None:
     lines.extend(["## Capability <-> Intent Diff", ""])
     if not report.misalignments:
@@ -494,7 +492,10 @@ def _append_capability_intent_diff(
     if consequence is None:
         lines.append("- No release consequence recorded.")
     else:
-        if include_decision:
+        # Adopted reports retain this pre-existing consequence projection byte
+        # for byte. Cold reports omit it so the primary release decision is
+        # the only ``Decision:`` line above the newly reordered detail.
+        if include_legacy_consequence_decision:
             lines.append(f"- Decision: {_safe_markdown_text(consequence.decision)}")
         lines.append(f"- {_safe_markdown_text(consequence.summary)}")
     lines.append("")

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -26,6 +26,12 @@ from agents_shipgate.core.findings.subject_rollup import (
 from agents_shipgate.core.privacy import sanitize_report
 from agents_shipgate.core.source_warnings import group_source_warnings
 from agents_shipgate.core.surface_exclusions import agent_label_index
+from agents_shipgate.report.human_order import (
+    HumanArtifactContext,
+    capability_delta_by_subject,
+    should_render_surface_first,
+    surface_lead,
+)
 from agents_shipgate.report.summary_text import evidence_coverage_text
 from agents_shipgate.schemas.bindings import AgentBindingGraphAssessment
 from agents_shipgate.schemas.report import (
@@ -88,10 +94,15 @@ def write_markdown_report(
     path: Path,
     *,
     sanitize_output: bool = True,
+    human_context: HumanArtifactContext | None = None,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        render_markdown_report(report, sanitize_output=sanitize_output),
+        render_markdown_report(
+            report,
+            sanitize_output=sanitize_output,
+            human_context=human_context,
+        ),
         encoding="utf-8",
     )
 
@@ -100,6 +111,7 @@ def render_markdown_report(
     report: ReadinessReport,
     *,
     sanitize_output: bool = True,
+    human_context: HumanArtifactContext | None = None,
 ) -> str:
     if sanitize_output:
         report = sanitize_report(report)
@@ -122,6 +134,11 @@ def render_markdown_report(
                 "",
             ]
         )
+    surface_first = should_render_surface_first(report, context=human_context)
+    if surface_first:
+        _append_cold_reader_surface(lines, report)
+        _append_cold_reader_delta(lines, report)
+        _append_top_findings(lines, report)
     _append_release_decision(lines, report)
     _append_policy_audit(lines, report)
     lines.extend(
@@ -140,9 +157,14 @@ def render_markdown_report(
             "",
         ]
     )
-    _append_top_findings(lines, report)
+    if not surface_first:
+        _append_top_findings(lines, report)
     _append_finding_provenance(lines, report.findings)
-    _append_capability_intent_diff(lines, report)
+    _append_capability_intent_diff(
+        lines,
+        report,
+        include_decision=not surface_first,
+    )
     _append_baseline(lines, report)
     _append_recommended_actions(lines, report.recommended_actions)
     _append_source_warnings(lines, report)
@@ -150,10 +172,12 @@ def render_markdown_report(
     _append_loaded_policy_packs(lines, report)
     _append_loaded_plugins(lines, report)
     _append_loaded_adapters(lines, report)
-    _append_tool_surface(lines, report)
-    _append_action_surface_diff(lines, report)
+    if not surface_first:
+        _append_tool_surface(lines, report)
+        _append_action_surface_diff(lines, report)
     _append_capability_runtime_evidence(lines, report)
-    _append_tool_surface_diff(lines, report)
+    if not surface_first:
+        _append_tool_surface_diff(lines, report)
     _append_api_surface(lines, report)
     _append_frameworks(lines, report)
     _append_codex_plugin_surface(lines, report)
@@ -162,6 +186,25 @@ def render_markdown_report(
     _append_inventory(lines, report)
     lines.extend(["", "## Disclaimer", "", DISCLAIMER, ""])
     return "\n".join(lines)
+
+
+def _append_cold_reader_surface(lines: list[str], report: ReadinessReport) -> None:
+    lines.extend(["## Capability Surface", ""])
+    for line in surface_lead(report).text_lines():
+        lines.append(_safe_markdown_text(line))
+    lines.append("")
+
+
+def _append_cold_reader_delta(lines: list[str], report: ReadinessReport) -> None:
+    groups = capability_delta_by_subject(report)
+    if not groups:
+        return
+    lines.extend(["## Capability Delta By Subject", ""])
+    for group in groups:
+        lines.append(f"- {_safe_markdown_text(group.subject)}")
+        for change in group.changes:
+            lines.append(f"  - {_safe_markdown_text(change)}")
+    lines.append("")
 
 
 def _append_release_decision(lines: list[str], report: ReadinessReport) -> None:
@@ -371,6 +414,8 @@ def _append_finding_provenance(lines: list[str], findings: list[Finding]) -> Non
 def _append_capability_intent_diff(
     lines: list[str],
     report: ReadinessReport,
+    *,
+    include_decision: bool = True,
 ) -> None:
     lines.extend(["## Capability <-> Intent Diff", ""])
     if not report.misalignments:
@@ -449,7 +494,8 @@ def _append_capability_intent_diff(
     if consequence is None:
         lines.append("- No release consequence recorded.")
     else:
-        lines.append(f"- Decision: {_safe_markdown_text(consequence.decision)}")
+        if include_decision:
+            lines.append(f"- Decision: {_safe_markdown_text(consequence.decision)}")
         lines.append(f"- {_safe_markdown_text(consequence.summary)}")
     lines.append("")
 

--- a/src/agents_shipgate/report/pr_comment.py
+++ b/src/agents_shipgate/report/pr_comment.py
@@ -12,6 +12,12 @@ from agents_shipgate.core.findings.subject_rollup import (
 from agents_shipgate.report.capability_lock_diff_markdown import (
     render_capability_lock_diff_markdown,
 )
+from agents_shipgate.report.human_order import (
+    HumanArtifactContext,
+    capability_delta_by_subject,
+    should_render_surface_first,
+    surface_lead,
+)
 from agents_shipgate.schemas.capabilities import CapabilityLockDiffV1
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.verifier import (
@@ -48,16 +54,19 @@ def render_pr_comment(
     report: ReadinessReport | None,
     style: str = "capability-review",
     capability_lock_diff: CapabilityLockDiffV1 | None = None,
+    human_context: HumanArtifactContext | None = None,
 ) -> str:
     if style == "findings":
         return _render_findings_comment(
             verifier,
             report=report,
+            human_context=human_context,
         )
     return _render_capability_review_comment(
         verifier,
         report=report,
         capability_lock_diff=capability_lock_diff,
+        human_context=human_context,
     )
 
 
@@ -66,6 +75,7 @@ def _render_capability_review_comment(
     *,
     report: ReadinessReport | None,
     capability_lock_diff: CapabilityLockDiffV1 | None,
+    human_context: HumanArtifactContext | None,
 ) -> str:
     prose_lines = [
         STICKY_MARKER,
@@ -74,6 +84,7 @@ def _render_capability_review_comment(
             verifier,
             report=report,
             capability_lock_diff=capability_lock_diff,
+            human_context=human_context,
         ),
     ]
     agent_block = _agent_instruction_block(verifier)
@@ -94,8 +105,14 @@ def _human_summary_lines(
     *,
     report: ReadinessReport | None,
     capability_lock_diff: CapabilityLockDiffV1 | None,
+    human_context: HumanArtifactContext | None,
 ) -> list[str]:
     lines = ["", "### Human summary"]
+    surface_first = bool(
+        report is not None and should_render_surface_first(report, context=human_context)
+    )
+    if surface_first and report is not None:
+        lines.extend(_cold_reader_lines(report))
     lines.append(f"- Merge verdict: `{verifier.merge_verdict}`")
     lines.append(f"- Can merge without human: `{str(verifier.can_merge_without_human).lower()}`")
     lines.append(f"- Agent control state: `{verifier.control.state}`")
@@ -160,7 +177,7 @@ def _human_summary_lines(
     )
     lines.append(f"- Static-verdict boundary: {_escape(STATIC_VERDICT_DISCLAIMER)}")
     lines.extend(_next_actor_lines(verifier))
-    if review.top_changes:
+    if review.top_changes and not surface_first:
         lines.append("- Top capability changes:")
         for change in review.top_changes[:5]:
             source = _source_suffix(change.source_path, change.source_start_line)
@@ -169,9 +186,10 @@ def _human_summary_lines(
                 f"`{change.subject}`: {_escape(_impact(change))}; "
                 f"{_escape(change.rationale)}{source}"
             )
-    elif review.notes:
+    elif review.notes and not surface_first:
         lines.append(f"- Capability delta note: {_escape(review.notes[0])}")
-    lines.extend(_subject_rollup_lines(report))
+    if not surface_first:
+        lines.extend(_subject_rollup_lines(report))
     if review.trust_root_touched or review.policy_weakened:
         if review.trust_root_touched:
             lines.append("- Trust root touched: `true`")
@@ -179,6 +197,19 @@ def _human_summary_lines(
             lines.extend(_policy_change_lines(review))
     lines.extend(_trigger_and_base_summary(verifier))
     lines.extend(_artifact_summary_lines(verifier))
+    return lines
+
+
+def _cold_reader_lines(report: ReadinessReport) -> list[str]:
+    lines = [f"- {_escape(line)}" for line in surface_lead(report).text_lines()]
+    groups = capability_delta_by_subject(report)
+    if groups:
+        lines.append("- Capability changes by subject:")
+        for group in groups:
+            lines.append(f"  - `{_escape(group.subject)}`")
+            for change in group.changes:
+                lines.append(f"    - {_escape(change)}")
+    lines.extend(_subject_rollup_lines(report))
     return lines
 
 
@@ -345,8 +376,19 @@ def _render_findings_comment(
     verifier: VerifierArtifact,
     *,
     report: ReadinessReport | None,
+    human_context: HumanArtifactContext | None,
 ) -> str:
-    lines = [STICKY_MARKER, f"## Agents Shipgate result: {verifier.merge_verdict}"]
+    surface_first = bool(
+        report is not None and should_render_surface_first(report, context=human_context)
+    )
+    title = (
+        "## Agents Shipgate"
+        if surface_first
+        else f"## Agents Shipgate result: {verifier.merge_verdict}"
+    )
+    lines = [STICKY_MARKER, title]
+    if surface_first and report is not None:
+        lines.extend(["", *_cold_reader_lines(report)])
     lines.extend(_verifier_lead(verifier))
     lines.append("")
     lines.append(f"Trigger: {_escape(verifier.trigger.get('rationale') or 'not evaluated')}")
@@ -387,10 +429,11 @@ def _render_findings_comment(
         surface = report.reviewer_summary.first_recommended_surface
         lines.append(f"Reviewer start: `{surface.name}` - {_escape(surface.why)}")
 
-    lines.extend(_diff_lines(report))
+    if not surface_first:
+        lines.extend(_diff_lines(report))
     groups = roll_up_findings(report)
     lines.append("")
-    if groups:
+    if groups and not surface_first:
         # Grouped by subject (#364). A reviewer reads this comment to decide
         # what to look at, and three rows of one check family on three sibling
         # tools names one thing to look at while the other four go unmentioned.
@@ -404,7 +447,7 @@ def _render_findings_comment(
                 row_prefix="  - ",
             )
         )
-    else:
+    elif not surface_first:
         lines.append("No critical or high findings.")
     lines.extend(_artifact_lines(verifier, links=False))
     return _truncate("\n".join(lines), 6000)

--- a/src/agents_shipgate/report/pr_comment.py
+++ b/src/agents_shipgate/report/pr_comment.py
@@ -38,6 +38,8 @@ _IMPACT_LABELS = {
     "none": "none",
 }
 _COMMENT_MAX_CHARS = 6000
+_COLD_READER_LEAD_MAX_CHARS = 2000
+_COLD_READER_OMISSION = "- … additional capability detail omitted; see report.md."
 
 # Budget for the grouped summary inside a comment that is truncated at
 # ``_COMMENT_MAX_CHARS``. Narrower than ``report.md`` on purpose: this block
@@ -177,7 +179,7 @@ def _human_summary_lines(
     )
     lines.append(f"- Static-verdict boundary: {_escape(STATIC_VERDICT_DISCLAIMER)}")
     lines.extend(_next_actor_lines(verifier))
-    if review.top_changes and not surface_first:
+    if review.top_changes:
         lines.append("- Top capability changes:")
         for change in review.top_changes[:5]:
             source = _source_suffix(change.source_path, change.source_start_line)
@@ -186,7 +188,7 @@ def _human_summary_lines(
                 f"`{change.subject}`: {_escape(_impact(change))}; "
                 f"{_escape(change.rationale)}{source}"
             )
-    elif review.notes and not surface_first:
+    elif review.notes:
         lines.append(f"- Capability delta note: {_escape(review.notes[0])}")
     if not surface_first:
         lines.extend(_subject_rollup_lines(report))
@@ -210,7 +212,24 @@ def _cold_reader_lines(report: ReadinessReport) -> list[str]:
             for change in group.changes:
                 lines.append(f"    - {_escape(change)}")
     lines.extend(_subject_rollup_lines(report))
-    return lines
+    return _bounded_cold_reader_lines(lines)
+
+
+def _bounded_cold_reader_lines(lines: list[str]) -> list[str]:
+    """Reserve PR-comment space for the verdict/control block that follows."""
+
+    if len("\n".join(lines)) <= _COLD_READER_LEAD_MAX_CHARS:
+        return lines
+    budget = _COLD_READER_LEAD_MAX_CHARS - len(_COLD_READER_OMISSION) - 1
+    shown: list[str] = []
+    used = 0
+    for line in lines:
+        added = len(line) + (1 if shown else 0)
+        if used + added > budget:
+            break
+        shown.append(line)
+        used += added
+    return [*shown, _COLD_READER_OMISSION]
 
 
 def _subject_rollup_lines(report: ReadinessReport) -> list[str]:
@@ -389,7 +408,12 @@ def _render_findings_comment(
     lines = [STICKY_MARKER, title]
     if surface_first and report is not None:
         lines.extend(["", *_cold_reader_lines(report)])
-    lines.extend(_verifier_lead(verifier))
+    lines.extend(
+        _verifier_lead(
+            verifier,
+            include_release_gate=report is None or not surface_first,
+        )
+    )
     lines.append("")
     lines.append(f"Trigger: {_escape(verifier.trigger.get('rationale') or 'not evaluated')}")
     if verifier.base_status != "not_requested":
@@ -429,8 +453,7 @@ def _render_findings_comment(
         surface = report.reviewer_summary.first_recommended_surface
         lines.append(f"Reviewer start: `{surface.name}` - {_escape(surface.why)}")
 
-    if not surface_first:
-        lines.extend(_diff_lines(report))
+    lines.extend(_diff_lines(report))
     groups = roll_up_findings(report)
     lines.append("")
     if groups and not surface_first:
@@ -453,13 +476,17 @@ def _render_findings_comment(
     return _truncate("\n".join(lines), 6000)
 
 
-def _verifier_lead(verifier: VerifierArtifact) -> list[str]:
+def _verifier_lead(
+    verifier: VerifierArtifact,
+    *,
+    include_release_gate: bool = True,
+) -> list[str]:
     lines = [
         "",
         f"Merge verdict: `{verifier.merge_verdict}`",
         f"Can merge without human: `{str(verifier.can_merge_without_human).lower()}`",
     ]
-    if verifier.decision:
+    if include_release_gate and verifier.decision:
         lines.append(f"Release gate: `{verifier.decision}`")
     if verifier.human_review is not None and verifier.human_review.required:
         why = verifier.human_review.why or "Human review required before merge."

--- a/tests/test_cold_reader_order.py
+++ b/tests/test_cold_reader_order.py
@@ -6,6 +6,7 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 from agents_shipgate.cli._helpers import _print_cli_summary, _run_multi_scan
 from agents_shipgate.cli.scan import run_scan
@@ -140,6 +141,23 @@ def test_empty_repository_is_cold(tmp_path):
 
     assert context.manifest_committed is False
     assert context.is_cold
+
+
+def test_git_probe_failure_keeps_manifest_provenance_unknown(tmp_path, monkeypatch):
+    repo = tmp_path / "unreadable-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    config = repo / "shipgate.yaml"
+    config.write_text("version: 1\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "agents_shipgate.cli.verify.git._run_git",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=128, stdout=""),
+    )
+
+    context = human_artifact_context(config, None)
+
+    assert context.manifest_committed is None
+    assert not context.is_cold
 
 
 def test_surface_lead_spells_out_destructive_actions(tmp_path, monkeypatch):

--- a/tests/test_cold_reader_order.py
+++ b/tests/test_cold_reader_order.py
@@ -8,6 +8,8 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from agents_shipgate.cli._helpers import _print_cli_summary, _run_multi_scan
 from agents_shipgate.cli.scan import run_scan
 from agents_shipgate.cli.scan.human_order import human_artifact_context
@@ -18,8 +20,10 @@ from agents_shipgate.packet.markdown import render_packet_markdown
 from agents_shipgate.report.human_order import (
     HumanArtifactContext,
     cold_reader_lead,
+    surface_lead,
 )
 from agents_shipgate.report.markdown import render_markdown_report
+from agents_shipgate.report.pr_comment import render_pr_comment
 from agents_shipgate.schemas.capability_change import (
     CapabilityChangeBlock,
     CapabilityChangeMember,
@@ -83,16 +87,34 @@ def test_unadopted_human_artifacts_lead_with_the_surface(
     assert markdown.index("## Capability Surface") < markdown.index("## Top Findings")
     assert markdown.index("## Top Findings") < markdown.index("## Release Decision")
     assert markdown.count("Decision: insufficient_evidence") == 1
+    for heading in (
+        "## Tool Surface Summary",
+        "## Action Surface Diff",
+        "## Tool Surface Diff",
+    ):
+        assert markdown.index("## Release Decision") < markdown.index(heading)
 
     _print_cli_summary(report, "advisory", 0, human_context=context)
     console = capsys.readouterr().out
     assert console.index("Surface: 9 tools from 3 sources.") < console.index("Findings by subject")
     assert console.index("Findings by subject") < console.index("Decision: insufficient_evidence")
     assert console.count("Decision: insufficient_evidence") == 1
+    assert console.index("Decision: insufficient_evidence") < console.index(
+        "Action-surface diff:"
+    )
+    assert console.index("Decision: insufficient_evidence") < console.index(
+        "Tool-surface diff:"
+    )
 
     assert github.index("### Capability surface") < github.index("### Findings")
     assert github.index("### Findings") < github.index("Decision: `insufficient_evidence`")
     assert github.count("Decision: `insufficient_evidence`") == 1
+    assert github.index("Decision: `insufficient_evidence`") < github.index(
+        "Action-surface diff:"
+    )
+    assert github.index("Decision: `insufficient_evidence`") < github.index(
+        "Tool-surface diff:"
+    )
 
     assert packet_markdown.index("## Capability surface") < packet_markdown.index(
         "## §3 High-risk tool surface"
@@ -104,12 +126,16 @@ def test_unadopted_human_artifacts_lead_with_the_surface(
         "## §1A Evidence matrix"
     )
     assert packet_markdown.count("- Decision: `insufficient_evidence`") == 1
+    assert "more finding" not in packet_markdown
+    assert "more subject" not in packet_markdown
     assert packet_html.index("<h2>Capability surface</h2>") < packet_html.index(
         "§3 High-risk tool surface"
     )
     assert packet_html.index("Findings by subject") < packet_html.index("§1 Release decision")
     assert packet_html.index("§1 Release decision") < packet_html.index("§1A Evidence matrix")
     assert packet_html.count("Decision: <code>insufficient_evidence</code>") == 1
+    assert "more finding" not in packet_html
+    assert "more subject" not in packet_html
 
     report_json = json.loads((repo / "reports" / "report.json").read_text())
     packet_json = json.loads((repo / "reports" / "packet.json").read_text())
@@ -128,6 +154,24 @@ def test_unadopted_human_artifacts_lead_with_the_surface(
     )
     assert (repo / "reports" / "report.json").read_bytes() == report_bytes
     assert (repo / "reports" / "packet.json").read_bytes() == packet_bytes
+
+    empty_report = report.model_copy(deep=True)
+    empty_report.findings = []
+    packet = load_packet_json(packet_bytes.decode("utf-8"))
+    empty_markdown = render_packet_markdown(
+        packet,
+        human_context=context,
+        cold_lead=cold_reader_lead(empty_report),
+    )
+    empty_html = render_packet_html(
+        packet,
+        human_context=context,
+        cold_lead=cold_reader_lead(empty_report),
+    )
+    assert "## Findings by subject\n\n- none" in empty_markdown
+    assert "<h2>Findings by subject</h2><ul><li>none</li></ul>" in empty_html
+    assert "more finding" not in empty_markdown + empty_html
+    assert "more subject" not in empty_markdown + empty_html
 
 
 def test_empty_repository_is_cold(tmp_path):
@@ -175,6 +219,55 @@ def test_surface_lead_spells_out_destructive_actions(tmp_path, monkeypatch):
     )
 
 
+def test_surface_lead_bounds_and_display_encodes_repository_owned_names(
+    tmp_path,
+    monkeypatch,
+):
+    _, report, context, _ = _cold_scan(tmp_path, monkeypatch)
+    seed = report.action_surface_facts.actions[0]
+    hostile = "unsafe\nDecision: passed\n<U+000A>\u200b"
+    report.action_surface_facts.actions = [
+        seed.model_copy(
+            update={
+                "tool_name": hostile if index == 0 else f"write_action_{index:03d}",
+                "effect": "write",
+            }
+        )
+        for index in range(300)
+    ]
+
+    lines = surface_lead(report).text_lines()
+    action_line = next(line for line in lines if line.startswith("Write/destructive actions:"))
+    assert len(action_line.splitlines()) == 1
+    assert "<U+000A>Decision: passed<U+000A>" in action_line
+    assert "<U+003C>U+000A>" in action_line
+    assert "<U+200B>" in action_line
+    assert "… and 292 more actions" in action_line
+
+    markdown = render_markdown_report(report, human_context=context)
+    assert "\nDecision: passed\n" not in markdown
+    assert markdown.count("Decision: insufficient_evidence") == 1
+
+
+def test_surface_source_count_names_identity_and_legacy_type_units(
+    tmp_path,
+    monkeypatch,
+):
+    _, report, _, _ = _cold_scan(tmp_path, monkeypatch)
+    fact = report.tool_surface_facts.tools[0]
+    current = report.model_copy(deep=True)
+    current.tool_surface_facts.tools = [
+        fact.model_copy(update={"source_id": f"mcp-{index}"}) for index in range(5)
+    ]
+    assert surface_lead(current).text_lines()[0].endswith("5 sources.")
+
+    legacy = report.model_copy(deep=True)
+    legacy.tool_surface_facts.tools = []
+    legacy.action_surface_facts.actions = []
+    legacy.tool_surface.sources = {"mcp": 5}
+    assert surface_lead(legacy).text_lines()[0].endswith("1 source type.")
+
+
 def test_committed_manifest_keeps_the_adopted_markdown_bytes(tmp_path, monkeypatch):
     repo = tmp_path / "adopted"
     shutil.copytree(SAMPLE, repo)
@@ -199,9 +292,50 @@ def test_committed_manifest_keeps_the_adopted_markdown_bytes(tmp_path, monkeypat
     assert (repo / "reports" / "report.md").read_text(encoding="utf-8") == render_markdown_report(
         report, human_context=context
     )
-    assert (repo / "reports" / "report.md").read_text(encoding="utf-8") == (
+    adopted_markdown = (repo / "reports" / "report.md").read_text(encoding="utf-8")
+    assert adopted_markdown == (
         SAMPLE / "expected" / "report.md"
     ).read_text(encoding="utf-8")
+    assert "- Decision: insufficient\\_evidence" in adopted_markdown
+
+
+def test_packet_lead_is_not_built_without_a_cold_human_packet(
+    tmp_path,
+    monkeypatch,
+):
+    def unexpected_lead(_report):
+        raise AssertionError("cold packet lead should not be built")
+
+    monkeypatch.setattr(
+        "agents_shipgate.cli.scan.writing.cold_reader_lead",
+        unexpected_lead,
+    )
+
+    cold = _unadopted_sample(tmp_path / "cold")
+    run_scan(
+        config_path=cold / "shipgate.yaml",
+        output_dir=cold / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=True,
+        packet_formats=["json"],
+    )
+
+    adopted = tmp_path / "adopted-packet"
+    shutil.copytree(SAMPLE, adopted)
+    _git(adopted, "init", "-q")
+    _git(adopted, "config", "user.name", "Shipgate Test")
+    _git(adopted, "config", "user.email", "shipgate@example.invalid")
+    _git(adopted, "add", ".")
+    _git(adopted, "commit", "-qm", "adopted repository")
+    run_scan(
+        config_path=adopted / "shipgate.yaml",
+        output_dir=adopted / "reports",
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=True,
+        packet_formats=["md"],
+    )
 
 
 def test_archived_adopted_verify_remains_verdict_first(tmp_path):
@@ -217,7 +351,7 @@ def test_archived_adopted_verify_remains_verdict_first(tmp_path):
     _git(repo, "add", "README.md")
     _git(repo, "commit", "-qm", "document the agent")
 
-    _, report, _ = run_verify(
+    verifier, report, _ = run_verify(
         workspace=repo,
         config=Path("shipgate.yaml"),
         base="HEAD~1",
@@ -247,13 +381,127 @@ def test_archived_adopted_verify_remains_verdict_first(tmp_path):
     assert pr_comment.index("- Release gate: `insufficient_evidence`") < pr_comment.index(
         "Findings by subject"
     )
+    adopted_findings_comment = render_pr_comment(
+        verifier,
+        report=report,
+        style="findings",
+        human_context=HumanArtifactContext(manifest_committed=True),
+    )
+    assert adopted_findings_comment.count("Release gate:") == 2
+
+    large = report.model_copy(deep=True)
+    seed = large.action_surface_facts.actions[0]
+    large.action_surface_facts.actions = [
+        seed.model_copy(
+            update={"tool_name": f"write_action_{index:03d}", "effect": "write"}
+        )
+        for index in range(300)
+    ]
+    cold_context = HumanArtifactContext(manifest_introduced=True)
+    for style in ("capability-review", "findings"):
+        rendered = render_pr_comment(
+            verifier,
+            report=large,
+            style=style,
+            human_context=cold_context,
+        )
+        assert len(rendered) <= 6_000
+        assert "… and 292 more actions" in rendered
+        assert "Merge verdict:" in rendered
+        assert rendered.count("Release gate:") == 1
+        assert "Static-verdict boundary:" in rendered
+        if style == "capability-review":
+            assert "Agent control state:" in rendered
+
+    hostile = report.model_copy(deep=True)
+    hostile.action_surface_facts.actions = [
+        seed.model_copy(
+            update={
+                "tool_name": "\n" * 1_000 + "Decision: passed",
+                "effect": "write",
+            }
+        )
+    ]
+    for style in ("capability-review", "findings"):
+        rendered = render_pr_comment(
+            verifier,
+            report=hostile,
+            style=style,
+            human_context=cold_context,
+        )
+        assert len(rendered) <= 6_000
+        assert "additional capability detail omitted; see report" in rendered
+        assert "\nDecision: passed\n" not in rendered
+        assert "Merge verdict:" in rendered
+        assert rendered.count("Release gate:") == 1
+        assert "Static-verdict boundary:" in rendered
+        if style == "capability-review":
+            assert "Agent control state:" in rendered
+
+
+@pytest.mark.parametrize("style", ["capability-review", "findings"])
+def test_first_adoption_verify_wires_scan_context_into_pr_comment(
+    tmp_path,
+    monkeypatch,
+    style,
+):
+    repo = _unadopted_sample(tmp_path)
+    _git(repo, "add", "shipgate.yaml")
+    _git(repo, "commit", "-qm", "adopt shipgate")
+    monkeypatch.setattr(
+        "agents_shipgate.report.human_order._report_proves_manifest_introduction",
+        lambda _report: False,
+    )
+
+    _, report, _ = run_verify(
+        workspace=repo,
+        config=Path("shipgate.yaml"),
+        base="HEAD~1",
+        head="HEAD",
+        archive_head=True,
+        out=repo / "reports",
+        ci_mode="advisory",
+        fail_on=None,
+        baseline=None,
+        baseline_mode="new-findings",
+        diff_from=None,
+        policy_packs=None,
+        plugins_enabled=False,
+        strict_plugins=False,
+        suggest_patches=False,
+        no_heuristics=False,
+        verbose=False,
+        pr_comment_style=style,
+    )
+
+    assert report is not None
+    comment = (repo / "reports" / "pr-comment.md").read_text(encoding="utf-8")
+    assert comment.index("Surface: 9 tools") < comment.index("Release gate:")
+    assert comment.count("Release gate:") == 1
+    if style == "capability-review":
+        assert "Capability delta note:" in comment or "Top capability changes:" in comment
+    else:
+        assert comment.index("Release gate:") < comment.index("Action-surface diff:")
+        assert comment.index("Release gate:") < comment.index("Tool-surface diff:")
 
 
 def test_unadopted_multi_scan_row_puts_the_surface_before_the_decision(
     tmp_path,
+    monkeypatch,
     capsys,
 ):
     repo = _unadopted_sample(tmp_path)
+    from agents_shipgate.cli.verify import git as verify_git
+
+    original = verify_git.path_committed_at_head
+    probes = 0
+
+    def counted_probe(root, relative):
+        nonlocal probes
+        probes += 1
+        return original(root, relative)
+
+    monkeypatch.setattr(verify_git, "path_committed_at_head", counted_probe)
 
     exit_code = _run_multi_scan(
         config_paths=[repo / "shipgate.yaml"],
@@ -282,6 +530,7 @@ def test_unadopted_multi_scan_row_puts_the_surface_before_the_decision(
         i for i, line in enumerate(manifest_lines) if ": insufficient_evidence " in line
     )
     assert findings_index < decision_index
+    assert probes == 1
 
 
 def test_cold_block_tier_content_keeps_verdict_first(tmp_path, monkeypatch):

--- a/tests/test_cold_reader_order.py
+++ b/tests/test_cold_reader_order.py
@@ -1,0 +1,367 @@
+"""Cold-reader human artifacts lead with capability value (#463)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from agents_shipgate.cli._helpers import _print_cli_summary, _run_multi_scan
+from agents_shipgate.cli.scan import run_scan
+from agents_shipgate.cli.scan.human_order import human_artifact_context
+from agents_shipgate.cli.verify.orchestrator import run_verify
+from agents_shipgate.packet.html import render_packet_html
+from agents_shipgate.packet.json_packet import load_packet_json
+from agents_shipgate.packet.markdown import render_packet_markdown
+from agents_shipgate.report.human_order import (
+    HumanArtifactContext,
+    cold_reader_lead,
+)
+from agents_shipgate.report.markdown import render_markdown_report
+from agents_shipgate.schemas.capability_change import (
+    CapabilityChangeBlock,
+    CapabilityChangeMember,
+)
+from agents_shipgate.schemas.report import ReadinessReport
+
+SAMPLE = Path("samples/google_adk_cold_start_agent")
+COLD_REPORT_GOLDEN = SAMPLE / "expected" / "cold-report.md"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _unadopted_sample(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    shutil.copytree(SAMPLE, repo)
+    shutil.rmtree(repo / "expected")
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Shipgate Test")
+    _git(repo, "config", "user.email", "shipgate@example.invalid")
+    _git(repo, "add", "agent.py", "inventories", "specs")
+    _git(repo, "commit", "-qm", "base without manifest")
+    return repo
+
+
+def _cold_scan(
+    tmp_path: Path,
+    monkeypatch,
+) -> tuple[Path, ReadinessReport, HumanArtifactContext, str]:
+    repo = _unadopted_sample(tmp_path)
+    summary_path = tmp_path / "step-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    report, _ = run_scan(
+        config_path=repo / "shipgate.yaml",
+        output_dir=repo / "reports",
+        formats=["markdown", "json"],
+        ci_mode="advisory",
+    )
+    context = human_artifact_context(repo / "shipgate.yaml", None)
+    assert context.manifest_committed is False
+    return repo, report, context, summary_path.read_text(encoding="utf-8")
+
+
+def test_unadopted_human_artifacts_lead_with_the_surface(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    repo, report, context, github = _cold_scan(tmp_path, monkeypatch)
+    markdown = (repo / "reports" / "report.md").read_text(encoding="utf-8")
+    packet_markdown = (repo / "reports" / "packet.md").read_text(encoding="utf-8")
+    packet_html = (repo / "reports" / "packet.html").read_text(encoding="utf-8")
+
+    assert markdown == COLD_REPORT_GOLDEN.read_text(encoding="utf-8")
+    assert markdown.index("## Capability Surface") < markdown.index("## Top Findings")
+    assert markdown.index("## Top Findings") < markdown.index("## Release Decision")
+    assert markdown.count("Decision: insufficient_evidence") == 1
+
+    _print_cli_summary(report, "advisory", 0, human_context=context)
+    console = capsys.readouterr().out
+    assert console.index("Surface: 9 tools from 3 sources.") < console.index("Findings by subject")
+    assert console.index("Findings by subject") < console.index("Decision: insufficient_evidence")
+    assert console.count("Decision: insufficient_evidence") == 1
+
+    assert github.index("### Capability surface") < github.index("### Findings")
+    assert github.index("### Findings") < github.index("Decision: `insufficient_evidence`")
+    assert github.count("Decision: `insufficient_evidence`") == 1
+
+    assert packet_markdown.index("## Capability surface") < packet_markdown.index(
+        "## §3 High-risk tool surface"
+    )
+    assert packet_markdown.index("## Findings by subject") < packet_markdown.index(
+        "## §1 Release decision"
+    )
+    assert packet_markdown.index("## §1 Release decision") < packet_markdown.index(
+        "## §1A Evidence matrix"
+    )
+    assert packet_markdown.count("- Decision: `insufficient_evidence`") == 1
+    assert packet_html.index("<h2>Capability surface</h2>") < packet_html.index(
+        "§3 High-risk tool surface"
+    )
+    assert packet_html.index("Findings by subject") < packet_html.index("§1 Release decision")
+    assert packet_html.index("§1 Release decision") < packet_html.index("§1A Evidence matrix")
+    assert packet_html.count("Decision: <code>insufficient_evidence</code>") == 1
+
+    report_json = json.loads((repo / "reports" / "report.json").read_text())
+    packet_json = json.loads((repo / "reports" / "packet.json").read_text())
+    assert "human_context" not in report_json
+    assert "human_context" not in packet_json
+    assert report_json["release_decision"]["decision"] == "insufficient_evidence"
+    assert packet_json["release_decision"]["decision"] == "insufficient_evidence"
+
+    report_bytes = (repo / "reports" / "report.json").read_bytes()
+    packet_bytes = (repo / "reports" / "packet.json").read_bytes()
+    render_markdown_report(report, human_context=context)
+    render_packet_markdown(
+        load_packet_json(packet_bytes.decode("utf-8")),
+        human_context=context,
+        cold_lead=cold_reader_lead(report),
+    )
+    assert (repo / "reports" / "report.json").read_bytes() == report_bytes
+    assert (repo / "reports" / "packet.json").read_bytes() == packet_bytes
+
+
+def test_empty_repository_is_cold(tmp_path):
+    repo = tmp_path / "empty-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    config = repo / "shipgate.yaml"
+    config.write_text("version: 1\n", encoding="utf-8")
+
+    context = human_artifact_context(config, None)
+
+    assert context.manifest_committed is False
+    assert context.is_cold
+
+
+def test_surface_lead_spells_out_destructive_actions(tmp_path, monkeypatch):
+    _, report, _, _ = _cold_scan(tmp_path, monkeypatch)
+    action = report.action_surface_facts.actions[0]
+    action.effect = "destructive"
+
+    lines = cold_reader_lead(report).surface.text_lines()
+
+    assert any("1 destructive" in line for line in lines)
+    assert any(
+        f"{action.tool_name} (destructive)" in line
+        for line in lines
+        if line.startswith("Write/destructive actions:")
+    )
+
+
+def test_committed_manifest_keeps_the_adopted_markdown_bytes(tmp_path, monkeypatch):
+    repo = tmp_path / "adopted"
+    shutil.copytree(SAMPLE, repo)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Shipgate Test")
+    _git(repo, "config", "user.email", "shipgate@example.invalid")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "adopted repository")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    report, _ = run_scan(
+        config_path=repo / "shipgate.yaml",
+        output_dir=repo / "reports",
+        formats=["markdown", "json"],
+        ci_mode="advisory",
+        packet_enabled=False,
+    )
+    context = human_artifact_context(repo / "shipgate.yaml", None)
+
+    assert context.manifest_committed is True
+    assert not context.is_cold
+    assert (repo / "reports" / "report.md").read_text(encoding="utf-8") == render_markdown_report(
+        report, human_context=context
+    )
+    assert (repo / "reports" / "report.md").read_text(encoding="utf-8") == (
+        SAMPLE / "expected" / "report.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_archived_adopted_verify_remains_verdict_first(tmp_path):
+    repo = tmp_path / "adopted-verify"
+    shutil.copytree(SAMPLE, repo)
+    shutil.rmtree(repo / "expected")
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Shipgate Test")
+    _git(repo, "config", "user.email", "shipgate@example.invalid")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "adopted repository")
+    (repo / "README.md").write_text("documentation only\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-qm", "document the agent")
+
+    _, report, _ = run_verify(
+        workspace=repo,
+        config=Path("shipgate.yaml"),
+        base="HEAD~1",
+        head="HEAD",
+        archive_head=True,
+        out=repo / "reports",
+        ci_mode="advisory",
+        fail_on=None,
+        baseline=None,
+        baseline_mode="new-findings",
+        diff_from=None,
+        policy_packs=None,
+        plugins_enabled=False,
+        strict_plugins=False,
+        suggest_patches=False,
+        no_heuristics=False,
+        verbose=False,
+    )
+
+    assert report is not None
+    assert report.release_decision is not None
+    assert report.release_decision.decision == "insufficient_evidence"
+    markdown = (repo / "reports" / "report.md").read_text(encoding="utf-8")
+    pr_comment = (repo / "reports" / "pr-comment.md").read_text(encoding="utf-8")
+    assert "## Capability Surface" not in markdown
+    assert markdown.index("## Release Decision") < markdown.index("## Top Findings")
+    assert pr_comment.index("- Release gate: `insufficient_evidence`") < pr_comment.index(
+        "Findings by subject"
+    )
+
+
+def test_unadopted_multi_scan_row_puts_the_surface_before_the_decision(
+    tmp_path,
+    capsys,
+):
+    repo = _unadopted_sample(tmp_path)
+
+    exit_code = _run_multi_scan(
+        config_paths=[repo / "shipgate.yaml"],
+        out=repo / "multi-reports",
+        formats=["json"],
+        ci_mode="advisory",
+        fail_on=None,
+        baseline=None,
+        diff_from=None,
+        baseline_mode="new-findings",
+        deep_import=False,
+        policy_packs=[],
+        plugins_enabled=None,
+        verbose=False,
+        packet_enabled=False,
+    )
+
+    output = capsys.readouterr().out
+    manifest_lines = [line for line in output.splitlines() if f"{repo / 'shipgate.yaml'}:" in line]
+    assert exit_code == 0
+    assert "Surface: 9 tools from 3 sources." in manifest_lines[0], manifest_lines
+    findings_index = next(
+        i for i, line in enumerate(manifest_lines) if "Findings by subject" in line
+    )
+    decision_index = next(
+        i for i, line in enumerate(manifest_lines) if ": insufficient_evidence " in line
+    )
+    assert findings_index < decision_index
+
+
+def test_cold_block_tier_content_keeps_verdict_first(tmp_path, monkeypatch):
+    repo, report, context, _ = _cold_scan(tmp_path, monkeypatch)
+    blocked = report.model_copy(deep=True)
+    assert blocked.release_decision is not None
+    blocked.release_decision.decision = "blocked"
+    blocked.release_decision.blockers = list(blocked.release_decision.review_items)
+    blocked.findings[0].blocks_release = True
+
+    markdown = render_markdown_report(blocked, human_context=context)
+    assert "## Capability Surface" not in markdown
+    assert markdown.index("## Release Decision") < markdown.index("## Tool Surface Summary")
+    assert "Decision: blocked" in markdown
+
+    packet = load_packet_json((repo / "reports" / "packet.json").read_text())
+    packet.release_decision.decision = "blocked"
+    packet.release_decision.verdict = "BLOCKED"
+    packet.release_decision.blockers = list(packet.release_decision.review_items)
+    rendered_packet = render_packet_markdown(
+        packet,
+        human_context=context,
+        cold_lead=cold_reader_lead(blocked),
+    )
+    assert "## Capability surface" not in rendered_packet
+    assert rendered_packet.index("## §1 Release decision") < rendered_packet.index(
+        "## §3 High-risk tool surface"
+    )
+    assert "- Decision: `blocked`" in rendered_packet
+
+    rendered_html = render_packet_html(
+        packet,
+        human_context=context,
+        cold_lead=cold_reader_lead(blocked),
+    )
+    assert "<h2>Capability surface</h2>" not in rendered_html
+    assert rendered_html.index("§1 Release decision") < rendered_html.index(
+        "§3 High-risk tool surface"
+    )
+
+
+def test_cold_delta_is_grouped_by_subject_before_findings_and_gate(
+    tmp_path,
+    monkeypatch,
+):
+    repo, report, context, _ = _cold_scan(tmp_path, monkeypatch)
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="alpha-action",
+                direction="added",
+                subject_kind="action",
+                tool="alpha",
+                action="alpha.write",
+                release_impact="review_required",
+            ),
+            CapabilityChangeMember(
+                id="alpha-scope",
+                direction="added",
+                subject_kind="scope",
+                tool="alpha",
+                scope="cases:write",
+                release_impact="review_required",
+            ),
+            CapabilityChangeMember(
+                id="beta-action",
+                direction="added",
+                subject_kind="action",
+                tool="beta",
+                action="beta.read",
+            ),
+        ],
+    )
+
+    markdown = render_markdown_report(report, human_context=context)
+    assert markdown.index("## Capability Surface") < markdown.index(
+        "## Capability Delta By Subject"
+    )
+    assert markdown.index("## Capability Delta By Subject") < markdown.index("## Top Findings")
+    assert markdown.index("## Top Findings") < markdown.index("## Release Decision")
+    delta = markdown.split("## Capability Delta By Subject", 1)[1].split("## Top Findings", 1)[0]
+    assert delta.count("- alpha") == 1
+    assert "  - added action alpha.write — review required" in delta
+    assert "  - added scope cases:write — review required" in delta
+    assert delta.count("- beta") == 1
+
+    packet = load_packet_json((repo / "reports" / "packet.json").read_text())
+    packet_markdown = render_packet_markdown(
+        packet,
+        human_context=context,
+        cold_lead=cold_reader_lead(report),
+    )
+    assert packet_markdown.index("## Capability delta by subject") < packet_markdown.index(
+        "## Findings by subject"
+    )
+    packet_delta = packet_markdown.split("## Capability delta by subject", 1)[1].split(
+        "## Findings by subject", 1
+    )[0]
+    assert packet_delta.count("- `alpha`") == 1
+    assert packet_delta.count("- `beta`") == 1

--- a/tests/test_cold_reader_order.py
+++ b/tests/test_cold_reader_order.py
@@ -322,6 +322,27 @@ def test_cold_block_tier_content_keeps_verdict_first(tmp_path, monkeypatch):
         "§3 High-risk tool surface"
     )
 
+    # Fail closed even if the serialized packet decision is inconsistent with
+    # the report finding substrate: active block-tier content still wins.
+    blocked.release_decision.decision = "review_required"
+    blocked.release_decision.blockers = []
+    packet.release_decision.decision = "review_required"
+    packet.release_decision.blockers = []
+    inconsistent_report = render_markdown_report(blocked, human_context=context)
+    inconsistent_markdown = render_packet_markdown(
+        packet,
+        human_context=context,
+        cold_lead=cold_reader_lead(blocked),
+    )
+    inconsistent_html = render_packet_html(
+        packet,
+        human_context=context,
+        cold_lead=cold_reader_lead(blocked),
+    )
+    assert "## Capability Surface" not in inconsistent_report
+    assert "## Capability surface" not in inconsistent_markdown
+    assert "<h2>Capability surface</h2>" not in inconsistent_html
+
 
 def test_cold_delta_is_grouped_by_subject_before_findings_and_gate(
     tmp_path,

--- a/tests/test_first_adoption.py
+++ b/tests/test_first_adoption.py
@@ -530,6 +530,15 @@ def test_clean_adoption_collapses_same_manifest_rows_into_one_human_act(
         "review_trust_root",
     } & {repair.id for repair in verifier.fix_task.allowed_repairs}
 
+    report_markdown = (repo / "agents-shipgate-reports" / "report.md").read_text(encoding="utf-8")
+    pr_comment = (repo / "agents-shipgate-reports" / "pr-comment.md").read_text(encoding="utf-8")
+    assert report_markdown.index("## Capability Surface") < report_markdown.index(
+        "## Release Decision"
+    )
+    assert report_markdown.count("Decision: review_required") == 1
+    assert pr_comment.index("Surface:") < pr_comment.index("- Release gate: `review_required`")
+    assert pr_comment.count("- Release gate: `review_required`") == 1
+
 
 def test_failed_head_scan_never_emits_adoption_or_merge_guidance(tmp_path):
     repo = _repo_adopting_shipgate(tmp_path)


### PR DESCRIPTION
Addresses #463

Summary:
- derive a presentation-only cold context from committed-manifest and first-adoption facts without changing report or packet schemas
- lead console, report, GitHub summary, PR comment, and packet Markdown/HTML/PDF with surface and subject-grouped findings/delta, then the unchanged release decision, while retaining the existing tool-surface and diff detail below it
- preserve verdict-first bytes for adopted repositories and force verdict-first whenever cold output carries block-tier content
- share one bounded findings projection, cap and display-encode repository-derived action names, and reserve the PR-comment verdict/control block even for very large or hostile tool surfaces
- reuse the scan-derived repository context in console and verifier output rather than re-probing Git
- add a committed cold-mode golden plus empty-repo, archived-verify, exact-once cold decision, destructive-action, machine-output, truncation, and adversarial regressions

Scope:
- this change covers report-backed scan and verify artifacts
- `verify --preview` remains routing-only and emits no readiness report to reorder
- the local-review surface described in #326 remains a follow-up

Validation:
- `python -m ruff check .`
- post-rebase focused regression suite: 296 passed
- full non-performance suite: all non-packaging tests passed; the isolated packaging build was rerun with dependency access
- `pytest tests/test_packaging.py -q` (8 passed)
- static-only adapter suite (442 passed) and P0 safety/binding/agent-boundary suites
- post-rebase Agents Shipgate verify: `control_state=complete`, `decision=passed`, `merge_verdict=mergeable`
