### PR TITLE
Read an MCP server's tool surface out of its own source (#431)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aid
 
 ## What this project is
 
-The deterministic merge gate for AI-generated agent capability changes. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, OpenAI API artifacts, Codex repo config, Codex plugin packages and marketplaces, n8n workflow JSON/stubs, Conductor OSS workflow JSON) and produces deterministic findings. Local-first and static by default — no agent execution, tool calls, LLM calls, or network access.
+The deterministic merge gate for AI-generated agent capability changes. Reads `shipgate.yaml` plus tool sources (MCP exports, MCP server source (TypeScript/Go registration idioms), OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, OpenAI API artifacts, Codex repo config, Codex plugin packages and marketplaces, n8n workflow JSON/stubs, Conductor OSS workflow JSON) and produces deterministic findings. Local-first and static by default — no agent execution, tool calls, LLM calls, or network access.
 
-- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · OpenAI API · Codex config · Codex plugin · n8n · Conductor OSS workflow JSON
+- **Inputs:** MCP · MCP server source · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · OpenAI API · Codex config · Codex plugin · n8n · Conductor OSS workflow JSON
 - **Outputs:** Markdown · JSON · SARIF
 - **Trust:** Static-by-default. No agent execution, tool calls, LLM calls, or network access.
 - **Marketing site:** [threemoonslab.com](https://threemoonslab.com/) — human-readable companion pages. **If you are an agent working inside this repo, use the in-tree [`.well-known/agents-shipgate.json`](.well-known/agents-shipgate.json) (current `main` contract, may be ahead of the site's released copy) for schema-version and gating-signal decisions.**
@@ -508,6 +508,7 @@ Do NOT use it for:
 | Trigger in this PR | Run Shipgate? |
 |---|---|
 | Adds/changes MCP exports, OpenAPI specs, or `tools/*openai*tools*.json` | Yes |
+| Adds/changes an MCP tool registration written in TypeScript or Go source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`) | Yes |
 | Adds/changes Codex repo config, hooks, or permission profiles | Yes |
 | Adds/changes coding-agent host config, hooks, permissions, MCP servers, or workflows | Yes |
 | Adds/changes Codex plugin manifests, marketplace files, `.app.json`, `.mcp.json`, or `SKILL.md` files | Yes |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 ## Unreleased
 
+- **An MCP server whose tool surface exists only as code now has a route.**
+  (#431) `detect` reported the official MongoDB and Grafana MCP servers as *not
+  an agent project*: both publish dozens of tools — `drop-database`,
+  `delete-many`, `update_incident` — and neither commits an export, so every
+  route discovery had was filename-shaped and found nothing. The discriminator
+  was never the language (two of the three servers walked are Go); it was
+  whether the repository happens to *emit* its tool list.
+
+  New input `tool_sources[].type: mcp_server_source` reads the tool name where
+  every one of them writes it: as a string literal at a registration site. It
+  runs no code, evaluates no schema library, infers no type, and reads no
+  annotation the source declares about itself. Which sites count comes from a
+  built-in, versioned registry of **named registration idioms**
+  (`agents_shipgate.inputs.mcp_idioms`), never from a configured pattern — at
+  `detect` time there is no manifest, and post-adoption a configured regex would
+  hand the definition of evidence to configuration shipping in the same pull
+  request as the tool it could hide. Five idioms ship, chosen by a 30-server
+  survey published at [`docs/mcp-registration-idioms.md`](docs/mcp-registration-idioms.md);
+  Python's FastMCP decorator is the largest measured shape and is deliberately
+  deferred, because it is a different extraction mechanism and #393 requires
+  each one to bring its own adversarial probe list.
+
+  `detect` offers the route only where a declared MCP dependency and a resolved
+  registration hold *together* — a class of one's own that spells a field
+  `toolName` is a coincidence of spelling until the repository says it speaks
+  MCP. Where a parseable MCP export also exists it stays preferred (`high`, with
+  the input schemas this route does not read) and the source route is withheld
+  and named in `excluded_sources` rather than silently dropped.
+
+  Extraction is `medium` and completeness is measured per file, not assumed: a
+  name built at runtime is reported as an unenumerated subject in the exclusion
+  ledger and holds its own file's surface at `partial`, and a file whose masking
+  pass cannot complete is reported unreadable rather than read as though the
+  rest were code. A `static operationType = "delete"` literal arrives as a
+  low-confidence inferred hint that can contradict a reviewer declaring the tool
+  read-only and can never prove anything on its own; `read` is deliberately
+  unmapped, because a tool server asserting its own harmlessness is the one
+  claim an untrusted source has an incentive to make.
+
+  `TRIGGER-MCP-TOOL-REGISTRATION-SOURCE` routes such a diff, on tokens derived
+  from the same registry and pinned against it. The trigger catalog's
+  `schema_version` is unchanged: the rule uses existing predicates and adds no
+  field, so no consumer has to change to keep reading it.
+
+  The zero-install detector (`tools/shipgate-detect.py`) does **not** gain this
+  detection, so it reports a repository whose tool surface exists only as code
+  as *not* an agent project while the installed CLI reports it as one. Porting
+  the reader means a second implementation of the load-bearing matcher and
+  needs its own increment with a shared conformance corpus; the divergence is
+  named in the script's own "intentional simplifications" list and pinned by
+  `test_framework_vocabulary_names_every_cli_omission`, which fails on any
+  further omission.
+
 - **Verifier and evidence explanations now preserve the fact that produced
   them.** (#436, #396, #414, #420) Plain blocked-run headlines name the
   deterministic worst blocker and bound untrusted multibyte titles by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@
   name built at runtime is reported as an unenumerated subject in the exclusion
   ledger and holds its own file's surface at `partial`, and a file whose masking
   pass cannot complete is reported unreadable rather than read as though the
-  rest were code. A `static operationType = "delete"` literal arrives as a
+  rest were code. String escapes are decoded with each language's own grammar
+  and anything neither grammar defines is refused rather than guessed, because
+  a mistranslated name is an action id nobody serves standing in for a real
+  one. A `static operationType = "delete"` literal arrives as a
   low-confidence inferred hint that can contradict a reviewer declaring the tool
   read-only and can never prove anything on its own; `read` is deliberately
   unmapped, because a tool server asserting its own harmlessness is the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
   request as the tool it could hide. Five idioms ship, chosen by a 30-server
   survey published at [`docs/mcp-registration-idioms.md`](docs/mcp-registration-idioms.md);
   Python's FastMCP decorator is the largest measured shape and is deliberately
-  deferred, because it is a different extraction mechanism and #393 requires
-  each one to bring its own adversarial probe list.
+  deferred (#484), because it is a different extraction mechanism and #393
+  requires each one to bring its own adversarial probe list.
 
   `detect` offers the route only where a declared MCP dependency and a resolved
   registration hold *together* — a class of one's own that spells a field
@@ -53,7 +53,7 @@
   needs its own increment with a shared conformance corpus; the divergence is
   named in the script's own "intentional simplifications" list and pinned by
   `test_framework_vocabulary_names_every_cli_omission`, which fails on any
-  further omission.
+  further omission (#485).
 
 - **Verifier and evidence explanations now preserve the fact that produced
   them.** (#436, #396, #414, #420) Plain blocked-run headlines name the

--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ Run Agents Shipgate when a PR adds or changes agent tool surfaces or the policy
 evidence around them:
 
 - MCP exports, OpenAPI specs, or local tool inventories.
+- An MCP server whose tool surface exists only as code — TypeScript or Go
+  registration sites, read through a built-in idiom registry.
 - OpenAI Agents SDK, Google ADK, LangChain/LangGraph, CrewAI, Anthropic
   Messages API, or OpenAI API artifact tool definitions.
 - Codex repo config such as `.codex/config.toml` or `.codex/hooks.json`.
@@ -811,7 +813,7 @@ Agents Shipgate is a static, manifest-first scanner. It is intentionally narrow:
 - It does not run agents, call tools, invoke LLMs, or verify model availability by default (static-by-default; see [Trust Model](#trust-model) and [`ALLOWED_EXCEPTIONS`](tests/test_adapter_static_only.py)).
 - It does not verify runtime behavior, latency, prompt quality, or routing decisions.
 - It does not replace dynamic security testing or human security review of the underlying systems.
-- It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, Anthropic/OpenAI API artifacts, optional SDK AST metadata, static Google ADK/LangChain/CrewAI/n8n/Conductor OSS inputs, Codex repo config, and static Codex plugin package metadata; tools that are not declared or statically discoverable are not scanned.
+- It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, MCP server source registrations, Anthropic/OpenAI API artifacts, optional SDK AST metadata, static Google ADK/LangChain/CrewAI/n8n/Conductor OSS inputs, Codex repo config, and static Codex plugin package metadata; tools that are not declared or statically discoverable are not scanned.
 - The manifest remains `version: "0.1"` so existing configs keep working. Current reports carry `report_schema_version: "0.42"`; every narrowing decision is recorded in `surface_exclusions` and reachable by the release decision, while v0.41 remains frozen for archived reports.
 
 See [ROADMAP.md](ROADMAP.md) for what is planned next.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@ A single entry point for human readers and AI agents walking the `docs/` tree.
 - [`trust-model.md`](trust-model.md) — what the scanner does and doesn't do
 - [`baseline.md`](baseline.md) — baseline workflow
 - [`framework-adapter-checklist.md`](framework-adapter-checklist.md) — checklist for adding static framework adapters
+- [`mcp-registration-idioms.md`](mcp-registration-idioms.md) — the 30-server survey behind the built-in MCP registration-idiom registry: which shapes ship, what the reader excludes, and why an export still wins
 - [`determinism-boundary.md`](determinism-boundary.md) — generated coverage matrix: what each input can establish per declaration shape, the extraction-confidence ceiling it reaches, and what that ceiling means for a verdict
 
 ## Reference

--- a/docs/determinism-boundary.json
+++ b/docs/determinism-boundary.json
@@ -117,6 +117,100 @@
       "reads": "A committed MCP `tools/list` response, or any file carrying the same `tools` array."
     },
     {
+      "adapter": "mcp_server_source",
+      "cells": [
+        {
+          "ceiling": null,
+          "emits": [],
+          "evidence_gaps": [],
+          "exclusion_detail": null,
+          "exclusion_reason": null,
+          "extraction_complete": false,
+          "extraction_permits_pass": false,
+          "outcome": "not_applicable",
+          "raises": [],
+          "reads": "A committed export is the server's own contract and is read by the MCP tool-export input at `high`, which stays the better route wherever one exists.",
+          "shape": "export_artifact",
+          "status": "not_applicable",
+          "surface": null,
+          "surface_complete": false,
+          "surface_flags": [],
+          "variant": null,
+          "verdict": "No such declaration exists for this input."
+        },
+        {
+          "ceiling": "medium",
+          "emits": [
+            "mcp_server_source"
+          ],
+          "evidence_gaps": [
+            "low_confidence_tool",
+            "unattested_surface"
+          ],
+          "exclusion_detail": null,
+          "exclusion_reason": null,
+          "extraction_complete": false,
+          "extraction_permits_pass": false,
+          "outcome": "low_confidence",
+          "raises": [],
+          "reads": "A tool name written as a string literal at a registration site \u2014 `static toolName = \"\u2026\"`, `.registerTool(\"\u2026\"`, `MustTool(\"\u2026\"`, `NewTool(\"\u2026\"`, `Tool{Name: \"\u2026\"}` \u2014 plus the sibling operation-class literal where the idiom defines one.",
+          "shape": "literal_registration",
+          "status": "extracted",
+          "surface": "enumerated",
+          "surface_complete": true,
+          "surface_flags": [],
+          "variant": null,
+          "verdict": "Every action from this route raises `low_confidence_tool` and either `unattested_surface` (when its set was enumerated) or `incomplete_surface` (when it was not), so none can be pass-eligible. Only the latter adds an exclusion-ledger row for an unread remainder. Semantic evidence gaps are zero-tolerance, so **one** such action is already enough to put the run below the evidence threshold and withhold a verdict. A reviewed tool inventory is the route out."
+        },
+        {
+          "ceiling": null,
+          "emits": [],
+          "evidence_gaps": [],
+          "exclusion_detail": null,
+          "exclusion_reason": null,
+          "extraction_complete": false,
+          "extraction_permits_pass": false,
+          "outcome": "not_extracted",
+          "raises": [],
+          "reads": "A helper that registers a table of tools contributes nothing on its own: resolving what it registers would mean evaluating it. Any registration site inside the helper is read on its own terms.",
+          "shape": "factory",
+          "status": "not_extracted",
+          "surface": null,
+          "surface_complete": false,
+          "surface_flags": [],
+          "variant": null,
+          "verdict": "No action enters the catalog, so nothing here carries an action-level ceiling. That is not the same as unseen: the scan records that it read this construct and refused to guess what it produces, and a framework check may raise a finding on the record itself \u2014 see the row's own `Raises` column."
+        },
+        {
+          "ceiling": null,
+          "emits": [],
+          "evidence_gaps": [],
+          "exclusion_detail": null,
+          "exclusion_reason": null,
+          "extraction_complete": false,
+          "extraction_permits_pass": false,
+          "outcome": "not_extracted",
+          "raises": [],
+          "reads": "A registration whose name is a variable, a concatenation, or a template substitution names no tool this reader can check. It enters no catalog and is recorded as an unenumerated subject in the exclusion ledger, which holds its file's surface at `partial`.",
+          "shape": "dynamic_construction",
+          "status": "not_extracted",
+          "surface": null,
+          "surface_complete": false,
+          "surface_flags": [],
+          "variant": null,
+          "verdict": "No action enters the catalog, so nothing here carries an action-level ceiling. That is not the same as unseen: the scan records that it read this construct and refused to guess what it produces, and a framework check may raise a finding on the record itself \u2014 see the row's own `Raises` column."
+        }
+      ],
+      "configured_as": [
+        "tool_sources"
+      ],
+      "inventory_key": null,
+      "label": "MCP server source",
+      "manifest_section": null,
+      "manifest_section_role": "activates",
+      "reads": "The TypeScript or Go source of an MCP server that does not commit an export, through a built-in registry of registration idioms."
+    },
+    {
       "adapter": "openapi",
       "cells": [
         {

--- a/docs/determinism-boundary.md
+++ b/docs/determinism-boundary.md
@@ -32,6 +32,7 @@ If you landed here from an `insufficient_evidence` verdict, this page is the rea
 | Your framework | …in a contract file | …written out in code | …built by a call | …not named at all |
 | --- | --- | --- | --- | --- |
 | [MCP tool export](#mcp-tool-export) | ✅ proven | · n/a | · n/a | ⚠️ set unproven |
+| [MCP server source](#mcp-server-source) | · n/a | ⚠️ not proven | ✖ not read | ✖ not read |
 | [OpenAPI document](#openapi-document) | ✅ proven | · n/a | · n/a | · n/a |
 | [OpenAI Agents SDK (Python)](#openai-agents-sdk-python) | · n/a | ⚠️ not proven | ✖ not read | ✖ not read |
 | [Google ADK](#google-adk) | ✅ proven | ✅ proven | ⚠️ not proven | ⚠️ not proven |
@@ -70,6 +71,28 @@ Where an input shows more than one answer for a shape, the table shows the best 
 | `literal_registration` | An export is a contract file, not source. A server declared in a host config is read by the Codex / MCP host config input. | — | — | `not_applicable` | — | — |
 | `factory` | An export is the result of construction, never the construction. | — | — | `not_applicable` | — | — |
 | `dynamic_construction` | `wildcard: true` or `tools: "*"`: one synthetic `<source>.*` action stands in for a surface the file declines to name. | `mcp` | `high` | `set_unproven` | `incomplete_surface` | `SHIP-INVENTORY-WILDCARD-TOOLS` |
+
+</details>
+
+### MCP server source
+
+*Configured as a `tool_sources[]` entry of type `mcp_server_source`.* The TypeScript or Go source of an MCP server that does not commit an export, through a built-in registry of registration idioms.
+
+**Can a verdict rest on it?**
+
+**Not on its own.** shipgate may still read and check actions here — the routes below say which — but none of them proves one well enough for a verdict to rest on it.
+
+**Getting to `proven` here:** no route on this input reaches `proven`. Publish the actions through an input that does, or accept that a verdict cannot rest on this surface alone.
+
+<details>
+<summary>Every route this input has, in full (4)</summary>
+
+| Declaration shape | What is read | Emits | Ceiling | Outcome | Evidence gaps | Raises |
+| --- | --- | --- | --- | --- | --- | --- |
+| `export_artifact` | A committed export is the server's own contract and is read by the MCP tool-export input at `high`, which stays the better route wherever one exists. | — | — | `not_applicable` | — | — |
+| `literal_registration` | A tool name written as a string literal at a registration site — `static toolName = "…"`, `.registerTool("…"`, `MustTool("…"`, `NewTool("…"`, `Tool{Name: "…"}` — plus the sibling operation-class literal where the idiom defines one. | `mcp_server_source` | `medium` | `low_confidence` | `low_confidence_tool`, `unattested_surface` | — |
+| `factory` | A helper that registers a table of tools contributes nothing on its own: resolving what it registers would mean evaluating it. Any registration site inside the helper is read on its own terms. | — | — | `not_extracted` | — | — |
+| `dynamic_construction` | A registration whose name is a variable, a concatenation, or a template substitution names no tool this reader can check. It enters no catalog and is recorded as an unenumerated subject in the exclusion ledger, which holds its file's surface at `partial`. | — | — | `not_extracted` | — | — |
 
 </details>
 

--- a/docs/mcp-registration-idioms.md
+++ b/docs/mcp-registration-idioms.md
@@ -65,7 +65,8 @@ the mechanism is reusable but each one needs its own adversarial probe list
 before it can claim anything — the lexical reader shipped here had eight
 fail-open constructs in its first draft, all found by writing that list. Python
 gets its own increment, its own probes, and a real AST rather than a masking
-lexer.
+lexer — filed as
+[#484](https://github.com/ThreeMoonsLab/agents-shipgate/issues/484).
 
 ## What the reader does and does not read
 
@@ -123,6 +124,12 @@ only support the one published server, so the split returned four scopes and
 reach. The over-broad route is visible in the manifest `init` writes and an
 adopter narrows it in one line; the withheld one leaves them where they
 started, which is the state #431 was filed about.
+
+The zero-install detector (`tools/shipgate-detect.py`) does not read registration
+sites at all, so it still answers "not an agent project" for these repositories
+while the installed CLI does not. That divergence is named in the script's own
+"intentional simplifications" list, pinned by a test, and filed as
+[#485](https://github.com/ThreeMoonsLab/agents-shipgate/issues/485).
 
 ## Routing a diff
 

--- a/docs/mcp-registration-idioms.md
+++ b/docs/mcp-registration-idioms.md
@@ -1,0 +1,148 @@
+# MCP registration idioms: the survey behind the built-in registry
+
+Most MCP servers never emit their tool surface. Three first-party vendor
+servers were walked before this input existed, and `detect` reported two of
+them as *not an agent project*:
+
+| repo | language | how a tool is named | seen before #431 |
+|---|---|---|---|
+| `mongodb-js/mongodb-mcp-server` | TypeScript | `static toolName = "aggregate"` | no |
+| `grafana/mcp-grafana` | Go | `mcpgrafana.MustTool("update_incident", …)` | no |
+| `github/github-mcp-server` | Go | `mcp.Tool{Name: "issue_read"}`, plus committed `__toolsnaps__/*.snap` | no |
+
+The discriminator was never the language — two of the three are Go. It is
+whether the repository happens to *emit* its tool list as a committed artifact,
+and only one of the three does. What all three do is write the tool's name as a
+**string literal at a registration site**.
+
+Issue [#431](https://github.com/ThreeMoonsLab/agents-shipgate/issues/431)
+settled the shape of the answer — a built-in, versioned registry of *named
+registration idioms*, never a user-configurable pattern — and required a survey
+before choosing which idioms to ship: *"count registration idioms across the
+top ~30 registry servers, then ship the smallest set that covers the beachhead
+and the measured majority. Anything below the survey's coverage line waits for
+evidence."*
+
+## Method
+
+Thirty MCP servers and the three official SDKs were cloned at `--depth 1` and
+scanned for candidate registration shapes. Counts are call sites, not tools;
+test files are included in these raw counts and excluded by the shipped reader
+(see *What the reader excludes*). Two listed repositories (`pulumi/mcp-server`,
+`influxdata/influxdb-mcp-server`) could not be cloned and are not counted.
+
+## Result
+
+| idiom | repositories | largest single repo | shipped |
+|---|---|---|---|
+| Python `@mcp.tool` (FastMCP decorator) | 5 | `awslabs/mcp` (488) | **no — next increment** |
+| Go `Tool{Name: "…"}` | 3 | `github/github-mcp-server` (135) | yes (`go_tool_struct`) |
+| TS `.tool(` / `.registerTool("…"` | 3 | `cloudflare/mcp-server-cloudflare` (85) | yes (`ts_sdk_register_tool`) |
+| Go `NewTool("…"` | 2 | `hashicorp/terraform-mcp-server` (63) | yes (`go_new_tool`) |
+| Go `MustTool("…"` | 1 | `grafana/mcp-grafana` (132) | yes (`go_must_tool`) |
+| TS `static toolName = "…"` | 1 | `mongodb-js/mongodb-mcp-server` (77) | yes (`ts_static_tool_name`) |
+
+The five shipped idioms cover every surveyed server whose tools are declared in
+TypeScript or Go, including all three walked vendors. Measured against the
+current heads of the three vendor repositories, the reader finds 61, 114, and
+110 tool names respectively, with 3, 1, and 3 registrations whose names are
+built at runtime — each recorded as an unenumerated subject rather than
+dropped.
+
+One shape was measured and deliberately rejected: an object literal carrying
+`name:` and `description:` keys, which appears in 14 of the surveyed
+repositories. It matches any object with those two keys, which is most
+configuration in a TypeScript codebase, and a reader resting on it would invent
+tools rather than find them.
+
+## Why Python FastMCP is not in this increment
+
+It is the largest single shape in the survey, and it is a **different
+extraction mechanism**: the name defaults to the decorated function's, the
+schema comes from the signature, and the provenance gate is an import binding
+rather than a declared dependency. Per [#393](https://github.com/ThreeMoonsLab/agents-shipgate/issues/393),
+the mechanism is reusable but each one needs its own adversarial probe list
+before it can claim anything — the lexical reader shipped here had eight
+fail-open constructs in its first draft, all found by writing that list. Python
+gets its own increment, its own probes, and a real AST rather than a masking
+lexer.
+
+## What the reader does and does not read
+
+It reads a name, an operation-class literal where the idiom defines one, and a
+description literal where one sits beside the name. It runs no code, evaluates
+no schema library (Zod included), infers no type, and reads no annotation the
+source declares about itself.
+
+The name is checkable against the registration site that carries it. Effect and
+authority still come from the declaration questionnaire, which is where they
+came from for an exported surface too. A `static operationType = "delete"`
+literal arrives as a low-confidence inferred hint that can *contradict* a
+reviewer who declares the tool read-only, and can never make an action
+pass-eligible on its own; `read` and `metadata` are deliberately unmapped,
+because a tool server asserting its own harmlessness is the one claim an
+untrusted source has an incentive to make.
+
+### What the reader excludes
+
+- **Test files** — `*_test.go`, `*.test.ts`, `*.spec.ts`, and files under
+  `test/`, `tests/`, `__tests__/`, `testdata/`, `fixtures/`. A test's fake tool
+  is not the published surface. Excluding them drops 14 phantom tools from the
+  MongoDB repository and 8 from Grafana.
+- **Vendored and built code** — `node_modules/`, `vendor/`, `dist/`, `build/`.
+  Somebody else's registrations are not this repository's surface.
+- **JSX** (`.tsx`, `.jsx`) — JSX puts prose in code position, so an apostrophe
+  in `<p>don't</p>` opens a string that never closes and the file reads as
+  unreadable. That is the fail-closed direction, which is exactly why it is
+  unaffordable: it would hold a whole repository's surface at `partial` over a
+  contraction in a React component. No measured server registers a tool from a
+  JSX module.
+
+## Confidence, and where an export still wins
+
+A literal at a registration site is `medium`. A committed export stays `high`
+and remains the better route wherever one exists: it is the server's own
+published contract and it carries the input schemas this input does not read.
+`detect` therefore withholds the source route whenever a parseable MCP export
+covers the workspace, and records the withheld route in `excluded_sources` with
+the export that displaced it — named and visible, never silently dropped.
+
+## Known limitation: a monorepo publishing several servers
+
+`detect` offers **one** route per workspace, at the deepest directory
+containing every registration it resolved. For a repository publishing several
+independent servers — `modelcontextprotocol/servers` (7 under `src/`),
+`cloudflare/mcp-server-cloudflare` (~15 under `apps/`) — that route is
+over-broad: it names them all as one tool surface.
+
+Splitting on which package declares the MCP dependency was implemented and
+rejected on measurement. In `mongodb-js/mongodb-mcp-server` the SDK is declared
+by an eval-harness package and, as a dev dependency, by three packages that
+only support the one published server, so the split returned four scopes and
+`detect` withheld the route entirely — from the repository this input exists to
+reach. The over-broad route is visible in the manifest `init` writes and an
+adopter narrows it in one line; the withheld one leaves them where they
+started, which is the state #431 was filed about.
+
+## Routing a diff
+
+`TRIGGER-MCP-TOOL-REGISTRATION-SOURCE` routes on the registry's published
+`diff_tokens`. Those are deliberately narrower than what the reader matches: a
+matched capability rule overrides the workspace stop condition, so a router
+firing on `.tool(` or a bare `Tool{` would turn "this is not an agent project"
+into "run" for any diff containing that substring. The router's job is to stop
+the *silent* miss; the reader's is to read the surface once the repository is
+adopted.
+
+## Adding an idiom
+
+Idioms live in `agents_shipgate.inputs.mcp_idioms`. Adding one means:
+
+1. Evidence that a real workflow needs it — a repository whose surface is
+   invisible without it, in the survey's terms.
+2. An entry in `IDIOMS` with its `diff_tokens`, and a positive sample in
+   `tests/test_mcp_idioms.py` (the sample is what proves the tokens are real).
+3. Adversarial cases in the same file for every way the shape can be faked or
+   built at runtime.
+4. A bump of `IDIOM_REGISTRY_VERSION`, because the trigger catalog's token list
+   is derived from this registry.

--- a/docs/mcp-registration-idioms.md
+++ b/docs/mcp-registration-idioms.md
@@ -75,6 +75,14 @@ description literal where one sits beside the name. It runs no code, evaluates
 no schema library (Zod included), infers no type, and reads no annotation the
 source declares about itself.
 
+Escape sequences are decoded with **each language's own grammar**, and anything
+either grammar does not define is refused rather than guessed. Go writes an
+octal escape as three digits — `MustTool("delete\137all", …)` registers
+`delete_all` — and one decoder shared between the two languages read that as
+`delete137all`: the real action missing from the catalog with an action id
+nobody serves standing in its place. A refusal becomes a recorded omission,
+which is the only affordable outcome for a *name*.
+
 The name is checkable against the registration site that carries it. Effect and
 authority still come from the declaration questionnaire, which is where they
 came from for an exported surface too. A `static operationType = "delete"`
@@ -104,9 +112,20 @@ untrusted source has an incentive to make.
 A literal at a registration site is `medium`. A committed export stays `high`
 and remains the better route wherever one exists: it is the server's own
 published contract and it carries the input schemas this input does not read.
-`detect` therefore withholds the source route whenever a parseable MCP export
-covers the workspace, and records the withheld route in `excluded_sources` with
-the export that displaced it — named and visible, never silently dropped.
+`detect` therefore withholds the source route when a committed export **names
+every tool the source route resolved**, and records the withheld route in
+`excluded_sources` with the export that displaced it — named and visible, never
+silently dropped.
+
+Containment is the test, not location and not mere existence. "Any export in
+the workspace wins" deleted real actions in two ways: in a repository holding
+two servers, an export committed for one suppressed every source-only
+registration of the other; and a partial export suppressed the rest of a single
+server's surface. Where an export exists but does not contain the source
+surface, both routes are suggested and the shortfall is named in the evidence —
+two sources describing one server are reconciled by a reviewed `tool_identity`
+binding, never by dropping one of them. A wildcard export claims a surface
+without enumerating it, so it can never be shown to contain anything.
 
 ## Known limitation: a monorepo publishing several servers
 

--- a/docs/triggers.json
+++ b/docs/triggers.json
@@ -95,6 +95,23 @@
       "command": "agents-shipgate verify --preview --json"
     },
     {
+      "id": "TRIGGER-MCP-TOOL-REGISTRATION-SOURCE",
+      "surface_class": "capability",
+      "agents_md_row": "Adds/changes an MCP tool registration written in TypeScript or Go source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`)",
+      "when": {
+        "any_of": [
+          {"diff_contains": ".registerTool("},
+          {"diff_contains": "MustTool("},
+          {"diff_contains": "NewTool("},
+          {"diff_contains": "mcp.Tool{"},
+          {"diff_contains": "static toolName"}
+        ]
+      },
+      "action": "run_shipgate",
+      "rationale": "Most MCP servers never emit their tool list: the official MongoDB and Grafana servers declare every tool as a string literal at a registration site in TypeScript or Go, and no filename or schema-content rule matches such a diff. These five tokens are the high-precision subset of the built-in idiom registry (`agents_shipgate.inputs.mcp_idioms.DIFF_TOKENS`), narrower than what that reader matches because a matched capability rule overrides the workspace stop condition. Routing this diff stops the silent miss; the `mcp_server_source` input reads the whole surface once the repository is adopted.",
+      "command": "agents-shipgate verify --preview --json"
+    },
+    {
       "id": "TRIGGER-OPENAPI-SPEC-CHANGED",
       "surface_class": "capability",
       "agents_md_row": "Adds/changes MCP exports, OpenAPI specs, or `tools/*openai*tools*.json`",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -33,9 +33,9 @@ Authoritative instructions for AI coding agents (Claude Code, Codex, Cursor, Aid
 
 ## What this project is
 
-The deterministic merge gate for AI-generated agent capability changes. Reads `shipgate.yaml` plus tool sources (MCP exports, OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, OpenAI API artifacts, Codex repo config, Codex plugin packages and marketplaces, n8n workflow JSON/stubs, Conductor OSS workflow JSON) and produces deterministic findings. Local-first and static by default — no agent execution, tool calls, LLM calls, or network access.
+The deterministic merge gate for AI-generated agent capability changes. Reads `shipgate.yaml` plus tool sources (MCP exports, MCP server source (TypeScript/Go registration idioms), OpenAPI specs, OpenAI Agents SDK Python files, Anthropic Messages API tool/prompt artifacts, Google ADK Python/config files, LangChain/LangGraph Python files, CrewAI Python files, OpenAI API artifacts, Codex repo config, Codex plugin packages and marketplaces, n8n workflow JSON/stubs, Conductor OSS workflow JSON) and produces deterministic findings. Local-first and static by default — no agent execution, tool calls, LLM calls, or network access.
 
-- **Inputs:** MCP · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · OpenAI API · Codex config · Codex plugin · n8n · Conductor OSS workflow JSON
+- **Inputs:** MCP · MCP server source · OpenAPI · OpenAI Agents SDK · Anthropic Messages API · Google ADK · LangChain/LangGraph · CrewAI · OpenAI API · Codex config · Codex plugin · n8n · Conductor OSS workflow JSON
 - **Outputs:** Markdown · JSON · SARIF
 - **Trust:** Static-by-default. No agent execution, tool calls, LLM calls, or network access.
 - **Marketing site:** [threemoonslab.com](https://threemoonslab.com/) — human-readable companion pages. **If you are an agent working inside this repo, use the in-tree [`.well-known/agents-shipgate.json`](.well-known/agents-shipgate.json) (current `main` contract, may be ahead of the site's released copy) for schema-version and gating-signal decisions.**
@@ -533,6 +533,7 @@ Do NOT use it for:
 | Trigger in this PR | Run Shipgate? |
 |---|---|
 | Adds/changes MCP exports, OpenAPI specs, or `tools/*openai*tools*.json` | Yes |
+| Adds/changes an MCP tool registration written in TypeScript or Go source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`) | Yes |
 | Adds/changes Codex repo config, hooks, or permission profiles | Yes |
 | Adds/changes coding-agent host config, hooks, permissions, MCP servers, or workflows | Yes |
 | Adds/changes Codex plugin manifests, marketplace files, `.app.json`, `.mcp.json`, or `SKILL.md` files | Yes |

--- a/src/agents_shipgate/checks/mcp_permissions.py
+++ b/src/agents_shipgate/checks/mcp_permissions.py
@@ -19,6 +19,7 @@ from agents_shipgate.core.lenses.tool_surface import (
     tool_annotation_hash,
 )
 from agents_shipgate.core.semantic_assessment import (
+    MCP_SOURCE_TYPES,
     acknowledged_effect_claim_ids,
     assess_tool_semantics,
 )
@@ -28,15 +29,6 @@ from agents_shipgate.schemas.report import Finding
 from agents_shipgate.schemas.semantic import SemanticClaimEvidence
 from agents_shipgate.schemas.surfaces import ActionFact, ActionSurfaceFacts
 
-MCP_SOURCE_TYPES = frozenset(
-    {
-        "mcp",
-        "codex_config_mcp",
-        "codex_plugin_mcp_inventory",
-        "n8n_mcp_client_tool",
-        "conductor_mcp_call",
-    }
-)
 CapabilityKey = tuple[str | None, str]
 EffectClaim = SemanticClaim | SemanticClaimEvidence
 

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -41,6 +41,7 @@ from pathlib import Path, PurePosixPath
 from agents_shipgate.inputs.mcp_idioms import (
     GO_FRAMEWORK_MODULES,
     MAX_SOURCE_FILE_BYTES,
+    SKIP_DIRECTORY_NAMES,
     TYPESCRIPT_FRAMEWORK_PACKAGES,
     SourceLanguage,
     is_scannable_path,
@@ -86,6 +87,11 @@ class McpSourceDiscovery:
     unresolved_count: int = 0
     #: Human-readable evidence for ``FrameworkDetection.evidence``.
     evidence: tuple[str, ...] = ()
+    #: The declared-dependency reasons behind the language gate, on their own.
+    #: Scoring reads this rather than indexing into ``evidence``: the rendered
+    #: lines are ordered for a human and gain conditional entries at the end,
+    #: so "the dependency reason" was a list position rather than a fact.
+    framework_evidence: tuple[str, ...] = ()
     #: Workspace-relative files that carried a resolved registration.
     candidate_files: tuple[str, ...] = ()
     #: ``{type, path, reason}`` rows for a route discovery found and withheld.
@@ -136,12 +142,17 @@ def discover_mcp_server_source(
         if pair[1] is not None
         and _language_in_scope(pair[1], framework.languages)
     ]
+    # Sorted before the cap, so which files are read is a property of the
+    # workspace and not of the walk order — and capped where the flag is set,
+    # rather than beside it: reporting `truncated` while reading every file
+    # published "this count is a lower bound" for a count that was exact.
+    scannable.sort(key=lambda pair: pair[1])
     truncated = len(scannable) > max_source_files
     names: set[str] = set()
     languages: set[SourceLanguage] = set()
     unresolved_by_file: dict[str, int] = {}
     candidate_files: list[str] = []
-    for path, relative in sorted(scannable, key=lambda item: item[1]):
+    for path, relative in scannable[:max_source_files]:
         language = language_for_path(path)
         if language is None:  # pragma: no cover - filtered above
             continue
@@ -205,6 +216,7 @@ def discover_mcp_server_source(
         tool_names=tuple(sorted(names)),
         unresolved_count=unresolved,
         evidence=evidence,
+        framework_evidence=tuple(sorted(framework.reasons)),
         candidate_files=tuple(sorted(candidate_files)),
         truncated=truncated,
     )
@@ -221,8 +233,13 @@ def _framework_evidence(
         relative = _relative(path, workspace)
         if relative is None:
             continue
+        # The same skip set the source walk uses, not a narrower one of its
+        # own: a manifest under `coverage/` or `out/` is no more this
+        # repository's declaration than one under `node_modules/`, and two
+        # lists would let a directory be skipped for registrations while still
+        # granting the language gate that admits them.
         parts = PurePosixPath(relative).parts
-        if any(part in {"node_modules", "vendor", "dist", "build"} for part in parts):
+        if any(part in SKIP_DIRECTORY_NAMES for part in parts):
             continue
         try:
             text = path.read_text(encoding="utf-8", errors="replace")

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -1,0 +1,354 @@
+"""Discovery for MCP servers whose tool surface exists only as code (#431).
+
+``detect`` classified the official MongoDB and Grafana MCP servers as "not an
+agent project". Both publish dozens of tools — ``drop-database``,
+``delete-many``, ``update_incident`` — and neither commits an export, so every
+route discovery had was filename-shaped and found nothing. This module supplies
+the missing route: it asks whether a workspace *is* an MCP server written in
+TypeScript or Go, and if so which directory holds the registrations.
+
+Two facts have to hold together before the route is offered, and the pairing is
+the whole design.
+
+**Declared framework evidence.** A repository that declares no MCP dependency
+is not an MCP server just because a class of its own happens to spell a field
+``toolName``. #393's lesson is that a proof resting on a spelling is the
+fail-open shape, so the dependency — ``@modelcontextprotocol/*`` in a
+``package.json``, an MCP module in a ``go.mod`` — is what turns a spelling into
+provenance. It is also the cheap half: a workspace with no such dependency is
+answered without reading a single source file.
+
+**A resolved registration.** Dependency evidence alone says the repository
+*uses* MCP, which every client does too. At least one tool name has to be
+readable at a registration site before this claims a tool surface.
+
+Where both hold and the workspace *also* has a parseable MCP export, the export
+wins: it is the server's own published contract, it carries the input schemas
+this route deliberately does not read, and it is ``high`` confidence against
+``medium``. The source route is then withheld and recorded in
+``excluded_sources`` — named and visible, never silently dropped, because a
+route that vanishes without a reason is indistinguishable from one nobody
+implemented.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+
+from agents_shipgate.inputs.mcp_idioms import (
+    GO_FRAMEWORK_MODULES,
+    MAX_SOURCE_FILE_BYTES,
+    TYPESCRIPT_FRAMEWORK_PACKAGES,
+    SourceLanguage,
+    is_scannable_path,
+    language_for_path,
+    scan_source,
+)
+from agents_shipgate.inputs.mcp_server_source import SOURCE_TYPE
+
+#: How many source files discovery reads before it stops. Discovery runs on an
+#: unknown workspace with no manifest and has to stay bounded; the scan-time
+#: adapter has its own, larger cap. Truncation is reported, never silent.
+DEFAULT_MAX_SOURCE_FILES = 1500
+
+#: How many tool names the detection evidence names before it summarises. The
+#: evidence line is read by a human deciding whether to adopt, and 110 names is
+#: not evidence, it is a wall.
+_EVIDENCE_NAME_LIMIT = 5
+
+#: Dependency sections of a ``package.json`` that count. ``devDependencies`` is
+#: included on purpose: a server that bundles the SDK declares it there as
+#: often as not, and the question here is "was this repository written against
+#: MCP", not "does it ship the SDK at runtime".
+_PACKAGE_JSON_DEPENDENCY_KEYS = (
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+)
+
+
+@dataclass(frozen=True)
+class McpSourceDiscovery:
+    """What discovery concluded about the workspace's own registration sites."""
+
+    #: Workspace-relative directory to point ``tool_sources[].path`` at, or
+    #: ``None`` when no route was found.
+    path: str | None = None
+    #: Languages whose idioms resolved at least one name.
+    languages: tuple[SourceLanguage, ...] = ()
+    #: Distinct resolved tool names, sorted.
+    tool_names: tuple[str, ...] = ()
+    #: Registration sites whose name could not be resolved to a literal.
+    unresolved_count: int = 0
+    #: Human-readable evidence for ``FrameworkDetection.evidence``.
+    evidence: tuple[str, ...] = ()
+    #: Workspace-relative files that carried a resolved registration.
+    candidate_files: tuple[str, ...] = ()
+    #: ``{type, path, reason}`` rows for a route discovery found and withheld.
+    excluded: tuple[dict[str, str], ...] = ()
+    #: Whether the file cap was reached before the walk finished.
+    truncated: bool = False
+
+    @property
+    def detected(self) -> bool:
+        return self.path is not None
+
+
+@dataclass
+class _FrameworkEvidence:
+    """Declared MCP dependencies, per language.
+
+    """
+
+    languages: set[SourceLanguage] = field(default_factory=set)
+    reasons: list[str] = field(default_factory=list)
+
+
+def discover_mcp_server_source(
+    workspace: Path,
+    *,
+    files: Sequence[Path],
+    exported_source_paths: Iterable[str] = (),
+    max_source_files: int = DEFAULT_MAX_SOURCE_FILES,
+) -> McpSourceDiscovery:
+    """Decide whether this workspace registers MCP tools in its own source.
+
+    ``exported_source_paths`` are the workspace-relative paths of MCP exports
+    discovery already accepted. Their presence is what withholds this route.
+    """
+
+    workspace = workspace.resolve()
+    framework = _framework_evidence(workspace, files)
+    if not framework.languages:
+        return McpSourceDiscovery()
+
+    # Paired with the workspace-relative path once, here: a file that is not
+    # under the workspace at all (a symlink out of the tree) has no relative
+    # form, and inventing one from its basename would put it in the wrong
+    # directory for both the skip rules and the route's common ancestor.
+    scannable = [
+        pair
+        for pair in ((path, _relative(path, workspace)) for path in files)
+        if pair[1] is not None
+        and _language_in_scope(pair[1], framework.languages)
+    ]
+    truncated = len(scannable) > max_source_files
+    names: set[str] = set()
+    languages: set[SourceLanguage] = set()
+    unresolved_by_file: dict[str, int] = {}
+    candidate_files: list[str] = []
+    for path, relative in sorted(scannable, key=lambda item: item[1]):
+        language = language_for_path(path)
+        if language is None:  # pragma: no cover - filtered above
+            continue
+        try:
+            if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        result = scan_source(text, language)
+        resolved = [site.name for site in result.sites if site.name is not None]
+        opaque = sum(1 for site in result.sites if site.name is None)
+        if opaque:
+            unresolved_by_file[relative] = opaque
+        if not resolved:
+            continue
+        languages.add(language)
+        names.update(resolved)
+        candidate_files.append(relative)
+
+    if not names:
+        return McpSourceDiscovery(
+            unresolved_count=sum(unresolved_by_file.values()), truncated=truncated
+        )
+
+    root = _common_directory(candidate_files)
+    # Counted over the directory the route actually points at, so the number
+    # discovery publishes is the number the adapter will report once the route
+    # is configured. A whole-workspace count would name registrations `scan`
+    # never reaches.
+    unresolved = sum(
+        count
+        for relative, count in unresolved_by_file.items()
+        if root == "." or PurePosixPath(relative).is_relative_to(root)
+    )
+    evidence = _evidence_lines(
+        framework, languages, names, root, truncated, unresolved
+    )
+    covering_export = _preferred_export(exported_source_paths)
+    if covering_export is not None:
+        return McpSourceDiscovery(
+            unresolved_count=unresolved,
+            truncated=truncated,
+            excluded=(
+                {
+                    "type": SOURCE_TYPE,
+                    "path": root,
+                    "reason": (
+                        f"An MCP tool export ({covering_export}) already names "
+                        "this server's surface, and an export is read at high "
+                        "confidence with its input schemas; reading the "
+                        "registrations in source would restate it at medium."
+                    ),
+                },
+            ),
+        )
+
+    return McpSourceDiscovery(
+        path=root,
+        languages=tuple(sorted(languages)),
+        tool_names=tuple(sorted(names)),
+        unresolved_count=unresolved,
+        evidence=evidence,
+        candidate_files=tuple(sorted(candidate_files)),
+        truncated=truncated,
+    )
+
+
+def _framework_evidence(
+    workspace: Path, files: Sequence[Path]
+) -> _FrameworkEvidence:
+    evidence = _FrameworkEvidence()
+    for path in files:
+        name = path.name
+        if name not in {"package.json", "go.mod"}:
+            continue
+        relative = _relative(path, workspace)
+        if relative is None:
+            continue
+        parts = PurePosixPath(relative).parts
+        if any(part in {"node_modules", "vendor", "dist", "build"} for part in parts):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if name == "go.mod":
+            lowered = text.lower()
+            for module in GO_FRAMEWORK_MODULES:
+                if module in lowered:
+                    evidence.languages.add("go")
+                    evidence.reasons.append(f"{relative} requires {module}")
+                    break
+            continue
+        package = _package_dependencies(text)
+        for dependency in sorted(package):
+            if any(
+                dependency.lower().startswith(token)
+                for token in TYPESCRIPT_FRAMEWORK_PACKAGES
+            ):
+                evidence.languages.add("typescript")
+                evidence.reasons.append(f"{relative} depends on {dependency}")
+                break
+    return evidence
+
+
+def _package_dependencies(text: str) -> set[str]:
+    try:
+        data = json.loads(text)
+    except ValueError:
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    names: set[str] = set()
+    for key in _PACKAGE_JSON_DEPENDENCY_KEYS:
+        section = data.get(key)
+        if isinstance(section, dict):
+            names.update(str(name) for name in section)
+    return names
+
+
+def _language_in_scope(relative: str, languages: set[SourceLanguage]) -> bool:
+    language = language_for_path(relative)
+    if language is None or language not in languages:
+        return False
+    return is_scannable_path(relative)
+
+
+def _relative(path: Path, workspace: Path) -> str | None:
+    try:
+        return path.resolve().relative_to(workspace).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
+def _common_directory(relative_files: Sequence[str]) -> str:
+    """The deepest directory containing every file that registered a tool.
+
+    Not a scope decision — #363 settled that a deepest-common-ancestor is the
+    wrong answer for *which project a manifest describes*. This is the narrower
+    question of which subtree the adapter has to walk, where the ancestor is
+    exactly right: widening it only costs a longer walk, and the adapter skips
+    everything that is not source anyway.
+    """
+
+    parts_list = [PurePosixPath(name).parent.parts for name in relative_files]
+    if not parts_list:
+        return "."
+    common = parts_list[0]
+    for parts in parts_list[1:]:
+        limit = min(len(common), len(parts))
+        index = 0
+        while index < limit and common[index] == parts[index]:
+            index += 1
+        common = common[:index]
+    return PurePosixPath(*common).as_posix() if common else "."
+
+
+def _preferred_export(exported_source_paths: Iterable[str]) -> str | None:
+    """The MCP export, if any, that this route stands down for.
+
+    Any accepted export in the workspace counts, not only one sitting inside
+    the registration directory — a server commits its export at the repository
+    root (``tools.json``, ``mcp-tools.json``) as readily as beside the code,
+    and a containment test read those two placements differently for one
+    server. ``detect`` refuses to answer for a workspace holding more than one
+    project scope, so "an export in this workspace" and "an export for this
+    server" are the same statement wherever this route is offered at all.
+
+    The alternative — suggesting both — is worse than a withheld route that
+    names itself: two sources describing one server put every tool in the
+    catalog twice, under two providers, with no reviewed identity binding to
+    join them.
+    """
+
+    candidates = sorted(exported_source_paths)
+    return candidates[0] if candidates else None
+
+
+def _evidence_lines(
+    framework: _FrameworkEvidence,
+    languages: set[SourceLanguage],
+    names: set[str],
+    root: str,
+    truncated: bool,
+    unresolved: int,
+) -> tuple[str, ...]:
+    sample = sorted(names)[:_EVIDENCE_NAME_LIMIT]
+    shown = ", ".join(sample)
+    if len(names) > len(sample):
+        shown += ", …"
+    lines = [
+        f"MCP tool registrations in {'/'.join(sorted(languages))} source under "
+        f"{root}/: {len(names)} tool name(s) — {shown}",
+    ]
+    lines.extend(sorted(framework.reasons)[:_EVIDENCE_NAME_LIMIT])
+    if unresolved:
+        # Named here because this is what a human reads when deciding whether
+        # to adopt, and "61 tools" without "and 3 more this reader cannot name"
+        # is the over-claim the whole input is built to avoid.
+        lines.append(
+            f"{unresolved} registration(s) name themselves at runtime and are "
+            "not enumerated"
+        )
+    if truncated:
+        lines.append(
+            "Discovery stopped at the source-file cap, so this count is a "
+            "lower bound."
+        )
+    return tuple(lines)

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -38,6 +38,8 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.inputs.common import load_text_file
 from agents_shipgate.inputs.mcp_idioms import (
     GO_FRAMEWORK_MODULES,
     MAX_SOURCE_FILE_BYTES,
@@ -152,6 +154,7 @@ def discover_mcp_server_source(
     languages: set[SourceLanguage] = set()
     unresolved_by_file: dict[str, int] = {}
     candidate_files: list[str] = []
+    unreadable = 0
     for path, relative in scannable[:max_source_files]:
         language = language_for_path(path)
         if language is None:  # pragma: no cover - filtered above
@@ -159,8 +162,15 @@ def discover_mcp_server_source(
         try:
             if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
                 continue
-            text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+            # The adapter's own reader, not a lenient copy of it. Decoding here
+            # with `errors="replace"` let `detect` resolve a registration out of
+            # a file `load_mcp_server_source` then refuses as `unreadable_file`,
+            # so the route this promised enumerated fewer tools than it named —
+            # the detect/scan agreement is the whole point of sharing
+            # `is_scannable_path`, and the read has to be shared too.
+            text = load_text_file(path)
+        except (OSError, InputParseError):
+            unreadable += 1
             continue
         result = scan_source(text, language)
         resolved = [site.name for site in result.sites if site.name is not None]
@@ -191,7 +201,9 @@ def discover_mcp_server_source(
     evidence = _evidence_lines(
         framework, languages, names, root, truncated, unresolved
     )
-    covering_export = _preferred_export(exported_source_paths)
+    covering_export, uncovered = _covering_export(
+        workspace, exported_source_paths, names
+    )
     if covering_export is not None:
         return McpSourceDiscovery(
             unresolved_count=unresolved,
@@ -202,12 +214,31 @@ def discover_mcp_server_source(
                     "path": root,
                     "reason": (
                         f"An MCP tool export ({covering_export}) already names "
-                        "this server's surface, and an export is read at high "
-                        "confidence with its input schemas; reading the "
-                        "registrations in source would restate it at medium."
+                        f"every one of these {len(names)} registrations, and an "
+                        "export is read at high confidence with its input "
+                        "schemas; reading them in source would restate it at "
+                        "medium."
                     ),
                 },
             ),
+        )
+    if uncovered:
+        # An export exists and does not account for the whole surface. It used
+        # to withhold this route anyway, which in a workspace holding two
+        # servers meant an export for one erased every source-only registration
+        # of the other, and for one server meant a partial export erased the
+        # remainder. Both routes are suggested instead, and the overlap is
+        # named: two sources describing one server are reconciled by a reviewed
+        # `tool_identity` binding (#386), never by dropping one of them.
+        sample = ", ".join(sorted(uncovered)[:_EVIDENCE_NAME_LIMIT])
+        if len(uncovered) > _EVIDENCE_NAME_LIMIT:
+            sample += ", …"
+        evidence = (
+            *evidence,
+            f"An MCP tool export is also present and does not name "
+            f"{len(uncovered)} of these registrations ({sample}); both routes "
+            "are suggested, and a reviewed tool_identity binding is what joins "
+            "the two surfaces",
         )
 
     return McpSourceDiscovery(
@@ -317,25 +348,55 @@ def _common_directory(relative_files: Sequence[str]) -> str:
     return PurePosixPath(*common).as_posix() if common else "."
 
 
-def _preferred_export(exported_source_paths: Iterable[str]) -> str | None:
-    """The MCP export, if any, that this route stands down for.
+def _covering_export(
+    workspace: Path, exported_source_paths: Iterable[str], names: set[str]
+) -> tuple[str | None, set[str]]:
+    """The export that names *every* registration, and what no export names.
 
-    Any accepted export in the workspace counts, not only one sitting inside
-    the registration directory — a server commits its export at the repository
-    root (``tools.json``, ``mcp-tools.json``) as readily as beside the code,
-    and a containment test read those two placements differently for one
-    server. ``detect`` refuses to answer for a workspace holding more than one
-    project scope, so "an export in this workspace" and "an export for this
-    server" are the same statement wherever this route is offered at all.
+    Location is not the test, and neither is mere existence. A server commits
+    its export at the repository root as readily as beside the code, so a
+    containment test read two placements of one server's export differently;
+    but "any export anywhere wins" is worse in the other direction, because a
+    workspace holding two servers has an export for one and source-only
+    registrations for the other, and a partial export covers part of a single
+    server. Both cases silently deleted real actions.
 
-    The alternative — suggesting both — is worse than a withheld route that
-    names itself: two sources describing one server put every tool in the
-    catalog twice, under two providers, with no reviewed identity binding to
-    join them.
+    So the question asked is the one that matters: does the exported surface
+    *contain* the surface read from source? Only then is the source route pure
+    restatement, and only then is withholding it lossless.
     """
 
-    candidates = sorted(exported_source_paths)
-    return candidates[0] if candidates else None
+    covered: set[str] = set()
+    for candidate in sorted(exported_source_paths):
+        exported = _export_tool_names(workspace, candidate)
+        if exported is None:
+            continue
+        covered |= exported
+        if names <= covered:
+            return candidate, set()
+    return None, names - covered
+
+
+def _export_tool_names(workspace: Path, relative: str) -> set[str] | None:
+    """Tool names an accepted MCP export publishes, read by the real adapter.
+
+    ``None`` when the export declines to name them — a wildcard export claims a
+    surface without enumerating it, so it can never be shown to contain
+    anything, and the source route is the more informative of the two.
+    """
+
+    from agents_shipgate.inputs.mcp import load_mcp_tools
+    from agents_shipgate.schemas.manifest import ToolSourceConfig
+
+    try:
+        loaded = load_mcp_tools(
+            ToolSourceConfig(id="export_probe", type="mcp", path=relative), workspace
+        )
+    except (InputParseError, OSError):
+        return None
+    if any(tool.annotations.get("wildcard_tools") is True for tool in loaded.tools):
+        return None
+    return {tool.name for tool in loaded.tools}
 
 
 def _evidence_lines(

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -68,6 +68,10 @@ from agents_shipgate.cli.discovery.artifacts import (
     _skip_part,
     probe_suggested_source,
 )
+from agents_shipgate.cli.discovery.mcp_source import (
+    McpSourceDiscovery,
+    discover_mcp_server_source,
+)
 from agents_shipgate.cli.discovery.scope import (
     PROJECT_MARKERS,
     WEAK_PROJECT_MARKERS,
@@ -78,6 +82,7 @@ from agents_shipgate.core.errors import DiscoveryError, InputParseError
 from agents_shipgate.core.surface_exclusions import build_detect_exclusions
 from agents_shipgate.inputs.codex_plugin import resolve_local_codex_marketplace_roots
 from agents_shipgate.inputs.conductor import conductor_agent_task_types
+from agents_shipgate.inputs.mcp_server_source import SOURCE_TYPE
 from agents_shipgate.invocation import render_command
 from agents_shipgate.schemas.detect import (
     AgentNameCandidate,
@@ -149,6 +154,28 @@ PACKAGE_HINTS: dict[str, tuple[str, ...]] = {
 }
 
 CONVENTIONAL_DIRS = ("prompts", "tools", ".agents-shipgate")
+
+#: The frameworks a conventional directory is weak evidence for. Deliberately
+#: *not* every key in :func:`_initial_framework_scores` — and named here rather
+#: than spelled out inside :func:`_collect_dir_hits`, so the difference reads as
+#: a decision instead of as a second copy that drifted.
+#:
+#: ``mcp_server_source`` is the one absentee. Its evidence is already a
+#: conjunction — a declared MCP dependency *and* a tool name resolved at a
+#: registration site — so a ``tools/`` directory adds nothing it does not
+#: already have, and adding it would let two conventional directories carry the
+#: published detection confidence to ``high`` for a route the engine caps at
+#: ``medium`` (#431).
+CONVENTIONAL_DIR_FRAMEWORKS: tuple[str, ...] = (
+    "langchain",
+    "crewai",
+    "google_adk",
+    "anthropic",
+    "openai_agents_sdk",
+    "n8n",
+    "conductor",
+    "openai_api",
+)
 
 # --- Agent-name evidence vocabulary -----------------------------------------
 
@@ -316,6 +343,24 @@ def detect_workspace(
         for d in dirs:
             scores[framework].add(0.5, "weak", f"conventional dir: {d}/")
 
+    # The artifact probe runs before the detection loop because the source
+    # route below is scored from its result: an MCP export is the better route
+    # to the same server, so this one stands down wherever one exists (#431).
+    suggested_sources, excluded_sources = _suggested_sources(
+        workspace, files=inventory
+    )
+    mcp_source = discover_mcp_server_source(
+        workspace,
+        files=inventory,
+        exported_source_paths=[
+            source["path"] for source in suggested_sources if source["type"] == "mcp"
+        ],
+    )
+    _score_mcp_server_source(mcp_source, scores)
+    excluded_sources.extend(mcp_source.excluded)
+    if mcp_source.path is not None:
+        suggested_sources.append({"type": SOURCE_TYPE, "path": mcp_source.path})
+
     detections: list[FrameworkDetection] = []
     for framework, state in scores.items():
         if state.score >= 2.0 and state.has_strong:
@@ -333,9 +378,6 @@ def detect_workspace(
     project_name_candidates = _project_name_candidates(workspace)
     agent_name_candidates = _rank_agent_name_candidates(
         py_facts, workspace, project_name_candidates
-    )
-    suggested_sources, excluded_sources = _suggested_sources(
-        workspace, files=inventory
     )
     codex_plugin_candidates = _codex_plugin_candidates(workspace, inventory)
     agent_project_candidates = _agent_project_candidates(
@@ -457,6 +499,50 @@ def detect_workspace(
 # --- Internals --------------------------------------------------------------
 
 
+def _score_mcp_server_source(
+    discovery: McpSourceDiscovery, scores: dict[str, _FrameworkScore]
+) -> None:
+    """Score the workspace's own MCP registration sites.
+
+    The registration evidence is strong and reaches the detection threshold on
+    its own, because the fact behind it is already a conjunction: a declared
+    MCP dependency *and* a tool name resolved at a registration site. Splitting
+    it into halves would let either alone reach the threshold with a
+    conventional directory beside it, which is the coincidence the pairing
+    exists to reject. The dependency then adds the same point a dependency adds
+    for every other framework, so a route backed by both facts publishes
+    `medium` rather than reading as the weakest thing discovery can say.
+
+    The candidate file is the **route directory**, not the registration files
+    under it, and that is a scope decision rather than a cosmetic one.
+    `_agent_project_candidates` reads `candidate_files` to ask how many things
+    one manifest would have to describe, and an MCP server is one thing however
+    many packages its tools are spread across: contributing each registration
+    file made `mongodb-js/mongodb-mcp-server` look like six separate projects,
+    and the per-project `init` that split then published leads to a package
+    whose own `package.json` declares no MCP dependency — a next step that
+    cannot change the answer (#399).
+
+    A monorepo publishing *several* servers therefore gets one route covering
+    all of them, which is over-broad. Splitting on which package declares the
+    MCP dependency was tried and rejected: in `mongodb-js/mongodb-mcp-server`
+    the SDK is declared by an eval-harness package and by three packages that
+    only support the one server, so the split returned four scopes and withheld
+    the route from the repository this input exists to reach. The over-broad
+    route is visible in the manifest `init` writes and an adopter narrows it;
+    the withheld one leaves them where they started. See #431 for the
+    measurement.
+    """
+
+    if not discovery.detected or discovery.path is None:
+        return
+    state = scores[SOURCE_TYPE]
+    state.add(2.0, "strong", discovery.evidence[0])
+    for index, line in enumerate(discovery.evidence[1:]):
+        state.add(1.0 if index == 0 else 0.0, "medium", line)
+    state.add_file(discovery.path)
+
+
 def _initial_framework_scores() -> dict[str, _FrameworkScore]:
     """A fresh, empty score sheet — one entry per framework this pass knows.
 
@@ -477,6 +563,13 @@ def _initial_framework_scores() -> dict[str, _FrameworkScore]:
         # (manifest.openai_api block). Distinct from openai_agents_sdk
         # (Python @function_tool decorators).
         "openai_api": _FrameworkScore(),
+        # mcp_server_source is not a Python framework and scores from neither
+        # the AST pass nor a filename glob: it is the workspace's own
+        # TypeScript or Go registration sites, scored by
+        # :func:`discover_mcp_server_source` (#431). It keeps an entry here
+        # because the detection loop reads this sheet, and a framework absent
+        # from it is a framework that can never be reported.
+        SOURCE_TYPE: _FrameworkScore(),
     }
 
 
@@ -1769,12 +1862,7 @@ def _conventional_dir_locations(
 def _collect_dir_hits(locations: dict[str, str]) -> dict[str, list[str]]:
     present = [locations[d] for d in CONVENTIONAL_DIRS if d in locations]
     if not present:
-        return {f: [] for f in (
-            "langchain", "crewai", "google_adk", "anthropic", "openai_agents_sdk",
-            "n8n",
-            "conductor",
-            "openai_api",
-        )}
+        return {framework: [] for framework in CONVENTIONAL_DIR_FRAMEWORKS}
     # Conventional dirs are weak signals shared across all framework
     # candidates — they hint "this looks like an agent project" but don't
     # narrow which framework. Apply the weak credit only when a strong

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -538,8 +538,17 @@ def _score_mcp_server_source(
         return
     state = scores[SOURCE_TYPE]
     state.add(2.0, "strong", discovery.evidence[0])
-    for index, line in enumerate(discovery.evidence[1:]):
-        state.add(1.0 if index == 0 else 0.0, "medium", line)
+    # The declared dependency carries the same point it carries for every other
+    # framework, and it is identified by *value* — the line is one of the
+    # discovery result's `framework_evidence` entries. Awarding it to
+    # `evidence[1]` read the point off a list position instead, in a list that
+    # is ordered for a human and gains conditional entries at the end.
+    reasons = set(discovery.framework_evidence)
+    awarded = False
+    for line in discovery.evidence[1:]:
+        dependency = not awarded and line in reasons
+        awarded = awarded or dependency
+        state.add(1.0 if dependency else 0.0, "medium" if dependency else "supporting", line)
     state.add_file(discovery.path)
 
 

--- a/src/agents_shipgate/cli/discovery/source_ids.py
+++ b/src/agents_shipgate/cli/discovery/source_ids.py
@@ -53,6 +53,7 @@ SOURCE_ID_PREFIXES: dict[str, str] = {
     "google_adk": "adk",
     "openai_agents_sdk": "openai_sdk",
     "mcp": "mcp",
+    "mcp_server_source": "mcp_src",
     "openapi": "openapi",
     "codex_plugin": "codex_plugin",
 }

--- a/src/agents_shipgate/core/semantic_assessment.py
+++ b/src/agents_shipgate/core/semantic_assessment.py
@@ -57,6 +57,7 @@ _EFFECT_VALUES = frozenset(_EFFECT_RANK)
 MCP_SOURCE_TYPES = frozenset(
     {
         "mcp",
+        "mcp_server_source",
         "codex_config_mcp",
         "codex_plugin_mcp_inventory",
         "n8n_mcp_client_tool",
@@ -71,6 +72,7 @@ MCP_SOURCE_TYPES = frozenset(
 #: type that says nothing is treated as incomplete.
 AST_ONLY_SOURCE_TYPES = frozenset(
     {
+        "mcp_server_source",
         "sdk_function",
         "langchain_function",
         "langchain_structured_tool",

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -780,8 +780,14 @@ _TS_STATIC_TOOL_NAME_RE = re.compile(
 _TS_STATIC_OPERATION_TYPE_RE = re.compile(
     rf"(?<![\w$])static\s+{_TS_MODIFIERS}operationType\s*(?::[^=;\n]*)?=\s*"
 )
+# ``(?<![\w$.])`` and not ``(?<![\w$])``: the character before ``description``
+# in ``this.description = "…"`` is a dot, which the narrower lookbehind admits,
+# so an assignment inside a method read as the class's description field — and
+# ``_first_literal_in`` returns the *first* match in the body, so it could win
+# over the real one. ``operationType`` never had the problem because its
+# pattern requires a leading ``static``.
 _TS_DESCRIPTION_RE = re.compile(
-    rf"(?<![\w$])(?:static\s+)?{_TS_MODIFIERS}description\s*(?::[^=;\n]*)?=\s*"
+    rf"(?<![\w$.])(?:static\s+)?{_TS_MODIFIERS}description\s*(?::[^=;\n]*)?=\s*"
 )
 _TS_REGISTER_TOOL_RE = re.compile(r"\.\s*(?:registerTool|tool)\s*\(\s*")
 _GO_MUST_TOOL_RE = re.compile(r"(?<![\w])MustTool\s*\(\s*")
@@ -946,14 +952,20 @@ def _ts_static_tool_name_sites(source: MaskedSource) -> list[RegistrationSite]:
                 source, _TS_STATIC_OPERATION_TYPE_RE, block
             )
             description = _first_literal_in(source, _TS_DESCRIPTION_RE, block)
-        span = block if block is not None else (match.start(), match.end())
+        # The construct, never the enclosing class body. `block` is the scope
+        # the sibling literals are looked up in; using it as the span made
+        # `_contains_another_site` read *any* registration written inside the
+        # class as "the same registration", so a class whose `toolName` is
+        # built at runtime lost its omission the moment it also called
+        # `.registerTool(` anywhere in its body — the exact silent miss this
+        # input exists to end.
         sites.append(
             RegistrationSite(
                 idiom="ts_static_tool_name",
                 name=name,
                 line=line,
                 column=column,
-                span=span,
+                span=(match.start(), max(end, match.end())),
                 description=description,
                 operation_type=operation_type,
                 unresolved_reason=unresolved,
@@ -1122,6 +1134,12 @@ def _contains_another_site(
     a literal is not a second registration; it is the outside of the one the
     nested site already reports, resolved or not. Reporting both turned
     ``NewTool(meta, mcp.Tool{Name: name})`` into two omissions for one tool.
+
+    This is sound only because every ``span`` is the *construct* that
+    registers — a call and its argument list, a composite literal, a field's
+    own statement. A span standing for a lookup *scope* would make any
+    registration written inside that scope suppress the site, which is a
+    different relationship entirely.
     """
 
     start, end = site.span

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -1,0 +1,1132 @@
+"""The built-in registry of MCP tool-registration idioms (#431).
+
+Most MCP servers never emit their tool surface. ``github/github-mcp-server``
+checks in ``__toolsnaps__/*.snap`` and is therefore readable; the official
+MongoDB and Grafana servers do not, and ``detect`` reported both as "not an
+agent project" — a first-party vendor server publishing ``drop-database`` and
+``delete-many`` with no route into the gate at all. The discriminator measured
+across three vendor walks was never the language (two of the three are Go); it
+was whether the repository happens to *emit* its tool list as a committed
+artifact, and only one of the three does.
+
+What every one of them does do is write the tool's name as a **string literal
+at a registration site**. The spelling differs per server — ``static toolName =
+"aggregate"``, ``mcpgrafana.MustTool("update_incident"``, ``mcp.Tool{Name:
+"issue_read"`` — the literal does not. This module reads that literal, and
+nothing else: no type inference, no Zod evaluation, no compilation, no
+execution. Effects and authority still come from the declaration questionnaire
+(#410), which is where they came from for an exported surface too.
+
+**Why a built-in registry and not a configurable pattern.** At ``detect`` time
+there is no manifest, so the patterns have to be built in for the activation
+case regardless. Post-adoption, a configured regex would hand the definition of
+evidence to configuration that ships in the same pull request as the tool it
+could hide — the #268 class, where an untrusted artifact gets to say what
+counts as evidence about itself. If a configured source ever needs to select
+behaviour it selects a *named idiom from this registry* (``go_must_tool``),
+never a pattern. Nothing selects one today; the constraint is recorded here so
+the first need is met the settled way.
+
+**Why an idiom and not a per-server list.** A per-server list is a support
+treadmill and proves nothing transferable. An idiom is a registration *shape*:
+the 30-server survey behind this module found five shapes covering every server
+whose tools are declared in TypeScript or Go, including all three walked
+vendors. Python's FastMCP decorator is the largest single shape in that survey
+and is deliberately absent: it is a different extraction mechanism (a real AST,
+a name that defaults to the function's, a schema that comes from the signature)
+and per #393 each mechanism needs its own adversarial probe list before it can
+claim anything.
+
+**Honest about what it proved.** Every observation records which idiom matched.
+A literal at a registration site is ``medium`` confidence — a committed export
+stays ``high`` and remains the better route wherever both exist. A name this
+reader cannot resolve to a literal is reported as *unenumerated*, never dropped:
+it becomes a typed omission that the exclusion ledger (#403) accounts for and
+that holds the whole file's surface at ``partial``.
+
+Reading is done over a **masked** copy of the source, in which comments and
+string bodies have been overwritten (see :func:`mask_source`). A registration
+site can therefore never be found inside a comment or inside another string,
+and a name is a name only when the masking pass recorded a real literal at that
+offset. Where masking cannot complete — an unterminated string or block comment
+— the file is reported partial rather than read as though the rest were code.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+#: The version of this registry's published vocabulary — the idiom ids, and the
+#: diff tokens the trigger catalog renders from them. Bumped when a consumer
+#: pinning an idiom id would have to change; adding an idiom bumps it, because
+#: the trigger catalog's token list is derived from this registry and a consumer
+#: that mirrors the list has to re-read it.
+IDIOM_REGISTRY_VERSION = "1"
+
+SourceLanguage = Literal["typescript", "go"]
+
+#: File suffixes each language's idioms are read from. TypeScript's list covers
+#: JavaScript too: the TS SDK is published as JavaScript and a server written
+#: against it in ``.mjs`` registers its tools identically.
+#:
+#: ``.tsx``/``.jsx`` are deliberately absent. JSX puts prose in code position,
+#: so an apostrophe in ``<p>don't</p>`` opens a string literal that never
+#: closes, and the masking pass would report the file unreadable. That is the
+#: fail-closed direction, which is exactly why it is unaffordable here: it
+#: would hold a whole repository's surface at ``partial`` over a contraction in
+#: a React component. No measured server registers a tool from a JSX module.
+LANGUAGE_EXTENSIONS: dict[SourceLanguage, tuple[str, ...]] = {
+    "typescript": (".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"),
+    "go": (".go",),
+}
+
+#: Declared-dependency tokens that establish an MCP framework for a language.
+#: Used by ``detect`` as the provenance gate: an idiom hit in a repository that
+#: declares no MCP dependency is a coincidence of spelling until something says
+#: otherwise, and #393's lesson is that a proof resting on a spelling is the
+#: fail-open shape. Matching is prefix-based for the scoped npm packages and
+#: substring-based for Go module paths, both case-insensitively.
+TYPESCRIPT_FRAMEWORK_PACKAGES: tuple[str, ...] = (
+    "@modelcontextprotocol/",
+    "fastmcp",
+    "mcp-framework",
+    "@mcp-ui/",
+    "xmcp",
+)
+GO_FRAMEWORK_MODULES: tuple[str, ...] = (
+    "github.com/modelcontextprotocol/go-sdk",
+    "github.com/mark3labs/mcp-go",
+    "github.com/metoro-io/mcp-golang",
+    "github.com/thinkinaixyz/go-mcp",
+    "github.com/ktr0731/go-mcp",
+)
+
+#: Directory names never walked for registration sites. Vendored dependencies
+#: and build output contain other people's registrations, and reporting them as
+#: this repository's surface is the same over-claim as reading a lockfile.
+SKIP_DIRECTORY_NAMES: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        ".next",
+        ".nuxt",
+        ".turbo",
+        ".venv",
+        "__pycache__",
+        "bin",
+        "build",
+        "coverage",
+        "dist",
+        "node_modules",
+        "obj",
+        "out",
+        "target",
+        "vendor",
+        "venv",
+    }
+)
+
+#: Path segments whose files declare tools for a test, not for the server. A
+#: test's fake tool is not the published surface, and entering one into the
+#: catalog invents a capability nobody ships. Go's ``_test.go`` suffix is
+#: enforced by the toolchain; the rest are conventions strong enough that every
+#: measured server follows them.
+TEST_DIRECTORY_NAMES: frozenset[str] = frozenset(
+    {
+        "__mocks__",
+        "__tests__",
+        "e2e",
+        "fixtures",
+        "test",
+        "test-fixtures",
+        "testdata",
+        "tests",
+    }
+)
+_TEST_FILE_SUFFIXES: tuple[str, ...] = (
+    "_test.go",
+    ".test.ts",
+    ".test.js",
+    ".test.mts",
+    ".test.mjs",
+    ".spec.ts",
+    ".spec.js",
+    ".spec.mts",
+    ".spec.mjs",
+)
+
+#: Every idiom's pattern requires these four characters, in some case, at the
+#: registration site: ``toolName``, ``.tool(``, ``.registerTool(``,
+#: ``MustTool(``, ``NewTool(``, ``Tool{``. A file that does not contain them
+#: cannot hold a registration, so :func:`scan_source` answers it without
+#: masking — which is most of the files in a server's repository.
+#:
+#: It lives *inside* :func:`scan_source` rather than at the call sites for the
+#: reason the rest of this module is built the way it is: a caller's own copy
+#: is a second, weaker matcher. The first draft put one in discovery keyed off
+#: the trigger catalog's diff tokens, and ``static toolName`` does not appear
+#: in ``public static readonly toolName: string = "…"`` — so four MongoDB
+#: tools were reported by ``scan`` and never by ``detect``.
+PREFILTER_TOKEN = "tool"
+
+#: The shape a tool name has to have to be read as one. A registration site
+#: whose literal fails this is reported unenumerated rather than entered into
+#: the catalog: ``.tool("Search the web for a query", …)`` is a call this reader
+#: matched and did not understand, and saying so is the difference between a
+#: measured miss and a silent one.
+TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+#: The largest source file this reader opens. Neither hand-written nor
+#: generated source reaches it — the largest module in the three vendor
+#: repositories is 1.4 MB — so what it bounds is a pathological input, at a
+#: masking cost of roughly 0.14 s per megabyte.
+#:
+#: Deliberately below :data:`agents_shipgate.inputs.common.MAX_INPUT_FILE_BYTES`.
+#: Above it the loader would refuse the file first and the omission would be
+#: recorded as ``unreadable_file``, naming a decoding problem for a file that
+#: was merely large.
+#:
+#: Exceeding it is recorded, never silently skipped: an unread file is a hole
+#: in the enumeration, so it holds the whole source at ``partial``.
+MAX_SOURCE_FILE_BYTES = 8 * 1024 * 1024
+
+#: Every reason token this reader can produce, with the sentence a reviewer
+#: acts on. Keyed by the token itself — the adapter writes both onto the same
+#: ``SourceSurfaceOmission``, and a detail looked up under a key the reason
+#: never uses is a second vocabulary for one event.
+#:
+#: The first two name a *site*: the reader matched a registration and could not
+#: resolve it. The last two name a *file*: past them nothing about the file is
+#: known, which is a stronger statement than "this one registration is opaque".
+OMISSION_REASONS: dict[str, str] = {
+    "name_not_literal": (
+        "The tool name at this registration site is not a string literal, so "
+        "the name this server registers is decided at runtime and cannot be "
+        "read from the source."
+    ),
+    "implausible_tool_name": (
+        "The literal at this registration site is not shaped like a tool name, "
+        "so this reader matched a call it does not understand."
+    ),
+    "unterminated_string": (
+        "A string literal is not closed, so past it this reader cannot tell "
+        "code from content and a registration there would not be seen."
+    ),
+    "unterminated_block_comment": (
+        "A block comment is not closed, so the rest of this file was read as "
+        "comment and a registration there would not be seen."
+    ),
+    "file_too_large": (
+        f"The file is larger than {MAX_SOURCE_FILE_BYTES} bytes, so it was not "
+        "read; any tool registered in it is absent from this catalog."
+    ),
+    "unreadable_file": (
+        "The file could not be decoded as UTF-8 source, so it was not read; "
+        "any tool registered in it is absent from this catalog."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class RegistrationIdiom:
+    """One named, built-in registration shape.
+
+    ``diff_tokens`` are the tokens the *trigger catalog* routes a diff on. The
+    catalog's content rule is pinned against them rather than repeating them,
+    because a route table kept beside the function that owns the routes drifts
+    in the direction nobody checks (#433).
+
+    They are deliberately **narrower** than what this module's patterns match.
+    A matched capability rule overrides the workspace stop condition (#403), so
+    a router firing on ``.tool(`` or a bare ``Tool{`` would turn "this is not
+    an agent project" into "run" for any diff containing that substring. The
+    router's job is to stop the *silent* miss, not to be the reader: a
+    registration it does not route is still read in full once the repository is
+    adopted. Both halves are checked — the catalog against this tuple, and this
+    tuple against each idiom's own positive sample.
+    """
+
+    id: str
+    label: str
+    language: SourceLanguage
+    reads: str
+    diff_tokens: tuple[str, ...]
+
+
+IDIOMS: tuple[RegistrationIdiom, ...] = (
+    RegistrationIdiom(
+        id="ts_static_tool_name",
+        label="TypeScript tool class with a static name field",
+        language="typescript",
+        reads=(
+            'A class field `static toolName = "…"`, with the sibling '
+            "`operationType` and `description` literals from the same class "
+            "body when they are present."
+        ),
+        diff_tokens=("static toolName",),
+    ),
+    RegistrationIdiom(
+        id="ts_sdk_register_tool",
+        label="TypeScript SDK call-site registration",
+        language="typescript",
+        reads=(
+            'A `.tool("…", …)` or `.registerTool("…", …)` call whose first '
+            "argument is a string literal."
+        ),
+        diff_tokens=(".registerTool(",),
+    ),
+    RegistrationIdiom(
+        id="go_must_tool",
+        label="Go MustTool call-site registration",
+        language="go",
+        reads='A `MustTool("…", …)` call whose first argument is a string literal.',
+        diff_tokens=("MustTool(",),
+    ),
+    RegistrationIdiom(
+        id="go_new_tool",
+        label="Go NewTool call-site registration",
+        language="go",
+        reads='A `NewTool("…", …)` call whose first argument is a string literal.',
+        diff_tokens=("NewTool(",),
+    ),
+    RegistrationIdiom(
+        id="go_tool_struct",
+        label="Go tool struct literal",
+        language="go",
+        reads=(
+            'A `Tool{…}` composite literal carrying a `Name: "…"` field, the '
+            "official Go SDK's declaration shape."
+        ),
+        diff_tokens=("mcp.Tool{",),
+    ),
+)
+
+IDIOMS_BY_ID: dict[str, RegistrationIdiom] = {idiom.id: idiom for idiom in IDIOMS}
+
+#: Every diff token the registry publishes, de-duplicated and ordered. One
+#: list, so the trigger catalog and this reader cannot disagree about which
+#: spellings mean "a tool was registered here".
+DIFF_TOKENS: tuple[str, ...] = tuple(
+    sorted({token for idiom in IDIOMS for token in idiom.diff_tokens})
+)
+
+
+@dataclass(frozen=True)
+class RegistrationSite:
+    """One registration this reader found, resolved or not.
+
+    ``span`` is the byte range of the construct that matched — the whole call
+    including its argument list, or the whole composite literal. Containment of
+    one span in another is what lets a wrapper call whose own first argument is
+    not a literal (``NewTool(meta, mcp.Tool{Name: "issue_read"})``) stay silent
+    instead of reporting an omission for a tool that was, in fact, named.
+    """
+
+    idiom: str
+    name: str | None
+    line: int
+    column: int
+    span: tuple[int, int]
+    description: str | None = None
+    operation_type: str | None = None
+    unresolved_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceScanResult:
+    """What one file yielded.
+
+    ``anomalies`` are masking failures — an unterminated string or block
+    comment. They are separate from an unresolved site because they are a fact
+    about the *file*, not about one registration: past the anomaly this reader
+    cannot tell code from content, so a site it did not find there proves
+    nothing.
+    """
+
+    sites: tuple[RegistrationSite, ...] = ()
+    anomalies: tuple[str, ...] = ()
+
+
+def language_for_path(path: Path | PurePosixPath | str) -> SourceLanguage | None:
+    """The language whose idioms apply to ``path``, or ``None``."""
+
+    suffix = PurePosixPath(str(path)).suffix.lower()
+    for language, extensions in LANGUAGE_EXTENSIONS.items():
+        if suffix in extensions:
+            return language
+    return None
+
+
+def is_scannable_path(relative_path: Path | PurePosixPath | str) -> bool:
+    """Whether a workspace-relative path is read for registration sites.
+
+    One predicate, used by both the adapter's walk and discovery's probe: two
+    copies would disagree about which files are the surface, and the pair that
+    disagrees is the pair where ``detect`` promises tools ``scan`` then refuses
+    to enumerate.
+    """
+
+    path = PurePosixPath(str(relative_path).replace("\\", "/"))
+    if language_for_path(path) is None:
+        return False
+    parts = path.parts
+    if any(part in SKIP_DIRECTORY_NAMES for part in parts):
+        return False
+    if any(part.lower() in TEST_DIRECTORY_NAMES for part in parts[:-1]):
+        return False
+    name = path.name.lower()
+    return not name.endswith(_TEST_FILE_SUFFIXES)
+
+
+def idioms_for_language(language: SourceLanguage) -> tuple[RegistrationIdiom, ...]:
+    return tuple(idiom for idiom in IDIOMS if idiom.language == language)
+
+
+# --- Masking -----------------------------------------------------------------
+
+#: Fill characters. Comments become spaces so a token cannot span the hole they
+#: leave; string literals become NULs so a literal's *position* stays findable
+#: (``literals`` is keyed by the opening quote's offset) while its content can
+#: never be matched as code.
+_COMMENT_FILL = " "
+_STRING_FILL = "\x00"
+
+# Characters after which a `/` opens a regular expression rather than dividing.
+# The standard lexical heuristic; getting it wrong in the other direction is
+# what matters, because a regex body read as code can contain `"` and desync
+# every string boundary after it.
+_REGEX_PRECEDING_CHARS = frozenset("(,=:[!&|?{};+-*%~^<>")
+_REGEX_PRECEDING_WORDS = frozenset(
+    {
+        "return",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "throw",
+        "case",
+        "do",
+        "else",
+        "yield",
+        "await",
+    }
+)
+
+#: The only characters that can begin a comment or a string in either language.
+#: The masking loop jumps between them instead of visiting every character:
+#: ordinary code is the overwhelming majority of any source file, and stepping
+#: through it in Python is what made the pass cost a second on a large module.
+_INTERESTING = re.compile(r"""[/'"`]""")
+
+_SIMPLE_ESCAPES = {
+    "n": "\n",
+    "t": "\t",
+    "r": "\r",
+    "b": "\b",
+    "f": "\f",
+    "v": "\v",
+    "0": "\0",
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    "`": "`",
+    "\n": "",
+}
+
+
+@dataclass(frozen=True)
+class MaskedSource:
+    """``text`` with comments and string bodies overwritten.
+
+    ``literals`` maps the offset of a string literal's opening quote to its
+    decoded value (``None`` when the literal is not a constant — a template
+    literal carrying a ``${…}`` substitution) and the offset just past its
+    closing quote. Callers ask "is there a literal here?" through
+    :meth:`literal_at`, which is the only way a name is ever read: matching a
+    quote in the raw text would accept one inside a comment, and matching one
+    in the masked text is impossible by construction.
+
+    The end offset is recorded rather than recovered by scanning the fill
+    characters, because masking preserves newlines: the fill run of a
+    multi-line template literal stops at its first line break, and the caller
+    that asks what follows the literal would be looking inside it.
+    """
+
+    text: str
+    masked: str
+    literals: dict[int, tuple[str | None, int]]
+    anomalies: tuple[str, ...]
+
+    def skip_space(self, index: int) -> int:
+        """The next index at or after ``index`` that is not whitespace."""
+
+        length = len(self.masked)
+        while index < length and self.masked[index].isspace():
+            index += 1
+        return index
+
+    def literal_at(self, index: int) -> tuple[bool, str | None, int]:
+        """Resolve a string literal starting at ``index`` (whitespace skipped).
+
+        Returns ``(found, value, end)``. ``found`` is False when no literal
+        starts there at all; ``value`` is ``None`` for a literal whose content
+        is not constant. ``end`` is the index just past the literal, or the
+        whitespace-skipped index when nothing was found.
+        """
+
+        start = self.skip_space(index)
+        record = self.literals.get(start)
+        if record is None:
+            return False, None, start
+        value, end = record
+        return True, value, end
+
+    def line_column(self, index: int) -> tuple[int, int]:
+        """1-based line and column of ``index``."""
+
+        prefix = self.text[:index]
+        line = prefix.count("\n") + 1
+        column = index - (prefix.rfind("\n") + 1) + 1
+        return line, column
+
+
+def mask_source(text: str, language: SourceLanguage) -> MaskedSource:
+    """Overwrite comments and string bodies, recording every string literal."""
+
+    if language == "go":
+        return _mask_go(text)
+    return _mask_typescript(text)
+
+
+def _decode_escapes(body: str) -> str:
+    if "\\" not in body:
+        return body
+    out: list[str] = []
+    index = 0
+    length = len(body)
+    while index < length:
+        char = body[index]
+        if char != "\\" or index + 1 >= length:
+            out.append(char)
+            index += 1
+            continue
+        marker = body[index + 1]
+        if marker == "u" and index + 2 < length and body[index + 2] == "{":
+            close = body.find("}", index + 3)
+            if close != -1:
+                try:
+                    out.append(chr(int(body[index + 3 : close], 16)))
+                except ValueError:
+                    out.append(body[index + 3 : close])
+                index = close + 1
+                continue
+        if marker in {"u", "x"}:
+            width = 4 if marker == "u" else 2
+            digits = body[index + 2 : index + 2 + width]
+            if len(digits) == width:
+                try:
+                    out.append(chr(int(digits, 16)))
+                    index += 2 + width
+                    continue
+                except ValueError:
+                    pass
+        out.append(_SIMPLE_ESCAPES.get(marker, marker))
+        index += 2
+    return "".join(out)
+
+
+class _Masker:
+    """Shared bookkeeping for the two language maskers."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.out: list[str] = list(text)
+        self.literals: dict[int, tuple[str | None, int]] = {}
+        self.anomalies: list[str] = []
+
+    def blank(self, start: int, end: int, fill: str) -> None:
+        end = min(end, len(self.out))
+        if end <= start:
+            return
+        segment = self.text[start:end]
+        # Newlines survive so line numbers stay the file's own. Slice
+        # assignment rather than a per-character loop: a masking pass that
+        # walked a 1.4 MB generated module one character at a time cost more
+        # than a second on a file that registers nothing.
+        if "\n" in segment:
+            self.out[start:end] = [
+                "\n" if char == "\n" else fill for char in segment
+            ]
+        else:
+            self.out[start:end] = fill * (end - start)
+
+    def record(self, start: int, end: int, value: str | None) -> None:
+        self.blank(start, end, _STRING_FILL)
+        self.literals[start] = (value, end)
+
+    def result(self) -> MaskedSource:
+        return MaskedSource(
+            text=self.text,
+            masked="".join(self.out),
+            literals=self.literals,
+            anomalies=tuple(self.anomalies),
+        )
+
+
+def _previous_significant(masked: list[str], index: int) -> str:
+    while index >= 0 and masked[index].isspace():
+        index -= 1
+    return masked[index] if index >= 0 else ""
+
+
+def _preceding_word(text: str, index: int) -> str:
+    while index >= 0 and text[index].isspace():
+        index -= 1
+    end = index + 1
+    while index >= 0 and (text[index].isalnum() or text[index] in "_$"):
+        index -= 1
+    return text[index + 1 : end]
+
+
+def _mask_typescript(text: str) -> MaskedSource:
+    masker = _Masker(text)
+    index = 0
+    length = len(text)
+    while index < length:
+        found = _INTERESTING.search(text, index)
+        if found is None:
+            break
+        index = found.start()
+        char = text[index]
+        if char == "/" and index + 1 < length and text[index + 1] == "/":
+            end = text.find("\n", index)
+            end = length if end == -1 else end
+            masker.blank(index, end, _COMMENT_FILL)
+            index = end
+            continue
+        if char == "/" and index + 1 < length and text[index + 1] == "*":
+            end = text.find("*/", index + 2)
+            if end == -1:
+                masker.blank(index, length, _COMMENT_FILL)
+                masker.anomalies.append("unterminated_block_comment")
+                break
+            masker.blank(index, end + 2, _COMMENT_FILL)
+            index = end + 2
+            continue
+        if char in {"'", '"'}:
+            index = _consume_quoted(masker, index, char, allow_newline=False)
+            continue
+        if char == "`":
+            index = _consume_template(masker, index)
+            continue
+        if char == "/" and _opens_regex(masker.out, text, index):
+            index = _consume_regex(masker, index)
+            continue
+        index += 1
+    return masker.result()
+
+
+def _opens_regex(out: list[str], text: str, index: int) -> bool:
+    previous = _previous_significant(out, index - 1)
+    if previous == "" or previous in _REGEX_PRECEDING_CHARS:
+        return True
+    if previous.isalnum() or previous in "_$":
+        return _preceding_word(text, index - 1) in _REGEX_PRECEDING_WORDS
+    return False
+
+
+def _consume_quoted(
+    masker: _Masker, start: int, quote: str, *, allow_newline: bool
+) -> int:
+    text = masker.text
+    length = len(text)
+    index = start + 1
+    while index < length:
+        char = text[index]
+        if char == "\\":
+            index += 2
+            continue
+        if char == quote:
+            masker.record(start, index + 1, _decode_escapes(text[start + 1 : index]))
+            return index + 1
+        if char == "\n" and not allow_newline:
+            break
+        index += 1
+    # Unterminated. Blank to the resync point but record no literal, and say so:
+    # past here this reader cannot tell code from content.
+    end = text.find("\n", start)
+    end = length if end == -1 or allow_newline else end
+    masker.blank(start, end, _STRING_FILL)
+    masker.anomalies.append("unterminated_string")
+    return max(end, start + 1)
+
+
+def _consume_template(masker: _Masker, start: int) -> int:
+    """Consume a backtick template literal, tracking ``${…}`` substitutions."""
+
+    text = masker.text
+    length = len(text)
+    index = start + 1
+    substituted = False
+    depth = 0
+    while index < length:
+        char = text[index]
+        if char == "\\":
+            index += 2
+            continue
+        if depth == 0 and char == "$" and index + 1 < length and text[index + 1] == "{":
+            substituted = True
+            depth = 1
+            index += 2
+            continue
+        if depth > 0:
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            index += 1
+            continue
+        if char == "`":
+            body = text[start + 1 : index]
+            masker.record(start, index + 1, None if substituted else _decode_escapes(body))
+            return index + 1
+        index += 1
+    masker.blank(start, length, _STRING_FILL)
+    masker.anomalies.append("unterminated_string")
+    return length
+
+
+def _consume_regex(masker: _Masker, start: int) -> int:
+    text = masker.text
+    length = len(text)
+    index = start + 1
+    in_class = False
+    while index < length:
+        char = text[index]
+        if char == "\\":
+            index += 2
+            continue
+        if char == "\n":
+            # Not a regex after all — a lone `/` on a line. Leave it as code.
+            return start + 1
+        if char == "[":
+            in_class = True
+        elif char == "]":
+            in_class = False
+        elif char == "/" and not in_class:
+            masker.blank(start, index + 1, _COMMENT_FILL)
+            return index + 1
+        index += 1
+    return start + 1
+
+
+def _mask_go(text: str) -> MaskedSource:
+    masker = _Masker(text)
+    index = 0
+    length = len(text)
+    while index < length:
+        found = _INTERESTING.search(text, index)
+        if found is None:
+            break
+        index = found.start()
+        char = text[index]
+        if char == "/" and index + 1 < length and text[index + 1] == "/":
+            end = text.find("\n", index)
+            end = length if end == -1 else end
+            masker.blank(index, end, _COMMENT_FILL)
+            index = end
+            continue
+        if char == "/" and index + 1 < length and text[index + 1] == "*":
+            end = text.find("*/", index + 2)
+            if end == -1:
+                masker.blank(index, length, _COMMENT_FILL)
+                masker.anomalies.append("unterminated_block_comment")
+                break
+            masker.blank(index, end + 2, _COMMENT_FILL)
+            index = end + 2
+            continue
+        if char == '"':
+            index = _consume_quoted(masker, index, '"', allow_newline=False)
+            continue
+        if char == "'":
+            index = _consume_quoted(masker, index, "'", allow_newline=False)
+            continue
+        if char == "`":
+            end = text.find("`", index + 1)
+            if end == -1:
+                masker.blank(index, length, _STRING_FILL)
+                masker.anomalies.append("unterminated_string")
+                break
+            masker.record(index, end + 1, text[index + 1 : end])
+            index = end + 1
+            continue
+        index += 1
+    return masker.result()
+
+
+# --- Idiom matchers ----------------------------------------------------------
+
+_TS_MODIFIERS = r"(?:(?:public|private|protected|readonly|override|declare|abstract)\s+)*"
+_TS_STATIC_TOOL_NAME_RE = re.compile(
+    rf"(?<![\w$])static\s+{_TS_MODIFIERS}toolName\s*(?::[^=;\n]*)?=\s*"
+)
+_TS_STATIC_OPERATION_TYPE_RE = re.compile(
+    rf"(?<![\w$])static\s+{_TS_MODIFIERS}operationType\s*(?::[^=;\n]*)?=\s*"
+)
+_TS_DESCRIPTION_RE = re.compile(
+    rf"(?<![\w$])(?:static\s+)?{_TS_MODIFIERS}description\s*(?::[^=;\n]*)?=\s*"
+)
+_TS_REGISTER_TOOL_RE = re.compile(r"\.\s*(?:registerTool|tool)\s*\(\s*")
+_GO_MUST_TOOL_RE = re.compile(r"(?<![\w])MustTool\s*\(\s*")
+_GO_NEW_TOOL_RE = re.compile(r"(?<![\w])NewTool\s*\(\s*")
+_GO_TOOL_STRUCT_RE = re.compile(r"(?<![\w])Tool\s*\{")
+_GO_STRUCT_NAME_FIELD_RE = re.compile(r"(?<![\w])Name\s*:\s*")
+
+
+def _matching_close(masked: str, open_index: int, opener: str, closer: str) -> int | None:
+    """Index just past the ``closer`` matching the ``opener`` at ``open_index``."""
+
+    depth = 0
+    for index in range(open_index, len(masked)):
+        char = masked[index]
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return None
+
+
+def _brace_pairs(masked: str) -> list[tuple[int, int]]:
+    """Every matched ``{…}`` span, innermost-first for a given opener."""
+
+    stack: list[int] = []
+    pairs: list[tuple[int, int]] = []
+    for match in re.finditer(r"[{}]", masked):
+        if match.group() == "{":
+            stack.append(match.start())
+        elif stack:
+            pairs.append((stack.pop(), match.start() + 1))
+    return pairs
+
+
+def _enclosing_block(pairs: list[tuple[int, int]], index: int) -> tuple[int, int] | None:
+    """The innermost ``{…}`` containing ``index``, as ``(open, close_exclusive)``.
+
+    Takes the file's brace spans rather than re-deriving them, because the
+    caller has one site per tool class and re-scanning the whole module for
+    each of them is quadratic in a file that declares many.
+    """
+
+    best: tuple[int, int] | None = None
+    for start, end in pairs:
+        if start <= index < end and (best is None or start > best[0]):
+            best = (start, end)
+    return best
+
+
+def _resolve_name(value: str | None, found: bool) -> tuple[str | None, str | None]:
+    if not found or value is None:
+        return None, "name_not_literal"
+    if not TOOL_NAME_RE.match(value):
+        return None, "implausible_tool_name"
+    return value, None
+
+
+def _literal_is_whole_value(
+    source: MaskedSource, end: int, terminators: str
+) -> bool:
+    """Whether the literal ending at ``end`` is the entire value, not part of one.
+
+    ``static toolName = "backup" + SUFFIX`` resolves to a literal this reader
+    can see, and reading it as the tool name would publish ``backup`` for a
+    tool the server registers under some other name — a fail-open of exactly
+    the shape #393 catalogues, where the proof rests on a spelling. The literal
+    counts only when the expression ends there: at one of ``terminators``, at
+    the end of input, or at a line break (JavaScript inserts the semicolon).
+    """
+
+    index = end
+    length = len(source.masked)
+    while index < length and source.masked[index] in " \t\r":
+        index += 1
+    if index >= length:
+        return True
+    return source.masked[index] in terminators or source.masked[index] == "\n"
+
+
+def _call_sites(
+    source: MaskedSource, pattern: re.Pattern[str], idiom: str
+) -> list[RegistrationSite]:
+    """Sites for a ``Name(<literal>, …)`` idiom."""
+
+    sites: list[RegistrationSite] = []
+    for match in pattern.finditer(source.masked):
+        open_paren = source.masked.rfind("(", match.start(), match.end())
+        if open_paren == -1:
+            continue
+        close = _matching_close(source.masked, open_paren, "(", ")")
+        span = (match.start(), close if close is not None else match.end())
+        found, value, end = source.literal_at(match.end())
+        name, unresolved = _resolve_name(value, found)
+        if name is not None:
+            # A registration passes the name *and* what to do with it, so the
+            # first argument is followed by a comma. Three other things can
+            # follow, and they are three different answers:
+            #   `)`  — a one-argument call. `map.tool("issues")` is a lookup,
+            #          not a registration, and reading it as one is how an
+            #          accessor becomes a phantom tool.
+            #   `+`  — the literal is part of a computed name, so the name is
+            #          not this literal. Unresolved, not resolved-wrongly.
+            #   else — same as `+`.
+            after = source.skip_space(end)
+            following = source.masked[after] if after < len(source.masked) else ""
+            if following == ")":
+                continue
+            if following != ",":
+                name, unresolved = None, "name_not_literal"
+        if name is None and (
+            close is None or not _has_second_argument(source.masked, open_paren, close)
+        ):
+            # An unresolved site needs the same second argument before it is
+            # reported: it is what keeps `map.tool(key)` out of the exclusion
+            # ledger.
+            continue
+        line, column = source.line_column(match.start())
+        sites.append(
+            RegistrationSite(
+                idiom=idiom,
+                name=name,
+                line=line,
+                column=column,
+                span=span,
+                unresolved_reason=unresolved,
+            )
+        )
+    return sites
+
+
+def _has_second_argument(masked: str, open_paren: int, close: int) -> bool:
+    """Whether the call at ``open_paren`` passes more than one argument."""
+
+    depth = 0
+    for index in range(open_paren, close):
+        char = masked[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "," and depth == 1:
+            return True
+    return False
+
+
+def _ts_static_tool_name_sites(source: MaskedSource) -> list[RegistrationSite]:
+    sites: list[RegistrationSite] = []
+    pairs = _brace_pairs(source.masked)
+    for match in _TS_STATIC_TOOL_NAME_RE.finditer(source.masked):
+        found, value, end = source.literal_at(match.end())
+        name, unresolved = _resolve_name(value, found)
+        if name is not None and not _literal_is_whole_value(source, end, ";}"):
+            name, unresolved = None, "name_not_literal"
+        line, column = source.line_column(match.start())
+        block = _enclosing_block(pairs, match.start())
+        operation_type: str | None = None
+        description: str | None = None
+        if block is not None and name is not None:
+            operation_type = _first_literal_in(
+                source, _TS_STATIC_OPERATION_TYPE_RE, block
+            )
+            description = _first_literal_in(source, _TS_DESCRIPTION_RE, block)
+        span = block if block is not None else (match.start(), match.end())
+        sites.append(
+            RegistrationSite(
+                idiom="ts_static_tool_name",
+                name=name,
+                line=line,
+                column=column,
+                span=span,
+                description=description,
+                operation_type=operation_type,
+                unresolved_reason=unresolved,
+            )
+        )
+    return sites
+
+
+def _first_literal_in(
+    source: MaskedSource, pattern: re.Pattern[str], block: tuple[int, int]
+) -> str | None:
+    start, end = block
+    for match in pattern.finditer(source.masked, start, end):
+        found, value, literal_end = source.literal_at(match.end())
+        if found and value and _literal_is_whole_value(source, literal_end, ";}"):
+            return value
+    return None
+
+
+def _go_tool_struct_sites(source: MaskedSource) -> list[RegistrationSite]:
+    sites: list[RegistrationSite] = []
+    for match in _GO_TOOL_STRUCT_RE.finditer(source.masked):
+        open_brace = source.masked.index("{", match.start())
+        close = _matching_close(source.masked, open_brace, "{", "}")
+        if close is None:
+            continue
+        if _has_keyed_field(source.masked, open_brace, close):
+            sites.extend(
+                _go_tool_struct_site(source, match.start(), open_brace, close)
+            )
+            continue
+        # No keyed field at this literal's own level, so it is a composite of
+        # elements — `[]mcp.Tool{{Name: "a"}, {Name: "b"}}`. Reading only the
+        # outer brace would find the first element's `Name:` two levels down,
+        # reject it as a nested field, and report nothing at all: a silent miss
+        # of exactly the kind this input exists to close.
+        for child_open, child_close in _child_braces(source.masked, open_brace, close):
+            sites.extend(
+                _go_tool_struct_site(source, child_open, child_open, child_close)
+            )
+    return sites
+
+
+def _go_tool_struct_site(
+    source: MaskedSource, start: int, open_brace: int, close: int
+) -> list[RegistrationSite]:
+    field = _GO_STRUCT_NAME_FIELD_RE.search(source.masked, open_brace + 1, close)
+    # Only the literal's own `Name:` field, never one belonging to something
+    # nested inside it: `mcp.Tool{Annotations: &mcp.ToolAnnotations{Name: …}}`
+    # names the annotation, not the tool.
+    while field is not None and _brace_depth(source.masked, open_brace, field.start()) != 1:
+        field = _GO_STRUCT_NAME_FIELD_RE.search(source.masked, field.end(), close)
+    if field is None:
+        return []
+    found, value, literal_end = source.literal_at(field.end())
+    name, unresolved = _resolve_name(value, found)
+    if name is not None and not _literal_is_whole_value(source, literal_end, ",}"):
+        name, unresolved = None, "name_not_literal"
+    line, column = source.line_column(start)
+    return [
+        RegistrationSite(
+            idiom="go_tool_struct",
+            name=name,
+            line=line,
+            column=column,
+            span=(start, close),
+            description=_go_struct_description(source, open_brace, close),
+            unresolved_reason=unresolved,
+        )
+    ]
+
+
+_GO_KEYED_FIELD_RE = re.compile(r"(?<![\w])[A-Za-z_]\w*\s*:")
+
+
+def _has_keyed_field(masked: str, open_brace: int, close: int) -> bool:
+    """Whether the literal names fields at its own level (a struct, not a list)."""
+
+    for match in _GO_KEYED_FIELD_RE.finditer(masked, open_brace + 1, close):
+        if _brace_depth(masked, open_brace, match.start()) == 1:
+            return True
+    return False
+
+
+def _child_braces(masked: str, open_brace: int, close: int) -> list[tuple[int, int]]:
+    children: list[tuple[int, int]] = []
+    index = open_brace + 1
+    while index < close - 1:
+        if masked[index] == "{":
+            child_close = _matching_close(masked, index, "{", "}")
+            if child_close is None or child_close > close:
+                break
+            children.append((index, child_close))
+            index = child_close
+            continue
+        index += 1
+    return children
+
+
+_GO_STRUCT_DESCRIPTION_FIELD_RE = re.compile(r"(?<![\w])Description\s*:\s*")
+
+
+def _go_struct_description(
+    source: MaskedSource, open_brace: int, close: int
+) -> str | None:
+    for match in _GO_STRUCT_DESCRIPTION_FIELD_RE.finditer(
+        source.masked, open_brace + 1, close
+    ):
+        if _brace_depth(source.masked, open_brace, match.start()) != 1:
+            continue
+        found, value, literal_end = source.literal_at(match.end())
+        if found and value and _literal_is_whole_value(source, literal_end, ",}"):
+            return value
+    return None
+
+
+def _brace_depth(masked: str, open_brace: int, index: int) -> int:
+    depth = 0
+    for position in range(open_brace, index):
+        char = masked[position]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+    return depth
+
+
+def scan_source(text: str, language: SourceLanguage) -> SourceScanResult:
+    """Find every registration site in one file.
+
+    An unresolved site is dropped when a resolved one sits inside it. The
+    wrapper shape is real and common — ``NewTool(metadata, mcp.Tool{Name:
+    "issue_read"}, …)`` in ``github/github-mcp-server`` is 132 of them — and
+    reporting the wrapper's non-literal first argument as an unenumerated tool
+    would fill the exclusion ledger with omissions for tools the very same call
+    names one argument later.
+    """
+
+    if PREFILTER_TOKEN not in text.lower():
+        return SourceScanResult()
+    source = mask_source(text, language)
+    sites: list[RegistrationSite] = []
+    if language == "typescript":
+        sites.extend(_ts_static_tool_name_sites(source))
+        sites.extend(_call_sites(source, _TS_REGISTER_TOOL_RE, "ts_sdk_register_tool"))
+    else:
+        sites.extend(_call_sites(source, _GO_MUST_TOOL_RE, "go_must_tool"))
+        sites.extend(_call_sites(source, _GO_NEW_TOOL_RE, "go_new_tool"))
+        sites.extend(_go_tool_struct_sites(source))
+
+    kept = [
+        site
+        for site in sites
+        if site.name is not None or not _contains_another_site(site, sites)
+    ]
+    kept.sort(key=lambda site: (site.line, site.column, site.idiom))
+    return SourceScanResult(sites=tuple(kept), anomalies=source.anomalies)
+
+
+def _contains_another_site(
+    site: RegistrationSite, sites: list[RegistrationSite]
+) -> bool:
+    """Whether a nested site describes the same registration as ``site``.
+
+    Only unresolved sites are tested. A wrapper whose own first argument is not
+    a literal is not a second registration; it is the outside of the one the
+    nested site already reports, resolved or not. Reporting both turned
+    ``NewTool(meta, mcp.Tool{Name: name})`` into two omissions for one tool.
+    """
+
+    start, end = site.span
+    return any(
+        start < other.span[0] and other.span[1] <= end
+        for other in sites
+        if other is not site
+    )

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -400,6 +400,12 @@ _STRING_FILL = "\x00"
 # what matters, because a regex body read as code can contain `"` and desync
 # every string boundary after it.
 _REGEX_PRECEDING_CHARS = frozenset("(,=:[!&|?{};+-*%~^<>")
+#: Keywords whose parenthesised condition can be followed directly by a regex
+#: that begins the statement's body. `)` alone cannot decide: `foo(a) / 2`
+#: divides and `if (a) /re/.test(b)` does not.
+_REGEX_PRECEDING_STATEMENTS = frozenset(
+    {"if", "for", "while", "switch", "catch", "with"}
+)
 _REGEX_PRECEDING_WORDS = frozenset(
     {
         "return",
@@ -425,20 +431,25 @@ _REGEX_PRECEDING_WORDS = frozenset(
 #: through it in Python is what made the pass cost a second on a large module.
 _INTERESTING = re.compile(r"""[/'"`]""")
 
-_SIMPLE_ESCAPES = {
+#: Escapes both languages spell the same way and mean the same thing.
+_SHARED_ESCAPES = {
     "n": "\n",
     "t": "\t",
     "r": "\r",
     "b": "\b",
     "f": "\f",
     "v": "\v",
-    "0": "\0",
     "\\": "\\",
     "'": "'",
     '"': '"',
-    "`": "`",
-    "\n": "",
 }
+#: JavaScript adds a backtick, ``\0`` for NUL, and a line continuation.
+_TYPESCRIPT_ESCAPES = {**_SHARED_ESCAPES, "`": "`", "\n": ""}
+#: Go adds the bell and has no line continuation and no bare ``\0``.
+_GO_ESCAPES = {**_SHARED_ESCAPES, "a": "\a"}
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+_OCTAL_DIGITS = frozenset("01234567")
 
 
 @dataclass(frozen=True)
@@ -505,48 +516,141 @@ def mask_source(text: str, language: SourceLanguage) -> MaskedSource:
     return _mask_typescript(text)
 
 
-def _decode_escapes(body: str) -> str:
+def decode_literal(body: str, language: SourceLanguage) -> str | None:
+    """The literal's value, or ``None`` when it cannot be decoded exactly.
+
+    Escape grammars are per language, and one decoder shared between them is a
+    silent mistranslation rather than a parse error. Go writes an octal escape
+    as three digits — ``mcp.MustTool("delete\\137all", …)`` registers
+    ``delete_all`` — and a JavaScript-shaped decoder read the ``1`` as an
+    unknown escape and produced ``delete137all``: the real action absent from
+    the catalog, and an action id nobody serves in its place.
+
+    So each language gets its own grammar, and **anything either grammar does
+    not define is refused**. A refusal returns ``None``, which reaches
+    :func:`_resolve_name` as ``name_not_literal`` — the tool becomes a recorded
+    omission instead of a guessed name. Guessing is the one outcome a reader of
+    a *name* cannot afford.
+    """
+
     if "\\" not in body:
         return body
+    if language == "go":
+        return _decode_go(body)
+    return _decode_typescript(body)
+
+
+def _hex_value(body: str, start: int, width: int) -> int | None:
+    digits = body[start : start + width]
+    if len(digits) != width or any(char not in _HEX_DIGITS for char in digits):
+        return None
+    return int(digits, 16)
+
+
+def _decode_typescript(body: str) -> str | None:
     out: list[str] = []
     index = 0
     length = len(body)
     while index < length:
         char = body[index]
-        if char != "\\" or index + 1 >= length:
+        if char != "\\":
             out.append(char)
             index += 1
             continue
+        if index + 1 >= length:
+            return None
         marker = body[index + 1]
-        if marker == "u" and index + 2 < length and body[index + 2] == "{":
-            close = body.find("}", index + 3)
-            if close != -1:
-                try:
-                    out.append(chr(int(body[index + 3 : close], 16)))
-                except ValueError:
-                    out.append(body[index + 3 : close])
+        if marker in _TYPESCRIPT_ESCAPES:
+            out.append(_TYPESCRIPT_ESCAPES[marker])
+            index += 2
+            continue
+        if marker == "0" and (index + 2 >= length or body[index + 2] not in "0123456789"):
+            out.append("\0")
+            index += 2
+            continue
+        if marker == "x":
+            value = _hex_value(body, index + 2, 2)
+            if value is None:
+                return None
+            out.append(chr(value))
+            index += 4
+            continue
+        if marker == "u":
+            if index + 2 < length and body[index + 2] == "{":
+                close = body.find("}", index + 3)
+                digits = body[index + 3 : close] if close != -1 else ""
+                if not digits or any(char not in _HEX_DIGITS for char in digits):
+                    return None
+                point = int(digits, 16)
+                if point > 0x10FFFF:
+                    return None
+                out.append(chr(point))
                 index = close + 1
                 continue
-        if marker in {"u", "x"}:
-            width = 4 if marker == "u" else 2
-            digits = body[index + 2 : index + 2 + width]
-            if len(digits) == width:
-                try:
-                    out.append(chr(int(digits, 16)))
-                    index += 2 + width
-                    continue
-                except ValueError:
-                    pass
-        out.append(_SIMPLE_ESCAPES.get(marker, marker))
+            value = _hex_value(body, index + 2, 4)
+            if value is None:
+                return None
+            out.append(chr(value))
+            index += 6
+            continue
+        if marker.isdigit():
+            # Legacy octal (`\1`-`\7`) is a syntax error under `use strict`
+            # and in a template literal, and octal *elsewhere*; `\8`/`\9` are
+            # their own special case. Which one a file means depends on a mode
+            # this reader does not track, so it refuses rather than pick.
+            return None
+        out.append(marker)
         index += 2
+    return "".join(out)
+
+
+def _decode_go(body: str) -> str | None:
+    out: list[str] = []
+    index = 0
+    length = len(body)
+    while index < length:
+        char = body[index]
+        if char != "\\":
+            out.append(char)
+            index += 1
+            continue
+        if index + 1 >= length:
+            return None
+        marker = body[index + 1]
+        if marker in _GO_ESCAPES:
+            out.append(_GO_ESCAPES[marker])
+            index += 2
+            continue
+        if marker in _OCTAL_DIGITS:
+            digits = body[index + 1 : index + 4]
+            if len(digits) != 3 or any(char not in _OCTAL_DIGITS for char in digits):
+                return None
+            value = int(digits, 8)
+            if value > 255:
+                return None
+            out.append(chr(value))
+            index += 4
+            continue
+        widths = {"x": 2, "u": 4, "U": 8}
+        if marker in widths:
+            value = _hex_value(body, index + 2, widths[marker])
+            if value is None or value > 0x10FFFF:
+                return None
+            out.append(chr(value))
+            index += 2 + widths[marker]
+            continue
+        # Every other escape is a Go compile error, so the file this reader is
+        # looking at is not the file that built the server.
+        return None
     return "".join(out)
 
 
 class _Masker:
     """Shared bookkeeping for the two language maskers."""
 
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, language: SourceLanguage) -> None:
         self.text = text
+        self.language = language
         self.out: list[str] = list(text)
         self.literals: dict[int, tuple[str | None, int]] = {}
         self.anomalies: list[str] = []
@@ -580,10 +684,12 @@ class _Masker:
         )
 
 
-def _previous_significant(masked: list[str], index: int) -> str:
+def _previous_significant(masked: list[str], index: int) -> tuple[str, int]:
+    """The last non-whitespace character at or before ``index``, and where."""
+
     while index >= 0 and masked[index].isspace():
         index -= 1
-    return masked[index] if index >= 0 else ""
+    return (masked[index], index) if index >= 0 else ("", -1)
 
 
 def _preceding_word(text: str, index: int) -> str:
@@ -596,7 +702,7 @@ def _preceding_word(text: str, index: int) -> str:
 
 
 def _mask_typescript(text: str) -> MaskedSource:
-    masker = _Masker(text)
+    masker = _Masker(text, "typescript")
     index = 0
     length = len(text)
     while index < length:
@@ -634,12 +740,41 @@ def _mask_typescript(text: str) -> MaskedSource:
 
 
 def _opens_regex(out: list[str], text: str, index: int) -> bool:
-    previous = _previous_significant(out, index - 1)
+    previous, previous_index = _previous_significant(out, index - 1)
     if previous == "" or previous in _REGEX_PRECEDING_CHARS:
         return True
+    if previous == ")":
+        # A `)` is usually the end of a call or a parenthesised expression, and
+        # `foo(a) / 2` divides. But it is also the end of a control statement's
+        # condition, and there a regex validly *begins the body*:
+        # `if (ok) /\.registerTool("fake", handler)/.test(value);` is
+        # JavaScript, and reading its `/` as division scanned the pattern as
+        # code and reported a `fake` tool — a registration invented out of a
+        # regex body, which is the one thing this module's masking exists to
+        # make impossible. Which of the two it is, is decided by the keyword in
+        # front of the matching `(`.
+        opener = _matching_open(out, previous_index)
+        if opener is None:
+            return False
+        return _preceding_word(text, opener - 1) in _REGEX_PRECEDING_STATEMENTS
     if previous.isalnum() or previous in "_$":
         return _preceding_word(text, index - 1) in _REGEX_PRECEDING_WORDS
     return False
+
+
+def _matching_open(out: list[str], close_index: int) -> int | None:
+    """Index of the ``(`` matching the ``)`` at ``close_index``."""
+
+    depth = 0
+    for index in range(close_index, -1, -1):
+        char = out[index]
+        if char == ")":
+            depth += 1
+        elif char == "(":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
 
 
 def _consume_quoted(
@@ -654,7 +789,9 @@ def _consume_quoted(
             index += 2
             continue
         if char == quote:
-            masker.record(start, index + 1, _decode_escapes(text[start + 1 : index]))
+            masker.record(
+                start, index + 1, decode_literal(text[start + 1 : index], masker.language)
+            )
             return index + 1
         if char == "\n" and not allow_newline:
             break
@@ -695,7 +832,11 @@ def _consume_template(masker: _Masker, start: int) -> int:
             continue
         if char == "`":
             body = text[start + 1 : index]
-            masker.record(start, index + 1, None if substituted else _decode_escapes(body))
+            masker.record(
+                start,
+                index + 1,
+                None if substituted else decode_literal(body, masker.language),
+            )
             return index + 1
         index += 1
     masker.blank(start, length, _STRING_FILL)
@@ -728,7 +869,7 @@ def _consume_regex(masker: _Masker, start: int) -> int:
 
 
 def _mask_go(text: str) -> MaskedSource:
-    masker = _Masker(text)
+    masker = _Masker(text, "go")
     index = 0
     length = len(text)
     while index < length:

--- a/src/agents_shipgate/inputs/mcp_server_source.py
+++ b/src/agents_shipgate/inputs/mcp_server_source.py
@@ -164,7 +164,7 @@ def load_mcp_server_source(source: ToolSourceConfig, base_dir: Path) -> LoadedTo
     for path in files:
         language = language_for_path(path)
         assert language is not None  # guaranteed by _scannable_files
-        relative = _relative_source_path(path, root, source.path, base_dir)
+        relative = _relative_source_path(path, source.path, base_dir)
         unread = _unread_reason(path)
         if unread is None:
             try:
@@ -347,16 +347,18 @@ def _scannable_files(root: Path) -> tuple[list[Path], bool]:
     return candidates[:MAX_SCANNED_FILES], len(candidates) > MAX_SCANNED_FILES
 
 
-def _relative_source_path(
-    path: Path, root: Path, configured: str, base_dir: Path
-) -> str:
+def _relative_source_path(path: Path, configured: str, base_dir: Path) -> str:
     """The manifest-relative path of the file a tool was read from.
 
     Not the configured ``path``: that is a directory for every real server, and
     a finding pointing at a directory sends a reviewer to look for a
-    registration in 300 files. ``resolve_input_path`` already refused anything
-    outside the manifest directory, so the relative form always exists — the
-    fallback is for the single-file case, where ``root`` *is* the file.
+    registration in 300 files.
+
+    ``resolve_input_path`` already refuses a source path outside the manifest
+    directory, so the relative form exists for every file this walk reaches.
+    The fallback covers the case that refusal cannot: a path that escapes
+    through a symlink after resolution, where naming the configured source is
+    better than raising in the middle of a catalog.
     """
 
     try:

--- a/src/agents_shipgate/inputs/mcp_server_source.py
+++ b/src/agents_shipgate/inputs/mcp_server_source.py
@@ -1,0 +1,436 @@
+"""Read an MCP server's tool surface out of its own source (#431).
+
+The route for a repository that *is* an MCP server and never emits its tool
+list. ``tool_sources[].path`` points at the directory (or the single file) that
+holds the registrations; this input walks it, applies the built-in idiom
+registry in :mod:`agents_shipgate.inputs.mcp_idioms`, and contributes one
+action per tool name written as a literal at a registration site.
+
+What it does **not** do is as much of the design as what it does. It runs no
+code, evaluates no schema library, infers no type, and reads no annotation the
+source declares about itself — the #268 lesson is that an artifact must never
+get to say what counts as evidence about itself, and a tool server's own source
+is exactly such an artifact. Effect and authority still come from the
+declaration questionnaire (#410). The one thing the source is trusted to state
+is a name, which is checkable against the registration site that carries it.
+
+Where a repository publishes a committed export, that export stays the better
+route: it is the server's own contract, it carries the input schemas this input
+deliberately does not read, and it is ``high`` confidence against this input's
+``medium``. ``detect`` therefore withholds this route wherever an export
+already covers the scope, and an adopter with both configured keeps the
+export's evidence untouched.
+
+**Completeness is per file**, following #393: one unresolved registration holds
+every tool that file produced at ``partial``, and its siblings elsewhere in the
+tree stay ``enumerated``. A name this reader cannot resolve is never dropped —
+it becomes a :class:`~agents_shipgate.core.domain.SourceSurfaceOmission` that
+the exclusion ledger accounts for by subject.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar, Literal
+
+from agents_shipgate.core.domain import (
+    SURFACE_ENUMERATED,
+    SURFACE_PARTIAL,
+    LoadedToolSource,
+    SourceSurfaceOmission,
+    Tool,
+    ToolRiskHint,
+)
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.inputs.common import (
+    load_text_file,
+    manifest_relative_path,
+    resolve_input_path,
+    stable_tool_id,
+    tool_name_warning,
+    walk_input_tree,
+)
+from agents_shipgate.inputs.coverage import BoundaryCell, SourceCoverage
+from agents_shipgate.inputs.mcp_idioms import (
+    IDIOM_REGISTRY_VERSION,
+    MAX_SOURCE_FILE_BYTES,
+    OMISSION_REASONS,
+    RegistrationSite,
+    is_scannable_path,
+    language_for_path,
+    scan_source,
+)
+from agents_shipgate.inputs.protocol import LoadedAdapterResult
+from agents_shipgate.schemas.manifest import (
+    AgentsShipgateManifest,
+    ToolSourceConfig,
+)
+
+#: The ``Tool.source_type`` and ``tool_sources[].type`` this input owns.
+SOURCE_TYPE = "mcp_server_source"
+
+#: The extraction method recorded on every action this input contributes.
+EXTRACTION_METHOD = "mcp_source_registration"
+
+#: Ceiling for a literal at a registration site. A name read from source is
+#: weaker evidence than a name read from the server's published contract, and
+#: the gap is not closable by reading more carefully: the export also carries
+#: the input schema, which this input does not read at all.
+EXTRACTION_CONFIDENCE = "medium"
+
+#: How many source files one configured source may be walked for. A cap that
+#: silently truncated would be the fail-open shape this input exists to close,
+#: so exceeding it is recorded as an omission and holds every action the source
+#: contributed at ``partial``: past the cap, nothing is known about what was
+#: not read.
+MAX_SCANNED_FILES = 4000
+
+#: ``operationType``-style classifications an idiom can read, mapped to the
+#: risk-tag vocabulary. Deliberately partial, in one direction only.
+#:
+#: ``read`` and ``metadata`` are absent on purpose. A heuristic must never
+#: *prove* a read-only action (#357/#409), and a tool server asserting its own
+#: harmlessness is the one claim an untrusted source has an incentive to make.
+#: The escalating classifications carry no such incentive, so reading them is
+#: safe — and they are the point: MongoDB writes ``static operationType =
+#: "delete"`` beside ``drop-database``, which is precisely the answer a
+#: reviewer should have to defend contradicting.
+#:
+#: These arrive as ``inferred_keyword`` claims at ``low`` confidence, so they
+#: are never policy-eligible: they cannot close an effect-evidence gap and
+#: cannot make an action pass-eligible on their own. What they can do is
+#: challenge a declaration that sits below them.
+OPERATION_TYPE_RISK_TAGS: dict[str, str] = {
+    "create": "write",
+    "update": "write",
+    "delete": "destructive",
+    "destroy": "destructive",
+    "drop": "destructive",
+    "write": "write",
+    "execute": "code_execution",
+}
+
+
+def load_mcp_server_source(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSource:
+    assert source.path is not None
+    root = resolve_input_path(base_dir, source.path)
+    if not root.exists():
+        raise InputParseError(f"Input path not found: {root}")
+
+    warnings: list[str] = []
+    omissions: list[SourceSurfaceOmission] = []
+    tools: list[Tool] = []
+    seen_names: set[str] = set()
+
+    files, capped = _scannable_files(root)
+    if not files:
+        raise InputParseError(
+            f"MCP server source has no TypeScript or Go files to read: {root}. "
+            "Point tool_sources[].path at the directory holding the server's "
+            "tool registrations, or at one such file."
+        )
+
+    def _omit(subject: str, reason: str, warning: str, detail: str) -> None:
+        warnings.append(warning)
+        omissions.append(
+            SourceSurfaceOmission(
+                subject=subject, reason=reason, detail=detail, warning=warning
+            )
+        )
+
+    # Gaps that belong to the *source*, not to one file. A file this reader
+    # never opened could register anything, so unlike a single unresolved
+    # registration these hold every action the source contributed at
+    # ``partial``: the question they leave open is which tools exist.
+    source_gaps: list[str] = []
+
+    if capped:
+        source_gaps.append("walk_capped")
+        _omit(
+            subject=manifest_relative_path(source.path, base_dir),
+            reason="walk_capped",
+            warning=(
+                f"MCP server source {source.id!r} stopped at {MAX_SCANNED_FILES} "
+                "source files; the rest of the tree was not read"
+            ),
+            detail=(
+                f"Reading stopped at {MAX_SCANNED_FILES} files, so any tool "
+                "registered past that point is absent from this catalog. Point "
+                "tool_sources[].path at the package that holds the "
+                "registrations rather than at the repository root."
+            ),
+        )
+
+    for path in files:
+        language = language_for_path(path)
+        assert language is not None  # guaranteed by _scannable_files
+        relative = _relative_source_path(path, root, source.path, base_dir)
+        unread = _unread_reason(path)
+        if unread is None:
+            try:
+                text = load_text_file(path)
+            except InputParseError:
+                unread = "unreadable_file"
+        if unread is not None:
+            # One unreadable file must not fail the whole scan: a repository
+            # carrying a generated bundle beside its server would then have no
+            # route at all, which is the state this input exists to end.
+            source_gaps.append(unread)
+            _omit(
+                subject=relative,
+                reason=unread,
+                warning=f"MCP server source {relative} was not read ({unread})",
+                detail=OMISSION_REASONS[unread],
+            )
+            continue
+        result = scan_source(text, language)
+
+        file_gaps: list[str] = []
+        for anomaly in result.anomalies:
+            file_gaps.append(anomaly)
+            _omit(
+                subject=relative,
+                reason=anomaly,
+                warning=(
+                    f"MCP server source {relative} could not be fully read "
+                    f"({anomaly})"
+                ),
+                detail=OMISSION_REASONS[anomaly],
+            )
+        for site in result.sites:
+            if site.name is not None:
+                continue
+            reason = site.unresolved_reason or "name_not_literal"
+            file_gaps.append(reason)
+            _omit(
+                subject=f"{relative}:{site.line}",
+                reason=reason,
+                warning=(
+                    f"MCP tool registered at {relative}:{site.line} does not "
+                    "name itself with a literal"
+                ),
+                detail=OMISSION_REASONS[reason],
+            )
+
+        surface = (
+            SURFACE_PARTIAL if (file_gaps or source_gaps) else SURFACE_ENUMERATED
+        )
+        gaps = sorted(set(file_gaps))
+        for site in result.sites:
+            if site.name is None:
+                continue
+            if site.name in seen_names:
+                # One name is one tool. Grafana registers
+                # `alerting_manage_silences` twice — a read-only build and a
+                # read-write one, exactly one of which is mounted — and two
+                # catalog rows sharing an id would be one action counted twice.
+                warnings.append(
+                    f"MCP tool {site.name!r} is registered more than once in "
+                    f"source {source.id!r}; the first registration is used"
+                )
+                continue
+            seen_names.add(site.name)
+            if warning := tool_name_warning(site.name):
+                warnings.append(warning)
+            tools.append(
+                _tool_from_site(
+                    site,
+                    source=source,
+                    source_path=relative,
+                    surface=surface,
+                    surface_gaps=gaps,
+                )
+            )
+
+    # A source gap found *after* a file was read still holds that file's
+    # actions: which tools exist is one question for the whole source, and
+    # answering it per file in walk order would leave the answer depending on
+    # where in the tree the unread file happened to sit.
+    if source_gaps:
+        _apply_source_gaps(tools, sorted(set(source_gaps)))
+
+    return LoadedToolSource(
+        source_id=source.id,
+        source_type=SOURCE_TYPE,
+        tools=tools,
+        warnings=warnings,
+        omissions=omissions,
+    )
+
+
+def _apply_source_gaps(tools: list[Tool], gaps: list[str]) -> None:
+    for tool in tools:
+        tool.extraction["surface"] = SURFACE_PARTIAL
+        merged = sorted(set(tool.extraction.get("surface_gaps", [])) | set(gaps))
+        tool.extraction["surface_gaps"] = merged
+
+
+def _unread_reason(path: Path) -> str | None:
+    """Why this file was not opened, or ``None`` when it was."""
+
+    try:
+        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+            return "file_too_large"
+    except OSError:
+        return "unreadable_file"
+    return None
+
+
+def _tool_from_site(
+    site: RegistrationSite,
+    *,
+    source: ToolSourceConfig,
+    source_path: str,
+    surface: str,
+    surface_gaps: list[str],
+) -> Tool:
+    assert site.name is not None
+    extraction: dict[str, object] = {
+        "method": EXTRACTION_METHOD,
+        "confidence": EXTRACTION_CONFIDENCE,
+        "idiom": site.idiom,
+        "registry_version": IDIOM_REGISTRY_VERSION,
+        "surface": surface,
+    }
+    if surface_gaps:
+        extraction["surface_gaps"] = surface_gaps
+    return Tool(
+        id=stable_tool_id(site.name),
+        name=site.name,
+        description=site.description,
+        source_type=SOURCE_TYPE,
+        source_id=source.id,
+        source_ref=source.path,
+        source_path=source_path,
+        source_start_line=site.line,
+        source_start_column=site.column,
+        risk_hints=_operation_type_hints(site),
+        extraction_confidence=EXTRACTION_CONFIDENCE,
+        extraction=extraction,
+    )
+
+
+def _operation_type_hints(site: RegistrationSite) -> list[ToolRiskHint]:
+    if site.operation_type is None:
+        return []
+    tag = OPERATION_TYPE_RISK_TAGS.get(site.operation_type.strip().lower())
+    if tag is None:
+        return []
+    return [
+        ToolRiskHint(
+            tag=tag,
+            source="mcp_operation_type",
+            confidence="low",
+            basis="inferred_keyword",
+            evidence={
+                "operation_type": site.operation_type,
+                "idiom": site.idiom,
+            },
+        )
+    ]
+
+
+def _scannable_files(root: Path) -> tuple[list[Path], bool]:
+    """Every source file under ``root`` this input reads, and whether it capped."""
+
+    if root.is_file():
+        if language_for_path(root) is None:
+            raise InputParseError(
+                f"MCP server source is not a TypeScript or Go file: {root}"
+            )
+        return [root], False
+    candidates = [
+        path
+        for path in walk_input_tree(root)
+        if path.is_file() and is_scannable_path(path.relative_to(root))
+    ]
+    return candidates[:MAX_SCANNED_FILES], len(candidates) > MAX_SCANNED_FILES
+
+
+def _relative_source_path(
+    path: Path, root: Path, configured: str, base_dir: Path
+) -> str:
+    """The manifest-relative path of the file a tool was read from.
+
+    Not the configured ``path``: that is a directory for every real server, and
+    a finding pointing at a directory sends a reviewer to look for a
+    registration in 300 files. ``resolve_input_path`` already refused anything
+    outside the manifest directory, so the relative form always exists — the
+    fallback is for the single-file case, where ``root`` *is* the file.
+    """
+
+    try:
+        return manifest_relative_path(str(path.relative_to(base_dir.resolve())), base_dir)
+    except ValueError:
+        return manifest_relative_path(configured, base_dir)
+
+
+class MCPServerSourceAdapter:
+    """``ToolSourceAdapter`` wrapping :func:`load_mcp_server_source`."""
+
+    source_type: ClassVar[str] = SOURCE_TYPE
+    scope: ClassVar[Literal["per_source", "per_scan"]] = "per_source"
+    artifact_class: ClassVar[type | None] = None
+
+    coverage: ClassVar[SourceCoverage] = SourceCoverage(
+        adapter=SOURCE_TYPE,
+        label="MCP server source",
+        reads=(
+            "The TypeScript or Go source of an MCP server that does not commit "
+            "an export, through a built-in registry of registration idioms."
+        ),
+        cells=(
+            BoundaryCell(
+                shape="export_artifact",
+                status="not_applicable",
+                reads=(
+                    "A committed export is the server's own contract and is read "
+                    "by the MCP tool-export input at `high`, which stays the "
+                    "better route wherever one exists."
+                ),
+            ),
+            BoundaryCell(
+                shape="literal_registration",
+                status="extracted",
+                reads=(
+                    'A tool name written as a string literal at a registration '
+                    'site — `static toolName = "…"`, `.registerTool("…"`, '
+                    '`MustTool("…"`, `NewTool("…"`, `Tool{Name: "…"}` — plus the '
+                    "sibling operation-class literal where the idiom defines one."
+                ),
+                emits=(SOURCE_TYPE,),
+                ceiling=EXTRACTION_CONFIDENCE,
+                surface=SURFACE_ENUMERATED,
+            ),
+            BoundaryCell(
+                shape="factory",
+                status="not_extracted",
+                reads=(
+                    "A helper that registers a table of tools contributes "
+                    "nothing on its own: resolving what it registers would mean "
+                    "evaluating it. Any registration site inside the helper is "
+                    "read on its own terms."
+                ),
+            ),
+            BoundaryCell(
+                shape="dynamic_construction",
+                status="not_extracted",
+                reads=(
+                    "A registration whose name is a variable, a concatenation, "
+                    "or a template substitution names no tool this reader can "
+                    "check. It enters no catalog and is recorded as an "
+                    "unenumerated subject in the exclusion ledger, which holds "
+                    "its file's surface at `partial`."
+                ),
+            ),
+        ),
+    )
+
+    def load(
+        self,
+        source: ToolSourceConfig | None,
+        base_dir: Path,
+        manifest: AgentsShipgateManifest,
+    ) -> LoadedAdapterResult:
+        assert source is not None, "per_source adapter requires a source"
+        return LoadedAdapterResult(tool_sources=[load_mcp_server_source(source, base_dir)])

--- a/src/agents_shipgate/inputs/protocol.py
+++ b/src/agents_shipgate/inputs/protocol.py
@@ -1,6 +1,6 @@
 """Adapter Protocol + AdapterRegistry for tool-source loading.
 
-Every tool-source or scan-artifact loader (mcp, openapi,
+Every tool-source or scan-artifact loader (mcp, mcp_server_source, openapi,
 openai_agents_sdk, google_adk, langchain, crewai, codex_config, codex_plugin,
 openai_api, anthropic_api, n8n, conductor, validation) is exposed as a
 ``ToolSourceAdapter``. The CLI's ``_load_sources`` walks ``REGISTRY``
@@ -299,6 +299,7 @@ def _register_builtin_adapters(registry: AdapterRegistry) -> None:
     from agents_shipgate.inputs.google_adk import GoogleADKAdapter
     from agents_shipgate.inputs.langchain import LangChainAdapter
     from agents_shipgate.inputs.mcp import MCPAdapter
+    from agents_shipgate.inputs.mcp_server_source import MCPServerSourceAdapter
     from agents_shipgate.inputs.n8n import N8nAdapter
     from agents_shipgate.inputs.openai_api import OpenAIAPIAdapter
     from agents_shipgate.inputs.openai_sdk_static import OpenAISDKAdapter
@@ -307,6 +308,7 @@ def _register_builtin_adapters(registry: AdapterRegistry) -> None:
 
     for adapter in (
         MCPAdapter(),
+        MCPServerSourceAdapter(),
         OpenAPIAdapter(),
         OpenAISDKAdapter(),
         GoogleADKAdapter(),

--- a/src/agents_shipgate/schemas/manifest/tool_sources.py
+++ b/src/agents_shipgate/schemas/manifest/tool_sources.py
@@ -22,6 +22,7 @@ from agents_shipgate.schemas.text import (
 #: types fail at dispatcher time via ``AdapterRegistry.require``.
 BUILTIN_TOOL_SOURCE_TYPES: tuple[str, ...] = (
     "mcp",
+    "mcp_server_source",
     "openapi",
     "openai_agents_sdk",
     "google_adk",

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -150,6 +150,7 @@ def test_canonical_registration_order():
 
     expected = [
         "mcp",
+        "mcp_server_source",
         "openapi",
         "openai_agents_sdk",
         "google_adk",

--- a/tests/test_mcp_idioms.py
+++ b/tests/test_mcp_idioms.py
@@ -24,6 +24,7 @@ from agents_shipgate.inputs.mcp_idioms import (
     OMISSION_REASONS,
     PREFILTER_TOKEN,
     SourceScanResult,
+    decode_literal,
     is_scannable_path,
     language_for_path,
     mask_source,
@@ -414,6 +415,66 @@ _ADVERSARIAL: list[tuple[str, str, str, list[str], list[str]]] = [
         [],
     ),
     (
+        "a Go octal escape decodes with Go's grammar, not JavaScript's",
+        "go",
+        'mcpgrafana.MustTool("delete\\137all", desc, handler)\n',
+        ["delete_all"],
+        [],
+    ),
+    (
+        "a Go hex and unicode escape decode exactly",
+        "go",
+        'mcpgrafana.MustTool("\\x61\\u0062c", desc, handler)\n',
+        ["abc"],
+        [],
+    ),
+    (
+        "an escape Go does not define is refused, not guessed",
+        "go",
+        'mcpgrafana.MustTool("delete\\qall", desc, handler)\n',
+        [],
+        ["name_not_literal"],
+    ),
+    (
+        "a truncated Go octal escape is refused",
+        "go",
+        'mcpgrafana.MustTool("delete\\13", desc, handler)\n',
+        [],
+        ["name_not_literal"],
+    ),
+    (
+        "a TypeScript hex escape decodes, and octal is refused",
+        "typescript",
+        'server.registerTool("\\x61bc", {}, h);\n'
+        'server.registerTool("de\\137f", {}, h);\n',
+        ["abc"],
+        ["name_not_literal"],
+    ),
+    (
+        "a regex beginning an if body cannot register a tool",
+        "typescript",
+        'if (ok) /\\.registerTool("fake", handler)/.test(value);\n'
+        'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a regex beginning a while body cannot register a tool",
+        "typescript",
+        'while (ok) /\\.registerTool("fake", h)/.test(v);\n'
+        'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "division after a call is still division",
+        "typescript",
+        "const ratio = total(a) / scale(b) / 2;\n"
+        'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
         "a concatenated Go struct name is not the literal it starts with",
         "go",
         'mcp.Tool{Name: "issue_" + verb, Description: "x"}\n',
@@ -496,6 +557,46 @@ def test_an_attribute_assignment_is_not_the_description_field():
 
     assert site.name == "t"
     assert site.description == "Runs an aggregation"
+
+
+def test_each_language_decodes_with_its_own_grammar():
+    """One decoder shared between two grammars is a silent mistranslation.
+
+    Go writes an octal escape as three digits and JavaScript does not, so a
+    JavaScript-shaped decoder turned `delete\\137all` — the name Go registers as
+    `delete_all` — into `delete137all`: the real action missing from the
+    catalog and an action id nobody serves standing in for it.
+    """
+
+    assert decode_literal(r"delete\137all", "go") == "delete_all"
+    # The same bytes in TypeScript are a legacy octal whose meaning depends on
+    # a strictness mode this reader does not track, so it refuses.
+    assert decode_literal(r"delete\137all", "typescript") is None
+
+    assert decode_literal(r"\x41\u0042", "go") == "AB"
+    assert decode_literal(r"\x41\u0042", "typescript") == "AB"
+    assert decode_literal(r"\u{1F600}", "typescript") == "\U0001F600"
+
+
+@pytest.mark.parametrize(
+    ("body", "language"),
+    [
+        (r"a\qb", "go"),
+        (r"a\13b", "go"),
+        (r"a\400b", "go"),
+        (r"a\x4", "go"),
+        (r"a\u12", "go"),
+        (r"a\x4", "typescript"),
+        (r"a\u{}", "typescript"),
+        (r"a\1b", "typescript"),
+    ],
+)
+def test_an_escape_that_cannot_be_decoded_exactly_is_refused(
+    body: str, language: str
+):
+    """A refusal becomes an omission; a guess becomes a wrong tool name."""
+
+    assert decode_literal(body, language) is None
 
 
 # --- Masking failures -------------------------------------------------------

--- a/tests/test_mcp_idioms.py
+++ b/tests/test_mcp_idioms.py
@@ -23,6 +23,7 @@ from agents_shipgate.inputs.mcp_idioms import (
     LANGUAGE_EXTENSIONS,
     OMISSION_REASONS,
     PREFILTER_TOKEN,
+    SourceScanResult,
     is_scannable_path,
     language_for_path,
     mask_source,
@@ -538,10 +539,31 @@ def test_masking_preserves_offsets_so_line_numbers_are_the_file_s():
     assert scan_source(text, "typescript").sites[0].line == 3
 
 
-def test_a_file_without_the_prefilter_token_is_answered_without_masking():
-    assert scan_source("package main\n\nfunc main() {}\n", "go") == scan_source(
-        "", "go"
-    )
+def test_a_file_without_the_prefilter_token_is_answered_without_masking(monkeypatch):
+    """The shortcut has to be observable, or the test is about nothing.
+
+    Comparing the result to an empty scan passes whether or not the prefilter
+    exists — both are empty either way — so a perturbation that deleted the
+    prefilter entirely went uncaught. The claim is that the file is answered
+    *without masking it*, so that is what is asserted: `mask_source` is never
+    reached.
+    """
+
+    import agents_shipgate.inputs.mcp_idioms as module
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError("a file with no registration token was masked")
+
+    monkeypatch.setattr(module, "mask_source", _fail)
+    assert scan_source("package main\n\nfunc main() {}\n", "go") == SourceScanResult()
+
+    # And the shortcut is only sound because it can never hide a real
+    # registration: every idiom's own sample carries the token, which
+    # `test_the_prefilter_cannot_hide_an_idiom_this_reader_matches` pins.
+    monkeypatch.undo()
+    assert scan_source(
+        _POSITIVE_SAMPLES["go_must_tool"].text, "go"
+    ).sites
 
 
 # --- The published token list ----------------------------------------------

--- a/tests/test_mcp_idioms.py
+++ b/tests/test_mcp_idioms.py
@@ -1,0 +1,502 @@
+"""The built-in MCP registration-idiom registry and its reader (#431).
+
+The reader turns source text into tool names, so every test here is really
+asking one of two questions: *can it be made to invent a tool?* and *can it be
+made to lose one silently?* The second is the reason this input exists — the
+gap it closes is three vendor servers reported as "not an agent project" — so a
+construct it cannot resolve has to become a recorded omission, never a gap in
+the output nobody can see.
+
+The adversarial sweep at the bottom is the probe list #393 requires of anything
+that publishes an extraction claim. Eight of its cases were fail-open in the
+first draft of this reader.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents_shipgate.inputs.mcp_idioms import (
+    DIFF_TOKENS,
+    IDIOMS,
+    IDIOMS_BY_ID,
+    LANGUAGE_EXTENSIONS,
+    OMISSION_REASONS,
+    PREFILTER_TOKEN,
+    is_scannable_path,
+    language_for_path,
+    mask_source,
+    scan_source,
+)
+
+
+def _names(text: str, language: str = "typescript") -> list[str]:
+    return [site.name for site in scan_source(text, language).sites if site.name]
+
+
+def _unresolved(text: str, language: str = "typescript") -> list[str]:
+    return [
+        site.unresolved_reason
+        for site in scan_source(text, language).sites
+        if site.name is None
+    ]
+
+
+# --- Registry shape ---------------------------------------------------------
+
+
+def test_every_idiom_has_a_language_this_reader_can_read():
+    for idiom in IDIOMS:
+        assert idiom.language in LANGUAGE_EXTENSIONS
+        assert idiom.id == idiom.id.lower()
+        assert idiom.diff_tokens
+
+
+def test_idiom_ids_are_unique():
+    assert len(IDIOMS_BY_ID) == len(IDIOMS)
+
+
+def test_the_prefilter_cannot_hide_an_idiom_this_reader_matches():
+    """``scan_source`` skips a file without the prefilter token.
+
+    That shortcut is only sound while every idiom's pattern requires the token.
+    The first draft put the prefilter at the *call site* and keyed it off the
+    trigger catalog's ``diff_tokens`` — which do not include the substring
+    ``static readonly toolName`` carries — and four MongoDB tools were reported
+    by ``scan`` and never by ``detect``.
+    """
+
+    for sample in _POSITIVE_SAMPLES.values():
+        assert PREFILTER_TOKEN in sample.text.lower(), sample.idiom
+
+
+def test_jsx_is_out_of_scope_so_prose_never_opens_a_string():
+    """JSX puts prose in code position; an apostrophe would read as a quote."""
+
+    assert ".tsx" not in LANGUAGE_EXTENSIONS["typescript"]
+    assert ".jsx" not in LANGUAGE_EXTENSIONS["typescript"]
+    assert language_for_path("app/Panel.tsx") is None
+
+
+@pytest.mark.parametrize(
+    ("path", "scannable"),
+    [
+        ("pkg/github/issues.go", True),
+        ("src/tools/aggregate.ts", True),
+        ("server.mjs", True),
+        ("pkg/github/issues_test.go", False),
+        ("src/tools/aggregate.test.ts", False),
+        ("src/tools/aggregate.spec.ts", False),
+        ("tests/helpers/fake.ts", False),
+        ("__tests__/fake.ts", False),
+        ("node_modules/sdk/index.ts", False),
+        ("vendor/other/tools.go", False),
+        ("testdata/sample.go", False),
+        ("README.md", False),
+    ],
+)
+def test_scannable_paths(path: str, scannable: bool):
+    assert is_scannable_path(path) is scannable
+
+
+# --- Positive samples, one per idiom ----------------------------------------
+
+
+class _Sample:
+    def __init__(self, idiom: str, language: str, text: str, name: str) -> None:
+        self.idiom = idiom
+        self.language = language
+        self.text = text
+        self.name = name
+
+
+_POSITIVE_SAMPLES: dict[str, _Sample] = {
+    "ts_static_tool_name": _Sample(
+        "ts_static_tool_name",
+        "typescript",
+        'export class DropDatabaseTool extends MongoDBToolBase {\n'
+        '    static toolName = "drop-database";\n'
+        '    public description = "Removes the specified database";\n'
+        '    static operationType: OperationType = "delete";\n'
+        "}\n",
+        "drop-database",
+    ),
+    "ts_sdk_register_tool": _Sample(
+        "ts_sdk_register_tool",
+        "typescript",
+        'server.registerTool("search_docs", { inputSchema: shape }, handler);\n',
+        "search_docs",
+    ),
+    "go_must_tool": _Sample(
+        "go_must_tool",
+        "go",
+        "var UpdateIncident = mcpgrafana.MustTool(\n"
+        '\t"update_incident",\n'
+        '\t"Update an incident",\n'
+        "\tupdateIncident,\n"
+        ")\n",
+        "update_incident",
+    ),
+    "go_new_tool": _Sample(
+        "go_new_tool",
+        "go",
+        'tool := mcp.NewTool("list_workspaces", mcp.WithDescription("List them"))\n',
+        "list_workspaces",
+    ),
+    "go_tool_struct": _Sample(
+        "go_tool_struct",
+        "go",
+        "return NewTool(\n"
+        "\tToolsetMetadataIssues,\n"
+        "\tmcp.Tool{\n"
+        '\t\tName:        "issue_read",\n'
+        '\t\tDescription: "Get information about an issue",\n'
+        "\t\tAnnotations: &mcp.ToolAnnotations{\n"
+        '\t\t\tTitle:        "Get issue details",\n'
+        "\t\t\tReadOnlyHint: true,\n"
+        "\t\t},\n"
+        "\t},\n"
+        "\thandler,\n"
+        ")\n",
+        "issue_read",
+    ),
+}
+
+
+def test_every_idiom_has_a_positive_sample():
+    assert set(_POSITIVE_SAMPLES) == set(IDIOMS_BY_ID)
+
+
+@pytest.mark.parametrize("idiom_id", sorted(_POSITIVE_SAMPLES))
+def test_positive_sample_resolves_exactly_its_own_tool(idiom_id: str):
+    sample = _POSITIVE_SAMPLES[idiom_id]
+    result = scan_source(sample.text, sample.language)
+    resolved = [site for site in result.sites if site.name is not None]
+    assert [site.name for site in resolved] == [sample.name]
+    assert resolved[0].idiom == idiom_id
+    assert result.anomalies == ()
+
+
+@pytest.mark.parametrize("idiom_id", sorted(_POSITIVE_SAMPLES))
+def test_published_diff_tokens_appear_in_the_sample_they_route(idiom_id: str):
+    """The trigger catalog routes on these tokens, so they must be real.
+
+    A token nobody can produce routes nothing, and nothing in the catalog file
+    would say so — the rule would read as coverage it does not have.
+    """
+
+    sample = _POSITIVE_SAMPLES[idiom_id]
+    for token in IDIOMS_BY_ID[idiom_id].diff_tokens:
+        assert token in sample.text, (idiom_id, token)
+
+
+def test_ts_static_field_reads_the_sibling_operation_class_and_description():
+    sample = _POSITIVE_SAMPLES["ts_static_tool_name"]
+    site = scan_source(sample.text, "typescript").sites[0]
+    assert site.operation_type == "delete"
+    assert site.description == "Removes the specified database"
+
+
+def test_a_go_struct_description_is_read_only_from_its_own_level():
+    sample = _POSITIVE_SAMPLES["go_tool_struct"]
+    site = scan_source(sample.text, "go").sites[0]
+    assert site.description == "Get information about an issue"
+
+
+def test_a_static_field_outside_a_class_still_names_its_tool():
+    """The enclosing block supplies siblings; its absence is not a failure."""
+
+    sites = scan_source('static toolName = "loose";\n', "typescript").sites
+    assert [site.name for site in sites] == ["loose"]
+    assert sites[0].operation_type is None
+
+
+def test_a_modifier_between_static_and_the_field_is_read():
+    """``public static readonly toolName: string = "…"`` is MongoDB's spelling
+    in four of its packages, and it is not ``static toolName``."""
+
+    text = 'class T { public static readonly toolName: string = "get_response"; }'
+    assert _names(text) == ["get_response"]
+
+
+# --- Adversarial sweep ------------------------------------------------------
+#
+# Each case names the fail-open or fail-closed it prevents. `expected_names` is
+# the complete set the reader may report; `expected_unresolved` the complete
+# set of omissions it must record. Both are exact: a case that adds an
+# unexpected omission is as wrong as one that loses a tool.
+
+_ADVERSARIAL: list[tuple[str, str, str, list[str], list[str]]] = [
+    (
+        "a line comment is not code",
+        "typescript",
+        '// server.registerTool("ghost", {}, h);\n'
+        'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a doc comment example is not a registration",
+        "typescript",
+        "/**\n"
+        " * Define a tool class:\n"
+        ' *   static toolName = "my-custom-tool";\n'
+        " */\n"
+        'class T { static toolName = "real"; }\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a name inside another string is not a registration",
+        "typescript",
+        'const doc = \'static toolName = "ghost";\';\n'
+        'class T { static toolName = "real"; }\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a template literal body is not code",
+        "typescript",
+        "const doc = `server.registerTool(\"ghost\", {}, h)`;\n"
+        'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a name built from a constant is unenumerated, not absent",
+        "typescript",
+        "class T { static toolName = EXPORT_TOOL_NAME; }\n",
+        [],
+        ["name_not_literal"],
+    ),
+    (
+        "a template substitution is not a constant name",
+        "typescript",
+        "server.registerTool(`${prefix}_search`, {}, h);\n",
+        [],
+        ["name_not_literal"],
+    ),
+    (
+        "a concatenated name is not the literal it starts with",
+        "typescript",
+        'server.registerTool("search_" + suffix, {}, h);\n',
+        [],
+        ["name_not_literal"],
+    ),
+    (
+        "a concatenated static field is not the literal it starts with",
+        "typescript",
+        'class T { static toolName = "search_" + SUFFIX; }\n',
+        [],
+        ["name_not_literal"],
+    ),
+    (
+        "a one-argument call is a lookup, not a registration",
+        "typescript",
+        'const t = registry.tool("issues");\n',
+        [],
+        [],
+    ),
+    (
+        "a one-argument call with a computed key is still a lookup",
+        "typescript",
+        "const t = registry.tool(key);\n",
+        [],
+        [],
+    ),
+    (
+        "a literal that is not shaped like a tool name is not one",
+        "typescript",
+        'panel.tool("Search the web for a query", handler);\n',
+        [],
+        ["implausible_tool_name"],
+    ),
+    (
+        "a regex literal containing a quote must not desync the lexer",
+        "typescript",
+        "const quote = /\"/;\n" 'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a regex literal containing a comment opener must not blank the file",
+        "typescript",
+        "const path = /a\\/\\/b/;\n" 'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a URL inside a string is not a line comment",
+        "typescript",
+        'const url = "https://example.test/x";\n'
+        'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "an escaped quote does not end its string",
+        "typescript",
+        'const s = "he said \\"registerTool\\"";\n'
+        'server.registerTool("real", {}, h);\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a method named toolName is not a field",
+        "typescript",
+        'class T { toolName() { return "ghost"; } }\n',
+        [],
+        [],
+    ),
+    (
+        "a wrapper naming its tool one argument later reports one site",
+        "go",
+        "return NewTool(meta, mcp.Tool{Name: \"issue_read\"}, handler)\n",
+        ["issue_read"],
+        [],
+    ),
+    (
+        "a wrapper naming nothing reports exactly one omission",
+        "go",
+        "return NewTool(meta, mcp.Tool{Name: name}, handler)\n",
+        [],
+        ["name_not_literal"],
+    ),
+    (
+        "a nested annotation Name is not the tool's name",
+        "go",
+        'mcp.Tool{Annotations: &mcp.ToolAnnotations{Name: "annotation"}}\n',
+        [],
+        [],
+    ),
+    (
+        "a slice of tool structs names every element",
+        "go",
+        'tools := []mcp.Tool{{Name: "a", Description: "x"}, {Name: "b"}}\n',
+        ["a", "b"],
+        [],
+    ),
+    (
+        "a Go raw string names its tool",
+        "go",
+        "mcpgrafana.MustTool(`raw_name`, desc, handler)\n",
+        ["raw_name"],
+        [],
+    ),
+    (
+        "a rune literal holding a quote must not desync the lexer",
+        "go",
+        "if c == '\"' {\n}\n" 'mcpgrafana.MustTool("real", desc, handler)\n',
+        ["real"],
+        [],
+    ),
+    (
+        "a Go comment is not a registration",
+        "go",
+        '// mcpgrafana.MustTool("ghost", desc, handler)\n'
+        'mcpgrafana.MustTool("real", desc, handler)\n',
+        ["real"],
+        [],
+    ),
+    (
+        "NewToolResultError is not NewTool",
+        "go",
+        'return utils.NewToolResultError("boom"), nil\n',
+        [],
+        [],
+    ),
+    (
+        "a type whose name merely ends in Tool is not a tool struct",
+        "go",
+        'deps := ToolDependencies{Name: "not_a_tool"}\n',
+        [],
+        [],
+    ),
+    (
+        "a concatenated Go struct name is not the literal it starts with",
+        "go",
+        'mcp.Tool{Name: "issue_" + verb, Description: "x"}\n',
+        [],
+        ["name_not_literal"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("case", "language", "text", "expected_names", "expected_unresolved"),
+    _ADVERSARIAL,
+    ids=[case[0] for case in _ADVERSARIAL],
+)
+def test_adversarial_constructs(
+    case: str,
+    language: str,
+    text: str,
+    expected_names: list[str],
+    expected_unresolved: list[str],
+):
+    result = scan_source(text, language)
+    assert sorted(site.name for site in result.sites if site.name) == sorted(
+        expected_names
+    ), case
+    assert sorted(
+        site.unresolved_reason for site in result.sites if site.name is None
+    ) == sorted(expected_unresolved), case
+    for site in result.sites:
+        if site.unresolved_reason is not None:
+            assert site.unresolved_reason in OMISSION_REASONS
+
+
+# --- Masking failures -------------------------------------------------------
+
+
+def test_an_unterminated_block_comment_is_an_anomaly_not_silence():
+    """Past an unterminated comment nothing is known, so say so.
+
+    Reporting no sites would be indistinguishable from a file that registers
+    nothing — the exact ambiguity this input exists to remove.
+    """
+
+    result = scan_source('/* open\nserver.registerTool("real", {}, h);\n', "typescript")
+    assert result.sites == ()
+    assert result.anomalies == ("unterminated_block_comment",)
+
+
+def test_an_unterminated_string_is_an_anomaly_and_resyncs_at_the_line():
+    result = scan_source(
+        'const broken = "oops;\n' 'server.registerTool("real", {}, h);\n',
+        "typescript",
+    )
+    assert "unterminated_string" in result.anomalies
+    assert [site.name for site in result.sites] == ["real"]
+
+
+def test_an_unterminated_go_raw_string_is_an_anomaly():
+    result = scan_source(
+        'var doc = `open\nmcpgrafana.MustTool("real", desc, handler)\n', "go"
+    )
+    assert result.anomalies == ("unterminated_string",)
+    # And the registration past it is not reported, because past the unclosed
+    # raw string this reader cannot tell code from content.
+    assert result.sites == ()
+
+
+def test_masking_preserves_offsets_so_line_numbers_are_the_file_s():
+    text = "// comment\n// comment\nclass T { static toolName = \"x\"; }\n"
+    masked = mask_source(text, "typescript")
+    assert len(masked.masked) == len(text)
+    assert scan_source(text, "typescript").sites[0].line == 3
+
+
+def test_a_file_without_the_prefilter_token_is_answered_without_masking():
+    assert scan_source("package main\n\nfunc main() {}\n", "go") == scan_source(
+        "", "go"
+    )
+
+
+# --- The published token list ----------------------------------------------
+
+
+def test_published_diff_tokens_are_the_union_of_the_idioms():
+    assert DIFF_TOKENS == tuple(
+        sorted({token for idiom in IDIOMS for token in idiom.diff_tokens})
+    )

--- a/tests/test_mcp_idioms.py
+++ b/tests/test_mcp_idioms.py
@@ -446,6 +446,57 @@ def test_adversarial_constructs(
             assert site.unresolved_reason in OMISSION_REASONS
 
 
+# --- Regressions from review ------------------------------------------------
+
+
+def test_a_class_that_registers_elsewhere_keeps_its_own_omission():
+    """A lookup scope is not a wrapper.
+
+    The unresolved field site needs the class body to find its sibling
+    `operationType` and `description` literals. Carrying that body as the
+    site's *span* made the containment rule read any registration written
+    inside the class as "the same registration", so a class whose `toolName`
+    is built at runtime lost its omission the moment its body also called
+    `.registerTool(` — neither enumerated nor recorded, which is the silent
+    miss this input exists to end.
+    """
+
+    text = (
+        "export class T extends Base {\n"
+        "    static toolName = DYNAMIC_NAME;\n"
+        '    register(s) { s.registerTool("inner", {}, h); }\n'
+        "}\n"
+    )
+    result = scan_source(text, "typescript")
+
+    assert sorted(site.name for site in result.sites if site.name) == ["inner"]
+    assert [
+        site.unresolved_reason for site in result.sites if site.name is None
+    ] == ["name_not_literal"]
+
+
+def test_an_attribute_assignment_is_not_the_description_field():
+    """`this.description = …` is not the class's description.
+
+    The lookbehind admitted a leading dot, and `_first_literal_in` returns the
+    first match in the body, so an assignment in a constructor won over the
+    real field and published a description that is not the tool's — into the
+    report and into the declaration questionnaire a reviewer answers from.
+    """
+
+    text = (
+        "class T {\n"
+        '    constructor() { this.description = "scratch label"; }\n'
+        '    static toolName = "t";\n'
+        '    public description = "Runs an aggregation";\n'
+        "}\n"
+    )
+    site = scan_source(text, "typescript").sites[0]
+
+    assert site.name == "t"
+    assert site.description == "Runs an aggregation"
+
+
 # --- Masking failures -------------------------------------------------------
 
 

--- a/tests/test_mcp_server_source.py
+++ b/tests/test_mcp_server_source.py
@@ -438,6 +438,66 @@ def test_a_dependency_without_a_registration_claims_nothing(tmp_path):
     ).detected
 
 
+def test_discovery_reads_no_more_files_than_it_says_it_did(tmp_path):
+    """The cap and the flag that reports it must describe the same walk.
+
+    The slice was dropped when the loop was rewritten, so `truncated` was
+    published on a run that had read every file: the evidence line told a
+    reader "this count is a lower bound" for a count that was exact, and
+    `detect` — which runs on an unknown workspace with no manifest — walked an
+    unbounded number of source files.
+    """
+
+    workspace = tmp_path / "many"
+    (workspace / "src").mkdir(parents=True)
+    (workspace / "package.json").write_text(
+        json.dumps({"dependencies": {"@modelcontextprotocol/sdk": "^1"}}),
+        encoding="utf-8",
+    )
+    for index in range(6):
+        (workspace / "src" / f"t{index}.ts").write_text(
+            f'server.registerTool("tool_{index}", {{}}, handler);\n', encoding="utf-8"
+        )
+
+    capped = discover_mcp_server_source(
+        workspace, files=_inventory(workspace), max_source_files=2
+    )
+    assert capped.truncated is True
+    assert len(capped.tool_names) == 2
+    assert any("lower bound" in line for line in capped.evidence)
+
+    whole = discover_mcp_server_source(workspace, files=_inventory(workspace))
+    assert whole.truncated is False
+    assert len(whole.tool_names) == 6
+    assert not any("lower bound" in line for line in whole.evidence)
+
+
+def test_the_dependency_point_is_awarded_to_dependency_evidence(tmp_path):
+    """Scored by value, not by position in the rendered evidence list.
+
+    `evidence` is ordered for a human and gains conditional lines at the end,
+    so awarding the point to `evidence[1]` made the published confidence
+    depend on a list index rather than on the fact it stands for.
+    """
+
+    workspace = _grafana_shaped(tmp_path)
+    found = discover_mcp_server_source(workspace, files=_inventory(workspace))
+
+    assert found.framework_evidence
+    # At least one dependency reason is rendered, which is what the scoring
+    # matches on. Not containment: `_evidence_lines` caps the reasons it shows,
+    # so a workspace with many declaring packages renders only some of them.
+    assert set(found.framework_evidence) & set(found.evidence)
+    detection = next(
+        item
+        for item in detect_workspace(workspace).frameworks
+        if item.type == SOURCE_TYPE
+    )
+    # 2.0 registration + 1.0 declared dependency.
+    assert detection.score == 3.0
+    assert detection.confidence == "medium"
+
+
 def test_a_committed_export_keeps_the_route_it_already_had(tmp_path):
     """Acceptance: the snapshot route stays preferred where both see one server.
 

--- a/tests/test_mcp_server_source.py
+++ b/tests/test_mcp_server_source.py
@@ -1,0 +1,711 @@
+"""The ``mcp_server_source`` input, its discovery route, and its trigger (#431).
+
+Three first-party vendor MCP servers were measured before this input existed
+and all three returned ``is_agent_project: false``: the MongoDB server (49
+tools at the time, including ``drop-database``), ``mcp-grafana`` (Go), and —
+had its committed snapshots not been unreachable from ``detect``'s filename
+globs — ``github-mcp-server``. The fixtures below reproduce each server's
+registration shape rather than its content, so the tests state the property
+("this shape is readable") instead of pinning a vendor's tool list.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.cli.discovery.mcp_source import discover_mcp_server_source
+from agents_shipgate.cli.discovery.signals import detect_workspace
+from agents_shipgate.core.domain import SURFACE_ENUMERATED, SURFACE_PARTIAL
+from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.semantic_assessment import (
+    AST_ONLY_SOURCE_TYPES,
+    MCP_SOURCE_TYPES,
+)
+from agents_shipgate.inputs.mcp_idioms import DIFF_TOKENS
+from agents_shipgate.inputs.mcp_server_source import (
+    MAX_SCANNED_FILES,
+    SOURCE_TYPE,
+    MCPServerSourceAdapter,
+    load_mcp_server_source,
+)
+from agents_shipgate.inputs.protocol import REGISTRY
+from agents_shipgate.schemas.manifest import BUILTIN_TOOL_SOURCE_TYPES, ToolSourceConfig
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# --- Fixtures modelled on the three measured vendor servers -----------------
+
+
+def _mongodb_shaped(root: Path) -> Path:
+    """A TypeScript server declaring each tool as a class with static fields."""
+
+    workspace = root / "mongo"
+    tools = workspace / "packages" / "tools-mongodb" / "src" / "tools"
+    (tools / "delete").mkdir(parents=True)
+    (tools / "read").mkdir(parents=True)
+    (tools / "delete" / "dropDatabase.ts").write_text(
+        'import { MongoDBToolBase } from "../../mongodbTool.js";\n'
+        "\n"
+        "export class DropDatabaseTool extends MongoDBToolBase {\n"
+        '    static toolName = "drop-database";\n'
+        '    public description = "Removes the specified database";\n'
+        '    static operationType: OperationType = "delete";\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    (tools / "delete" / "deleteMany.ts").write_text(
+        "export class DeleteManyTool extends MongoDBToolBase {\n"
+        '    static toolName = "delete-many";\n'
+        '    static operationType: OperationType = "delete";\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    (tools / "read" / "aggregate.ts").write_text(
+        "export class AggregateTool extends MongoDBToolBase {\n"
+        '    static toolName = "aggregate";\n'
+        '    static operationType: OperationType = "read";\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    (workspace / "package.json").write_text(
+        json.dumps({"dependencies": {"@modelcontextprotocol/sdk": "^1.0.0"}}),
+        encoding="utf-8",
+    )
+    return workspace
+
+
+def _grafana_shaped(root: Path) -> Path:
+    """A Go server registering through a ``MustTool`` helper."""
+
+    workspace = root / "grafana"
+    (workspace / "tools").mkdir(parents=True)
+    (workspace / "tools" / "incident.go").write_text(
+        "package tools\n"
+        "\n"
+        "var UpdateIncident = mcpgrafana.MustTool(\n"
+        '\t"update_incident",\n'
+        '\t"Update an existing incident",\n'
+        "\tupdateIncident,\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    (workspace / "go.mod").write_text(
+        "module github.com/grafana/mcp-grafana\n"
+        "\n"
+        "require github.com/mark3labs/mcp-go v0.58.0\n",
+        encoding="utf-8",
+    )
+    return workspace
+
+
+def _source(path: str, source_id: str = "server") -> ToolSourceConfig:
+    return ToolSourceConfig(id=source_id, type=SOURCE_TYPE, path=path)
+
+
+# --- Registration -----------------------------------------------------------
+
+
+def test_the_input_is_registered_and_configurable():
+    assert SOURCE_TYPE in BUILTIN_TOOL_SOURCE_TYPES
+    assert REGISTRY.get(SOURCE_TYPE) is not None
+    assert REGISTRY.get(SOURCE_TYPE).scope == "per_source"
+
+
+def test_the_source_type_is_in_both_engine_vocabularies():
+    """It reads source, and what it reads is an MCP server.
+
+    ``AST_ONLY_SOURCE_TYPES`` is what makes completeness something this input
+    has to *establish* rather than assume; ``MCP_SOURCE_TYPES`` is what gives a
+    tool with no effect evidence the MCP protocol default instead of silence.
+    Both vocabularies had a second copy of themselves at some point, which is
+    why the check names them together.
+    """
+
+    assert SOURCE_TYPE in AST_ONLY_SOURCE_TYPES
+    assert SOURCE_TYPE in MCP_SOURCE_TYPES
+
+    from agents_shipgate.checks.mcp_permissions import (
+        MCP_SOURCE_TYPES as CHECK_MCP_SOURCE_TYPES,
+    )
+
+    assert CHECK_MCP_SOURCE_TYPES is MCP_SOURCE_TYPES
+
+
+def test_the_published_boundary_row_names_the_route():
+    coverage = MCPServerSourceAdapter.coverage
+    literal = next(
+        cell for cell in coverage.cells if cell.shape == "literal_registration"
+    )
+    assert literal.status == "extracted"
+    assert literal.emits == (SOURCE_TYPE,)
+    assert literal.ceiling == "medium"
+    assert literal.surface == SURFACE_ENUMERATED
+    dynamic = next(
+        cell for cell in coverage.cells if cell.shape == "dynamic_construction"
+    )
+    assert dynamic.status == "not_extracted"
+
+
+# --- Reading a server -------------------------------------------------------
+
+
+def test_a_typescript_server_yields_its_tools_at_medium_confidence(tmp_path):
+    workspace = _mongodb_shaped(tmp_path)
+    loaded = load_mcp_server_source(_source("packages"), workspace)
+
+    by_name = {tool.name: tool for tool in loaded.tools}
+    assert set(by_name) == {"drop-database", "delete-many", "aggregate"}
+    drop = by_name["drop-database"]
+    assert drop.source_type == SOURCE_TYPE
+    assert drop.extraction_confidence == "medium"
+    assert drop.extraction["surface"] == SURFACE_ENUMERATED
+    assert drop.extraction["idiom"] == "ts_static_tool_name"
+    assert drop.description == "Removes the specified database"
+    # The evidence is the file that registers the tool, not the configured
+    # directory: a finding pointing at `packages` sends a reviewer looking
+    # through the whole tree.
+    assert drop.source_path == "packages/tools-mongodb/src/tools/delete/dropDatabase.ts"
+    assert drop.source_start_line == 4
+    assert loaded.omissions == []
+
+
+def test_a_declared_operation_class_challenges_but_never_proves(tmp_path):
+    """``static operationType = "delete"`` is the vendor's own classification.
+
+    It arrives as a low-confidence ``inferred_keyword`` hint, which can
+    contradict a reviewer who declares ``drop-database`` read-only and can
+    never make an action pass-eligible on its own. ``read`` is deliberately
+    unmapped: a source asserting its own harmlessness is the one claim it has
+    an incentive to make.
+    """
+
+    workspace = _mongodb_shaped(tmp_path)
+    by_name = {
+        tool.name: tool
+        for tool in load_mcp_server_source(_source("packages"), workspace).tools
+    }
+
+    hint = by_name["drop-database"].risk_hints[0]
+    assert hint.tag == "destructive"
+    assert hint.source == "mcp_operation_type"
+    assert hint.confidence == "low"
+    assert hint.basis == "inferred_keyword"
+    assert hint.provenance_kind == "keyword_heuristic"
+    assert by_name["aggregate"].risk_hints == []
+
+
+def test_a_go_server_yields_its_tools(tmp_path):
+    workspace = _grafana_shaped(tmp_path)
+    loaded = load_mcp_server_source(_source("tools"), workspace)
+
+    assert [tool.name for tool in loaded.tools] == ["update_incident"]
+    assert loaded.tools[0].extraction["idiom"] == "go_must_tool"
+
+
+def test_a_single_file_path_is_accepted(tmp_path):
+    workspace = _grafana_shaped(tmp_path)
+    loaded = load_mcp_server_source(_source("tools/incident.go"), workspace)
+    assert [tool.name for tool in loaded.tools] == ["update_incident"]
+
+
+# --- What it refuses to guess ----------------------------------------------
+
+
+def test_a_runtime_name_is_recorded_as_unenumerated_not_dropped(tmp_path):
+    workspace = _mongodb_shaped(tmp_path)
+    (workspace / "packages" / "tools-mongodb" / "src" / "tools" / "read" / "export.ts").write_text(
+        "export class ExportTool extends MongoDBToolBase {\n"
+        "    static toolName = EXPORT_TOOL_NAME;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(_source("packages"), workspace)
+
+    assert [omission.reason for omission in loaded.omissions] == ["name_not_literal"]
+    omission = loaded.omissions[0]
+    assert omission.subject == (
+        "packages/tools-mongodb/src/tools/read/export.ts:2"
+    )
+    # The warning text is the join key the exclusion ledger uses, so it has to
+    # be the same string the omission carries.
+    assert omission.warning in loaded.warnings
+    assert "drop-database" in {tool.name for tool in loaded.tools}
+
+
+def test_completeness_is_per_file_not_per_source(tmp_path):
+    """#393's rule: one unresolved construct holds the file, not the tree.
+
+    Holding the whole source would make ``insufficient_evidence`` the answer
+    for any server with a single dynamically named tool, which is the constant
+    verdict #393 exists to stop being.
+    """
+
+    workspace = _mongodb_shaped(tmp_path)
+    tools = workspace / "packages" / "tools-mongodb" / "src" / "tools"
+    (tools / "read" / "mixed.ts").write_text(
+        'class A { static toolName = "find"; }\n'
+        "class B { static toolName = DYNAMIC; }\n",
+        encoding="utf-8",
+    )
+    by_name = {
+        tool.name: tool
+        for tool in load_mcp_server_source(_source("packages"), workspace).tools
+    }
+
+    assert by_name["find"].extraction["surface"] == SURFACE_PARTIAL
+    assert by_name["find"].extraction["surface_gaps"] == ["name_not_literal"]
+    assert by_name["drop-database"].extraction["surface"] == SURFACE_ENUMERATED
+
+
+def test_a_duplicate_registration_is_one_tool_and_says_so(tmp_path):
+    """Grafana registers ``alerting_manage_silences`` twice — one build is
+    mounted. Two catalog rows sharing an id would be one action counted twice.
+    """
+
+    workspace = _grafana_shaped(tmp_path)
+    (workspace / "tools" / "silences.go").write_text(
+        "package tools\n"
+        'var Read = mcpgrafana.MustTool("alerting_manage_silences", a, b)\n'
+        'var Write = mcpgrafana.MustTool("alerting_manage_silences", c, d)\n',
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(_source("tools"), workspace)
+
+    names = [tool.name for tool in loaded.tools]
+    assert names.count("alerting_manage_silences") == 1
+    assert any("registered more than once" in warning for warning in loaded.warnings)
+
+
+def test_test_files_do_not_contribute_tools(tmp_path):
+    workspace = _grafana_shaped(tmp_path)
+    (workspace / "tools" / "incident_test.go").write_text(
+        "package tools\n" 'var T = mcpgrafana.MustTool("demo_tool", a, b)\n',
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(_source("tools"), workspace)
+    assert "demo_tool" not in {tool.name for tool in loaded.tools}
+
+
+def test_a_path_with_no_readable_source_is_a_parse_error(tmp_path):
+    workspace = tmp_path / "empty"
+    (workspace / "docs").mkdir(parents=True)
+    (workspace / "docs" / "README.md").write_text("# hi\n", encoding="utf-8")
+    with pytest.raises(InputParseError, match="no TypeScript or Go files"):
+        load_mcp_server_source(_source("docs"), workspace)
+
+
+def test_a_single_file_in_another_language_is_a_parse_error(tmp_path):
+    workspace = tmp_path / "py"
+    workspace.mkdir()
+    (workspace / "server.py").write_text("x = 1\n", encoding="utf-8")
+    with pytest.raises(InputParseError, match="not a TypeScript or Go file"):
+        load_mcp_server_source(_source("server.py"), workspace)
+
+
+def test_a_missing_path_is_a_parse_error(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(InputParseError, match="Input path not found"):
+        load_mcp_server_source(_source("nope"), workspace)
+
+
+def test_the_file_cap_is_reported_and_holds_every_surface_partial(
+    tmp_path, monkeypatch
+):
+    """A cap that truncated silently would be the fail-open this input closes."""
+
+    monkeypatch.setattr(
+        "agents_shipgate.inputs.mcp_server_source.MAX_SCANNED_FILES", 2
+    )
+    workspace = _mongodb_shaped(tmp_path)
+    loaded = load_mcp_server_source(_source("packages"), workspace)
+
+    assert any(omission.reason == "walk_capped" for omission in loaded.omissions)
+    assert loaded.tools
+    for tool in loaded.tools:
+        assert tool.extraction["surface"] == SURFACE_PARTIAL
+        assert "walk_capped" in tool.extraction["surface_gaps"]
+
+
+def test_a_file_too_large_to_read_holds_the_whole_source_partial(
+    tmp_path, monkeypatch
+):
+    """An unread file is a hole in the enumeration, not a smaller enumeration.
+
+    Unlike one unresolved registration — which holds its own file — a file this
+    reader never opened could register anything, so the question it leaves open
+    is which tools exist at all.
+    """
+
+    monkeypatch.setattr(
+        "agents_shipgate.inputs.mcp_server_source.MAX_SOURCE_FILE_BYTES", 1000
+    )
+    workspace = _mongodb_shaped(tmp_path)
+    bundle = workspace / "packages" / "tools-mongodb" / "src" / "bundle.js"
+    bundle.write_text("// tool\n" + ("x" * 2000), encoding="utf-8")
+
+    loaded = load_mcp_server_source(_source("packages"), workspace)
+
+    assert [
+        omission.subject
+        for omission in loaded.omissions
+        if omission.reason == "file_too_large"
+    ] == ["packages/tools-mongodb/src/bundle.js"]
+    assert loaded.tools
+    for tool in loaded.tools:
+        assert tool.extraction["surface"] == SURFACE_PARTIAL
+        assert "file_too_large" in tool.extraction["surface_gaps"]
+
+
+def test_the_source_size_bound_sits_below_the_loader_s(tmp_path):
+    """Above the loader's limit the omission would name the wrong problem.
+
+    ``load_text_file`` refuses an oversized file first, and this input would
+    then record ``unreadable_file`` — a decoding problem — for a file that was
+    merely large.
+    """
+
+    from agents_shipgate.inputs.common import MAX_INPUT_FILE_BYTES
+    from agents_shipgate.inputs.mcp_idioms import MAX_SOURCE_FILE_BYTES
+
+    assert MAX_SOURCE_FILE_BYTES < MAX_INPUT_FILE_BYTES
+
+
+def test_a_file_that_is_not_utf8_is_recorded_rather_than_fatal(tmp_path):
+    """One undecodable file must not cost the repository its whole route."""
+
+    workspace = _mongodb_shaped(tmp_path)
+    broken = workspace / "packages" / "tools-mongodb" / "src" / "broken.ts"
+    broken.write_bytes(b'// tool\nconst s = "\xff\xfe";\n')
+
+    loaded = load_mcp_server_source(_source("packages"), workspace)
+
+    assert [
+        omission.reason
+        for omission in loaded.omissions
+        if omission.subject.endswith("broken.ts")
+    ] == ["unreadable_file"]
+    assert "drop-database" in {tool.name for tool in loaded.tools}
+
+
+def test_the_cap_default_is_a_real_bound():
+    assert MAX_SCANNED_FILES > 0
+
+
+# --- Discovery --------------------------------------------------------------
+
+
+def _inventory(workspace: Path) -> list[Path]:
+    from agents_shipgate.cli.discovery.artifacts import _candidate_files
+
+    return _candidate_files(workspace)
+
+
+def test_discovery_needs_both_a_dependency_and_a_registration(tmp_path):
+    workspace = _mongodb_shaped(tmp_path)
+    found = discover_mcp_server_source(workspace, files=_inventory(workspace))
+    assert found.detected
+    assert found.path == "packages/tools-mongodb/src/tools"
+    assert "drop-database" in found.tool_names
+
+    # Remove the dependency evidence and the same registrations prove nothing:
+    # a class of one's own that spells a field `toolName` is a coincidence of
+    # spelling until the repository says it speaks MCP.
+    (workspace / "package.json").write_text(
+        json.dumps({"dependencies": {"express": "^4"}}), encoding="utf-8"
+    )
+    assert not discover_mcp_server_source(
+        workspace, files=_inventory(workspace)
+    ).detected
+
+
+def test_a_dependency_without_a_registration_claims_nothing(tmp_path):
+    workspace = tmp_path / "client"
+    (workspace / "src").mkdir(parents=True)
+    (workspace / "package.json").write_text(
+        json.dumps({"dependencies": {"@modelcontextprotocol/sdk": "^1"}}),
+        encoding="utf-8",
+    )
+    (workspace / "src" / "client.ts").write_text(
+        'const client = new Client();\nawait client.callTool("x");\n', encoding="utf-8"
+    )
+    assert not discover_mcp_server_source(
+        workspace, files=_inventory(workspace)
+    ).detected
+
+
+def test_a_committed_export_keeps_the_route_it_already_had(tmp_path):
+    """Acceptance: the snapshot route stays preferred where both see one server.
+
+    An export is the server's own contract, carries the input schemas this
+    input does not read, and is ``high`` against this route's ``medium``. The
+    withheld route is *named* in ``excluded_sources`` — a route that vanished
+    without a reason would be indistinguishable from one nobody implemented.
+    """
+
+    workspace = _grafana_shaped(tmp_path)
+    (workspace / "mcp-tools.json").write_text(
+        json.dumps({"tools": [{"name": "update_incident", "inputSchema": {}}]}),
+        encoding="utf-8",
+    )
+    result = detect_workspace(workspace)
+
+    assert [source["type"] for source in result.suggested_sources] == ["mcp"]
+    withheld = [
+        entry for entry in result.excluded_sources if entry["type"] == SOURCE_TYPE
+    ]
+    assert len(withheld) == 1
+    assert "mcp-tools.json" in withheld[0]["reason"]
+
+
+# --- detect -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("build", [_mongodb_shaped, _grafana_shaped])
+def test_detect_reports_a_server_it_used_to_call_a_non_agent_project(
+    tmp_path, build
+):
+    workspace = build(tmp_path)
+    result = detect_workspace(workspace)
+
+    assert result.is_agent_project is True
+    detection = next(
+        item for item in result.frameworks if item.type == SOURCE_TYPE
+    )
+    assert detection.evidence
+    assert [source["type"] for source in result.suggested_sources] == [SOURCE_TYPE]
+    assert "Stop:" not in result.next_action
+
+
+def test_detect_and_scan_agree_on_the_tool_set(tmp_path):
+    """A route ``detect`` promises and ``scan`` refuses is the worst outcome.
+
+    They read the same files through the same predicate for exactly this
+    reason; the first draft had a second, weaker pre-filter in discovery and
+    the two disagreed by four tools on the MongoDB repository.
+    """
+
+    workspace = _mongodb_shaped(tmp_path)
+    found = discover_mcp_server_source(workspace, files=_inventory(workspace))
+    loaded = load_mcp_server_source(_source(found.path or "."), workspace)
+
+    assert set(found.tool_names) == {tool.name for tool in loaded.tools}
+
+
+def test_a_monorepo_server_resolves_to_one_manifest_scope(tmp_path):
+    """One server is one scope, however many packages hold its tools.
+
+    Contributing each registration file as scope evidence made
+    ``mongodb-js/mongodb-mcp-server`` read as six separate projects, so
+    ``detect`` published "run init in one of these" — and the package that
+    actually holds the tools declares no MCP dependency of its own, so the
+    published step returned ``is_agent_project: false``. A next step that
+    cannot change the answer is the defect #399 named.
+    """
+
+    workspace = _mongodb_shaped(tmp_path)
+    other = workspace / "packages" / "tools-atlas" / "src" / "tools"
+    other.mkdir(parents=True)
+    (other / "createCluster.ts").write_text(
+        'class C { static toolName = "atlas-create-cluster"; }\n', encoding="utf-8"
+    )
+    for package in ("tools-mongodb", "tools-atlas"):
+        (workspace / "packages" / package / "package.json").write_text(
+            json.dumps({"name": package}), encoding="utf-8"
+        )
+
+    result = detect_workspace(workspace)
+
+    assert result.agent_scope == "single"
+    assert [candidate.path for candidate in result.agent_project_candidates] == ["."]
+    detection = next(
+        item for item in result.frameworks if item.type == SOURCE_TYPE
+    )
+    assert detection.candidate_files == ["packages"]
+    assert result.suggested_sources == [{"type": SOURCE_TYPE, "path": "packages"}]
+    # And the route the scope resolves to is the one that reads both packages.
+    loaded = load_mcp_server_source(_source("packages"), workspace)
+    assert "atlas-create-cluster" in {tool.name for tool in loaded.tools}
+
+
+def test_the_detection_confidence_reflects_both_facts_behind_it(tmp_path):
+    """A registration *and* a declared dependency is not the weakest answer.
+
+    The label is what a reader of ``detect --json`` sees beside the route, and
+    reporting ``low`` for a conjunction the gate deliberately requires would
+    understate the only evidence there is.
+    """
+
+    workspace = _grafana_shaped(tmp_path)
+    detection = next(
+        item
+        for item in detect_workspace(workspace).frameworks
+        if item.type == SOURCE_TYPE
+    )
+    assert detection.confidence == "medium"
+
+
+def test_init_writes_the_source_detect_suggested(tmp_path):
+    from agents_shipgate.cli.discovery.template import render_auto_manifest
+
+    workspace = _grafana_shaped(tmp_path)
+    rendered = render_auto_manifest(workspace, detect_workspace(workspace))
+
+    assert f"type: {SOURCE_TYPE}" in rendered.text
+    assert "path: tools" in rendered.text
+    assert rendered.tool_surface_origin == "detected"
+
+
+# --- End to end -------------------------------------------------------------
+
+
+def test_scan_publishes_the_tools_and_accounts_for_the_unenumerated_one(tmp_path):
+    from agents_shipgate.cli.scan import run_scan
+
+    workspace = _mongodb_shaped(tmp_path)
+    (workspace / "packages" / "tools-mongodb" / "src" / "tools" / "read" / "export.ts").write_text(
+        "export class ExportTool extends MongoDBToolBase {\n"
+        "    static toolName = EXPORT_TOOL_NAME;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (workspace / "shipgate.yaml").write_text(
+        'version: "0.1"\n'
+        "project:\n"
+        "  name: mongodb-mcp-server\n"
+        "agent:\n"
+        "  name: mongodb-mcp-server\n"
+        "  declared_purpose:\n"
+        "    - expose MongoDB operations as MCP tools\n"
+        "environment:\n"
+        "  target: local\n"
+        "tool_sources:\n"
+        "  - id: mongodb_tools\n"
+        f"    type: {SOURCE_TYPE}\n"
+        "    path: packages\n",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=workspace / "shipgate.yaml",
+        output_dir=tmp_path / "out",
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=False,
+    )
+
+    names = {row["name"] for row in report.tool_catalog}
+    assert {"drop-database", "delete-many"} <= names
+    assert "export" not in names
+
+    ledger = report.surface_exclusions
+    unenumerated = [
+        entry for entry in ledger.entries if entry.reason == "name_not_literal"
+    ]
+    assert len(unenumerated) == 1
+    assert unenumerated[0].stage == "adapter_parse"
+    assert unenumerated[0].subject.endswith("export.ts:2")
+    assert unenumerated[0].accounting == "evidence_gap"
+
+
+def test_an_export_beside_the_source_route_keeps_its_high_confidence(tmp_path):
+    """Both routes configured: neither degrades the other.
+
+    Observations are never joined by name (#386), so the export's actions keep
+    their own provider-scoped identity and their ``high`` extraction evidence,
+    and the source route's sit beside them at ``medium``.
+    """
+
+    from agents_shipgate.cli.scan import run_scan
+
+    workspace = _grafana_shaped(tmp_path)
+    (workspace / "tools.json").write_text(
+        json.dumps({"tools": [{"name": "update_incident", "inputSchema": {}}]}),
+        encoding="utf-8",
+    )
+    (workspace / "shipgate.yaml").write_text(
+        'version: "0.1"\n'
+        "project:\n"
+        "  name: mcp-grafana\n"
+        "agent:\n"
+        "  name: mcp-grafana\n"
+        "  declared_purpose:\n"
+        "    - expose Grafana operations as MCP tools\n"
+        "environment:\n"
+        "  target: local\n"
+        "tool_sources:\n"
+        "  - id: exported\n"
+        "    type: mcp\n"
+        "    path: tools.json\n"
+        "  - id: registrations\n"
+        f"    type: {SOURCE_TYPE}\n"
+        "    path: tools\n",
+        encoding="utf-8",
+    )
+
+    report, _ = run_scan(
+        config_path=workspace / "shipgate.yaml",
+        output_dir=tmp_path / "out",
+        formats=["json"],
+        ci_mode="advisory",
+        packet_enabled=False,
+    )
+
+    by_provider = {row["provider"]: row for row in report.tool_catalog}
+    assert by_provider["exported"]["confidence"] == "high"
+    assert by_provider["registrations"]["confidence"] == "medium"
+
+
+# --- The trigger catalog ----------------------------------------------------
+
+
+def test_the_trigger_rule_routes_exactly_the_published_idiom_tokens():
+    """One token list, or the router and the reader drift apart.
+
+    A route table hand-maintained beside the function that owns the routes
+    drifts in the direction nobody checks (#433), and the direction nobody
+    checks here is a registration idiom that stops routing its own diffs.
+    """
+
+    catalog = json.loads((REPO_ROOT / "docs" / "triggers.json").read_text())
+    rule = next(
+        item
+        for item in catalog["rules"]
+        if item["id"] == "TRIGGER-MCP-TOOL-REGISTRATION-SOURCE"
+    )
+    tokens = sorted(clause["diff_contains"] for clause in rule["when"]["any_of"])
+    assert tokens == sorted(DIFF_TOKENS)
+    assert rule["action"] == "run_shipgate"
+    assert rule["surface_class"] == "capability"
+
+
+def test_the_trigger_rule_routes_the_diff_that_motivated_it():
+    """A diff adding a write-stage confirmation to a MongoDB tool class.
+
+    ``mongodb-js/mongodb-mcp-server#1417`` was the walk that produced this
+    issue: ``verify --preview`` reported ``matched_rules: []`` on it, so the
+    change that adds a human confirmation control to write-stage aggregations
+    routed nowhere.
+    """
+
+    from agents_shipgate.triggers import evaluate
+
+    verdict = evaluate(
+        paths=["packages/tools-mongodb/src/tools/read/aggregate.ts"],
+        diff_text=(
+            "+++ b/packages/tools-mongodb/src/tools/read/aggregate.ts\n"
+            '+    static toolName = "aggregate";\n'
+            "+    protected async confirmWriteStages(): Promise<void> {}\n"
+        ),
+        manifest_present=False,
+        user_requested=False,
+    )
+
+    assert "TRIGGER-MCP-TOOL-REGISTRATION-SOURCE" in [
+        rule["id"] for rule in verdict["matched_rules"]
+    ]
+    assert verdict["should_run"] is True

--- a/tests/test_mcp_server_source.py
+++ b/tests/test_mcp_server_source.py
@@ -522,6 +522,131 @@ def test_a_committed_export_keeps_the_route_it_already_had(tmp_path):
     assert "mcp-tools.json" in withheld[0]["reason"]
 
 
+def test_an_export_for_one_server_does_not_erase_another_s_registrations(tmp_path):
+    """The export has to name *this* surface before it displaces it.
+
+    Withholding on the mere existence of an export anywhere in the workspace
+    meant that in a repository holding two servers, an export committed for one
+    deleted every source-only registration of the other. The route that stood
+    down was the only route those tools had.
+    """
+
+    workspace = tmp_path / "two"
+    for name, tool in (("alpha", "alpha_read"), ("beta", "beta_write")):
+        package = workspace / "servers" / name
+        package.mkdir(parents=True)
+        (package / "package.json").write_text(
+            json.dumps({"dependencies": {"@modelcontextprotocol/sdk": "^1"}}),
+            encoding="utf-8",
+        )
+        (package / "index.ts").write_text(
+            f'server.registerTool("{tool}", {{}}, handler);\n', encoding="utf-8"
+        )
+    # Only alpha commits an export.
+    (workspace / "servers" / "alpha" / "mcp-tools.json").write_text(
+        json.dumps({"tools": [{"name": "alpha_read", "inputSchema": {}}]}),
+        encoding="utf-8",
+    )
+
+    found = discover_mcp_server_source(
+        workspace,
+        files=_inventory(workspace),
+        exported_source_paths=["servers/alpha/mcp-tools.json"],
+    )
+
+    assert found.detected
+    assert "beta_write" in found.tool_names
+    assert found.excluded == ()
+    assert any("does not name 1 of these registrations" in line for line in found.evidence)
+    assert any("beta_write" in line for line in found.evidence)
+
+
+def test_a_partial_export_does_not_erase_the_rest_of_one_server(tmp_path):
+    """Same rule inside a single server: cover the surface or stand aside."""
+
+    workspace = _grafana_shaped(tmp_path)
+    (workspace / "tools" / "extra.go").write_text(
+        "package tools\n"
+        'var Delete = mcpgrafana.MustTool("delete_incident", d, h)\n',
+        encoding="utf-8",
+    )
+    (workspace / "tools.json").write_text(
+        json.dumps({"tools": [{"name": "update_incident", "inputSchema": {}}]}),
+        encoding="utf-8",
+    )
+
+    found = discover_mcp_server_source(
+        workspace, files=_inventory(workspace), exported_source_paths=["tools.json"]
+    )
+
+    assert found.detected
+    assert "delete_incident" in found.tool_names
+    assert found.excluded == ()
+
+
+def test_a_complete_export_still_displaces_the_source_route(tmp_path):
+    """The withheld case is unchanged where the export really does cover."""
+
+    workspace = _grafana_shaped(tmp_path)
+    (workspace / "tools.json").write_text(
+        json.dumps({"tools": [{"name": "update_incident", "inputSchema": {}}]}),
+        encoding="utf-8",
+    )
+
+    found = discover_mcp_server_source(
+        workspace, files=_inventory(workspace), exported_source_paths=["tools.json"]
+    )
+
+    assert not found.detected
+    assert len(found.excluded) == 1
+    assert "names every one of these 1 registrations" in found.excluded[0]["reason"]
+
+
+def test_a_wildcard_export_never_displaces_the_source_route(tmp_path):
+    """A wildcard claims a surface without naming it, so it contains nothing."""
+
+    workspace = _grafana_shaped(tmp_path)
+    (workspace / "tools.json").write_text(
+        json.dumps({"wildcard": True, "tools": []}), encoding="utf-8"
+    )
+
+    found = discover_mcp_server_source(
+        workspace, files=_inventory(workspace), exported_source_paths=["tools.json"]
+    )
+
+    assert found.detected
+    assert found.excluded == ()
+
+
+def test_detect_and_scan_read_a_file_the_same_way(tmp_path):
+    """One decoding contract, or `detect` names a route `scan` cannot fill.
+
+    Discovery decoded with `errors="replace"`, so it could resolve a
+    registration out of a file the adapter then refuses as `unreadable_file` —
+    `detect` promising tools that `scan` does not enumerate.
+    """
+
+    workspace = _grafana_shaped(tmp_path)
+    # The undecodable bytes sit in a comment and the registration beside them
+    # is perfectly ordinary. That is what makes the two readers disagree: a
+    # lenient decode replaces the bytes and goes on to resolve `broken_file`,
+    # while the adapter refuses the file and enumerates nothing from it. A
+    # test whose bad bytes are *inside the name* cannot see the difference,
+    # because the replacement characters fail the tool-name shape either way.
+    (workspace / "tools" / "broken.go").write_bytes(
+        b"package tools\n"
+        b"// \xff\xfe\n"
+        b'var T = mcpgrafana.MustTool("broken_file", d, h)\n'
+    )
+
+    found = discover_mcp_server_source(workspace, files=_inventory(workspace))
+    loaded = load_mcp_server_source(_source("tools"), workspace)
+
+    assert set(found.tool_names) == {tool.name for tool in loaded.tools}
+    assert "broken_file" not in found.tool_names
+    assert "unreadable_file" in {omission.reason for omission in loaded.omissions}
+
+
 # --- detect -----------------------------------------------------------------
 
 

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -123,6 +123,49 @@ def test_script_does_not_claim_drop_in_parity(script_module):
     )
 
 
+def test_framework_vocabulary_names_every_cli_omission(script_module):
+    """Every framework the CLI can report is either here or a named omission.
+
+    The parity test above compares the two on ``samples/``, which is only as
+    strong as the fixtures: a detection the CLI gains and the script does not
+    is invisible to it until a sample exercises the difference. That is exactly
+    what happened with ``mcp_server_source`` (#431) — the CLI reads an MCP
+    server's tool names out of TypeScript or Go registration sites, no sample
+    contains one, and the script goes on reporting a repository like
+    ``mongodb-js/mongodb-mcp-server`` as *not an agent project*.
+
+    So the omission is written down instead of discovered. Adding a detection
+    to the CLI now fails here until it is either ported or listed, and the list
+    is the thing a reader can check against the script's own documented
+    simplifications.
+    """
+
+    from agents_shipgate.cli.discovery.signals import _initial_framework_scores
+
+    # Documented, deliberate, and filed as a follow-up to #431. Porting the
+    # reader means a second implementation of the load-bearing matcher, which
+    # needs its own increment and a conformance corpus shared with the package.
+    known_omissions = {"mcp_server_source"}
+
+    cli = set(_initial_framework_scores())
+    script = set(script_module.FRAMEWORKS)
+
+    assert script <= cli, (
+        f"the script reports frameworks the CLI cannot: {sorted(script - cli)}"
+    )
+    assert cli - script == known_omissions, (
+        "the script's framework vocabulary drifted from the CLI's: "
+        f"{sorted((cli - script) ^ known_omissions)}. Port the detection, or "
+        "add it to `known_omissions` here and to the script's `Intentional "
+        "simplifications` list."
+    )
+    for omitted in known_omissions:
+        assert omitted in SCRIPT_PATH.read_text(encoding="utf-8"), (
+            f"{omitted!r} is a known omission but the script never says so; "
+            "a reader of the script cannot discover it."
+        )
+
+
 def test_script_emits_canonical_top_level_keys(script_module):
     """The script's JSON output must carry the same top-level keys as
     DetectResult, plus ``script_version`` to distinguish it from the

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -142,9 +142,9 @@ def test_framework_vocabulary_names_every_cli_omission(script_module):
 
     from agents_shipgate.cli.discovery.signals import _initial_framework_scores
 
-    # Documented, deliberate, and filed as a follow-up to #431. Porting the
-    # reader means a second implementation of the load-bearing matcher, which
-    # needs its own increment and a conformance corpus shared with the package.
+    # Documented, deliberate, and filed as #485. Porting the reader means a
+    # second implementation of the load-bearing matcher, which needs its own
+    # increment and a conformance corpus shared with the package.
     known_omissions = {"mcp_server_source"}
 
     cli = set(_initial_framework_scores())

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -48,6 +48,14 @@ Intentional simplifications vs. the canonical CLI:
 
 - No ``diagnostics[]`` / ``next_actions[]`` (the diagnostic engine is
   not in scope for stdlib-only / zero-install).
+- **No ``mcp_server_source`` detection.** The installed CLI reads an MCP
+  server's tool names out of TypeScript or Go registration sites through a
+  built-in idiom registry (#431); this script does not, so a repository whose
+  tool surface exists only as code is reported here as *not* an agent project
+  while the CLI reports it as one. That is the largest divergence in this list
+  and the only one that changes ``is_agent_project``. No sample exercises it
+  today, so the parity test cannot see it; ``test_framework_vocabulary_names_every_cli_omission``
+  pins it instead, and it is filed as a follow-up to #431.
 - ``agent_scope`` / ``agent_scope_truncated`` / ``python_parse_truncated`` /
   ``agent_project_candidates[]``
   are carried, and the contract test pins them against the CLI: an agent that

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -55,7 +55,7 @@ Intentional simplifications vs. the canonical CLI:
   while the CLI reports it as one. That is the largest divergence in this list
   and the only one that changes ``is_agent_project``. No sample exercises it
   today, so the parity test cannot see it; ``test_framework_vocabulary_names_every_cli_omission``
-  pins it instead, and it is filed as a follow-up to #431.
+  pins it instead, and it is filed as #485.
 - ``agent_scope`` / ``agent_scope_truncated`` / ``python_parse_truncated`` /
   ``agent_project_candidates[]``
   are carried, and the contract test pins them against the CLI: an agent that


### PR DESCRIPTION
Closes #431.

`detect` reported the official MongoDB and Grafana MCP servers as **not an agent
project**. Both publish dozens of tools — `drop-database`, `delete-many`,
`update_incident` — and neither commits an export, so every route discovery had
was filename-shaped and found nothing. The discriminator was never the language
(two of the three servers walked are Go); it was whether the repository happens
to *emit* its tool list.

Reproduced before the change, on all three:

```
is_agent_project : false
suggested_sources: []
next_action      : "Stop: … no framework imports and no parseable tool artifact"
```

## What this adds

`tool_sources[].type: mcp_server_source` reads the tool name where every one of
those servers writes it: as a string literal at a registration site. It runs no
code, evaluates no schema library, infers no type, and reads no annotation the
source declares about itself.

Which sites count comes from a **built-in, versioned registry of named
registration idioms** (`agents_shipgate.inputs.mcp_idioms`), never from a
configured pattern — at `detect` time there is no manifest, and post-adoption a
configured regex would hand the definition of evidence to configuration
shipping in the same pull request as the tool it could hide (#268). Reading is
done over a **masked** copy of the source in which comments and string bodies
are overwritten, so a registration can never be found inside a comment or
inside another string, and a name is a name only when the masking pass recorded
a real literal at that offset.

## Scope, by measurement

The issue required a survey before choosing the idiom set. Thirty MCP servers
and the three official SDKs were cloned and scanned; the result is published at
[`docs/mcp-registration-idioms.md`](docs/mcp-registration-idioms.md).

| idiom | repos | largest | shipped |
|---|---|---|---|
| Python `@mcp.tool` (FastMCP) | 5 | `awslabs/mcp` (488) | **no — follow-up** |
| Go `Tool{Name: "…"}` | 3 | `github/github-mcp-server` (135) | yes |
| TS `.tool(` / `.registerTool("…"` | 3 | `cloudflare/mcp-server-cloudflare` (85) | yes |
| Go `NewTool("…"` | 2 | `hashicorp/terraform-mcp-server` (63) | yes |
| Go `MustTool("…"` | 1 | `grafana/mcp-grafana` (132) | yes |
| TS `static toolName = "…"` | 1 | `mongodb-js/mongodb-mcp-server` (77) | yes |

Python FastMCP is the largest measured shape and is deliberately deferred: it
is a different extraction mechanism (real AST, name from the function, schema
from the signature, provenance from an import binding), and #393 requires each
mechanism to bring its own adversarial probe list. The lexical reader here had
**eight fail-open constructs in its first draft**, all found by writing that
list. Filed as a follow-up with the measurement.

One shape was measured and rejected: a `{name: …, description: …}` object
literal, in 14 of the surveyed repositories. It matches most configuration in a
TypeScript codebase; a reader resting on it would invent tools rather than find
them.

## Verified against the live repositories

| acceptance (#431) | result |
|---|---|
| `detect` on `mongodb-mcp-server` → `is_agent_project: true`, named source | `mcp_server_source` at `packages`, confidence `medium` |
| `scan` enumerates the tools, `drop-database` + `delete-many` present | 61 tools, both present, each with its own file and line |
| extraction confidence measured, not assumed (#393) | `medium` + per-file `extraction.surface` `enumerated`/`partial` |
| a runtime-built name is unenumerated, and the ledger records it (#403) | 3 rows, `adapter_parse` / `name_not_literal` / `evidence_gap` |
| `mcp-grafana` #1080 delta names `update_incident` | 107 → 108, added `update_incident`, nothing removed |
| `github-mcp-server` regresses nothing | export route stays preferred and `high`; source route withheld and named |

The full chain was run on the real MongoDB checkout: `detect` → `init --write`
→ `scan` produces a manifest naming the route and a report with 61 tools.
Grafana's delta was measured by loading `pull/1080/head` and its parent: the
counts differ from the issue's 99 → 100 (a different counting method, and the
reader excludes test files), the **delta** is exactly the one the issue names.

Six repositories beyond the beachhead were checked end to end and all resolve a
route: cloudflare (80 tools), terraform (61), `modelcontextprotocol/servers`
(24 + 18 unenumerated), context7 (2), plus the three vendors.

## What it refuses to guess

- A name that is not a literal — a constant, a template substitution, a
  concatenation — is reported **unenumerated**, never dropped: a typed
  `SourceSurfaceOmission` the exclusion ledger accounts for by subject, holding
  its own file's surface at `partial` (per-file, as #393 settled).
- A file whose masking pass cannot complete (an unterminated string or block
  comment) is reported unreadable rather than read as though the rest were
  code, and holds the **whole source** at `partial` — as does a file skipped
  for size and the walk cap.
- `.tool("issues")` with one argument is a lookup, not a registration.
- `static toolName = "backup" + SUFFIX` resolves to a literal this reader can
  see; reading it as the name would publish a tool the server registers under
  another one, so it is unresolved instead.
- `NewTool(meta, mcp.Tool{Name: "issue_read"})` reports **one** site, not a
  tool and an omission for the wrapper that named it one argument later.

## Where an export still wins

An export is the server's own published contract, carries the input schemas
this route deliberately does not read, and is `high` against this route's
`medium`. `detect` withholds the source route wherever a parseable MCP export
covers the workspace and records the withheld route in `excluded_sources` with
the export that displaced it — named and visible, never silently dropped. With
both configured, observations are never joined by name (#386), so the export's
actions keep their own identity and their `high` evidence.

## Effect evidence

MongoDB writes `static operationType = "delete"` beside `drop-database`. That
arrives as a **low-confidence `inferred_keyword` hint**: it can contradict a
reviewer who declares the tool read-only and can never close an effect gap or
make an action pass-eligible on its own. `read` and `metadata` are deliberately
unmapped — a tool server asserting its own harmlessness is the one claim an
untrusted source has an incentive to make.

## Routing

`TRIGGER-MCP-TOOL-REGISTRATION-SOURCE` routes such a diff, on tokens derived
from the same registry and pinned against it by test. They are deliberately
narrower than what the reader matches: a matched capability rule overrides the
workspace stop condition, so a router firing on `.tool(` would turn "not an
agent project" into "run" for any diff containing that substring. Verified
against the real `mongodb-mcp-server#1417` diff — the walk that produced this
issue, and which previously matched no rule at all.

The trigger catalog's `schema_version` is **unchanged**: the rule uses existing
predicates and adds no field, so no consumer has to change to keep reading it.
`report_schema_version` is unchanged too — `generate_schemas.py --check` moves
only the determinism-boundary artifacts, which gain the new input's four rows.

## Surface discipline

- **Headline metric:** activation rate and time-to-first-verdict for MCP
  servers whose surface is only in code — currently *undefined* rather than
  poor, since `detect` says Stop.
- **Existing surface:** extended, not paralleled — one adapter in the existing
  registry, feeding the one decision engine and the existing questionnaire.
- **Non-goal:** filed as the evidence the "a real workflow needs one" clause
  asks for. Three vendor servers measured, two invisible; thirty surveyed.

## Also in this change

- `checks/mcp_permissions.MCP_SOURCE_TYPES` was a second copy of the constant in
  `core.semantic_assessment`; it now imports the one, and a test pins that.
- `_collect_dir_hits`'s framework list is named `CONVENTIONAL_DIR_FRAMEWORKS`
  with the reason it differs from the score sheet, instead of being a second
  copy inline.
- `tools/shipgate-detect.py` (zero-install) does **not** gain this detection:
  porting the reader means a second implementation of the load-bearing matcher,
  which deserves its own increment and a shared conformance corpus. The
  divergence is named in the script's own "intentional simplifications" list and
  pinned by a test, and it is filed as a follow-up.

## Review notes

Two things were implemented, measured, and reverted; both are recorded in code
comments and in the survey doc so the next person does not re-derive them:

1. **Splitting a monorepo by which package declares the MCP dependency.** More
   correct for `modelcontextprotocol/servers` and cloudflare; on MongoDB the SDK
   is declared by an eval-harness package and by three dev-dependency packages
   supporting the one server, so the split returned four scopes and withheld the
   route from the repository this issue is about. The single route is
   over-broad for a multi-server monorepo, visible in the manifest, and narrowed
   in one line.
2. **A pre-filter at the call site keyed off the trigger's diff tokens.**
   `static toolName` does not appear in `public static readonly toolName:
   string = "…"`, so four MongoDB tools were reported by `scan` and never by
   `detect`. The pre-filter now lives inside `scan_source`, where no caller can
   implement a weaker copy of it, and a test pins that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
