### PR TITLE
docs(release): record the pre-1.0 labeling protocol and the participant-validation gate (#456)

### DIFF
--- a/benchmark/safety-qualification/README.md
+++ b/benchmark/safety-qualification/README.md
@@ -13,9 +13,16 @@ The runner consumes four independently content-addressed inputs:
    importing or executing it and records the wheel SHA-256.
 2. A `shipgate.safety_corpus/v4` JSON/YAML corpus. Every case has two blind,
    attributable labels (`security_governance` and `framework_tooling`), an
-   evidence-backed final decision, a remediation condition, and a third-human
+   evidence-backed final decision, a remediation condition, and a third-party
    adjudication for every disagreement. `frozen_labels_sha256` must match the
-   canonical label payload.
+   canonical label payload. **Who produces the two labels is governed by
+   [Amendment 1](../../docs/release-evidence-policy-decision.md#amendment-1--the-pre-10-labeling-protocol-and-the-participant-validation-gate):**
+   for the `pre_1_0` corpus, two independent agent sessions on different model
+   families under its six admissibility conditions, with the owner
+   adjudicating every disagreement; the `beta` (1.0) corpus commits to human
+   primary labels. After labels are frozen and receipts exist, the
+   non-gating [participant-validation gate](participant-validation.md) sends
+   each case's real author/reviewer a case card for validation.
 3. A `shipgate.safety_receipt_index/v4` JSON/YAML index created only after
    labels are frozen. It binds the exact wheel, corpus, labels, policy bundle,
    and one terminal `shipgate.verification_receipt/v1` plus its

--- a/benchmark/safety-qualification/participant-validation.md
+++ b/benchmark/safety-qualification/participant-validation.md
@@ -1,0 +1,113 @@
+# Participant Validation (Gate 2)
+
+The corpus's real-history cases were written and reviewed by real people, and
+those people are better judges of *"should this change have been blocked"* than
+any rater we can supply. This gate sends each reachable author and reviewer a
+one-page case card and two questions, and records what comes back.
+
+Governed by [Amendment 1 of the release evidence policy
+decision](../../docs/release-evidence-policy-decision.md#amendment-1--the-pre-10-labeling-protocol-and-the-participant-validation-gate),
+which fixes the five pre-registered rules. The short form:
+
+- **This gate does not gate the tag.** It runs after labels are frozen and
+  receipts exist; the tag does not wait for responses.
+- **Validation, not relabeling.** Frozen labels do not move. A material
+  disagreement triggers a case review whose corrections land in the `beta`
+  corpus — except a material error found before the tag ships, which may force
+  a re-freeze.
+- **Reviewers outrank authors.** Both are asked; recorded separately.
+- **Two questions, recorded apart.** Label validation and product signal have
+  different consumers.
+- **Naming needs consent.** Asked inside the outreach message; absent a yes,
+  the response is aggregate-only.
+
+## Who is contacted, in what order
+
+For each `real_history` / `rejected_or_reverted` case: first the reviewer whose
+decision resolved the PR (approved, requested changes, rejected, or reverted),
+then the author. Design-partner cases go through the partner contact.
+No bulk mail, no bot comments, no more than one follow-up. A non-response is a
+data point, not an invitation to persist.
+
+## The case card (one page, generated per case)
+
+```
+Case <id> — <repo>#<PR>  (base <sha7> → head <sha7>)
+Profile: <profile>            Origin: <origin>
+
+What the change does (2–3 lines, from the diff, no speculation)
+
+Frozen label: <passed|review_required|insufficient_evidence|blocked>
+  security_governance:  <label>  — <one-line rationale>
+  framework_tooling:    <label>  — <one-line rationale>
+  adjudication:         <only if the two disagreed>
+
+What the verifier concluded, with its top evidence rows
+  <decision> — <headline>
+  - <subject>: <finding / capability delta row>  (<file:line>)
+  - <subject>: <finding / capability delta row>  (<file:line>)
+
+Reproduce it yourself:
+  <one pinned, copy-pasteable command>
+```
+
+Everything on the card is generated from the frozen corpus entry and the
+case's receipt-bound artifacts — nothing is written by hand except the 2–3
+line change description, which quotes no one and claims nothing the diff does
+not show.
+
+## The message template
+
+Subject: `Your call on <repo>#<PR> — did we judge it right?`
+
+```
+Hi <name>,
+
+I maintain agents-shipgate, an open-source, deterministic gate that reviews
+what an AI agent is able to do after a code change. We are qualifying a
+release against a benchmark of real capability-change PRs, and <repo>#<PR> —
+which you <reviewed|wrote> — is one of the 56 cases, at pinned commits
+<base>..<head>.
+
+You were there and we were not, so your judgment outranks our labels. One
+page attached; two separate questions:
+
+1. The case says this change should have been "<frozen label>". From what
+   you knew as its <reviewer|author>, is that the right call? If not, what
+   should it have been, and what did we miss?
+
+2. Separately from whether we got it right: would output like this have been
+   useful to you when the PR was open?
+
+One consent question: if you reply, may we name you and <repo> in the
+published validation results, or should your response stay aggregate-only?
+
+You can re-run the whole thing yourself with the command on the card.
+Thank you — a one-line answer to either question is already valuable.
+
+<sender>
+```
+
+Two rules the template encodes on purpose: question 1 and question 2 are
+never merged, and the consent ask is in the first message, not a follow-up.
+
+## The response log
+
+One row per contact in `participant-validation-log.csv`, committed with
+responses redacted to what consent allows:
+
+| column | meaning |
+|---|---|
+| `case_id` | corpus case |
+| `contact_role` | `reviewer` / `author` / `design_partner` |
+| `contacted_at` | date of first message |
+| `responded` | `yes` / `no` (blank until closed) |
+| `label_agreement` | `agrees` / `disagrees` / `qualified` / `no_answer` |
+| `disagreement_note` | their alternative label + reason, if any |
+| `value_signal` | `useful` / `not_useful` / `mixed` / `no_answer` |
+| `naming_consent` | `named` / `aggregate_only` |
+| `case_review_opened` | issue ref, when rule 1 triggered |
+
+Aggregate results are reported as *agreement among responders, with n* — never
+as a rate over the contacted population, and never with a pre-registered
+threshold this sample size cannot support.

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -200,3 +200,98 @@ timeout, a non-publishing rehearsal path, and a wheel-scoped signed SBOM.
 
 Whichever bar applies, it is enforced by a pipeline that also proves the bytes
 it publishes came from the tagged commit.
+
+---
+
+## Amendment 1 — the pre-1.0 labeling protocol, and the participant-validation gate
+
+**Status: decided.**
+**Owner: Pengfei Hu (`pengfei-threemoonslab`), product/security. Recorded
+2026-08-31.** Tracked by
+[#456](https://github.com/ThreeMoonsLab/agents-shipgate/issues/456).
+
+The base decision fixed *how much* evidence a `0.x` tag needs. It left open
+*who produces the two blind primary labels*. This amendment records that
+choice for the `pre_1_0` corpus, and adds a second, non-gating validation
+layer. It applies to the `pre_1_0` tier **only**: the `beta` (1.0) corpus
+commits to human primary labels, and since `pre_1_0` evidence cannot qualify a
+`1.0` tag by construction, nothing recorded here can leak upward.
+
+### The protocol
+
+For the 56-case `pre_1_0` corpus, the two blind primary labels are produced by
+**two independent agent sessions**, one per discipline role, and **every
+disagreement is adjudicated by the owner**, who is never a primary rater.
+Three distinct identities per disputed case, exactly as the schema demands.
+
+### Admissibility conditions — all mandatory
+
+1. **Two model families.** The `security_governance` and `framework_tooling`
+   sessions run on different underlying model families. The κ ≥ 0.80 floor
+   exists to measure agreement between genuinely distinct raters; two sessions
+   of one model would partly measure a model agreeing with itself, and the
+   floor would be easier than the base decision intended.
+2. **Blindness, mechanically enforced.** Each rater session is fresh and
+   receives only: the pinned repository state, the PR diff, and the labeling
+   guide (`benchmark/miner/LABELING.md`). No verifier output, no other label,
+   no project memory, no walk history. A session that was exposed to any of
+   these produces no admissible label.
+3. **Attribution and archived transcripts.** `reviewer_id` names the model and
+   session. The complete rater transcript for every label is archived
+   content-addressed beside the corpus. This is the agent protocol's
+   compensating strength over human rationale: an auditor can inspect *how*
+   every label was reached, not a summary of it.
+4. **Adjudication with walked-case disclosure.** The owner adjudicates every
+   disagreement. For cases the owner has personally walked — where the
+   verifier's verdict is already known to them — the adjudication record
+   discloses that, per case.
+5. **A calibration round first.** The protocol runs on five non-corpus cases
+   before any corpus label exists; ambiguities it finds in the labeling guide
+   are fixed first. A κ failure discovered after 56 labels is a relabeling of
+   56 cases.
+6. **A disclosure block in the artifact.** The published qualification
+   artifact names this protocol, the model families, and the location of the
+   archived transcripts. The schema's label type is named
+   `IndependentHumanLabelV1`; that name records the 1.0 expectation, the
+   enforced properties are independence, attribution, and third-party
+   adjudication, and this amendment — not silence — is what reconciles the
+   two for `pre_1_0`.
+
+### Gate 2 — participant validation (does not gate the tag)
+
+The people who wrote and reviewed the corpus's real-history PRs are better
+judges of "should this have been blocked" than any rater we can supply. After
+labels are frozen and receipts exist, each reachable author and reviewer is
+sent a one-page case card and two questions. The protocol, card format, and
+message template live in
+[`benchmark/safety-qualification/participant-validation.md`](../benchmark/safety-qualification/participant-validation.md).
+Its pre-registered rules, fixed here so they cannot drift under incentive:
+
+1. **Validation, not relabeling.** Frozen labels do not move. A material
+   disagreement triggers a case review; corrections land in the `beta`
+   corpus. The single exception: a material label error found *before* the
+   tag ships may force a re-freeze and receipt regeneration.
+2. **Reviewers outrank authors.** An author judging whether their own PR
+   should have been blocked is conflicted in the obvious direction; the
+   reviewer who approved, changed, or rejected it is not. Both are asked;
+   they are recorded separately.
+3. **Two questions, recorded apart.** "Is the label right?" (validation) and
+   "would this output have been useful?" (product signal) are different
+   questions with different consumers; one conversation, two records.
+4. **Response realism.** Reported as agreement-among-responders with the
+   response count. No percentage threshold is pre-registered at this sample
+   size; instead, *any* material disagreement triggers rule 1 regardless of
+   rate.
+5. **Naming needs consent; aggregates do not.** Public PRs may be benchmark
+   cases without permission; naming a person or quoting them in published
+   results requires their explicit yes, asked in the outreach message itself.
+
+### Acceptance
+
+- [x] The protocol, its admissibility conditions, and the Gate 2 rules are
+      recorded by the named owner — above, 2026-08-31.
+- [ ] The calibration round has run and the labeling guide reflects it.
+- [ ] The corpus's rater transcripts are archived and referenced by the
+      artifact's disclosure block.
+- [ ] Gate 2 outreach uses the committed card and template, and its responses
+      are recorded in the committed log format.


### PR DESCRIPTION
Amendment 1 to [`docs/release-evidence-policy-decision.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/release-evidence-policy-decision.md), unblocking Cut C of #456.

## What it records

**The pre-1.0 labeling protocol** (option 3 of the decision block in #456, hardened): two independent agent sessions on **different model families** produce the two blind primary labels; the owner adjudicates every disagreement and is never a rater. Six mandatory admissibility conditions: model-family separation, mechanically enforced blindness (fresh session; pinned repo + diff + labeling guide only), attribution with **content-addressed archived transcripts** per label, walked-case disclosure in adjudication records, a 5-case calibration round before any corpus label, and a disclosure block in the published artifact. Scope is `pre_1_0` only — the `beta` corpus commits to human primary labels, and `pre_1_0` evidence cannot qualify a 1.0 tag by construction.

**Gate 2 — participant validation** (new, non-gating): after labels freeze and receipts exist, each real-history case's author and reviewer receive a one-page case card and two separated questions — "is the label right?" and "would this have been useful?". Five pre-registered rules fix what responses can change: frozen labels do not move (corrections land in the `beta` corpus; only a pre-tag material error can force a re-freeze), reviewers outrank authors, the two questions are recorded apart, results report agreement-among-responders with n, and naming requires consent asked in the first message.

## Files

- `docs/release-evidence-policy-decision.md` — Amendment 1, in the base decision's voice, with its own acceptance boxes.
- `benchmark/safety-qualification/participant-validation.md` — new: contact order, the generated case-card format, the message template (questions separated, consent line included), and the response-log columns.
- `benchmark/safety-qualification/README.md` — the corpus runbook now points at the amendment where it defines the two labels (the base decision names the runbook as the easy-to-miss site).

Docs only; no code or schema changes. The schema's `IndependentHumanLabelV1` name is reconciled in the amendment text, not renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)