### PR TITLE
Make a preview wheel report one version instead of two (#491)

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -136,12 +136,19 @@ jobs:
           echo "Preview version: ${version}"
 
       - name: Build the preview wheel
-        # The source difference between this wheel and the committed tree is
-        # exactly one line. The round-trip below is what makes that a fact
-        # rather than an intention: restoring the original version string must
-        # reproduce the committed bytes, so a stamping step that also rewrote a
-        # dependency, a classifier or an entry point is refused before the
-        # build runs.
+        # The version lives in TWO places and both must move together.
+        # `pyproject.toml` decides the wheel's METADATA, and
+        # `src/agents_shipgate/__init__.py` carries `__version__` as a literal,
+        # which is what `--version` and `doctor` report. Stamping only the
+        # first shipped a wheel whose METADATA said `…+preview…` while the CLI
+        # said plain `0.16.0` — indistinguishable from the qualified release,
+        # and enough to make `doctor` emit a false `installed_version_differs`
+        # claiming two copies were shadowing each other when only one existed.
+        #
+        # The round trip is the proof, per file: restoring the original version
+        # string must reproduce the committed bytes, so a stamping step that
+        # also rewrote a dependency, a classifier or an entry point is refused
+        # before the build runs.
         id: build
         env:
           PREVIEW_VERSION: ${{ steps.version.outputs.version }}
@@ -153,27 +160,40 @@ jobs:
           import pathlib
           import re
 
-          path = pathlib.Path("pyproject.toml")
-          original = path.read_text(encoding="utf-8")
-          pattern = re.compile(r'^version = "(?P<value>[^"]*)"$', re.MULTILINE)
-          matches = pattern.findall(original)
-          if len(matches) != 1:
-              raise SystemExit(
-                  "::error::Expected exactly one version line in pyproject.toml, found %d."
-                  % len(matches)
+          version = os.environ["PREVIEW_VERSION"]
+          targets = {
+              "pyproject.toml": r'^version = "(?P<value>[^"]*)"$',
+              "src/agents_shipgate/__init__.py": r'^__version__ = "(?P<value>[^"]*)"$',
+          }
+          for name, raw in targets.items():
+              path = pathlib.Path(name)
+              original = path.read_text(encoding="utf-8")
+              pattern = re.compile(raw, re.MULTILINE)
+              found = pattern.findall(original)
+              if len(found) != 1:
+                  raise SystemExit(
+                      "::error::Expected exactly one version line in %s, found %d."
+                      % (name, len(found))
+                  )
+              stamped = pattern.sub(
+                  lambda match: match.group(0).replace(match.group("value"), version),
+                  original,
+                  count=1,
               )
-          stamped = pattern.sub(
-              'version = "%s"' % os.environ["PREVIEW_VERSION"], original, count=1
-          )
-          # The round trip: undo the stamp and the file must be byte-identical.
-          if pattern.sub('version = "%s"' % matches[0], stamped, count=1) != original:
-              raise SystemExit("::error::Stamping changed more than the version line.")
-          path.write_text(stamped, encoding="utf-8")
-          print("Stamped %s -> %s" % (matches[0], os.environ["PREVIEW_VERSION"]))
+              restored = pattern.sub(
+                  lambda match, old=found[0]: match.group(0).replace(version, old),
+                  stamped,
+                  count=1,
+              )
+              if restored != original:
+                  raise SystemExit("::error::Stamping %s changed more than the version." % name)
+              path.write_text(stamped, encoding="utf-8")
+              print("Stamped %s: %s -> %s" % (name, found[0], version))
           PY
-          changed="$(git diff --name-only)"
-          if [ "${changed}" != "pyproject.toml" ]; then
-            echo "::error::Stamping the preview version touched more than pyproject.toml: ${changed}"
+          changed="$(git diff --name-only | sort | tr '\n' ' ')"
+          expected="pyproject.toml src/agents_shipgate/__init__.py "
+          if [ "${changed}" != "${expected}" ]; then
+            echo "::error::Stamping touched an unexpected file set: ${changed}"
             exit 1
           fi
           # `--no-isolation` so the hash-locked hatchling installed above is
@@ -189,11 +209,18 @@ jobs:
             echo "wheel_sha256=$(sha256sum "${wheel}" | cut -d' ' -f1)"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Confirm the preview is unpublishable to a public index
-        # Asserted here, on the artifact itself, and not only in the tests: a
-        # wheel whose version lost its local segment would still install, and
-        # would then be uploadable to PyPI under a version the qualified build
-        # needs. Fail before the artifact leaves the job.
+      - name: Confirm the wheel describes itself as an unpublishable preview
+        # Asserted on the built artifact, never on the strings this job
+        # computed, because the interesting failures are the ones where the
+        # workflow believed it stamped something and the wheel disagrees.
+        #
+        # Two properties, and the second is the one the first shipped preview
+        # violated: METADATA must carry a local segment (so no public index
+        # will accept these bytes), AND the `__version__` the CLI reports must
+        # equal it. A wheel whose METADATA says `…+preview…` while `--version`
+        # says plain `0.16.0` is exactly the confusion this channel exists to
+        # prevent, and it also makes `doctor` report a shadowed installation
+        # that does not exist.
         env:
           WHEEL_FILENAME: ${{ steps.build.outputs.wheel_filename }}
           PREVIEW_VERSION: ${{ steps.version.outputs.version }}
@@ -204,20 +231,37 @@ jobs:
             *) echo "::error::Preview version lost its local segment: ${PREVIEW_VERSION}"; exit 1 ;;
           esac
           python - <<'PY'
-          import os, pathlib, zipfile
+          import os
+          import pathlib
+          import re
+          import zipfile
           from email.parser import BytesParser
           from email.policy import default
+
           wheel = pathlib.Path("dist") / os.environ["WHEEL_FILENAME"]
           with zipfile.ZipFile(wheel) as archive:
-              name = next(n for n in archive.namelist() if n.endswith(".dist-info/METADATA"))
-              metadata = BytesParser(policy=default).parsebytes(archive.read(name))
-          version = metadata["Version"]
-          if "+" not in version:
+              metadata_name = next(
+                  n for n in archive.namelist() if n.endswith(".dist-info/METADATA")
+              )
+              metadata = BytesParser(policy=default).parsebytes(archive.read(metadata_name))
+              runtime = archive.read("agents_shipgate/__init__.py").decode("utf-8")
+
+          declared = metadata["Version"]
+          if "+" not in declared:
               raise SystemExit(
                   "::error::Wheel METADATA version %r carries no local segment; "
-                  "a public index would accept it." % version
+                  "a public index would accept it." % declared
               )
-          print("OK: wheel version %s is refused by any public index." % version)
+          match = re.search(r'^__version__ = "([^"]*)"$', runtime, re.MULTILINE)
+          if match is None:
+              raise SystemExit("::error::Wheel carries no __version__ literal.")
+          if match.group(1) != declared:
+              raise SystemExit(
+                  "::error::Wheel METADATA says %r but the packaged __version__ says %r; "
+                  "`--version` would report a release that was never built."
+                  % (declared, match.group(1))
+              )
+          print("OK: wheel reports %s from both METADATA and __version__." % declared)
           PY
 
       - name: Upload the preview wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **A preview wheel now reports one version, not two.** (#491) The first
+  published preview stamped `pyproject.toml` and not
+  `src/agents_shipgate/__init__.py`, so its METADATA said
+  `0.16.0+preview.20260902.gcc59410` while `--version` said plain `0.16.0` —
+  the exact confusion the local version segment exists to prevent. `doctor` was
+  collateral: comparing `installed_version` against `imported_version`, it
+  reported `installed_version_differs` and told the user two copies were
+  shadowing each other, on an environment holding one.
+
+  The build now stamps both sites and proves each with its own round trip over
+  a closed file set, but the durable guard is on the artifact: it opens the
+  wheel it just built and requires `METADATA: Version` to equal the packaged
+  `__version__`. That fails on any future divergence however the stamping is
+  written. A companion test pins the committed tree to exactly two version
+  sites that already agree, so a third one cannot be added and silently left
+  unstamped.
+
+
 - **Releases run on a cadence, and work that cannot be tagged can still be
   installed.** (#491) 81% of this changelog had never reached a user: 5,039 of
   6,242 lines sat under `## Unreleased`, two milestones were complete and

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -400,6 +400,40 @@ the build is not. No tier name appears in it.
 who lands on the repository's releases page sees the newest *qualified* release
 labelled as such, and previews below it labelled as not one.
 
+### Field note: the first preview violated C1, and what now enforces it
+
+Recorded because this amendment asserted a property the first implementation did
+not have. C1 claims a preview is "self-describing in `pip freeze`, in
+`--version`, and in any bug report a preview user files." The first published
+preview — `0.16.0+preview.20260902.gcc59410`, cut from `cc594109` — was not.
+
+The version lives in **two** places: `pyproject.toml` decides the wheel's
+METADATA, and `src/agents_shipgate/__init__.py` carries `__version__` as a
+literal, which is what `--version` and `doctor` report. The workflow stamped
+only the first. The published wheel therefore said `0.16.0+preview…` in its
+METADATA — so C1's index refusal held — while the installed CLI reported plain
+`0.16.0`, **indistinguishable from the qualified release it was supposed to be
+distinguishable from**.
+
+The second-order effect was worse than the first. `doctor` compares
+`installed_version` against `imported_version` and emitted a
+`installed_version_differs` mismatch reading *"Two installed copies are
+shadowing each other; which one runs depends on path order"* — on an
+environment holding exactly one copy. A diagnostic built (#334) to be
+trustworthy was made to lie by a normal install.
+
+What enforces it now is not "stamp both files". It is a check on the
+**artifact**: the build opens the wheel it just produced and requires
+`METADATA: Version` to equal the `__version__` literal packaged inside it. That
+holds regardless of how many version sites exist or how the stamping is spelled,
+and a companion test pins the committed tree to exactly two sites that already
+agree. Both are in `tests/test_release_pipeline.py` § #491, and a perturbation
+sweep replays the shipped defect to confirm the guard fails on it.
+
+The general lesson, which is not specific to previews: **a claim in this
+document is not a control.** C1's index refusal was structural and held. C1's
+self-description was prose, and did not.
+
 ### What the channel does and does not attest
 
 The issue proposed attaching "the wheel built by the existing verify path".

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -3023,11 +3023,69 @@ def test_the_preview_version_carries_a_local_segment() -> None:
     # nested, because `a+b+c` is not a PEP 440 version at all.
     assert "already carries a local version" in derive
 
-    confirm = _test_step_command(build, "Confirm the preview is unpublishable to a public index")
+    confirm = _test_step_command(
+        build, "Confirm the wheel describes itself as an unpublishable preview"
+    )
     # Asserted on the built wheel's own METADATA, not on the string the
     # workflow computed: the check has to survive a build that rewrote it.
     assert "METADATA" in confirm
-    assert 'if "+" not in version' in confirm
+    assert 'if "+" not in declared' in confirm
+
+
+def test_the_preview_wheel_reports_one_version_from_both_of_its_sites() -> None:
+    """The defect the first published preview actually shipped.
+
+    The version lives twice — `pyproject.toml` decides METADATA, and
+    `src/agents_shipgate/__init__.py` carries the `__version__` literal that
+    `--version` and `doctor` report. Stamping only the first produced a wheel
+    whose METADATA said `0.16.0+preview…` while the CLI said plain `0.16.0`:
+    indistinguishable from the qualified release, and enough to make `doctor`
+    emit a false `installed_version_differs` claiming two copies were shadowing
+    each other when the environment held exactly one.
+
+    Both halves are pinned: that the build stamps both files, and that the
+    *artifact* is checked for agreement afterwards. The second is what makes
+    this durable — it fails on any future divergence regardless of how the
+    stamping is spelled.
+    """
+
+    build = _preview()["jobs"]["build"]
+    stamp = _test_step_command(build, "Build the preview wheel")
+    confirm = _test_step_command(
+        build, "Confirm the wheel describes itself as an unpublishable preview"
+    )
+
+    assert '"pyproject.toml": r\'^version = "(?P<value>[^"]*)"$\'' in stamp
+    assert (
+        '"src/agents_shipgate/__init__.py": r\'^__version__ = "(?P<value>[^"]*)"$\'' in stamp
+    )
+    # The stamped file set is closed, so a third version site cannot be added
+    # to the tree and silently left behind here.
+    assert 'expected="pyproject.toml src/agents_shipgate/__init__.py "' in stamp
+    # And the artifact itself is required to agree.
+    assert 'archive.read("agents_shipgate/__init__.py")' in confirm
+    assert 'if match.group(1) != declared' in confirm
+
+
+def test_the_repository_has_exactly_the_two_version_sites_the_preview_stamps() -> None:
+    """The closed set above is only closed if the tree agrees with it.
+
+    A third literal version site added later would be stamped by nothing, and
+    the preview would ship a wheel that disagrees with itself again — the
+    workflow's own file-set guard would catch it, but only after someone cut a
+    preview. This fails in CI instead.
+    """
+
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    init = (REPO_ROOT / "src/agents_shipgate/__init__.py").read_text(encoding="utf-8")
+
+    assert len(re.findall(r'^version = "[^"]*"$', pyproject, re.MULTILINE)) == 1
+    assert len(re.findall(r'^__version__ = "[^"]*"$', init, re.MULTILINE)) == 1
+    # They must already agree in the committed tree, or a release build ships
+    # the same split the preview did.
+    assert re.search(r'^version = "([^"]*)"$', pyproject, re.MULTILINE).group(1) == re.search(
+        r'^__version__ = "([^"]*)"$', init, re.MULTILINE
+    ).group(1)
 
 
 def test_a_preview_ref_cannot_trigger_the_release_pipeline() -> None:
@@ -3133,10 +3191,10 @@ def test_the_preview_wheel_comes_from_the_release_build_toolchain() -> None:
     assert "--require-hashes" in install
     assert "constraints/release-seal.txt" in install
     assert "python -m build --wheel --no-isolation" in compile_step
-    # The only difference from the committed tree is the version line, proved
-    # by a round trip rather than asserted.
-    assert "Stamping changed more than the version line" in compile_step
-    assert "touched more than pyproject.toml" in compile_step
+    # The only difference from the committed tree is the version, proved by a
+    # per-file round trip rather than asserted, over a closed file set.
+    assert "changed more than the version" in compile_step
+    assert "Stamping touched an unexpected file set" in compile_step
 
 
 def test_the_release_handoff_invariants_were_not_relaxed_to_fit_a_preview(


### PR DESCRIPTION
Found by installing the first preview, not by reading it. `preview-0.16.0+preview.20260902.gcc59410` (from `cc594109`) is live and carries this defect.

## What shipped wrong

The version lives in **two** places:

| Site | Decides |
|---|---|
| `pyproject.toml` | the wheel's `METADATA: Version` |
| `src/agents_shipgate/__init__.py` | the `__version__` literal that `--version` and `doctor` report |

`release-preview.yml` stamped only the first. Installed from the published wheel:

```
$ agents-shipgate --version
Agents Shipgate 0.16.0          ← indistinguishable from the qualified release
```

C1's index refusal still held (METADATA carried the local segment, so PyPI would refuse it). What failed was C1's *other* half — self-description.

**The second-order effect is worse.** `doctor` compares `installed_version` against `imported_version`:

```json
{"code": "installed_version_differs",
 "detail": "…is 0.16.0+preview.20260902.gcc59410, but the package imported … reports 0.16.0.
            Two installed copies are shadowing each other; which one runs depends on path order.",
 "severity": "warning"}
```

There was exactly **one** copy. A diagnostic built in #334 to be trustworthy was made to lie by an ordinary install, and would have sent an evaluator chasing a shadowing problem that does not exist.

## The fix is on the artifact, not on the intention

"Stamp both files" is what I would have written if the goal were to close this instance. The durable guard is the one that does not care how stamping is spelled:

> the build opens the wheel it just produced and requires `METADATA: Version` to equal the `__version__` packaged inside it.

That holds for any number of version sites and any future rewrite of the stamping step. Around it:

- stamping covers both sites, each proved by **its own round trip** (restore the original string ⇒ committed bytes reproduced);
- the stamped file set is **closed** — an unexpected file in `git diff` fails before the build;
- a companion test pins the committed tree to exactly two version sites **that already agree**, so a third cannot be added and silently left unstamped.

## Verification

A four-case perturbation sweep, all **CAUGHT**:

| Mutation | |
|---|---|
| revert to stamping only `pyproject.toml` (a direct replay of the shipped defect) | ✓ |
| delete the artifact self-agreement check | ✓ |
| relax the closed file-set guard to accept anything | ✓ |
| desynchronize the two version sites in the committed tree | ✓ |

Full suite green, `ruff check .` clean.

## Also

`docs/release-evidence-policy-decision.md` § Amendment 2 gains a field note, because that amendment asserted this property before anything enforced it. The lesson recorded there is the general one: **a claim in a design document is not a control.** C1's index refusal was structural and held. C1's self-description was prose, and did not.

The live preview `preview-0.16.0+preview.20260902.gcc59410` still carries the defect and should be deleted once this lands — a re-cut from the fix produces a different version and tag, so it will not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)