### PR TITLE
Fix capability delta subject and exclusion reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@
   and `top_changes[]` fields remain change-record compatibility fields, and
   verifier/report schemas, release decisions, and gate behavior are unchanged.
 
+  The human projection recovers canonical tool identity from the report's
+  existing action/tool facts and diffs, so same-named tools from different
+  providers remain distinct while a legacy row with ambiguous identity is not
+  guessed onto either tool. Reader detail resolves canonical action hashes to
+  operation names and retains semantic rationale. Group provenance is labelled
+  explicitly and rendered as Markdown-safe code spans; exact hidden counts are
+  emitted before bounded subject rows, so long repository-controlled names
+  cannot erase the truncation disclosure.
+
 - **Cold-reader artifacts now lead with what the agent can do.** (#463) On a
   repository with no committed Shipgate manifest, human output starts with the
   root-reachable tool surface, its effect breakdown and write/destructive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@
   scan `run_id` binds that key-presence because it changes whether the draft is
   coding-agent- or human-owned.
 
+- **Capability delta now answers the reviewer’s question in subjects, without
+  changing its machine contract.** (#437, #439) PR comments group the complete
+  analysed `capability_change` by reader subject before applying their display
+  limit, so one bound tool that produces `tool_added` and `action_added` is
+  shown once with both changes instead of as two capabilities. Added,
+  modified, and removed subject counts are memberships over that grouped set;
+  a subject changed in more than one direction keeps every direction. Groups
+  are ranked by their worst release impact and then change direction, every
+  selected group keeps its distinct change types visible, and truncation names
+  the exact hidden subject and underlying-change counts.
+
+  The adjacent exclusion is now explicit rather than folded into capability:
+  when a successful base comparison finds
+  `binding_surface_diff.added_unbound_tool_ids`, the same line separately says
+  how many subjects are **newly outside the analysed surface**. That neutral
+  wording covers both an added-but-unbound tool and a previously reachable
+  tool that lost its binding. Pre-existing unwired catalog operations,
+  including the large sample’s 58 intentional operations, add nothing; a plain
+  scan has no base-relative term; and a requested comparison that could not
+  run reports the outside-analysis value as unknown rather than zero.
+
+  Both PR-comment styles and cold-reader ordering use one projection. The
+  existing `verifier.json` `capability_review.added`, `modified`, `removed`,
+  and `top_changes[]` fields remain change-record compatibility fields, and
+  verifier/report schemas, release decisions, and gate behavior are unchanged.
+
 - **Cold-reader artifacts now lead with what the agent can do.** (#463) On a
   repository with no committed Shipgate manifest, human output starts with the
   root-reachable tool surface, its effect breakdown and write/destructive

--- a/src/agents_shipgate/report/human_order.py
+++ b/src/agents_shipgate/report/human_order.py
@@ -15,10 +15,17 @@ from typing import Literal
 from agents_shipgate.core.action_semantics import ACTION_EFFECT_RANK, effect_phrase
 from agents_shipgate.core.evidence_actions import display_literal
 from agents_shipgate.core.findings.subject_rollup import SubjectGroup, roll_up_findings
+from agents_shipgate.core.findings.verifier_blocks import build_capability_change
 from agents_shipgate.core.policy_reason_codes import is_adoption_evidence
-from agents_shipgate.schemas.capability_change import CapabilityChangeMember
+from agents_shipgate.schemas.capability_change import (
+    CapabilityChangeBlock,
+    CapabilityChangeDirection,
+    CapabilityChangeMember,
+)
+from agents_shipgate.schemas.common import SourceReference
 from agents_shipgate.schemas.packet import EvidencePacket
 from agents_shipgate.schemas.report import ReadinessReport
+from agents_shipgate.schemas.text import has_visible_content
 
 
 @dataclass(frozen=True)
@@ -72,6 +79,99 @@ class SurfaceLead:
 class CapabilityDeltaSubject:
     subject: str
     changes: tuple[str, ...]
+
+
+CapabilityDeltaBucket = Literal["added", "modified", "removed"]
+CapabilityDeltaOutsideAnalysisStatus = Literal[
+    "not_requested",
+    "unavailable",
+    "complete",
+]
+
+_DIRECTION_TO_BUCKET: dict[CapabilityChangeDirection, CapabilityDeltaBucket] = {
+    "added": "added",
+    "broadened": "modified",
+    "narrowed": "modified",
+    "removed": "removed",
+}
+_CAPABILITY_IMPACT_ORDER = {
+    "blocks_release": 0,
+    "insufficient_evidence": 1,
+    "review_required": 2,
+    "informational": 3,
+    "none": 4,
+}
+_CAPABILITY_DIRECTION_ORDER: dict[CapabilityChangeDirection, int] = {
+    "added": 0,
+    "broadened": 1,
+    "narrowed": 2,
+    "removed": 3,
+}
+
+
+@dataclass(frozen=True)
+class CapabilityDeltaSubjectGroup:
+    """Every canonical capability-change row about one reader subject.
+
+    ``changes``, ``change_types``, and ``change_buckets`` are parallel tuples:
+    no row is discarded merely because another row names the same subject.
+    That is the distinction #439 needs — one added tool is one subject while
+    its tool-catalog and action-surface changes both remain visible.
+    """
+
+    subject: str
+    changes: tuple[str, ...]
+    change_types: tuple[str, ...]
+    change_buckets: tuple[CapabilityDeltaBucket, ...]
+    sources: tuple[CapabilityDeltaSource, ...]
+
+    @property
+    def change_count(self) -> int:
+        return len(self.changes)
+
+
+@dataclass(frozen=True)
+class CapabilityDeltaSource:
+    """One complete-report source retained for a grouped human row."""
+
+    path: str
+    start_line: int | None
+
+
+@dataclass(frozen=True)
+class CapabilityDeltaOutsideAnalysis:
+    """Base-relative subjects the binding graph left outside analysis.
+
+    This axis is deliberately not joined to the analysed subject groups.  A
+    tool can lose its binding and therefore be both removed from analysed
+    capability and newly outside analysis, and the two substrates use
+    different identities (display tool strings versus canonical tool ids).
+    """
+
+    status: CapabilityDeltaOutsideAnalysisStatus
+    newly_outside_subjects: int
+
+
+@dataclass(frozen=True)
+class CapabilityDeltaSubjectRollup:
+    """The complete subject-keyed human projection of ``capability_change``.
+
+    Directional counts are memberships, not a partition: one subject that is
+    both added and broadened counts once under ``added_subjects`` and once
+    under ``modified_subjects``, while ``total_subjects`` still counts it once.
+    Counts are computed before ``subject_limit`` is applied, so truncation can
+    always disclose exactly how many subjects it hid.
+    """
+
+    enabled: bool
+    total_subjects: int
+    added_subjects: int
+    modified_subjects: int
+    removed_subjects: int
+    change_count: int
+    subjects: tuple[CapabilityDeltaSubjectGroup, ...]
+    hidden_subjects: int
+    outside_analysis: CapabilityDeltaOutsideAnalysis
 
 
 @dataclass(frozen=True)
@@ -182,26 +282,229 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
 def capability_delta_by_subject(
     report: ReadinessReport,
 ) -> list[CapabilityDeltaSubject]:
-    """The canonical capability delta grouped by the tool it changes."""
+    """Compatibility view of the canonical subject rollup.
 
-    change = report.capability_change
-    if change is None or not change.enabled:
-        return []
-    grouped: dict[str, list[str]] = defaultdict(list)
-    for member in (
+    Existing human surfaces consume only ``subject`` plus rendered ``changes``.
+    Keep that shape while deriving it from the structured projection so a
+    second grouping rule cannot drift from the PR-comment rollup.
+    """
+
+    return [
+        CapabilityDeltaSubject(
+            subject=group.subject,
+            changes=group.changes,
+        )
+        for group in capability_delta_subject_rollup(report).subjects
+    ]
+
+
+def capability_delta_subject_rollup(
+    report: ReadinessReport,
+    *,
+    subject_limit: int | None = None,
+) -> CapabilityDeltaSubjectRollup:
+    """Group every canonical change by reader subject, then optionally bound it.
+
+    The grouping happens over the complete ``capability_change`` member set;
+    ``subject_limit`` is applied only after groups and counts exist.  This is
+    the subject equivalent of ``project_top_findings``'s truncation contract:
+    duplicate rows for one subject never consume another subject's slot, and
+    hidden counts describe what was actually omitted rather than the nominal
+    limit.
+    """
+
+    outside_analysis = _outside_analysis_delta(report)
+    change = _capability_change_block(report)
+    if not change.enabled:
+        return CapabilityDeltaSubjectRollup(
+            enabled=False,
+            total_subjects=0,
+            added_subjects=0,
+            modified_subjects=0,
+            removed_subjects=0,
+            change_count=0,
+            subjects=(),
+            hidden_subjects=0,
+            outside_analysis=outside_analysis,
+        )
+
+    grouped: dict[str, list[CapabilityChangeMember]] = defaultdict(list)
+    labels: dict[str, str] = {}
+    bucket_subjects: dict[CapabilityDeltaBucket, set[str]] = {
+        "added": set(),
+        "modified": set(),
+        "removed": set(),
+    }
+    members = _capability_change_members(change)
+    source_by_finding_id = {
+        finding.id: finding.source
+        for finding in report.findings
+        if finding.id and finding.source is not None and finding.source.path
+    }
+    for member in members:
+        subject_key, subject_label = _capability_reader_subject(member)
+        grouped[subject_key].append(member)
+        labels.setdefault(subject_key, subject_label)
+        bucket_subjects[_DIRECTION_TO_BUCKET[member.direction]].add(subject_key)
+
+    all_subjects: list[CapabilityDeltaSubjectGroup] = []
+    for subject_key in sorted(
+        grouped,
+        key=lambda key: _capability_group_sort_key(key, grouped[key]),
+    ):
+        subject_members = sorted(grouped[subject_key], key=_capability_member_sort_key)
+        all_subjects.append(
+            CapabilityDeltaSubjectGroup(
+                subject=labels[subject_key],
+                changes=tuple(
+                    _delta_description(member, group_subject=subject_key)
+                    for member in subject_members
+                ),
+                change_types=tuple(_delta_change_type(member) for member in subject_members),
+                change_buckets=tuple(
+                    _DIRECTION_TO_BUCKET[member.direction] for member in subject_members
+                ),
+                sources=_capability_group_sources(
+                    subject_members,
+                    source_by_finding_id=source_by_finding_id,
+                ),
+            )
+        )
+    bounded_limit = len(all_subjects) if subject_limit is None else max(0, subject_limit)
+    shown_subjects = tuple(all_subjects[:bounded_limit])
+    return CapabilityDeltaSubjectRollup(
+        enabled=True,
+        total_subjects=len(all_subjects),
+        added_subjects=len(bucket_subjects["added"]),
+        modified_subjects=len(bucket_subjects["modified"]),
+        removed_subjects=len(bucket_subjects["removed"]),
+        change_count=len(members),
+        subjects=shown_subjects,
+        hidden_subjects=max(0, len(all_subjects) - len(shown_subjects)),
+        outside_analysis=outside_analysis,
+    )
+
+
+def _capability_change_block(report: ReadinessReport) -> CapabilityChangeBlock:
+    if report.capability_change is not None:
+        return report.capability_change
+    # Match ``build_capability_review`` for older/test callers that predate the
+    # canonical report block.  This remains a presentation projection: the
+    # shared builder reads existing surface diffs and introduces no decision.
+    return build_capability_change(report)
+
+
+def _capability_change_members(
+    change: CapabilityChangeBlock,
+) -> tuple[CapabilityChangeMember, ...]:
+    return (
         *change.added,
         *change.broadened,
         *change.narrowed,
         *change.removed,
-    ):
-        grouped[member.tool].append(_delta_description(member))
-    return [
-        CapabilityDeltaSubject(
-            subject=display_literal(subject),
-            changes=tuple(grouped[subject]),
+    )
+
+
+def _capability_group_sort_key(
+    subject_key: str,
+    members: list[CapabilityChangeMember],
+) -> tuple[int, int, str, str]:
+    """Keep the most consequential complete subject groups inside the limit."""
+
+    return (
+        min(_CAPABILITY_IMPACT_ORDER.get(member.release_impact, 99) for member in members),
+        min(_CAPABILITY_DIRECTION_ORDER.get(member.direction, 99) for member in members),
+        subject_key,
+        min(member.id for member in members),
+    )
+
+
+def _capability_member_sort_key(
+    member: CapabilityChangeMember,
+) -> tuple[int, int, str, str, str, str, str]:
+    """Keep each selected subject's highest-signal details visible first."""
+
+    return (
+        _CAPABILITY_IMPACT_ORDER.get(member.release_impact, 99),
+        _CAPABILITY_DIRECTION_ORDER.get(member.direction, 99),
+        member.subject_kind,
+        member.action or "",
+        member.scope or "",
+        member.tool,
+        member.id,
+    )
+
+
+def _capability_group_sources(
+    members: list[CapabilityChangeMember],
+    *,
+    source_by_finding_id: dict[str, SourceReference],
+) -> tuple[CapabilityDeltaSource, ...]:
+    """Retain provenance without depending on the truncated verifier projection."""
+
+    sources: list[CapabilityDeltaSource] = []
+    seen: set[tuple[str, int | None]] = set()
+    for member in members:
+        for finding_id in member.related_finding_ids:
+            source = source_by_finding_id.get(finding_id)
+            if source is None or not source.path:
+                continue
+            key = (source.path, source.start_line)
+            if key not in seen:
+                seen.add(key)
+                sources.append(
+                    CapabilityDeltaSource(
+                        path=display_literal(source.path),
+                        start_line=source.start_line,
+                    )
+                )
+            # Match the stable verifier projection: one source per change,
+            # chosen by the member's sorted related-finding ids.
+            break
+    return tuple(sources)
+
+
+def _capability_reader_subject(member: CapabilityChangeMember) -> tuple[str, str]:
+    """Stable group key plus a visible, injective display label.
+
+    ``tool`` is the reader's unit for ordinary changes: it intentionally folds
+    the tool-catalog and action-surface rows #439 observed.  A policy-drift row
+    may carry no tool at all, so fall through to its scope/action and finally
+    its stable member id instead of rendering an empty heading.
+    """
+
+    for candidate in (member.tool, member.scope, member.action, member.id):
+        if not isinstance(candidate, str):
+            continue
+        rendered = display_literal(candidate)
+        if has_visible_content(rendered):
+            return candidate, rendered
+    fallback = "unknown capability"
+    return fallback, fallback
+
+
+def _delta_change_type(member: CapabilityChangeMember) -> str:
+    return f"{member.subject_kind}_{member.direction}"
+
+
+def _outside_analysis_delta(
+    report: ReadinessReport,
+) -> CapabilityDeltaOutsideAnalysis:
+    diff = report.binding_surface_diff
+    if diff.enabled:
+        return CapabilityDeltaOutsideAnalysis(
+            status="complete",
+            newly_outside_subjects=len(set(diff.added_unbound_tool_ids)),
         )
-        for subject in sorted(grouped)
-    ]
+    if diff.base_comparison_requested:
+        return CapabilityDeltaOutsideAnalysis(
+            status="unavailable",
+            newly_outside_subjects=0,
+        )
+    return CapabilityDeltaOutsideAnalysis(
+        status="not_requested",
+        newly_outside_subjects=0,
+    )
 
 
 def cold_reader_lead(report: ReadinessReport) -> ColdReaderLead:
@@ -218,9 +521,22 @@ def cold_reader_lead(report: ReadinessReport) -> ColdReaderLead:
     )
 
 
-def _delta_description(member: CapabilityChangeMember) -> str:
-    target = display_literal(member.action or member.scope or member.tool)
-    detail = f"{member.direction} {member.subject_kind} {target}"
+def _delta_description(
+    member: CapabilityChangeMember,
+    *,
+    group_subject: str | None = None,
+) -> str:
+    target_value = next(
+        (
+            candidate
+            for candidate in (member.action, member.scope, member.tool, member.id)
+            if isinstance(candidate, str) and has_visible_content(candidate)
+        ),
+        "unknown capability",
+    )
+    detail = f"{member.direction} {member.subject_kind}"
+    if target_value != group_subject:
+        detail += f" {display_literal(target_value)}"
     if member.before_scope is not None or member.after_scope is not None:
         before = display_literal(member.before_scope or "none")
         after = display_literal(member.after_scope or "none")

--- a/src/agents_shipgate/report/human_order.py
+++ b/src/agents_shipgate/report/human_order.py
@@ -21,10 +21,12 @@ from agents_shipgate.schemas.capability_change import (
     CapabilityChangeBlock,
     CapabilityChangeDirection,
     CapabilityChangeMember,
+    CapabilityReleaseImpact,
 )
 from agents_shipgate.schemas.common import SourceReference
 from agents_shipgate.schemas.packet import EvidencePacket
 from agents_shipgate.schemas.report import ReadinessReport
+from agents_shipgate.schemas.surfaces import ActionSurfaceChange
 from agents_shipgate.schemas.text import has_visible_content
 
 
@@ -172,6 +174,44 @@ class CapabilityDeltaSubjectRollup:
     subjects: tuple[CapabilityDeltaSubjectGroup, ...]
     hidden_subjects: int
     outside_analysis: CapabilityDeltaOutsideAnalysis
+
+
+@dataclass(frozen=True)
+class _CapabilityReaderSubject:
+    """Canonical grouping identity plus the deliberately separate label."""
+
+    key: str
+    name: str
+    label: str
+
+
+_CapabilityMemberSignature = tuple[str, str, str, str, str]
+
+
+@dataclass(frozen=True)
+class _CapabilitySubjectIndex:
+    """Ephemeral bridge from compatibility rows to canonical tool identity.
+
+    ``CapabilityChangeMember`` intentionally keeps its established wire shape,
+    which names the owning tool but does not repeat ``tool_id`` or provider.
+    The complete report already carries those identities in its action/tool
+    facts and diffs.  This index joins them only for the human projection, so
+    same-named tools from different providers stay separate without changing
+    verifier.json.
+    """
+
+    subjects_by_key: dict[str, _CapabilityReaderSubject]
+    keys_by_name: dict[str, tuple[str, ...]]
+    keys_by_signature: dict[_CapabilityMemberSignature, tuple[str, ...]]
+    key_by_tool_id: dict[str, str]
+    key_by_action_id: dict[str, str]
+    operation_by_action_id: dict[str, str]
+    sources_by_member_key: dict[
+        tuple[_CapabilityMemberSignature, str],
+        tuple[CapabilityDeltaSource, ...],
+    ]
+    colliding_keys: frozenset[str]
+    blocking_keys: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -330,34 +370,64 @@ def capability_delta_subject_rollup(
 
     grouped: dict[str, list[CapabilityChangeMember]] = defaultdict(list)
     labels: dict[str, str] = {}
+    group_names: dict[str, str] = {}
     bucket_subjects: dict[CapabilityDeltaBucket, set[str]] = {
         "added": set(),
         "modified": set(),
         "removed": set(),
     }
     members = _capability_change_members(change)
+    subject_index = _capability_subject_index(report)
     source_by_finding_id = {
-        finding.id: finding.source
+        finding.id: (
+            finding.source,
+            subject_index.key_by_tool_id.get(finding.tool_id or ""),
+        )
         for finding in report.findings
         if finding.id and finding.source is not None and finding.source.path
     }
     for member in members:
-        subject_key, subject_label = _capability_reader_subject(member)
-        grouped[subject_key].append(member)
-        labels.setdefault(subject_key, subject_label)
-        bucket_subjects[_DIRECTION_TO_BUCKET[member.direction]].add(subject_key)
+        for subject in _capability_reader_subjects(member, index=subject_index):
+            grouped[subject.key].append(member)
+            labels.setdefault(subject.key, subject.label)
+            group_names.setdefault(subject.key, subject.name)
+            bucket_subjects[_DIRECTION_TO_BUCKET[member.direction]].add(subject.key)
+    labels = _injective_capability_labels(labels)
 
     all_subjects: list[CapabilityDeltaSubjectGroup] = []
     for subject_key in sorted(
         grouped,
-        key=lambda key: _capability_group_sort_key(key, grouped[key]),
+        key=lambda key: _capability_group_sort_key(
+            key,
+            grouped[key],
+            index=subject_index,
+        ),
     ):
-        subject_members = sorted(grouped[subject_key], key=_capability_member_sort_key)
+        subject_members = sorted(
+            grouped[subject_key],
+            key=lambda member: _capability_member_sort_key(
+                member,
+                release_impact=_capability_reader_impact(
+                    member,
+                    subject_key=subject_key,
+                    index=subject_index,
+                ),
+            ),
+        )
         all_subjects.append(
             CapabilityDeltaSubjectGroup(
                 subject=labels[subject_key],
                 changes=tuple(
-                    _delta_description(member, group_subject=subject_key)
+                    _delta_description(
+                        member,
+                        group_subject=group_names[subject_key],
+                        operation_by_action_id=subject_index.operation_by_action_id,
+                        release_impact=_capability_reader_impact(
+                            member,
+                            subject_key=subject_key,
+                            index=subject_index,
+                        ),
+                    )
                     for member in subject_members
                 ),
                 change_types=tuple(_delta_change_type(member) for member in subject_members),
@@ -367,6 +437,13 @@ def capability_delta_subject_rollup(
                 sources=_capability_group_sources(
                     subject_members,
                     source_by_finding_id=source_by_finding_id,
+                    canonical_sources=_capability_member_sources(
+                        subject_members,
+                        subject_key=subject_key,
+                        index=subject_index,
+                    ),
+                    subject_key=subject_key,
+                    colliding_keys=subject_index.colliding_keys,
                 ),
             )
         )
@@ -378,7 +455,11 @@ def capability_delta_subject_rollup(
         added_subjects=len(bucket_subjects["added"]),
         modified_subjects=len(bucket_subjects["modified"]),
         removed_subjects=len(bucket_subjects["removed"]),
-        change_count=len(members),
+        # A compatibility member that omitted canonical identity may represent
+        # more than one same-named provider tool.  Count the complete human
+        # associations rendered above, while verifier.json keeps its existing
+        # change-record counts unchanged.
+        change_count=sum(len(subject_members) for subject_members in grouped.values()),
         subjects=shown_subjects,
         hidden_subjects=max(0, len(all_subjects) - len(shown_subjects)),
         outside_analysis=outside_analysis,
@@ -408,11 +489,23 @@ def _capability_change_members(
 def _capability_group_sort_key(
     subject_key: str,
     members: list[CapabilityChangeMember],
+    *,
+    index: _CapabilitySubjectIndex,
 ) -> tuple[int, int, str, str]:
     """Keep the most consequential complete subject groups inside the limit."""
 
     return (
-        min(_CAPABILITY_IMPACT_ORDER.get(member.release_impact, 99) for member in members),
+        min(
+            _CAPABILITY_IMPACT_ORDER.get(
+                _capability_reader_impact(
+                    member,
+                    subject_key=subject_key,
+                    index=index,
+                ),
+                99,
+            )
+            for member in members
+        ),
         min(_CAPABILITY_DIRECTION_ORDER.get(member.direction, 99) for member in members),
         subject_key,
         min(member.id for member in members),
@@ -421,11 +514,13 @@ def _capability_group_sort_key(
 
 def _capability_member_sort_key(
     member: CapabilityChangeMember,
+    *,
+    release_impact: str | None = None,
 ) -> tuple[int, int, str, str, str, str, str]:
     """Keep each selected subject's highest-signal details visible first."""
 
     return (
-        _CAPABILITY_IMPACT_ORDER.get(member.release_impact, 99),
+        _CAPABILITY_IMPACT_ORDER.get(release_impact or member.release_impact, 99),
         _CAPABILITY_DIRECTION_ORDER.get(member.direction, 99),
         member.subject_kind,
         member.action or "",
@@ -435,19 +530,53 @@ def _capability_member_sort_key(
     )
 
 
+def _capability_reader_impact(
+    member: CapabilityChangeMember,
+    *,
+    subject_key: str,
+    index: _CapabilitySubjectIndex,
+) -> CapabilityReleaseImpact:
+    """Remove name-scoped blocker bleed after canonical subject splitting."""
+
+    if subject_key not in index.colliding_keys:
+        return member.release_impact
+    if subject_key in index.blocking_keys:
+        return "blocks_release"
+    if member.release_impact != "blocks_release":
+        return member.release_impact
+    # The compatibility builder related findings by display name. Once that
+    # name resolves to several canonical tools, only an exact finding.tool_id
+    # can keep the blocking label on one split group.
+    if member.direction in {"added", "broadened"}:
+        return "review_required"
+    return "informational"
+
+
 def _capability_group_sources(
     members: list[CapabilityChangeMember],
     *,
-    source_by_finding_id: dict[str, SourceReference],
+    source_by_finding_id: dict[str, tuple[SourceReference, str | None]],
+    canonical_sources: tuple[CapabilityDeltaSource, ...] = (),
+    subject_key: str,
+    colliding_keys: frozenset[str],
 ) -> tuple[CapabilityDeltaSource, ...]:
     """Retain provenance without depending on the truncated verifier projection."""
 
-    sources: list[CapabilityDeltaSource] = []
-    seen: set[tuple[str, int | None]] = set()
+    sources: list[CapabilityDeltaSource] = list(canonical_sources)
+    seen: set[tuple[str, int | None]] = {
+        (source.path, source.start_line) for source in canonical_sources
+    }
     for member in members:
         for finding_id in member.related_finding_ids:
-            source = source_by_finding_id.get(finding_id)
-            if source is None or not source.path:
+            source_entry = source_by_finding_id.get(finding_id)
+            if source_entry is None:
+                continue
+            source, finding_subject_key = source_entry
+            if subject_key in colliding_keys and finding_subject_key != subject_key:
+                # A name-only relation cannot identify one of several
+                # same-named providers. Preserve an exact finding.tool_id
+                # source for its own group, while refusing to bleed that
+                # provenance into its siblings.
                 continue
             key = (source.path, source.start_line)
             if key not in seen:
@@ -464,23 +593,451 @@ def _capability_group_sources(
     return tuple(sources)
 
 
-def _capability_reader_subject(member: CapabilityChangeMember) -> tuple[str, str]:
-    """Stable group key plus a visible, injective display label.
+def _capability_member_sources(
+    members: list[CapabilityChangeMember],
+    *,
+    subject_key: str,
+    index: _CapabilitySubjectIndex,
+) -> tuple[CapabilityDeltaSource, ...]:
+    """Return only sources that evidence these changes on this subject.
 
-    ``tool`` is the reader's unit for ordinary changes: it intentionally folds
-    the tool-catalog and action-surface rows #439 observed.  A policy-drift row
-    may carry no tool at all, so fall through to its scope/action and finally
-    its stable member id instead of rendering an empty heading.
+    Action facts establish identity, but unchanged sibling actions are not
+    provenance for a changed member. Sources are therefore indexed by both
+    the compatibility-member signature and canonical subject. An action diff
+    may fall back to the matching action fact when its enriched source is
+    absent; unrelated action facts never enter this map.
     """
 
+    sources: list[CapabilityDeltaSource] = []
+    seen: set[tuple[str, int | None]] = set()
+    for member in members:
+        signature = _capability_member_signature(
+            member.direction,
+            member.subject_kind,
+            member.tool,
+            member.action,
+            member.scope,
+        )
+        for source in index.sources_by_member_key.get((signature, subject_key), ()):
+            key = (source.path, source.start_line)
+            if key not in seen:
+                seen.add(key)
+                sources.append(source)
+    return tuple(sources)
+
+
+def _capability_subject_index(report: ReadinessReport) -> _CapabilitySubjectIndex:
+    """Join compatibility rows to canonical identities already in the report."""
+
+    records: dict[str, dict[str, str]] = {}
+    raw_keys_by_name: dict[str, set[str]] = defaultdict(set)
+    raw_keys_by_signature: dict[_CapabilityMemberSignature, set[str]] = defaultdict(set)
+    raw_key_by_action_id: dict[str, str] = {}
+    operation_by_action_id: dict[str, str] = {}
+    raw_sources_by_member_key: dict[
+        tuple[_CapabilityMemberSignature, str],
+        set[tuple[str, int | None]],
+    ] = defaultdict(set)
+    action_fact_source_by_id: dict[str, tuple[str, int | None]] = {}
+
+    def add_subject(
+        *,
+        tool_id: str | None,
+        name: str | None,
+        qualifier: str | None = None,
+    ) -> str | None:
+        clean_name = name if isinstance(name, str) and has_visible_content(name) else ""
+        if not clean_name:
+            return None
+        clean_qualifier = (
+            qualifier if isinstance(qualifier, str) and has_visible_content(qualifier) else ""
+        )
+        clean_tool_id = (
+            tool_id if isinstance(tool_id, str) and has_visible_content(tool_id) else ""
+        )
+        existing_name_keys = raw_keys_by_name.get(clean_name, set())
+        if clean_tool_id:
+            raw_key = clean_tool_id
+        elif clean_qualifier:
+            matching_qualifier_keys = tuple(
+                key
+                for key in existing_name_keys
+                if records[key]["qualifier"] == clean_qualifier
+            )
+            raw_key = (
+                matching_qualifier_keys[0]
+                if len(matching_qualifier_keys) == 1
+                else f"legacy:{clean_qualifier}:{clean_name}"
+            )
+        elif len(existing_name_keys) == 1:
+            # Older action diffs omitted tool_id. If the complete report names
+            # exactly one canonical tool with this display name, join it rather
+            # than manufacturing a second legacy subject (#439).
+            raw_key = next(iter(existing_name_keys))
+        elif existing_name_keys:
+            # More than one canonical provider owns this display name and the
+            # row supplies no identity capable of choosing between them. Keep
+            # the signature unresolved so the reader sees the explicit
+            # ``identity unavailable`` group, never this implementation key.
+            return None
+        else:
+            raw_key = f"legacy:{clean_qualifier}:{clean_name}"
+        record = records.setdefault(
+            raw_key,
+            {"name": clean_name, "qualifier": clean_qualifier},
+        )
+        # Conflicting display metadata on one canonical id is not identity.
+        # Pick a stable visible spelling; the key still prevents a false join.
+        record["name"] = min(value for value in (record["name"], clean_name) if value)
+        qualifiers = [value for value in (record["qualifier"], clean_qualifier) if value]
+        record["qualifier"] = min(qualifiers) if qualifiers else ""
+        raw_keys_by_name[clean_name].add(raw_key)
+        return raw_key
+
+    def add_signature(
+        signature: _CapabilityMemberSignature,
+        raw_key: str | None,
+        *,
+        source_path: str | None = None,
+        source_start_line: int | None = None,
+    ) -> None:
+        if raw_key is not None:
+            raw_keys_by_signature[signature].add(raw_key)
+            if source_path and has_visible_content(source_path):
+                raw_sources_by_member_key[(signature, raw_key)].add(
+                    (source_path, source_start_line)
+                )
+
+    for tool in report.tool_surface_facts.tools:
+        add_subject(
+            tool_id=tool.tool_id,
+            name=tool.name,
+            qualifier=tool.provider or tool.source_id or tool.source_type,
+        )
+    for change in report.tool_surface_diff.tools:
+        raw_key = add_subject(
+            tool_id=change.tool_id,
+            name=change.name,
+            qualifier=change.provider or change.source_id or change.source_type,
+        )
+        direction = {
+            "added": "added",
+            "removed": "removed",
+            "changed": "broadened",
+        }[change.kind]
+        add_signature(
+            _capability_member_signature(direction, "tool", change.name, None, None),
+            raw_key,
+            source_path=change.source_path,
+            source_start_line=change.source_start_line,
+        )
+
+    for action in report.action_surface_facts.actions:
+        raw_key = add_subject(
+            tool_id=action.tool_id,
+            name=action.tool_name,
+            qualifier=action.provider or action.source_id or action.source_type,
+        )
+        if raw_key is not None:
+            raw_key_by_action_id[action.action_id] = raw_key
+        if has_visible_content(action.operation):
+            operation_by_action_id[action.action_id] = action.operation
+        if action.source_path and has_visible_content(action.source_path):
+            action_fact_source_by_id[action.action_id] = (
+                action.source_path,
+                action.source_start_line,
+            )
+
+    action_changes: tuple[tuple[str, list[ActionSurfaceChange]], ...] = (
+        ("added", report.action_surface_diff.added),
+        ("removed", report.action_surface_diff.removed),
+        ("broadened", report.action_surface_diff.modified),
+    )
+    for direction, changes in action_changes:
+        for change in changes:
+            existing_action_key = raw_key_by_action_id.get(change.action_id)
+            compatible_existing_key = (
+                existing_action_key
+                if existing_action_key is not None
+                and not change.tool_id
+                and (
+                    not change.tool_name
+                    or records[existing_action_key]["name"] == change.tool_name
+                )
+                else None
+            )
+            raw_key = compatible_existing_key or add_subject(
+                tool_id=change.tool_id,
+                name=change.tool_name,
+            )
+            if raw_key is not None and (
+                existing_action_key is None or raw_key == existing_action_key
+            ):
+                # An ID-less diff may enrich a compatible fact mapping but may
+                # not replace exact action identity. Conflicting explicit ids
+                # remain separate evidence instead of silently changing owner.
+                raw_key_by_action_id[change.action_id] = raw_key
+            if change.operation and has_visible_content(change.operation):
+                operation_by_action_id[change.action_id] = change.operation
+            signature = _capability_member_signature(
+                direction,
+                "action",
+                change.tool_name or "",
+                change.action_id,
+                None,
+            )
+            fallback_source = action_fact_source_by_id.get(change.action_id)
+            add_signature(
+                signature,
+                raw_key,
+                source_path=(
+                    change.source_path
+                    or (fallback_source[0] if fallback_source is not None else None)
+                ),
+                source_start_line=(
+                    change.source_start_line
+                    if change.source_path
+                    else (fallback_source[1] if fallback_source is not None else None)
+                ),
+            )
+
+    def keys_for_tool_reference(name: str, tool_id: str | None) -> tuple[str, ...]:
+        if tool_id:
+            # An explicit canonical id is identity even when this is the first
+            # complete-report row that mentions it. Register it before any
+            # display-name fallback; fanning an unseen id across same-named
+            # providers discards the strongest evidence the diff carries.
+            raw_key = add_subject(tool_id=tool_id, name=name)
+            return (raw_key,) if raw_key is not None else ()
+        candidates = raw_keys_by_name.get(name, set())
+        if candidates:
+            return tuple(sorted(candidates))
+        raw_key = add_subject(tool_id=tool_id, name=name)
+        return (raw_key,) if raw_key is not None else ()
+
+    for scope_change in report.tool_surface_diff.scopes:
+        direction = "narrowed" if scope_change.kind == "removed" else "broadened"
+        # ``tool_names`` and ``tool_ids`` are independently sorted by the
+        # producer, not parallel arrays. Resolve ids through their canonical
+        # records instead of zipping two unrelated orders.
+        for name in scope_change.tool_names:
+            matching_ids = tuple(
+                sorted(
+                    tool_id
+                    for tool_id in scope_change.tool_ids
+                    if records.get(tool_id, {}).get("name") == name
+                )
+            )
+            raw_keys = (
+                matching_ids
+                if matching_ids
+                else keys_for_tool_reference(name, None)
+            )
+            for raw_key in raw_keys:
+                add_signature(
+                    _capability_member_signature(
+                        direction,
+                        "scope",
+                        name,
+                        None,
+                        scope_change.scope,
+                    ),
+                    raw_key,
+                )
+
+    for control_change in report.tool_surface_diff.controls:
+        direction = "narrowed" if control_change.kind == "added" else "broadened"
+        for raw_key in keys_for_tool_reference(
+            control_change.tool,
+            control_change.tool_id,
+        ):
+            add_signature(
+                _capability_member_signature(
+                    direction,
+                    "policy",
+                    control_change.tool,
+                    control_change.control,
+                    None,
+                ),
+                raw_key,
+                source_path=control_change.source_path,
+                source_start_line=control_change.source_start_line,
+            )
+
+    for effect_change in report.tool_surface_diff.high_risk_effects:
+        direction = "narrowed" if effect_change.kind == "removed" else "broadened"
+        for raw_key in keys_for_tool_reference(effect_change.tool, effect_change.tool_id):
+            add_signature(
+                _capability_member_signature(
+                    direction,
+                    "action",
+                    effect_change.tool,
+                    effect_change.tag,
+                    None,
+                ),
+                raw_key,
+                source_path=effect_change.source_path,
+                source_start_line=effect_change.source_start_line,
+            )
+
+    qualifier_counts = Counter(
+        (record["name"], record["qualifier"])
+        for record in records.values()
+        if record["qualifier"]
+    )
+    subjects_by_key: dict[str, _CapabilityReaderSubject] = {}
+    raw_to_group_key: dict[str, str] = {}
+    for raw_key, record in sorted(records.items()):
+        name = record["name"]
+        qualifier = record["qualifier"]
+        collides = len(raw_keys_by_name[name]) > 1
+        if not collides:
+            label = name
+        elif qualifier and qualifier_counts[(name, qualifier)] == 1:
+            label = f"{name} [{qualifier}]"
+        else:
+            identity = f"{qualifier}; {raw_key}" if qualifier else raw_key
+            label = f"{name} [{identity}]"
+        group_key = f"canonical:{raw_key}"
+        raw_to_group_key[raw_key] = group_key
+        subjects_by_key[group_key] = _CapabilityReaderSubject(
+            key=group_key,
+            name=name,
+            label=display_literal(label),
+        )
+
+    return _CapabilitySubjectIndex(
+        subjects_by_key=subjects_by_key,
+        keys_by_name={
+            name: tuple(raw_to_group_key[key] for key in sorted(raw_keys))
+            for name, raw_keys in raw_keys_by_name.items()
+        },
+        keys_by_signature={
+            signature: tuple(raw_to_group_key[key] for key in sorted(raw_keys))
+            for signature, raw_keys in raw_keys_by_signature.items()
+        },
+        key_by_tool_id=dict(raw_to_group_key),
+        key_by_action_id={
+            action_id: raw_to_group_key[raw_key]
+            for action_id, raw_key in raw_key_by_action_id.items()
+            if raw_key in raw_to_group_key
+        },
+        operation_by_action_id=operation_by_action_id,
+        sources_by_member_key={
+            (signature, raw_to_group_key[raw_key]): tuple(
+                CapabilityDeltaSource(
+                    path=display_literal(path),
+                    start_line=start_line,
+                )
+                for path, start_line in sorted(
+                    sources,
+                    key=lambda item: (item[0], item[1] if item[1] is not None else -1),
+                )
+            )
+            for (signature, raw_key), sources in raw_sources_by_member_key.items()
+            if raw_key in raw_to_group_key
+        },
+        colliding_keys=frozenset(
+            raw_to_group_key[raw_key]
+            for raw_keys in raw_keys_by_name.values()
+            if len(raw_keys) > 1
+            for raw_key in raw_keys
+        ),
+        blocking_keys=frozenset(
+            raw_to_group_key[finding.tool_id]
+            for finding in report.findings
+            if not finding.suppressed
+            and finding.blocks_release
+            and finding.tool_id in raw_to_group_key
+        ),
+    )
+
+
+def _capability_member_signature(
+    direction: str,
+    subject_kind: str,
+    tool: str,
+    action: str | None,
+    scope: str | None,
+) -> _CapabilityMemberSignature:
+    return direction, subject_kind, tool, action or "", scope or ""
+
+
+def _capability_reader_subjects(
+    member: CapabilityChangeMember,
+    *,
+    index: _CapabilitySubjectIndex,
+) -> tuple[_CapabilityReaderSubject, ...]:
+    """Resolve one compatibility member to one or more canonical subjects."""
+
+    keys: tuple[str, ...] = ()
+    if member.action and member.action in index.key_by_action_id:
+        keys = (index.key_by_action_id[member.action],)
+    if not keys:
+        signature = _capability_member_signature(
+            member.direction,
+            member.subject_kind,
+            member.tool,
+            member.action,
+            member.scope,
+        )
+        keys = index.keys_by_signature.get(signature, ())
+    if not keys and member.tool:
+        name_keys = index.keys_by_name.get(member.tool, ())
+        if len(name_keys) == 1:
+            keys = name_keys
+    if keys:
+        return tuple(index.subjects_by_key[key] for key in dict.fromkeys(keys))
+
+    if member.tool and len(index.keys_by_name.get(member.tool, ())) > 1:
+        label = display_literal(f"{member.tool} [identity unavailable]")
+        return (
+            _CapabilityReaderSubject(
+                key=f"legacy-ambiguous:{member.tool}",
+                name=member.tool,
+                label=label,
+            ),
+        )
+
+    # Policy drift and frozen legacy reports may have no canonical tool
+    # identity to join.  Keep the historical visible fallback without letting
+    # it collide with a real canonical key.
     for candidate in (member.tool, member.scope, member.action, member.id):
         if not isinstance(candidate, str):
             continue
         rendered = display_literal(candidate)
         if has_visible_content(rendered):
-            return candidate, rendered
+            return (
+                _CapabilityReaderSubject(
+                    key=f"legacy-display:{candidate}",
+                    name=candidate,
+                    label=rendered,
+                ),
+            )
     fallback = "unknown capability"
-    return fallback, fallback
+    return (
+        _CapabilityReaderSubject(
+            key=f"legacy-display:{fallback}",
+            name=fallback,
+            label=fallback,
+        ),
+    )
+
+
+def _injective_capability_labels(labels: dict[str, str]) -> dict[str, str]:
+    """Make the final rendered headings unique without changing group keys."""
+
+    unique: dict[str, str] = {}
+    used: set[str] = set()
+    for key, base_label in sorted(labels.items(), key=lambda item: (item[1], item[0])):
+        label = base_label
+        ordinal = 2
+        while label in used:
+            label = f"{base_label} [subject {ordinal}]"
+            ordinal += 1
+        unique[key] = label
+        used.add(label)
+    return unique
 
 
 def _delta_change_type(member: CapabilityChangeMember) -> str:
@@ -525,11 +1082,23 @@ def _delta_description(
     member: CapabilityChangeMember,
     *,
     group_subject: str | None = None,
+    operation_by_action_id: dict[str, str] | None = None,
+    release_impact: CapabilityReleaseImpact | None = None,
 ) -> str:
+    operation_by_action_id = operation_by_action_id or {}
+    action = member.action
+    if action in operation_by_action_id:
+        action = operation_by_action_id[action]
+    elif action and ":action_v2_" in action:
+        # Canonical ids are useful machine join keys, not reader operations.
+        # When a frozen report has no action diff/fact to resolve the id, the
+        # rationale below still states the semantic change without leaking a
+        # long opaque digest into the review.
+        action = None
     target_value = next(
         (
             candidate
-            for candidate in (member.action, member.scope, member.tool, member.id)
+            for candidate in (action, member.scope, member.tool, member.id)
             if isinstance(candidate, str) and has_visible_content(candidate)
         ),
         "unknown capability",
@@ -541,9 +1110,34 @@ def _delta_description(
         before = display_literal(member.before_scope or "none")
         after = display_literal(member.after_scope or "none")
         detail += f" ({before} -> {after})"
-    if member.release_impact not in {"none", "informational"}:
-        detail += f" — {effect_phrase(member.release_impact)}"
+    qualifiers: list[str] = []
+    rationale = display_literal(member.rationale)
+    if has_visible_content(rationale) and _rationale_adds_detail(member, rationale):
+        qualifiers.append(rationale.rstrip("."))
+    effective_impact = release_impact or member.release_impact
+    if effective_impact not in {"none", "informational"}:
+        qualifiers.append(effect_phrase(effective_impact))
+    if qualifiers:
+        detail += f" — {'; '.join(qualifiers)}"
     return detail
+
+
+def _rationale_adds_detail(member: CapabilityChangeMember, rationale: str) -> bool:
+    """Suppress tautologies while retaining semantic field-level changes."""
+
+    normalized = " ".join(rationale.casefold().rstrip(".").split())
+    generic = {
+        f"{member.subject_kind} {member.direction}",
+        f"{member.direction} {member.subject_kind}",
+        f"capability {member.direction}",
+    }
+    if normalized in generic:
+        return False
+    if member.direction in {"added", "removed"} and normalized.startswith(
+        f"{member.subject_kind} {member.direction}:"
+    ):
+        return False
+    return True
 
 
 def _report_proves_manifest_introduction(report: ReadinessReport) -> bool:

--- a/src/agents_shipgate/report/human_order.py
+++ b/src/agents_shipgate/report/human_order.py
@@ -970,18 +970,23 @@ def _capability_reader_subjects(
 ) -> tuple[_CapabilityReaderSubject, ...]:
     """Resolve one compatibility member to one or more canonical subjects."""
 
-    keys: tuple[str, ...] = ()
-    if member.action and member.action in index.key_by_action_id:
-        keys = (index.key_by_action_id[member.action],)
-    if not keys:
-        signature = _capability_member_signature(
-            member.direction,
-            member.subject_kind,
-            member.tool,
-            member.action,
-            member.scope,
-        )
-        keys = index.keys_by_signature.get(signature, ())
+    signature = _capability_member_signature(
+        member.direction,
+        member.subject_kind,
+        member.tool,
+        member.action,
+        member.scope,
+    )
+    # The exact change signature outranks coincidental value overlap. Tool
+    # controls and high-risk effects store their control/tag in ``action``;
+    # either string may legally equal an unrelated action_id.
+    keys = index.keys_by_signature.get(signature, ())
+    if not keys and member.subject_kind == "action" and member.action:
+        action_key = index.key_by_action_id.get(member.action)
+        if action_key is not None:
+            action_subject = index.subjects_by_key[action_key]
+            if not member.tool or action_subject.name == member.tool:
+                keys = (action_key,)
     if not keys and member.tool:
         name_keys = index.keys_by_name.get(member.tool, ())
         if len(name_keys) == 1:

--- a/src/agents_shipgate/report/pr_comment.py
+++ b/src/agents_shipgate/report/pr_comment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 
 from agents_shipgate.core.declaration_questions import progress_sentence
 from agents_shipgate.core.disclaimers import STATIC_VERDICT_DISCLAIMER
@@ -51,6 +52,10 @@ _COMMENT_SUBJECT_LIMIT = 4
 _COMMENT_ROW_LIMIT = 3
 _COMMENT_CAPABILITY_SUBJECT_LIMIT = 5
 _COMMENT_CAPABILITY_CHANGE_LIMIT = 4
+_COMMENT_CAPABILITY_SOURCE_LIMIT = 3
+_COMMENT_CAPABILITY_MAX_CHARS = 1200
+_COMMENT_PROSE_FIELD_MAX_CHARS = 400
+_COMMENT_PROSE_OMISSION = "- … additional human summary detail omitted; see report.md."
 
 
 def render_pr_comment(
@@ -150,11 +155,13 @@ def _human_summary_lines(
     lines.append(f"- Agent may update this PR: `{str(permissions.update_pr).lower()}`")
     lines.append(f"- Agent may merge: `{str(permissions.merge).lower()}`")
     if verifier.control.stop_reason:
-        lines.append(f"- Agent stop reason: `{verifier.control.stop_reason}`")
+        lines.append(
+            f"- Agent stop reason: {_bounded_identity_code(verifier.control.stop_reason)}"
+        )
 
     headline = _headline(verifier, report)
     if headline:
-        lines.append(f"- Summary: {_escape(headline)}")
+        lines.append(f"- Summary: {_bounded_prose(headline)}")
 
     if report is None or report.release_decision is None:
         if verifier.head_status == "skipped":
@@ -173,7 +180,7 @@ def _human_summary_lines(
     decision = report.release_decision
     assert review is not None
     lines.append(f"- Release gate: `{decision.decision}`")
-    lines.append(f"- Reason: {_escape(decision.reason)}")
+    lines.append(f"- Reason: {_bounded_prose(decision.reason)}")
     if not surface_first:
         lines.extend(capability_lines)
     if capability_lock_diff is not None:
@@ -250,53 +257,71 @@ def _capability_delta_lines(
     elif outside.status == "unavailable":
         summary += "; newly outside the analysed surface: unknown (comparison unavailable)"
 
-    lines = [summary]
-    if rollup.subjects:
-        lines.append("- Top capability changes by subject:")
-        for group in rollup.subjects:
-            shown_changes = group.changes[:_COMMENT_CAPABILITY_CHANGE_LIMIT]
-            detail = "; ".join(_escape(change) for change in shown_changes)
-            hidden_changes = group.change_count - len(shown_changes)
-            if hidden_changes:
-                shown_types = set(group.change_types[:_COMMENT_CAPABILITY_CHANGE_LIMIT])
-                omitted_types = tuple(
-                    dict.fromkeys(
-                        change_type
-                        for change_type in group.change_types[_COMMENT_CAPABILITY_CHANGE_LIMIT:]
-                        if change_type not in shown_types
-                    )
+    if not rollup.subjects:
+        lines = [summary]
+        if review.notes:
+            lines.append(f"- Capability delta note: {_bounded_prose(review.notes[0])}")
+        return lines
+
+    group_rows: list[str] = []
+    for group in rollup.subjects:
+        shown_changes = group.changes[:_COMMENT_CAPABILITY_CHANGE_LIMIT]
+        detail = "; ".join(_escape(change) for change in shown_changes)
+        hidden_changes = group.change_count - len(shown_changes)
+        if hidden_changes:
+            shown_types = set(group.change_types[:_COMMENT_CAPABILITY_CHANGE_LIMIT])
+            omitted_types = tuple(
+                dict.fromkeys(
+                    change_type
+                    for change_type in group.change_types[_COMMENT_CAPABILITY_CHANGE_LIMIT:]
+                    if change_type not in shown_types
                 )
-                if omitted_types:
-                    labels = ", ".join(
-                        _capability_change_type_label(change_type) for change_type in omitted_types
-                    )
-                    detail += f"; omitted change types: {_escape(labels)}"
-                change_noun = "change" if hidden_changes == 1 else "changes"
-                detail += f"; … and {hidden_changes} more {change_noun}"
-            if group.sources:
-                source = group.sources[0]
-                detail += _source_suffix(
-                    source.path,
-                    source.start_line,
+            )
+            if omitted_types:
+                labels = ", ".join(
+                    _capability_change_type_label(change_type) for change_type in omitted_types
                 )
-                hidden_sources = len(group.sources) - 1
-                if hidden_sources:
-                    noun = "source" if hidden_sources == 1 else "sources"
-                    detail += f" (+{hidden_sources} more {noun})"
-            lines.append(f"  - {_identity_code(group.subject)}: {detail}")
-        if rollup.hidden_subjects:
-            shown_change_count = sum(group.change_count for group in rollup.subjects)
-            hidden_change_count = rollup.change_count - shown_change_count
-            subject_noun = "subject" if rollup.hidden_subjects == 1 else "subjects"
+                detail += f"; omitted change types: {_escape(labels)}"
+            change_noun = "change" if hidden_changes == 1 else "changes"
+            detail += f"; … and {hidden_changes} more {change_noun}"
+        if group.sources:
+            shown_sources = group.sources[:_COMMENT_CAPABILITY_SOURCE_LIMIT]
+            detail += "; sources: " + ", ".join(
+                _source_location_code(source.path, source.start_line)
+                for source in shown_sources
+            )
+            hidden_sources = len(group.sources) - len(shown_sources)
+            if hidden_sources:
+                noun = "source" if hidden_sources == 1 else "sources"
+                detail += f" (+{hidden_sources} more {noun})"
+        group_rows.append(f"  - {_identity_code(group.subject)}: {detail}")
+
+    heading = "- Top capability changes by subject:"
+    # Choose the largest risk-ranked prefix that fits the capability block's
+    # own budget. Counts then include both the subject limit and the character
+    # budget; an outer comment bound never turns an exact claim into a lie.
+    for shown_count in range(len(group_rows), -1, -1):
+        shown_change_count = sum(
+            group.change_count for group in rollup.subjects[:shown_count]
+        )
+        hidden_subjects = rollup.total_subjects - shown_count
+        hidden_change_count = rollup.change_count - shown_change_count
+        candidate = [summary, heading]
+        if hidden_subjects:
+            subject_noun = "subject" if hidden_subjects == 1 else "subjects"
             change_noun = "change" if hidden_change_count == 1 else "changes"
-            lines.append(
+            candidate.append(
                 "  - … and "
-                f"{rollup.hidden_subjects} more {subject_noun} "
+                f"{hidden_subjects} more {subject_noun} "
                 f"({hidden_change_count} {change_noun}) not shown."
             )
-    elif review.notes:
-        lines.append(f"- Capability delta note: {_escape(review.notes[0])}")
-    return lines
+        candidate.extend(group_rows[:shown_count])
+        if len("\n".join(candidate)) <= _COMMENT_CAPABILITY_MAX_CHARS:
+            return candidate
+
+    # Summary + heading + exact disclosure are bounded constants; the loop's
+    # zero-row candidate always fits. Keep a defensive return for type tools.
+    return [summary]
 
 
 def _cold_reader_lines(
@@ -304,26 +329,51 @@ def _cold_reader_lines(
     *,
     capability_lines: list[str] | None = None,
 ) -> list[str]:
-    lines = [f"- {_escape(line)}" for line in surface_lead(report).text_lines()]
-    lines.extend(capability_lines or [])
-    lines.extend(_subject_rollup_lines(report))
-    return _bounded_cold_reader_lines(lines)
+    surface_lines = [f"- {_escape(line)}" for line in surface_lead(report).text_lines()]
+    return _bounded_cold_reader_lines(
+        surface_lines,
+        required_lines=capability_lines or [],
+        trailing_lines=_subject_rollup_lines(report),
+    )
 
 
-def _bounded_cold_reader_lines(lines: list[str]) -> list[str]:
-    """Reserve PR-comment space for the verdict/control block that follows."""
+def _bounded_cold_reader_lines(
+    surface_lines: list[str],
+    *,
+    required_lines: list[str],
+    trailing_lines: list[str],
+) -> list[str]:
+    """Bound a cold lead while preserving its exact capability disclosure."""
 
+    lines = [*surface_lines, *required_lines, *trailing_lines]
     if len("\n".join(lines)) <= _COLD_READER_LEAD_MAX_CHARS:
         return lines
     budget = _COLD_READER_LEAD_MAX_CHARS - len(_COLD_READER_OMISSION) - 1
-    shown: list[str] = []
-    used = 0
-    for line in lines:
-        added = len(line) + (1 if shown else 0)
-        if used + added > budget:
+
+    required_length = len("\n".join(required_lines))
+    if required_length > budget:
+        # ``_capability_delta_lines`` has its own stricter 1,200-character
+        # budget, so this is defensive for direct/private callers only.
+        return [
+            *_truncate_markdown_lines(
+                required_lines,
+                budget,
+                omission=_COLD_READER_OMISSION,
+            ).splitlines()
+        ]
+
+    shown_surface: list[str] = []
+    for line in surface_lines:
+        candidate = [*shown_surface, line, *required_lines]
+        if len("\n".join(candidate)) > budget:
+            break
+        shown_surface.append(line)
+
+    shown = [*shown_surface, *required_lines]
+    for line in trailing_lines:
+        if len("\n".join([*shown, line])) > budget:
             break
         shown.append(line)
-        used += added
     return [*shown, _COLD_READER_OMISSION]
 
 
@@ -364,13 +414,17 @@ def _next_actor_lines(verifier: VerifierArtifact) -> list[str]:
         return ["- Next actor: `human`"]
     lines = [f"- Next actor: `{action.actor}`"]
     if action.why:
-        lines.append(f"- Next action: {_escape(action.why)}")
+        lines.append(f"- Next action: {_bounded_prose(action.why)}")
     if action.command:
         lines.append(f"- Next command: {_code(action.command)}")
     return lines
 
 
 def _trigger_and_base_summary(verifier: VerifierArtifact) -> list[str]:
+    # This block follows the capability disclosure in the default layout, so
+    # the outer row-aware truncator may consume it without hiding the delta.
+    # Retain the full value here for report compatibility; the findings layout
+    # places the trigger first and therefore bounds its own copy.
     lines = [f"- Trigger: {_escape(verifier.trigger.get('rationale') or 'not evaluated')}"]
     if verifier.base_status != "not_requested":
         base = verifier.base_ref or "(none)"
@@ -461,10 +515,13 @@ def _join_with_preserved_agent_block(
     limit: int,
 ) -> str:
     block = "\n".join(agent_block)
-    prose = "\n".join(prose_lines)
     budget = limit - len(block) - 1
     if budget > 0:
-        prose = _truncate(prose, budget).rstrip()
+        prose = _truncate_markdown_lines(
+            prose_lines,
+            budget,
+            omission=_COMMENT_PROSE_OMISSION,
+        )
     else:
         prose = "\n".join(
             [
@@ -481,9 +538,15 @@ def _join_with_preserved_agent_block(
 def _source_suffix(path: str | None, line: int | None) -> str:
     if not path:
         return ""
-    if line is not None:
-        return f" ({path}:{line})"
-    return f" ({path})"
+    # Paths are data, not Markdown. A dynamic code fence preserves brackets,
+    # emphasis markers, and embedded backticks without allowing them to forge
+    # links or formatting in a PR comment.
+    return f" ({_source_location_code(path, line)})"
+
+
+def _source_location_code(path: str, line: int | None) -> str:
+    location = f"{path}:{line}" if line is not None else path
+    return _identity_code(location)
 
 
 def _render_findings_comment(
@@ -528,13 +591,19 @@ def _render_findings_comment(
             include_release_gate=report is None or not surface_first,
         )
     )
+    if not surface_first:
+        # Keep the exact grouped disclosure ahead of repository-controlled
+        # prose. The final row-aware bound may omit later context, but it must
+        # never turn a seven-subject delta into a summary with no exact hidden
+        # count merely because a trigger or release reason contains Markdown.
+        lines.extend(capability_lines)
     lines.append("")
-    lines.append(f"Trigger: {_escape(verifier.trigger.get('rationale') or 'not evaluated')}")
+    lines.append(f"Trigger: {_bounded_prose(verifier.trigger.get('rationale') or 'not evaluated')}")
     if verifier.base_status != "not_requested":
         base = verifier.base_ref or "(none)"
         lines.append(f"Base diff: `{base}` -> `{verifier.base_status}`")
         for note in verifier.base_notes[:2]:
-            lines.append(f"- {_escape(note)}")
+            lines.append(f"- {_bounded_prose(note)}")
 
     if report is None or report.release_decision is None:
         if verifier.head_status == "skipped":
@@ -544,14 +613,18 @@ def _render_findings_comment(
             lines.append("")
             lines.append(f"Head scan did not produce a report (exit {verifier.head_exit_code}).")
         lines.extend(_artifact_lines(verifier, links=False))
-        return _truncate("\n".join(lines), 6000)
+        return _truncate_markdown_lines(
+            lines,
+            6000,
+            omission=_COMMENT_PROSE_OMISSION,
+        )
 
     decision = report.release_decision
     lines.extend(
         [
             "",
             f"Release gate: `{decision.decision}`",
-            f"Reason: {_escape(decision.reason)}",
+            f"Reason: {_bounded_prose(decision.reason)}",
             (f"Blockers: {len(decision.blockers)} · Review items: {len(decision.review_items)}"),
             (
                 "Fail policy: "
@@ -562,13 +635,14 @@ def _render_findings_comment(
         ]
     )
     if report.agent_summary and report.agent_summary.headline:
-        lines.append(f"Summary: {_escape(report.agent_summary.headline)}")
+        lines.append(f"Summary: {_bounded_prose(report.agent_summary.headline)}")
     if report.reviewer_summary and report.reviewer_summary.first_recommended_surface:
         surface = report.reviewer_summary.first_recommended_surface
-        lines.append(f"Reviewer start: `{surface.name}` - {_escape(surface.why)}")
+        lines.append(
+            "Reviewer start: "
+            f"{_bounded_identity_code(surface.name)} - {_bounded_prose(surface.why)}"
+        )
 
-    if not surface_first:
-        lines.extend(capability_lines)
     lines.extend(_diff_lines(report))
     groups = roll_up_findings(report)
     lines.append("")
@@ -589,7 +663,11 @@ def _render_findings_comment(
     elif not surface_first:
         lines.append("No critical or high findings.")
     lines.extend(_artifact_lines(verifier, links=False))
-    return _truncate("\n".join(lines), 6000)
+    return _truncate_markdown_lines(
+        lines,
+        6000,
+        omission=_COMMENT_PROSE_OMISSION,
+    )
 
 
 def _verifier_lead(
@@ -606,7 +684,7 @@ def _verifier_lead(
         lines.append(f"Release gate: `{verifier.decision}`")
     if verifier.human_review is not None and verifier.human_review.required:
         why = verifier.human_review.why or "Human review required before merge."
-        lines.append(f"Human review: `{_escape(why)}`")
+        lines.append(f"Human review: {_bounded_identity_code(why)}")
     return lines
 
 
@@ -624,13 +702,13 @@ def _headline(
 def _trigger_and_base_lines(verifier: VerifierArtifact) -> list[str]:
     lines = [
         "",
-        f"Trigger: {_escape(verifier.trigger.get('rationale') or 'not evaluated')}",
+        f"Trigger: {_bounded_prose(verifier.trigger.get('rationale') or 'not evaluated')}",
     ]
     if verifier.base_status != "not_requested":
         base = verifier.base_ref or "(none)"
         lines.append(f"Base diff: `{base}` -> `{verifier.base_status}`")
         for note in verifier.base_notes[:2]:
-            lines.append(f"- {_escape(note)}")
+            lines.append(f"- {_bounded_prose(note)}")
     return lines
 
 
@@ -869,6 +947,59 @@ def _escape(value: object) -> str:
     return _ESCAPE_RE.sub(r"\\\1", str(value or ""))
 
 
+def _bounded_prose(
+    value: object,
+    limit: int = _COMMENT_PROSE_FIELD_MAX_CHARS,
+) -> str:
+    """Escape and bound one repository-controlled value by rendered size."""
+
+    text = _single_line(value)
+    rendered = _escape(text)
+    if len(rendered) <= limit:
+        return rendered
+    return _longest_bounded_rendering(text, limit=limit, renderer=_escape)
+
+
+def _bounded_identity_code(
+    value: object,
+    limit: int = _COMMENT_PROSE_FIELD_MAX_CHARS,
+) -> str:
+    """Render one dynamic code span within a complete rendered-size budget."""
+
+    text = _single_line(value)
+    rendered = _identity_code(text)
+    if len(rendered) <= limit:
+        return rendered
+    return _longest_bounded_rendering(text, limit=limit, renderer=_identity_code)
+
+
+def _single_line(value: object) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ")
+
+
+def _longest_bounded_rendering(
+    text: str,
+    *,
+    limit: int,
+    renderer: Callable[[object], str],
+) -> str:
+    """Binary-search a raw prefix whose complete Markdown rendering fits."""
+
+    suffix = "…"
+    low = 0
+    high = len(text)
+    best = renderer(suffix)
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = renderer(f"{text[:midpoint]}{suffix}")
+        if len(candidate) <= limit:
+            best = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return best
+
+
 def _table_cell(value: object) -> str:
     return str(value or "").replace("\r", " ").replace("\n", " ").replace("|", "\\|")
 
@@ -921,6 +1052,33 @@ def _truncate(value: str, limit: int) -> str:
     if limit <= 3:
         return "." * max(limit, 0)
     return value[: limit - 3] + "..."
+
+
+def _truncate_markdown_lines(
+    lines: list[str],
+    limit: int,
+    *,
+    omission: str,
+) -> str:
+    """Bound Markdown without cutting through a row, link, or code fence."""
+
+    rendered = "\n".join(lines)
+    if len(rendered) <= limit:
+        return rendered
+    if limit <= len(omission):
+        return _truncate(omission, limit)
+    budget = limit - len(omission) - 1
+    shown: list[str] = []
+    used = 0
+    for line in lines:
+        added = len(line) + (1 if shown else 0)
+        if used + added > budget:
+            break
+        shown.append(line)
+        used += added
+    if not shown:
+        return omission
+    return "\n".join([*shown, omission])
 
 
 __all__ = ["STICKY_MARKER", "render_pr_comment"]

--- a/src/agents_shipgate/report/pr_comment.py
+++ b/src/agents_shipgate/report/pr_comment.py
@@ -13,8 +13,9 @@ from agents_shipgate.report.capability_lock_diff_markdown import (
     render_capability_lock_diff_markdown,
 )
 from agents_shipgate.report.human_order import (
+    CapabilityDeltaSubjectRollup,
     HumanArtifactContext,
-    capability_delta_by_subject,
+    capability_delta_subject_rollup,
     should_render_surface_first,
     surface_lead,
 )
@@ -48,6 +49,8 @@ _COLD_READER_OMISSION = "- … additional capability detail omitted; see report.
 # surface however it is laid out.
 _COMMENT_SUBJECT_LIMIT = 4
 _COMMENT_ROW_LIMIT = 3
+_COMMENT_CAPABILITY_SUBJECT_LIMIT = 5
+_COMMENT_CAPABILITY_CHANGE_LIMIT = 4
 
 
 def render_pr_comment(
@@ -113,8 +116,29 @@ def _human_summary_lines(
     surface_first = bool(
         report is not None and should_render_surface_first(report, context=human_context)
     )
+    review = (
+        _capability_review(verifier, report)
+        if report is not None and report.release_decision is not None
+        else None
+    )
+    capability_lines = (
+        _capability_delta_lines(
+            capability_delta_subject_rollup(
+                report,
+                subject_limit=_COMMENT_CAPABILITY_SUBJECT_LIMIT,
+            ),
+            review=review,
+        )
+        if report is not None and review is not None
+        else []
+    )
     if surface_first and report is not None:
-        lines.extend(_cold_reader_lines(report))
+        lines.extend(
+            _cold_reader_lines(
+                report,
+                capability_lines=capability_lines,
+            )
+        )
     lines.append(f"- Merge verdict: `{verifier.merge_verdict}`")
     lines.append(f"- Can merge without human: `{str(verifier.can_merge_without_human).lower()}`")
     lines.append(f"- Agent control state: `{verifier.control.state}`")
@@ -147,12 +171,11 @@ def _human_summary_lines(
         return lines
 
     decision = report.release_decision
-    review = _capability_review(verifier, report)
+    assert review is not None
     lines.append(f"- Release gate: `{decision.decision}`")
     lines.append(f"- Reason: {_escape(decision.reason)}")
-    lines.append(
-        f"- Capability delta: +{review.added}, {review.modified} modified, -{review.removed}"
-    )
+    if not surface_first:
+        lines.extend(capability_lines)
     if capability_lock_diff is not None:
         summary = capability_lock_diff.summary
         lines.append(
@@ -179,17 +202,6 @@ def _human_summary_lines(
     )
     lines.append(f"- Static-verdict boundary: {_escape(STATIC_VERDICT_DISCLAIMER)}")
     lines.extend(_next_actor_lines(verifier))
-    if review.top_changes:
-        lines.append("- Top capability changes:")
-        for change in review.top_changes[:5]:
-            source = _source_suffix(change.source_path, change.source_start_line)
-            lines.append(
-                "  - "
-                f"`{change.subject}`: {_escape(_impact(change))}; "
-                f"{_escape(change.rationale)}{source}"
-            )
-    elif review.notes:
-        lines.append(f"- Capability delta note: {_escape(review.notes[0])}")
     if not surface_first:
         lines.extend(_subject_rollup_lines(report))
     if review.trust_root_touched or review.policy_weakened:
@@ -202,15 +214,98 @@ def _human_summary_lines(
     return lines
 
 
-def _cold_reader_lines(report: ReadinessReport) -> list[str]:
+def _capability_delta_lines(
+    rollup: CapabilityDeltaSubjectRollup,
+    *,
+    review: VerifierCapabilityReview,
+) -> list[str]:
+    """Render the question a reviewer asks: how many subjects changed?
+
+    The stable ``capability_review`` counts remain change-record counts for
+    existing machine consumers.  Human copy instead uses the complete
+    canonical report rollup, so a tool/action pair consumes one subject slot
+    while both changes remain visible (#439).  The binding-diff axis stays
+    separate: a subject newly outside analysis is not proven capability, but
+    reporting ``+0`` without naming that fact is equally misleading (#437).
+    """
+
+    if rollup.enabled:
+        subject_noun = "subject" if rollup.total_subjects == 1 else "subjects"
+        change_noun = "change" if rollup.change_count == 1 else "changes"
+        summary = (
+            "- Capability delta (analysed surface): "
+            f"{rollup.total_subjects} {subject_noun} across "
+            f"{rollup.change_count} {change_noun} "
+            f"(+{rollup.added_subjects} added, "
+            f"{rollup.modified_subjects} modified, "
+            f"-{rollup.removed_subjects} removed)"
+        )
+    else:
+        summary = "- Capability delta (analysed surface): unavailable"
+
+    outside = rollup.outside_analysis
+    if outside.status == "complete" and outside.newly_outside_subjects:
+        noun = "subject" if outside.newly_outside_subjects == 1 else "subjects"
+        summary += f"; {outside.newly_outside_subjects} {noun} newly outside the analysed surface"
+    elif outside.status == "unavailable":
+        summary += "; newly outside the analysed surface: unknown (comparison unavailable)"
+
+    lines = [summary]
+    if rollup.subjects:
+        lines.append("- Top capability changes by subject:")
+        for group in rollup.subjects:
+            shown_changes = group.changes[:_COMMENT_CAPABILITY_CHANGE_LIMIT]
+            detail = "; ".join(_escape(change) for change in shown_changes)
+            hidden_changes = group.change_count - len(shown_changes)
+            if hidden_changes:
+                shown_types = set(group.change_types[:_COMMENT_CAPABILITY_CHANGE_LIMIT])
+                omitted_types = tuple(
+                    dict.fromkeys(
+                        change_type
+                        for change_type in group.change_types[_COMMENT_CAPABILITY_CHANGE_LIMIT:]
+                        if change_type not in shown_types
+                    )
+                )
+                if omitted_types:
+                    labels = ", ".join(
+                        _capability_change_type_label(change_type) for change_type in omitted_types
+                    )
+                    detail += f"; omitted change types: {_escape(labels)}"
+                change_noun = "change" if hidden_changes == 1 else "changes"
+                detail += f"; … and {hidden_changes} more {change_noun}"
+            if group.sources:
+                source = group.sources[0]
+                detail += _source_suffix(
+                    source.path,
+                    source.start_line,
+                )
+                hidden_sources = len(group.sources) - 1
+                if hidden_sources:
+                    noun = "source" if hidden_sources == 1 else "sources"
+                    detail += f" (+{hidden_sources} more {noun})"
+            lines.append(f"  - {_identity_code(group.subject)}: {detail}")
+        if rollup.hidden_subjects:
+            shown_change_count = sum(group.change_count for group in rollup.subjects)
+            hidden_change_count = rollup.change_count - shown_change_count
+            subject_noun = "subject" if rollup.hidden_subjects == 1 else "subjects"
+            change_noun = "change" if hidden_change_count == 1 else "changes"
+            lines.append(
+                "  - … and "
+                f"{rollup.hidden_subjects} more {subject_noun} "
+                f"({hidden_change_count} {change_noun}) not shown."
+            )
+    elif review.notes:
+        lines.append(f"- Capability delta note: {_escape(review.notes[0])}")
+    return lines
+
+
+def _cold_reader_lines(
+    report: ReadinessReport,
+    *,
+    capability_lines: list[str] | None = None,
+) -> list[str]:
     lines = [f"- {_escape(line)}" for line in surface_lead(report).text_lines()]
-    groups = capability_delta_by_subject(report)
-    if groups:
-        lines.append("- Capability changes by subject:")
-        for group in groups:
-            lines.append(f"  - `{_escape(group.subject)}`")
-            for change in group.changes:
-                lines.append(f"    - {_escape(change)}")
+    lines.extend(capability_lines or [])
     lines.extend(_subject_rollup_lines(report))
     return _bounded_cold_reader_lines(lines)
 
@@ -400,6 +495,17 @@ def _render_findings_comment(
     surface_first = bool(
         report is not None and should_render_surface_first(report, context=human_context)
     )
+    capability_lines = (
+        _capability_delta_lines(
+            capability_delta_subject_rollup(
+                report,
+                subject_limit=_COMMENT_CAPABILITY_SUBJECT_LIMIT,
+            ),
+            review=verifier.capability_review,
+        )
+        if report is not None and report.release_decision is not None
+        else []
+    )
     title = (
         "## Agents Shipgate"
         if surface_first
@@ -407,7 +513,15 @@ def _render_findings_comment(
     )
     lines = [STICKY_MARKER, title]
     if surface_first and report is not None:
-        lines.extend(["", *_cold_reader_lines(report)])
+        lines.extend(
+            [
+                "",
+                *_cold_reader_lines(
+                    report,
+                    capability_lines=capability_lines,
+                ),
+            ]
+        )
     lines.extend(
         _verifier_lead(
             verifier,
@@ -453,6 +567,8 @@ def _render_findings_comment(
         surface = report.reviewer_summary.first_recommended_surface
         lines.append(f"Reviewer start: `{surface.name}` - {_escape(surface.why)}")
 
+    if not surface_first:
+        lines.extend(capability_lines)
     lines.extend(_diff_lines(report))
     groups = roll_up_findings(report)
     lines.append("")
@@ -760,6 +876,38 @@ def _table_cell(value: object) -> str:
 def _code(value: object) -> str:
     text = str(value or "").replace("`", "")
     return f"`{text}`"
+
+
+def _identity_code(value: object) -> str:
+    """Render a visible identity without deleting embedded backticks.
+
+    A fence longer than every run in the value keeps the reader-facing label
+    intact. CommonMark removes one space from both edges only when both are
+    present, so padding must be symmetric: it is needed for edge backticks and
+    for a value that genuinely starts *and* ends with a space. One-sided spaces
+    are already preserved without padding.
+    """
+
+    text = str(value or "")
+    longest_run = max(
+        (len(match.group(0)) for match in re.finditer(r"`+", text)),
+        default=0,
+    )
+    fence = "`" * (longest_run + 1)
+    needs_padding = (
+        text.startswith("`") or text.endswith("`") or (text.startswith(" ") and text.endswith(" "))
+    )
+    padded = f" {text} " if needs_padding else text
+    return f"{fence}{padded}{fence}"
+
+
+def _capability_change_type_label(change_type: str) -> str:
+    """Turn ``action_added`` into compact adopter-facing prose."""
+
+    subject_kind, separator, direction = change_type.rpartition("_")
+    if not separator:
+        return change_type.replace("_", " ")
+    return f"{subject_kind.replace('_', ' ')} {direction}"
 
 
 def _escape_link(value: object) -> str:

--- a/tests/test_cold_reader_order.py
+++ b/tests/test_cold_reader_order.py
@@ -476,7 +476,12 @@ def test_first_adoption_verify_wires_scan_context_into_pr_comment(
 
     assert report is not None
     comment = (repo / "reports" / "pr-comment.md").read_text(encoding="utf-8")
-    assert comment.index("Surface: 9 tools") < comment.index("Release gate:")
+    assert (
+        comment.index("Surface: 9 tools")
+        < comment.index("Capability delta (analysed surface)")
+        < comment.index("Release gate:")
+    )
+    assert comment.count("Capability delta (analysed surface)") == 1
     assert comment.count("Release gate:") == 1
     if style == "capability-review":
         assert "Capability delta note:" in comment or "Top capability changes:" in comment

--- a/tests/test_subject_rollup.py
+++ b/tests/test_subject_rollup.py
@@ -1322,7 +1322,7 @@ def test_every_builtin_obligation_has_a_phrase_and_round_trips():
 
 
 def test_the_grouped_block_does_not_evict_the_agent_instruction_block():
-    """The default comment truncates at ``_COMMENT_MAX_CHARS`` and preserves
+    """The default comment stays within ``_COMMENT_MAX_CHARS`` and preserves
     the agent block; adding prose above it must not change that.
 
     A machine reads that block. Losing it to a rendering addition would turn
@@ -1356,6 +1356,7 @@ def test_the_grouped_block_does_not_evict_the_agent_instruction_block():
     report.release_decision = _decision(blockers=findings, review_items=[])
 
     comment = _pr_comment(report, trigger_rationale="x" * 4000)
-    assert len(comment) == _COMMENT_MAX_CHARS
+    assert len(comment) <= _COMMENT_MAX_CHARS
+    assert "additional human summary detail omitted" in comment
     assert "### Agent instruction block" in comment
     assert "Findings by subject" in comment

--- a/tests/test_surface_exclusions.py
+++ b/tests/test_surface_exclusions.py
@@ -140,7 +140,12 @@ def test_a_destructive_tool_added_by_the_diff_is_gated(tmp_path):
     assert len(graph.unbound_tool_ids) == 1, "the new tool is still excluded from analysis"
     assert report.binding_surface_diff.enabled is True
     assert report.binding_surface_diff.added_unbound_tool_ids == graph.unbound_tool_ids
-    outside = capability_delta_subject_rollup(report).outside_analysis
+    rollup = capability_delta_subject_rollup(report)
+    outside = rollup.outside_analysis
+    # The excluded tool is reported only on the binding-diff axis. It has no
+    # analysed capability row and must not inflate the +added subject count.
+    assert rollup.total_subjects == 0
+    assert rollup.added_subjects == 0
     assert outside.status == "complete"
     assert outside.newly_outside_subjects == 1
 

--- a/tests/test_surface_exclusions.py
+++ b/tests/test_surface_exclusions.py
@@ -41,6 +41,7 @@ from agents_shipgate.core.surface_exclusions import (
     exclusion_phrase,
     nameable_subject,
 )
+from agents_shipgate.report.human_order import capability_delta_subject_rollup
 from agents_shipgate.schemas.exclusions import (
     MAX_LEDGER_ENTRIES,
     SurfaceExclusion,
@@ -139,6 +140,9 @@ def test_a_destructive_tool_added_by_the_diff_is_gated(tmp_path):
     assert len(graph.unbound_tool_ids) == 1, "the new tool is still excluded from analysis"
     assert report.binding_surface_diff.enabled is True
     assert report.binding_surface_diff.added_unbound_tool_ids == graph.unbound_tool_ids
+    outside = capability_delta_subject_rollup(report).outside_analysis
+    assert outside.status == "complete"
+    assert outside.newly_outside_subjects == 1
 
     decision = report.release_decision
     assert decision is not None
@@ -221,6 +225,9 @@ def test_a_pre_existing_unbound_tool_is_recorded_and_not_gated(tmp_path):
 
     assert len(report.binding_surface_facts.unbound_tool_ids) == 1
     assert report.binding_surface_diff.added_unbound_tool_ids == []
+    outside = capability_delta_subject_rollup(report).outside_analysis
+    assert outside.status == "complete"
+    assert outside.newly_outside_subjects == 0
     rows = [
         entry
         for entry in report.surface_exclusions.entries
@@ -247,6 +254,23 @@ def test_a_plain_scan_has_no_base_and_gates_nothing_new(tmp_path):
     assert report.binding_surface_diff.added_unbound_tool_ids == []
     assert [row.reason for row in report.surface_exclusions.entries] == ["unbound_tool"]
     assert report.surface_exclusions.gated == 0
+    outside = capability_delta_subject_rollup(report).outside_analysis
+    assert outside.status == "not_requested"
+    assert outside.newly_outside_subjects == 0
+
+
+def test_large_sample_unbound_catalog_does_not_become_a_new_delta(tmp_path):
+    """The 58 by-design unwired operations are not a base-backed change (#437)."""
+
+    report, _ = _scan(
+        Path("samples/large_multi_framework_agent/shipgate.yaml"),
+        tmp_path / "large-sample-reports",
+    )
+
+    assert len(report.binding_surface_facts.unbound_tool_ids) == 58
+    outside = capability_delta_subject_rollup(report).outside_analysis
+    assert outside.status == "not_requested"
+    assert outside.newly_outside_subjects == 0
 
 
 # --- the invariant itself ---------------------------------------------------
@@ -1397,7 +1421,10 @@ def test_a_new_gap_names_the_subject_that_left_the_analysed_surface(tmp_path):
     action = verifier.first_next_action
     assert action is not None and "find_duplicate [server_mcp]" in action.why
     # And on the surface a human actually opens.
-    assert "find_duplicate" in render_pr_comment(verifier, report=report)
+    comment = render_pr_comment(verifier, report=report)
+    assert "find_duplicate" in comment
+    assert "- Capability delta (analysed surface):" in comment
+    assert "; 1 subject newly outside the analysed surface" in comment
 
 
 def test_the_named_subject_is_the_ledger_spelling(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -58,9 +58,16 @@ from agents_shipgate.schemas.report import (
     ToolSurfaceSummary,
 )
 from agents_shipgate.schemas.surfaces import (
+    ActionFact,
     ActionSurfaceChange,
     ActionSurfaceDiff,
     ActionSurfaceDiffSummary,
+    ActionSurfaceFacts,
+    ActionSurfaceHashes,
+    ToolSurfaceControlChange,
+    ToolSurfaceDiff,
+    ToolSurfaceScopeChange,
+    ToolSurfaceToolChange,
 )
 from agents_shipgate.schemas.verifier import (
     VerifierArtifact,
@@ -1073,7 +1080,7 @@ def test_capability_review_pr_comment_leads_with_top_changes_and_trust_root() ->
         "- Capability delta (analysed surface): "
         "1 subject across 1 change (+1 added, 0 modified, -0 removed)" in comment
     )
-    assert "`stripe.create_refund`: added action refund — blocks release" in comment
+    assert "`stripe.create_refund`: added action create\\_refund — blocks release" in comment
     assert "- Next actor: `human`" in comment
     assert "A human owner must confirm approval and idempotency evidence" in comment
     assert "- Trust root touched: `true`" in comment
@@ -1126,6 +1133,12 @@ def test_capability_review_groups_one_bound_tool_without_changing_legacy_counts(
             report=report,
             human_context=HumanArtifactContext(manifest_introduced=True),
         ),
+        render_pr_comment(
+            verifier,
+            report=report,
+            style="findings",
+            human_context=HumanArtifactContext(manifest_introduced=True),
+        ),
     ]
 
     # ``verifier.json`` stays backward compatible: these are still two
@@ -1153,6 +1166,552 @@ def test_capability_review_groups_one_bound_tool_without_changing_legacy_counts(
         assert normalized_summary.count("update_incident") == 1
         assert "added action" in normalized_summary
         assert "added tool" in normalized_summary
+
+
+def test_capability_review_keeps_same_named_provider_tools_as_distinct_subjects() -> None:
+    """Display names never replace canonical tool identity during grouping."""
+
+    report = _report(decision="review_required", exit_code=0)
+    alpha_action = "agent:alpha/agent:action_v2_" + "a" * 64
+    beta_action = "agent:beta/agent:action_v2_" + "b" * 64
+    report.findings = [
+        Finding(
+            id="F-alpha-blocker",
+            check_id="SHIP-TEST-ALPHA",
+            title="alpha search is blocked",
+            severity="critical",
+            category="test",
+            tool_id="tool-alpha",
+            tool_name="search",
+            recommendation="Fix alpha.",
+            blocks_release=True,
+        )
+    ]
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-alpha",
+                name="search",
+                provider="alpha",
+                source_type="mcp",
+                source_path="alpha-tools.json",
+                source_start_line=10,
+            ),
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-beta",
+                name="search",
+                provider="beta",
+                source_type="mcp",
+                source_path="beta-tools.json",
+                source_start_line=20,
+            ),
+        ],
+    )
+    report.action_surface_diff = ActionSurfaceDiff(
+        enabled=True,
+        summary=ActionSurfaceDiffSummary(actions_added=2),
+        added=[
+            ActionSurfaceChange(
+                type="ACTION_ADDED",
+                action_id=alpha_action,
+                tool_id="tool-alpha",
+                tool_name="search",
+                operation="search_alpha",
+                reason="Action added: search",
+                source_path="alpha-tools.json",
+                source_start_line=10,
+            ),
+            ActionSurfaceChange(
+                type="ACTION_ADDED",
+                action_id=beta_action,
+                tool_id="tool-beta",
+                tool_name="search",
+                operation="search_beta",
+                reason="Action added: search",
+                source_path="beta-tools.json",
+                source_start_line=20,
+            ),
+        ],
+    )
+    # Exercise the production compatibility builder. Its established member
+    # shape omits provider/tool_id, so the human projection must recover the
+    # canonical identities from the complete report without changing schema.
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.total_subjects == 2
+    assert rollup.added_subjects == 2
+    assert rollup.change_count == 4
+    assert {subject.subject for subject in rollup.subjects} == {
+        "search [alpha]",
+        "search [beta]",
+    }
+    assert all(
+        subject.change_types == ("action_added", "tool_added")
+        for subject in rollup.subjects
+    )
+    by_subject = {subject.subject: subject for subject in rollup.subjects}
+    assert [(source.path, source.start_line) for source in by_subject["search [alpha]"].sources] == [
+        ("alpha-tools.json", 10)
+    ]
+    assert [(source.path, source.start_line) for source in by_subject["search [beta]"].sources] == [
+        ("beta-tools.json", 20)
+    ]
+    assert all("blocks release" in detail for detail in by_subject["search [alpha]"].changes)
+    assert all(
+        "blocks release" not in detail and "review required" in detail
+        for detail in by_subject["search [beta]"].changes
+    )
+
+
+def test_capability_review_keeps_unseen_explicit_tool_id_out_of_name_fanout() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="changed",
+                tool_id="tool-alpha",
+                name="search",
+                provider="alpha",
+                source_type="mcp",
+            ),
+            ToolSurfaceToolChange(
+                kind="changed",
+                tool_id="tool-beta",
+                name="search",
+                provider="beta",
+                source_type="mcp",
+            ),
+        ],
+        controls=[
+            ToolSurfaceControlChange(
+                kind="removed",
+                control="approval_policy",
+                tool="search",
+                tool_id="tool-gamma",
+            )
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.total_subjects == 3
+    assert rollup.change_count == 3
+    assert {subject.subject for subject in rollup.subjects} == {
+        "search [alpha]",
+        "search [beta]",
+        "search [tool-gamma]",
+    }
+    gamma = next(subject for subject in rollup.subjects if "tool-gamma" in subject.subject)
+    assert gamma.change_types == ("policy_broadened",)
+
+
+def test_capability_review_keeps_only_exact_finding_source_on_name_collision() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.findings = [
+        Finding(
+            id="F-alpha-blocker",
+            check_id="SHIP-TEST-ALPHA",
+            title="alpha search is blocked",
+            severity="critical",
+            category="test",
+            tool_id="tool-alpha",
+            tool_name="search",
+            recommendation="Fix alpha.",
+            blocks_release=True,
+            source=SourceReference(type="mcp", path="alpha.py", start_line=42),
+        )
+    ]
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-alpha",
+                name="search",
+                provider="alpha",
+                source_type="mcp",
+            ),
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-beta",
+                name="search",
+                provider="beta",
+                source_type="mcp",
+            ),
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+    by_subject = {subject.subject: subject for subject in rollup.subjects}
+
+    assert [(source.path, source.start_line) for source in by_subject["search [alpha]"].sources] == [
+        ("alpha.py", 42)
+    ]
+    assert by_subject["search [beta]"].sources == ()
+
+
+def test_capability_review_labels_idless_ambiguous_action_without_internal_key() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-alpha",
+                name="search",
+                provider="alpha",
+                source_type="mcp",
+            ),
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-beta",
+                name="search",
+                provider="beta",
+                source_type="mcp",
+            ),
+        ],
+    )
+    report.action_surface_diff = ActionSurfaceDiff(
+        enabled=True,
+        added=[
+            ActionSurfaceChange(
+                type="ACTION_ADDED",
+                action_id="legacy-search-action",
+                tool_id=None,
+                tool_name="search",
+                operation="search",
+                reason="Action added: search",
+            )
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+    labels = {subject.subject for subject in rollup.subjects}
+
+    assert rollup.total_subjects == 3
+    assert rollup.change_count == 3
+    assert "search [identity unavailable]" in labels
+    assert all("legacy:" not in label for label in labels)
+
+
+def test_capability_review_preserves_exact_action_fact_identity_for_idless_diff() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.action_surface_facts = ActionSurfaceFacts(
+        actions=[
+            _capability_action_fact(
+                action_id="aid",
+                tool_id="tool-alpha",
+                tool_name="search",
+                provider="alpha",
+                operation="search_alpha",
+                source_path="alpha.json",
+                source_start_line=11,
+            ),
+            _capability_action_fact(
+                action_id="beta-aid",
+                tool_id="tool-beta",
+                tool_name="search",
+                provider="beta",
+                operation="search_beta",
+                source_path="beta.json",
+                source_start_line=22,
+            ),
+        ]
+    )
+    report.action_surface_diff = ActionSurfaceDiff(
+        enabled=True,
+        modified=[
+            ActionSurfaceChange(
+                type="INPUT_SCHEMA_EXPANDED",
+                action_id="aid",
+                tool_id=None,
+                tool_name="search",
+                operation="search_alpha",
+                reason="Input schema expanded.",
+            )
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.total_subjects == 1
+    assert rollup.subjects[0].subject == "search [alpha]"
+    assert [(source.path, source.start_line) for source in rollup.subjects[0].sources] == [
+        ("alpha.json", 11)
+    ]
+
+
+def test_capability_review_sources_only_the_changed_action_fact() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.action_surface_facts = ActionSurfaceFacts(
+        actions=[
+            _capability_action_fact(
+                action_id=action_id,
+                tool_id="tool-search",
+                tool_name="search",
+                provider="alpha",
+                operation=action_id,
+                source_path=f"{action_id}.json",
+                source_start_line=line,
+            )
+            for line, action_id in enumerate(("a", "b", "c", "d", "z"), start=1)
+        ]
+    )
+    report.action_surface_facts.actions[-1].source_start_line = 99
+    report.action_surface_diff = ActionSurfaceDiff(
+        enabled=True,
+        modified=[
+            ActionSurfaceChange(
+                type="INPUT_SCHEMA_EXPANDED",
+                action_id="z",
+                tool_id="tool-search",
+                tool_name="search",
+                operation="z",
+                reason="Input schema expanded.",
+            )
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert [(source.path, source.start_line) for source in rollup.subjects[0].sources] == [
+        ("z.json", 99)
+    ]
+
+
+def test_capability_review_does_not_invent_identity_for_ambiguous_legacy_member() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="changed",
+                tool_id="tool-alpha",
+                name="search",
+                provider="alpha",
+                source_type="mcp",
+            ),
+            ToolSurfaceToolChange(
+                kind="changed",
+                tool_id="tool-beta",
+                name="search",
+                provider="beta",
+                source_type="mcp",
+            ),
+        ],
+    )
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="legacy-search",
+                direction="added",
+                subject_kind="action",
+                tool="search",
+                action="legacy-operation",
+            )
+        ],
+    )
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.total_subjects == 1
+    assert rollup.change_count == 1
+    assert rollup.subjects[0].subject == "search [identity unavailable]"
+
+
+def test_capability_review_final_labels_are_injective_after_disambiguation() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-alpha",
+                name="search",
+                provider="alpha",
+                source_type="mcp",
+            ),
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-beta",
+                name="search",
+                provider="beta",
+                source_type="mcp",
+            ),
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-literal",
+                name="search [alpha]",
+                provider="literal",
+                source_type="mcp",
+            ),
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+    labels = [subject.subject for subject in rollup.subjects]
+
+    assert rollup.total_subjects == 3
+    assert len(set(labels)) == 3
+    assert any("[subject 2]" in label for label in labels)
+
+
+def test_capability_review_joins_legacy_action_change_to_unique_canonical_tool() -> None:
+    """An omitted legacy tool_id must not split one tool into two subjects."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="added",
+                tool_id="tool-incident",
+                name="incident",
+                provider="pager",
+                source_type="mcp",
+            )
+        ],
+    )
+    report.action_surface_diff = ActionSurfaceDiff(
+        enabled=True,
+        added=[
+            ActionSurfaceChange(
+                type="ACTION_ADDED",
+                action_id="legacy-action-id",
+                tool_id=None,
+                tool_name="incident",
+                operation="update_incident",
+                reason="Action added: incident",
+            )
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.total_subjects == 1
+    assert rollup.change_count == 2
+    assert rollup.subjects[0].subject == "incident"
+    assert rollup.subjects[0].change_types == ("action_added", "tool_added")
+
+
+def test_capability_review_matches_independently_sorted_scope_names_and_ids() -> None:
+    """Scope tool_names/tool_ids are sets, not positional parallel arrays."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        tools=[
+            ToolSurfaceToolChange(
+                kind="changed",
+                tool_id="z-tool",
+                name="alpha",
+                provider="provider-alpha",
+                source_type="mcp",
+            ),
+            ToolSurfaceToolChange(
+                kind="changed",
+                tool_id="a-tool",
+                name="beta",
+                provider="provider-beta",
+                source_type="mcp",
+            ),
+        ],
+        scopes=[
+            ToolSurfaceScopeChange(
+                kind="added",
+                scope="production",
+                scope_kind="tool_required",
+                tool_names=["alpha", "beta"],
+                # The producer sorts these independently, so positions do not
+                # express alpha->z-tool / beta->a-tool.
+                tool_ids=["a-tool", "z-tool"],
+            )
+        ],
+    )
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        broadened=[
+            CapabilityChangeMember(
+                id="cap-alpha-scope",
+                direction="broadened",
+                subject_kind="scope",
+                tool="alpha",
+                scope="production",
+                release_impact="blocks_release",
+                rationale="Alpha production access expanded.",
+            ),
+            CapabilityChangeMember(
+                id="cap-beta-scope",
+                direction="broadened",
+                subject_kind="scope",
+                tool="beta",
+                scope="production",
+                release_impact="informational",
+                rationale="Beta production access expanded.",
+            ),
+        ],
+    )
+
+    rollup = capability_delta_subject_rollup(report)
+    by_subject = {subject.subject: subject for subject in rollup.subjects}
+
+    assert "blocks release" in by_subject["alpha"].changes[0]
+    assert "Alpha production access expanded" in by_subject["alpha"].changes[0]
+    assert "blocks release" not in by_subject["beta"].changes[0]
+    assert "Beta production access expanded" in by_subject["beta"].changes[0]
+
+
+def test_capability_review_renders_operation_and_semantic_rationale_not_action_id() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    action_id = "agent:incident/agent:action_v2_" + "c" * 64
+    report.action_surface_diff = ActionSurfaceDiff(
+        enabled=True,
+        modified=[
+            ActionSurfaceChange(
+                type="INPUT_SCHEMA_EXPANDED",
+                action_id=action_id,
+                tool_id="tool-incident",
+                tool_name="incident",
+                operation="update_incident",
+                reason="Input schema now accepts the production_region field.",
+            )
+        ],
+    )
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        broadened=[
+            CapabilityChangeMember(
+                id="cap-incident-input",
+                direction="broadened",
+                subject_kind="action",
+                tool="incident",
+                action=action_id,
+                release_impact="review_required",
+                rationale="Input schema now accepts the production_region field.",
+            )
+        ],
+    )
+
+    rollup = capability_delta_subject_rollup(report)
+    (detail,) = rollup.subjects[0].changes
+
+    assert "update_incident" in detail
+    assert "production_region" in detail
+    assert "action_v2_" not in detail
 
 
 def test_capability_delta_subject_rollup_preserves_overlapping_buckets() -> None:
@@ -1224,7 +1783,57 @@ def test_capability_delta_subject_rollup_preserves_overlapping_buckets() -> None
     # stable member/finding relation, not a lossy rendered-subject join.
     verifier = _capability_verifier(report, review=build_capability_review(report))
     comment = render_pr_comment(verifier, report=report)
-    assert "(tools.json:42)" in comment
+    assert "sources: `tools.json:42`" in comment
+
+
+def test_capability_review_labels_all_group_sources_without_row_misassociation() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.findings = [
+        Finding(
+            id="F-action-source",
+            check_id="SHIP-TEST-ACTION",
+            title="action changed",
+            severity="medium",
+            category="test",
+            recommendation="Review action.",
+            source=SourceReference(type="openapi", path="a.json", start_line=1),
+        ),
+        Finding(
+            id="F-tool-source",
+            check_id="SHIP-TEST-TOOL",
+            title="tool changed",
+            severity="medium",
+            category="test",
+            recommendation="Review tool.",
+            source=SourceReference(type="mcp", path="b.json", start_line=2),
+        ),
+    ]
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="cap-action-source",
+                direction="added",
+                subject_kind="action",
+                tool="deploy",
+                action="run",
+                related_finding_ids=["F-action-source"],
+            ),
+            CapabilityChangeMember(
+                id="cap-tool-source",
+                direction="added",
+                subject_kind="tool",
+                tool="deploy",
+                related_finding_ids=["F-tool-source"],
+            ),
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+
+    comment = render_pr_comment(verifier, report=report)
+
+    assert "sources: `a.json:1`, `b.json:2`" in comment
+    assert "+1 more source" not in comment
 
 
 def test_capability_review_pr_comment_truncates_complete_ranked_subjects() -> None:
@@ -1278,6 +1887,143 @@ def test_capability_review_pr_comment_truncates_complete_ranked_subjects() -> No
         assert normalized_summary.count(f"a_tool_{index}") == 1
     assert "a_tool_4" not in normalized_summary
     assert "a_tool_5" not in normalized_summary
+
+
+def test_capability_review_keeps_exact_hidden_counts_with_long_subject_rows() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id=f"cap-long-{index}",
+                direction="added",
+                subject_kind="tool",
+                tool=f"tool-{index}-" + ("x" * 1800),
+            )
+            for index in range(7)
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+    comments = [
+        render_pr_comment(verifier, report=report),
+        render_pr_comment(verifier, report=report, style="findings"),
+        render_pr_comment(
+            verifier,
+            report=report,
+            human_context=HumanArtifactContext(manifest_introduced=True),
+        ),
+        render_pr_comment(
+            verifier,
+            report=report,
+            style="findings",
+            human_context=HumanArtifactContext(manifest_introduced=True),
+        ),
+    ]
+
+    for comment in comments:
+        assert len(comment) <= 6000
+        assert "… and 7 more subjects (7 changes) not shown." in comment
+
+
+def test_capability_review_survives_long_release_reason_before_its_rows() -> None:
+    """An oversized prose field cannot erase the exact capability disclosure."""
+
+    report = _report(decision="review_required", exit_code=0)
+    assert report.release_decision is not None
+    report.release_decision.reason = "R" * 7000
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id=f"cap-short-{index}",
+                direction="added",
+                subject_kind="tool",
+                tool=f"tool-{index}",
+            )
+            for index in range(7)
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+
+    for style in ("capability-review", "findings"):
+        comment = render_pr_comment(verifier, report=report, style=style)
+
+        assert len(comment) <= 6000
+        assert "Capability delta (analysed surface)" in comment
+        assert "… and 2 more subjects (2 changes) not shown." in comment
+
+
+def test_capability_review_survives_escaped_prose_budget_in_findings_style() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    assert report.release_decision is not None
+    report.release_decision.reason = "*" * 7000
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id=f"cap-escaped-{index}",
+                direction="added",
+                subject_kind="tool",
+                tool=f"tool-{index}",
+            )
+            for index in range(7)
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+    verifier.trigger = {"rationale": "*" * 7000}
+    verifier.base_status = "cache_hit"
+    verifier.base_ref = "origin/main"
+    verifier.base_notes = ["*" * 7000, "*" * 7000]
+
+    comment = render_pr_comment(verifier, report=report, style="findings")
+
+    assert len(comment) <= 6000
+    assert "Capability delta (analysed surface)" in comment
+    assert "… and 2 more subjects (2 changes) not shown." in comment
+
+
+def test_cold_capability_review_reserves_delta_ahead_of_long_surface_row() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    assert report.release_decision is not None
+    report.release_decision.reason = "R" * 7000
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id=f"cap-cold-{index}",
+                direction="added",
+                subject_kind="tool",
+                tool=f"tool-{index}",
+            )
+            for index in range(7)
+        ],
+    )
+    report.action_surface_facts = ActionSurfaceFacts(
+        actions=[
+            _capability_action_fact(
+                action_id="long-write-action",
+                tool_id="tool-write",
+                tool_name="write_" + ("W" * 3000),
+                provider="write-provider",
+                operation="write",
+                effect="write",
+            )
+        ]
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+    context = HumanArtifactContext(manifest_introduced=True)
+
+    for style in ("capability-review", "findings"):
+        comment = render_pr_comment(
+            verifier,
+            report=report,
+            style=style,
+            human_context=context,
+        )
+
+        assert len(comment) <= 6000
+        assert "Capability delta (analysed surface)" in comment
+        assert "… and 2 more subjects (2 changes) not shown." in comment
 
 
 def test_capability_review_keeps_omitted_change_types_and_worst_detail_visible() -> None:
@@ -1398,6 +2144,42 @@ def test_capability_review_preserves_adversarial_subject_identities_in_markdown(
     comment = render_pr_comment(verifier, report=report).split("### Agent instruction block", 1)[0]
     assert "`line<U+000A>break`" in comment
     assert "line\nbreak" not in comment
+
+
+def test_capability_review_renders_adversarial_source_paths_as_code() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.findings = [
+        Finding(
+            id="F-source-markdown",
+            check_id="SHIP-TEST",
+            title="source path needs review",
+            severity="medium",
+            category="test",
+            recommendation="Review it.",
+            source=SourceReference(
+                type="openapi",
+                path="specs/[prod](unsafe)`tools*.json",
+                start_line=17,
+            ),
+        )
+    ]
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="cap-source-markdown",
+                direction="added",
+                subject_kind="tool",
+                tool="safe_subject",
+                related_finding_ids=["F-source-markdown"],
+            )
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+
+    comment = render_pr_comment(verifier, report=report)
+
+    assert "sources: ``specs/[prod](unsafe)`tools*.json:17``" in comment
 
 
 def test_capability_delta_subject_rollup_builds_a_missing_legacy_block() -> None:
@@ -3020,6 +3802,38 @@ def _capability_verifier(
         control=_human_control("review_required"),
         capability_review=review,
         artifacts={"verifier_json": "agents-shipgate-reports/verifier.json"},
+    )
+
+
+def _capability_action_fact(
+    *,
+    action_id: str,
+    tool_id: str,
+    tool_name: str,
+    provider: str,
+    operation: str,
+    effect: str = "read",
+    source_path: str | None = None,
+    source_start_line: int | None = None,
+) -> ActionFact:
+    return ActionFact(
+        action_id=action_id,
+        agent_id="agent:test",
+        tool_id=tool_id,
+        tool_name=tool_name,
+        provider=provider,
+        source_type="mcp",
+        operation=operation,
+        effect=effect,  # type: ignore[arg-type]
+        source_path=source_path,
+        source_start_line=source_start_line,
+        input_schema_hash=f"schema:{action_id}",
+        hashes=ActionSurfaceHashes(
+            identity_hash=f"identity:{action_id}",
+            schema_hash=f"schema:{action_id}",
+            policy_hash=f"policy:{action_id}",
+            risk_hash=f"risk:{action_id}",
+        ),
     )
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -66,6 +66,7 @@ from agents_shipgate.schemas.surfaces import (
     ActionSurfaceHashes,
     ToolSurfaceControlChange,
     ToolSurfaceDiff,
+    ToolSurfaceHighRiskEffectChange,
     ToolSurfaceScopeChange,
     ToolSurfaceToolChange,
 )
@@ -1310,6 +1311,41 @@ def test_capability_review_keeps_unseen_explicit_tool_id_out_of_name_fanout() ->
     }
     gamma = next(subject for subject in rollup.subjects if "tool-gamma" in subject.subject)
     assert gamma.change_types == ("policy_broadened",)
+
+
+def test_capability_review_prefers_effect_signature_over_unrelated_action_id() -> None:
+    """A risk tag that equals an action id still belongs to its exact tool."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.action_surface_facts = ActionSurfaceFacts(
+        actions=[
+            _capability_action_fact(
+                action_id="financial_write",
+                tool_id="tool-alpha",
+                tool_name="alpha",
+                provider="alpha-provider",
+                operation="read_alpha",
+            )
+        ]
+    )
+    report.tool_surface_diff = ToolSurfaceDiff(
+        enabled=True,
+        high_risk_effects=[
+            ToolSurfaceHighRiskEffectChange(
+                kind="added",
+                tool_id="tool-beta",
+                tool="beta",
+                tag="financial_write",
+            )
+        ],
+    )
+    report.capability_change = None
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.total_subjects == 1
+    assert rollup.subjects[0].subject == "beta"
+    assert rollup.subjects[0].change_types == ("action_broadened",)
 
 
 def test_capability_review_keeps_only_exact_finding_source_on_name_collision() -> None:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -23,8 +23,13 @@ from agents_shipgate.cli.verify.pr_comment import render_pr_comment
 from agents_shipgate.core.agent_control import derive_agent_control
 from agents_shipgate.core.errors import AgentsShipgateError, ConfigError, InputParseError
 from agents_shipgate.core.trust_roots import PathIdentityIssue
+from agents_shipgate.report.human_order import (
+    HumanArtifactContext,
+    capability_delta_subject_rollup,
+)
 from agents_shipgate.report.json_report import report_json_payload
 from agents_shipgate.schemas.agent_control import HumanControlAction
+from agents_shipgate.schemas.bindings import BindingSurfaceDiff
 from agents_shipgate.schemas.capabilities import (
     CapabilityLockFileV1,
     CapabilityLockHashes,
@@ -38,6 +43,7 @@ from agents_shipgate.schemas.capability_change import (
     VerifierCapabilityDeltaSummary,
     VerifierSummary,
 )
+from agents_shipgate.schemas.common import SourceReference
 from agents_shipgate.schemas.human_authorization import AuthorizationEvaluationV1
 from agents_shipgate.schemas.patches import RemovePointerPatch
 from agents_shipgate.schemas.report import (
@@ -1063,8 +1069,11 @@ def test_capability_review_pr_comment_leads_with_top_changes_and_trust_root() ->
     assert "Summary: This PR adds a refund action without approval evidence" in comment
     assert "- Release gate: `blocked`" in comment
     assert "- Reason: test decision" in comment
-    assert "- Capability delta: +1, 0 modified, -0" in comment
-    assert "`stripe.create_refund`: blocks release" in comment
+    assert (
+        "- Capability delta (analysed surface): "
+        "1 subject across 1 change (+1 added, 0 modified, -0 removed)" in comment
+    )
+    assert "`stripe.create_refund`: added action refund — blocks release" in comment
     assert "- Next actor: `human`" in comment
     assert "A human owner must confirm approval and idempotency evidence" in comment
     assert "- Trust root touched: `true`" in comment
@@ -1077,6 +1086,348 @@ def test_capability_review_pr_comment_leads_with_top_changes_and_trust_root() ->
         '"verification_command": "agents-shipgate verify --base origin/main --head HEAD --json"'
         in comment
     )
+
+
+def test_capability_review_groups_one_bound_tool_without_changing_legacy_counts() -> None:
+    """One reader subject may still carry two stable machine change rows (#439)."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="cap-update-incident-action",
+                direction="added",
+                subject_kind="action",
+                tool="update_incident",
+                action="update_incident",
+                release_impact="review_required",
+                rationale="Capability added.",
+            ),
+            CapabilityChangeMember(
+                id="cap-update-incident-tool",
+                direction="added",
+                subject_kind="tool",
+                tool="update_incident",
+                release_impact="review_required",
+                rationale="Tool added.",
+            ),
+        ],
+    )
+
+    legacy_review = build_capability_review(report)
+    rollup = capability_delta_subject_rollup(report)
+    verifier = _capability_verifier(report, review=legacy_review)
+    comments = [
+        render_pr_comment(verifier, report=report),
+        render_pr_comment(verifier, report=report, style="findings"),
+        render_pr_comment(
+            verifier,
+            report=report,
+            human_context=HumanArtifactContext(manifest_introduced=True),
+        ),
+    ]
+
+    # ``verifier.json`` stays backward compatible: these are still two
+    # independently useful change rows and the published count remains two.
+    assert legacy_review.added == 2
+    assert {change.change_type for change in legacy_review.top_changes} == {
+        "action_added",
+        "tool_added",
+    }
+
+    # The schema-free human projection answers the reader's question instead:
+    # one thing changed, in two independently visible ways.
+    assert rollup.total_subjects == 1
+    assert rollup.added_subjects == 1
+    assert rollup.change_count == 2
+    assert len(rollup.subjects) == 1
+    assert rollup.subjects[0].subject == "update_incident"
+    assert rollup.subjects[0].change_types == ("action_added", "tool_added")
+    assert rollup.subjects[0].change_count == 2
+    for comment in comments:
+        human_summary = comment.split("### Agent instruction block", 1)[0]
+        assert "1 subject" in human_summary
+        assert "2 changes" in human_summary
+        normalized_summary = human_summary.replace("\\_", "_").lower()
+        assert normalized_summary.count("update_incident") == 1
+        assert "added action" in normalized_summary
+        assert "added tool" in normalized_summary
+
+
+def test_capability_delta_subject_rollup_preserves_overlapping_buckets() -> None:
+    """Grouping must not make an added-and-modified subject choose one fact."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.findings = [
+        Finding(
+            id="F-deploy-scope",
+            check_id="SHIP-TEST",
+            title="deployment scope changed",
+            severity="medium",
+            category="test",
+            recommendation="Review the scope change.",
+            source=SourceReference(
+                type="openapi",
+                path="tools.json",
+                start_line=42,
+            ),
+        )
+    ]
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="cap-deploy-tool",
+                direction="added",
+                subject_kind="tool",
+                tool="deploy_service",
+                release_impact="review_required",
+                rationale="Tool added.",
+            )
+        ],
+        broadened=[
+            CapabilityChangeMember(
+                id="cap-deploy-scope",
+                direction="broadened",
+                subject_kind="scope",
+                tool="deploy_service",
+                scope="production",
+                before_scope="staging",
+                after_scope="production",
+                release_impact="review_required",
+                rationale="Scope broadened.",
+                related_finding_ids=["F-deploy-scope"],
+            )
+        ],
+    )
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.total_subjects == 1
+    assert rollup.added_subjects == 1
+    assert rollup.modified_subjects == 1
+    assert rollup.removed_subjects == 0
+    assert rollup.change_count == 2
+    (subject,) = rollup.subjects
+    assert subject.subject == "deploy_service"
+    assert subject.change_types == ("tool_added", "scope_broadened")
+    assert subject.change_buckets == ("added", "modified")
+    assert subject.change_count == 2
+    assert len(subject.changes) == 2
+    assert any("added tool" in detail for detail in subject.changes)
+    assert any("broadened scope" in detail for detail in subject.changes)
+    assert [(source.path, source.start_line) for source in subject.sources] == [("tools.json", 42)]
+
+    # The legacy verifier subject is ``deploy_service:production`` while the
+    # human rollup subject is ``deploy_service``. Provenance is carried by the
+    # stable member/finding relation, not a lossy rendered-subject join.
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+    comment = render_pr_comment(verifier, report=report)
+    assert "(tools.json:42)" in comment
+
+
+def test_capability_review_pr_comment_truncates_complete_ranked_subjects() -> None:
+    """The five-row budget ranks groups first and accounts for every hidden row."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            member
+            for subject in [*(f"a_tool_{index}" for index in range(6)), "z_blocking_tool"]
+            for member in (
+                CapabilityChangeMember(
+                    id=f"cap-{subject}-action",
+                    direction="added",
+                    subject_kind="action",
+                    tool=subject,
+                    action=subject,
+                    release_impact=(
+                        "blocks_release" if subject == "z_blocking_tool" else "informational"
+                    ),
+                    rationale="Capability added.",
+                ),
+                CapabilityChangeMember(
+                    id=f"cap-{subject}-tool",
+                    direction="added",
+                    subject_kind="tool",
+                    tool=subject,
+                    release_impact=(
+                        "blocks_release" if subject == "z_blocking_tool" else "informational"
+                    ),
+                    rationale="Tool added.",
+                ),
+            )
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+
+    human_summary = render_pr_comment(verifier, report=report).split(
+        "### Agent instruction block", 1
+    )[0]
+    normalized_summary = human_summary.replace("\\_", "_")
+
+    assert "7 subjects" in human_summary
+    assert "14 changes" in human_summary
+    assert "… and 2 more subjects (4 changes) not shown." in human_summary
+    # Ranking happens on complete subject groups, so the blocking z_* subject
+    # stays visible ahead of informational a_* subjects without losing a row.
+    assert normalized_summary.count("z_blocking_tool") == 1
+    for index in range(4):
+        assert normalized_summary.count(f"a_tool_{index}") == 1
+    assert "a_tool_4" not in normalized_summary
+    assert "a_tool_5" not in normalized_summary
+
+
+def test_capability_review_keeps_omitted_change_types_and_worst_detail_visible() -> None:
+    """A selected subject cannot hide a distinct change kind behind its row limit."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="cap-deploy-tool-added",
+                direction="added",
+                subject_kind="tool",
+                tool="deploy_service",
+                release_impact="informational",
+            ),
+            CapabilityChangeMember(
+                id="cap-deploy-action-added",
+                direction="added",
+                subject_kind="action",
+                tool="deploy_service",
+                action="deploy",
+                release_impact="review_required",
+            ),
+        ],
+        broadened=[
+            CapabilityChangeMember(
+                id="cap-deploy-scope-broadened",
+                direction="broadened",
+                subject_kind="scope",
+                tool="deploy_service",
+                scope="production",
+                release_impact="informational",
+            )
+        ],
+        narrowed=[
+            CapabilityChangeMember(
+                id="cap-deploy-policy-narrowed",
+                direction="narrowed",
+                subject_kind="policy",
+                tool="deploy_service",
+                action="approval",
+                release_impact="blocks_release",
+            )
+        ],
+        removed=[
+            CapabilityChangeMember(
+                id="cap-deploy-action-removed",
+                direction="removed",
+                subject_kind="action",
+                tool="deploy_service",
+                action="rollback",
+                release_impact="informational",
+            )
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+
+    comment = render_pr_comment(verifier, report=report).split("### Agent instruction block", 1)[0]
+
+    assert "narrowed policy approval — blocks release" in comment
+    assert "omitted change types: action removed" in comment
+    assert "… and 1 more change" in comment
+
+
+def test_capability_review_reports_requested_but_unavailable_comparison_as_unknown() -> None:
+    report = _report(decision="review_required", exit_code=0)
+    report.capability_change = CapabilityChangeBlock(enabled=False)
+    report.binding_surface_diff = BindingSurfaceDiff(
+        enabled=False,
+        base_comparison_requested=True,
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+
+    comment = render_pr_comment(verifier, report=report)
+
+    assert "newly outside the analysed surface: unknown (comparison unavailable)" in comment
+    assert "0 subjects newly outside" not in comment
+
+
+def test_capability_review_preserves_adversarial_subject_identities_in_markdown() -> None:
+    subjects = ["`leading", "trailing`", " leading", "trailing ", " both "]
+    report = _report(decision="review_required", exit_code=0)
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id=f"cap-identity-{index}",
+                direction="added",
+                subject_kind="tool",
+                tool=subject,
+            )
+            for index, subject in enumerate(subjects)
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+
+    comment = render_pr_comment(verifier, report=report).split("### Agent instruction block", 1)[0]
+
+    assert "`` `leading ``" in comment
+    assert "`` trailing` ``" in comment
+    assert "` leading`" in comment
+    assert "`trailing `" in comment
+    assert "`  both  `" in comment
+
+    report.capability_change = CapabilityChangeBlock(
+        enabled=True,
+        added=[
+            CapabilityChangeMember(
+                id="cap-control-identity",
+                direction="added",
+                subject_kind="tool",
+                tool="line\nbreak",
+            )
+        ],
+    )
+    verifier = _capability_verifier(report, review=build_capability_review(report))
+    comment = render_pr_comment(verifier, report=report).split("### Agent instruction block", 1)[0]
+    assert "`line<U+000A>break`" in comment
+    assert "line\nbreak" not in comment
+
+
+def test_capability_delta_subject_rollup_builds_a_missing_legacy_block() -> None:
+    """Older in-memory callers still project the existing surface diff."""
+
+    report = _report(decision="review_required", exit_code=0)
+    report.capability_change = None
+    report.action_surface_diff = ActionSurfaceDiff(
+        enabled=True,
+        summary=ActionSurfaceDiffSummary(actions_added=1),
+        added=[
+            ActionSurfaceChange(
+                type="ACTION_ADDED",
+                action_id="refund",
+                tool_name="stripe.create_refund",
+                operation="create_refund",
+                severity="high",
+                reason="Action added: stripe.create_refund",
+            )
+        ],
+    )
+
+    rollup = capability_delta_subject_rollup(report)
+
+    assert rollup.enabled is True
+    assert rollup.total_subjects == 1
+    assert rollup.added_subjects == 1
+    assert rollup.change_count == 1
+    assert rollup.subjects[0].subject == "stripe.create_refund"
+    assert rollup.subjects[0].change_types == ("action_added",)
 
 
 def test_capability_review_pr_comment_preserves_valid_agent_json_when_compacted() -> None:
@@ -2643,6 +2994,32 @@ def _human_control(reason: str):
         ),
         human_review_required=True,
         unsafe_block=reason == "blocked",
+    )
+
+
+def _capability_verifier(
+    report: ReadinessReport,
+    *,
+    review: VerifierCapabilityReview,
+) -> VerifierArtifact:
+    """Minimal verifier envelope for PR-comment capability regressions."""
+
+    assert report.release_decision is not None
+    return VerifierArtifact(
+        workspace="/tmp/work",
+        diff_status=VerifierDiffStatus(),
+        config="shipgate.yaml",
+        authorization=AuthorizationEvaluationV1.not_requested(),
+        trigger={"rationale": "1 run_shipgate rule(s) matched."},
+        execution="succeeded",
+        head_status="succeeded",
+        release_decision=report.release_decision,
+        decision=report.release_decision.decision,
+        merge_verdict="human_review_required",
+        applicability="verified",
+        control=_human_control("review_required"),
+        capability_review=review,
+        artifacts={"verifier_json": "agents-shipgate-reports/verifier.json"},
     )
 
 


### PR DESCRIPTION
## Summary

- Collapse human capability-delta output into one row per subject while preserving every change type, overlapping direction membership, risk-first ordering, and exact truncation counts.
- Report subjects newly outside the analysed surface separately from analysed capability changes using the base-backed binding surface diff, without counting existing unbound catalogue entries.
- Share one cold-reader projection across both PR-comment styles while leaving verifier v0.15 machine fields unchanged. Existing capability_review counts and top_changes remain change-record compatibility fields.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [x] Report, schema, or SARIF output
- [ ] Documentation only

## Verification

CI is authoritative for python -m ruff check ., python -m compileall -q src tests, and python -m pytest.

Additional local checks run:

- Full non-performance suite passed after separating the isolated wheel build.
- Packaging module: 8 passed.
- Static-only adapter guard: 443 passed.
- Backward-compatibility consumer suites: 133 passed.
- Generated-schema drift check passed.
- Ruff and git diff hygiene passed.
- Two independent review passes completed; no actionable findings remain.
- Agents Shipgate origin/main...HEAD verification: control complete, release decision passed, merge verdict mergeable.

## Surface discipline

- Reviewer-facing metric improved: one subject is counted once instead of once per underlying change record, and newly excluded surface no longer appears as a misleading +0 capability delta.
- Existing surface extended: the shared human projection now serves both PR-comment styles; no new public machine contract was introduced.
- Non-goals preserved: static-only analysis, no network or runtime execution, no second verdict, and no change to verifier v0.15 compatibility fields.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in docs/checks.md — no check IDs changed
- [x] Report/schema changes are additive or documented in STABILITY.md — machine schemas are unchanged and the human-output correction is documented in CHANGELOG.md

Closes #437
Closes #439