### PR TITLE
Correct two stale qualification claims, and bind them to what they claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ Agents Shipgate is a static, manifest-first scanner. It is intentionally narrow:
 - It does not verify runtime behavior, latency, prompt quality, or routing decisions.
 - It does not replace dynamic security testing or human security review of the underlying systems.
 - It only inspects what is declared in `shipgate.yaml`, local OpenAPI specs, MCP exports, MCP server source registrations, Anthropic/OpenAI API artifacts, optional SDK AST metadata, static Google ADK/LangChain/CrewAI/n8n/Conductor OSS inputs, Codex repo config, and static Codex plugin package metadata; tools that are not declared or statically discoverable are not scanned.
-- The manifest remains `version: "0.1"` so existing configs keep working. Current reports carry `report_schema_version: "0.42"`; every narrowing decision is recorded in `surface_exclusions` and reachable by the release decision, while v0.41 remains frozen for archived reports.
+- The manifest remains `version: "0.1"` so existing configs keep working. Current reports carry `report_schema_version: "0.43"`; every narrowing decision is recorded in `surface_exclusions` and reachable by the release decision, while v0.42 remains frozen for archived reports.
 
 See [ROADMAP.md](ROADMAP.md) for what is planned next.
 

--- a/benchmark/safety-qualification/README.md
+++ b/benchmark/safety-qualification/README.md
@@ -33,7 +33,7 @@ The runner consumes four independently content-addressed inputs:
 Receipt entries must point to real `verify` artifacts. Each receipt needs
 successful base and head tree-bound runs plus content-addressed
 `verifier_json` and `report_json` artifacts. The report must use the schema
-`required_report_schema_version` pins (`0.42` today, identical in both
+`required_report_schema_version` pins (`0.43` today, identical in both
 policies and asserted equal to what the engine emits by
 `test_the_qualification_gate_demands_the_schema_the_engine_emits`),
 contain binding and semantic coverage, and agree with the verifier receipt. Missing,
@@ -165,7 +165,7 @@ sigstore sign --bundle safety-qualification.sigstore.json safety-qualification.j
 Release promotion consumes the signed result and the same wheel through
 protected `pypi` environment variables. See
 [`docs/distribution.md`](../../docs/distribution.md#protected-qualification-inputs)
-for the exact six-variable contract. The tag workflow verifies the signer, a
+for the exact variable contract. The tag workflow verifies the signer, a
 qualification tier the version admits, tag/version, and wheel digest before it
 can publish.
 

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -58,6 +58,7 @@ from agents_shipgate.schemas.org_evidence_bundle import ORG_EVIDENCE_BUNDLE_SCHE
 from agents_shipgate.schemas.packet import EvidencePacket
 from agents_shipgate.schemas.registry import REGISTRY_SCHEMA_VERSION
 from agents_shipgate.schemas.report import ReadinessReport
+from agents_shipgate.schemas.safety_qualification import pre_release_safety_requirements
 from agents_shipgate.schemas.verifier import VerifierArtifact
 from agents_shipgate.triggers import (
     VALID_SURFACE_CLASSES,
@@ -719,6 +720,46 @@ def test_constants_match_contract_doc():
     assert runtime_match.group(1) == _load_pyproject_version(), (
         f"contract doc says in-tree runtime is {runtime_match.group(1)}; "
         f"pyproject.toml says {_load_pyproject_version()}."
+    )
+
+
+def test_the_prose_that_states_the_current_report_schema_states_the_current_one():
+    """Two more places name the schema version in a sentence, and both drifted.
+
+    The contract doc and `docs/architecture.md` were already bound above; these
+    two were not, so a bump left them behind. ``README.md`` ended up
+    contradicting itself -- one section said `0.43` while Limitations still said
+    `0.42` -- and the qualification runbook stated a pin the policy no longer
+    used. Both are current-state claims, not frozen-reference mentions, so each
+    is matched by the sentence that makes the claim rather than by searching the
+    file for a number.
+    """
+
+    readme = re.search(
+        r'Current reports carry `report_schema_version: "(\d+\.\d+)"`', _read("README.md")
+    )
+    assert readme, "README.md must state 'Current reports carry `report_schema_version: \"X.Y\"`'."
+    assert readme.group(1) == CURRENT_REPORT_SCHEMA_VERSION, (
+        f"README.md Limitations says reports carry {readme.group(1)!r}; "
+        f"the engine emits {CURRENT_REPORT_SCHEMA_VERSION!r}."
+    )
+
+    # The runbook's claim is about the *policy's* pin, which a separate test
+    # already holds equal to what the engine emits. Checking it against the
+    # policy keeps this guard about the sentence rather than duplicating that
+    # equality.
+    pinned = pre_release_safety_requirements().required_report_schema_version
+    runbook = re.search(
+        r"`required_report_schema_version` pins \(`(\d+\.\d+)` today",
+        _read("benchmark/safety-qualification/README.md"),
+    )
+    assert runbook, (
+        "benchmark/safety-qualification/README.md must state which version "
+        "`required_report_schema_version` pins."
+    )
+    assert runbook.group(1) == pinned, (
+        f"the qualification runbook says the policy pins {runbook.group(1)!r}; "
+        f"pre_release_safety_requirements() pins {pinned!r}."
     )
 
 


### PR DESCRIPTION
## Summary

Three sentences that state a current fact had drifted from the fact. Found while explaining the release-evidence gate on #456; all three are the same class — a value restated in prose with nothing checking it.

- **`benchmark/safety-qualification/README.md`** said the policy pins report schema `0.42`. `pre_release_safety_requirements()` pins **`0.43`**. The pin itself was never wrong — `test_the_qualification_gate_demands_the_schema_the_engine_emits` holds it equal to what the engine emits — only the sentence describing it.
- **The same file** cited "the exact **six**-variable contract" for `docs/distribution.md`, which documents **four**. The other two are not missing: the Sigstore signer identity and OIDC issuer moved into `.github/release-trust-roots.json` on purpose, so an actor able to set variables cannot also replace the identity that vouches for the evidence, in one step with no diff to review. The count is **dropped** rather than corrected — an unguarded number sitting beside the table that owns the fact is what drifted.
- **`README.md` contradicted itself**: one section says reports carry `0.43`, while Limitations still said `0.42` and named `v0.41` as the frozen reference.

## The guard

`docs/agent-contract-current.md` and `docs/architecture.md` were already bound to `CURRENT_REPORT_SCHEMA_VERSION` in `tests/test_public_surface_contract.py`. These two sentences were not, which is exactly why a schema bump left them behind — the [report-schema bump checklist](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/STABILITY.md) covers the machine surfaces, and these are prose.

`test_the_prose_that_states_the_current_report_schema_states_the_current_one` now covers both. Two deliberate choices in how:

- **It matches the sentence that makes the claim**, not any number in the file. Both files legitimately carry frozen-schema references (`report-schema.v0.42.json` is the frozen compatibility reference), so a bare version search would trip over correct text.
- **The runbook's claim is checked against the policy value**, not against the engine's. A separate test already holds the policy equal to the engine; checking the sentence against the policy keeps this guard about the sentence rather than duplicating that equality.

## Type

- [ ] Check or risk-model change
- [ ] Input adapter change
- [ ] CLI or GitHub Action behavior
- [ ] Report, schema, or SARIF output
- [x] Documentation only, plus the test that keeps it true

## Verification

CI is authoritative for `python -m ruff check .`, `python -m compileall -q src tests`, and `python -m pytest`.

Additional local checks run:

- Full suite `pytest -n auto -m "not perf"`: exit 0. `ruff check .`: clean.
- The new guard was verified by reverting each fix rather than by construction: `README.md` back to `0.42` fails it, the runbook back to `0.42` fails it, and deleting the runbook sentence altogether fails it.
- Swept the tree for both drifts rather than fixing only the two spots I first noticed — which is how the `README.md` Limitations instance turned up.

## Things a reviewer should know

**One instance was found and deliberately left alone.** `prompts/fix-top-finding.md` carries `(contract v26 / report v0.42)` in **four** byte-identical copies (`prompts/`, `skills/`, `adoption-kits/claude-code-skill/`, `plugins/claude-code/`), pinned by `EXPECTED_CLAUDE_CODE_SKILL_RENDER_SHA256` in `tests/test_agent_instructions_renderers.py`. Changing it means the bundled-prompt bump procedure — four copies, both hash constants, and appending the outgoing hashes to `prior_render_sha256`. It also reads like a deliberate provenance stamp for the contract version the prompt was written against, rather than a stale current-state claim. That is a decision to make, not a typo to fix; say the word and it is a separate PR.

**`tests/test_public_surface_contract.py` is left format-dirty.** `ruff format --check` wants to reformat two hunks at lines ~423 and ~1137 — both pre-existing on `main`, neither touched here. CI runs `ruff check`, not `ruff format --check`, so this is the status quo; reformatting the file would put unrelated churn in a three-sentence docs fix. My addition is format-clean.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — none changed
- [x] Report/schema changes are additive or documented in `STABILITY.md` — none; this corrects prose *about* a schema version, and moves no version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
