### PR TITLE
Publish an opt-in adopters registry, and the rule that every adoption number comes from it (#475)

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopter_entry.yml
+++ b/.github/ISSUE_TEMPLATE/adopter_entry.yml
@@ -27,8 +27,11 @@ body:
     id: repository
     attributes:
       label: Repository
-      description: "`owner/repo` for a public repository, or the single word `private`."
-      placeholder: "owner/repo"
+      description: >-
+        A link to your public repository, on whichever host it lives — GitHub,
+        GitLab, Codeberg, self-hosted — or the single word `private`. One row
+        covers one repository; ask for a second row if you gate more than one.
+      placeholder: "https://gitlab.com/acme/agent"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/adopter_entry.yml
+++ b/.github/ISSUE_TEMPLATE/adopter_entry.yml
@@ -1,0 +1,64 @@
+name: Adopter entry
+description: Ask to be listed in the public, opt-in adopters registry (ADOPTERS.md).
+title: "[Adopter]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Being counted is something you do, never something done to you.
+        Agents Shipgate collects nothing, so
+        [`ADOPTERS.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/ADOPTERS.md)
+        is the only source for any adoption number this project publishes.
+
+        This issue is the public, attributable record that you asked — it
+        becomes the `Entry` link on your row. Everything you type here is
+        public. A private repository is listed at organization granularity:
+        write `private` below and the row will say who and which tier, and
+        nothing about where. Entries are removed on request, without a reason.
+  - type: input
+    id: adopter
+    attributes:
+      label: Adopter
+      description: The organization, project, or person to list.
+    validations:
+      required: true
+  - type: input
+    id: repository
+    attributes:
+      label: Repository
+      description: "`owner/repo` for a public repository, or the single word `private`."
+      placeholder: "owner/repo"
+    validations:
+      required: true
+  - type: input
+    id: gated
+    attributes:
+      label: What it gates
+      description: One clause — which capability surface Agents Shipgate reviews for you.
+      placeholder: "MCP tool exports on every pull request"
+    validations:
+      required: true
+  - type: dropdown
+    id: use
+    attributes:
+      label: Use
+      description: >-
+        As defined in ADOPTERS.md. Advisory CI publishes a result that does not
+        decide the merge; blocking CI fails on a verdict AND is a required
+        check. Nobody will raise this on inference, so state what is true today.
+      options:
+        - local evaluation
+        - advisory CI
+        - blocking CI
+    validations:
+      required: true
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Consent
+      options:
+        - label: I can speak for the adopter named above, and I am asking to be listed.
+          required: true
+        - label: I understand this entry is public, is a dated statement rather than a commitment, and can be removed on request at any time.
+          required: true

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,203 @@
+# Adopters
+
+Who has said, publicly and on their own initiative, that they run Agents
+Shipgate — and exactly what each of those statements is worth.
+
+Agents Shipgate collects nothing. Local-first and static by default: no
+telemetry, no analytics, no phone-home, no account, no crash reports
+([trust model](docs/trust-model.md)). That stance is deliberate and it has a
+price: this project cannot count its own users. This file is that price, paid
+honestly. It is the **only** source for any adoption number this project
+publishes, and every row in it was put there by the party the row names.
+
+**What an entry proves.** That a consenting party stated, on a date, that they
+used Agents Shipgate the way the row says. That is the whole claim. It is not
+evidence of continued use, review quality, team size, or willingness to pay,
+and the `Use` column is self-reported: nobody verifies it and nobody upgrades
+it. Adoption evidence is held to the same bar as capability evidence here —
+explicit, attributable and verifiable, or absent.
+
+## Counts
+
+**Counts as of: 2026-09-06.**
+
+- **External adopter entries: 0.**
+- **Maintainer dogfooding entries: 1.**
+
+The two counts are reported separately and never added together. A dogfooding
+entry cannot satisfy an external adoption claim or an external repeat-use
+claim — see [Claims policy](#claims-policy). The zero is published rather than
+omitted, for the same reason the pilot publishes its zeros in
+[`docs/design-partner-pilot-results.md`](docs/design-partner-pilot-results.md):
+an absent number reads as a modest one, and it is not.
+
+## External adopters
+
+| Adopter | Repository | What it gates | Use | Since | Entry |
+| --- | --- | --- | --- | --- | --- |
+
+**No external entries yet.** Nobody outside Three Moons Lab has asked to be
+listed. That is the count as of the date above, not a rounding of something
+larger.
+
+## Maintainer dogfooding
+
+Entries operated by the maintainers. They are listed for completeness and are
+never counted as external adoption.
+
+| Adopter | Repository | What it gates | Use | Since | Entry |
+| --- | --- | --- | --- | --- | --- |
+| Three Moons Lab (maintainer) | [ThreeMoonsLab/agents-shipgate](https://github.com/ThreeMoonsLab/agents-shipgate) | Its own Codex plugin package and marketplace entry, on every pull request — `agents-shipgate.yml` and `agents-shipgate-self.yml`. The Python scanner itself is covered by the ordinary test suite, not by this gate. | advisory CI | 2026-09-06 | [#475](https://github.com/ThreeMoonsLab/agents-shipgate/issues/475) |
+
+That row says `advisory CI`, not `blocking CI`, and the difference is worth
+reading. Both workflows do fail the run on `blocked` and `unknown` — but
+`main` carries no required status check, so a red run stops no merge. Under
+the definitions below that is advisory, and writing anything stronger in our
+own row would be the exact failure this file exists to prevent.
+
+## What the Use column means
+
+Three values, and no others. Each describes what the gate can do at the moment
+the entry is written, not how much anyone likes it.
+
+- **`local evaluation`** — run by hand, or from a coding-agent session. No CI
+  job runs it.
+- **`advisory CI`** — runs in CI on changes and publishes its result, but the
+  result does not decide whether the change may merge: the check is not
+  required, or the job never fails on a verdict.
+- **`blocking CI`** — runs in CI *and* can stop a merge: the job fails on at
+  least one merge verdict, and that check is required on the protected branch.
+
+A row states one of these because its author says so. Nothing in this
+repository checks that the CI it describes exists, and no maintainer will
+raise a row to a stronger tier on inference — not from a badge, not from a
+workflow file spotted in the wild, not from a conversation.
+
+## Add yourself
+
+Being counted is an act you perform, never one performed on you. Two paths;
+both leave a public, attributable record, which is what makes the count
+worth anything.
+
+**The short path — open an issue.** Use the
+[Adopter entry](https://github.com/ThreeMoonsLab/agents-shipgate/issues/new?template=adopter_entry.yml)
+form. It asks for the four fields that are yours to state; the date is when
+the row lands and the `Entry` link is that issue. A maintainer opens the pull
+request.
+
+**The direct path — open a pull request** adding one row to the table above.
+The `Entry` column needs a link to a public act in this repository, so open
+the PR as a draft, then push the row with your own PR's URL and mark it ready.
+Move the external count and the as-of date in [Counts](#counts) in the same
+PR: a guard fails the build if the counts disagree with the rows, or if the
+as-of date is older than the newest entry.
+
+A valid entry has all six fields:
+
+| Field | What goes in it |
+| --- | --- |
+| `Adopter` | The organization, project or person being counted. |
+| `Repository` | `owner/repo` as a link, or the single word `private`. A private-repo entry names the organization and nothing else — no repository name, no counts, no internal detail. |
+| `What it gates` | One clause: which capability surface the gate reviews. |
+| `Use` | One of the three values above, as they are defined above. |
+| `Since` | `YYYY-MM-DD`, the date the entry is added. It is not a start date and not a renewal — an entry is never automatically re-confirmed. |
+| `Entry` | A link to the issue, discussion or pull request in this repository where you asked to be listed. |
+
+**Only you may add you.** An entry submitted by someone who does not speak for
+the adopter is removed on sight, and a maintainer who cannot tell will ask
+before merging. Before merging any row a maintainer checks four things: that
+the requester speaks for the adopter, that the `Use` value matches what the
+requester actually wrote, that the repository link resolves or the row says
+`private`, and that the counts and as-of date moved with the row.
+
+**Removing yourself** takes an issue, a comment, or an email to
+`help@threemoonslab.com` saying so. No reason is required, none will be asked
+for, and the next published number is restated at the next as-of date. Please
+also update the row when your use changes tier or stops — nothing here expires
+on its own, which is why every published number is quoted with its date.
+
+## Badge
+
+Optional, for adopters who want to point at the registry from their own
+README:
+
+```markdown
+[![agent capability review: Agents Shipgate](https://img.shields.io/badge/agent%20capability%20review-Agents%20Shipgate-2f6feb)](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/ADOPTERS.md)
+```
+
+One badge, deliberately tier-neutral. There is no blocking-CI variant and
+there will not be one: a badge is a link, not evidence, and a badge that
+implied a tier would be an adoption claim nobody could check. **A badge is not
+an entry** — displaying it adds nobody to this file, removing it removes
+nobody from it, and no number published by this project will ever be derived
+from counting badges.
+
+## Privacy
+
+- **Nothing is collected, ever.** Agents Shipgate does not phone home, and
+  this registry adds no exception to that. There is no automatic collection of
+  any kind behind this file — no scraping of dependents, forks, stars,
+  download counts or workflow files into a row.
+- **Every public entry is user-initiated and consenting.** Appearing here
+  requires a public act by the adopter, linked from the row.
+- **Private repositories are welcome, at organization granularity.** Write
+  `private` in the `Repository` column; the row then says who and what tier,
+  and nothing about where.
+- **Private pilot observations are a separate ledger with separate consent.**
+  The design-partner pilot
+  ([runbook](docs/design-partner-verifier-pilot.md),
+  [results](docs/design-partner-pilot-results.md)) takes three separately
+  granted consents — public naming, source links, raw bundles — and none of
+  them makes a public adopter entry. A pilot participant who wants to be
+  listed here adds themselves, by one of the paths above, as a distinct
+  decision.
+- **Removal is unconditional**, as described above.
+
+## Claims policy
+
+Rules for any adoption number this project publishes — in the README, the
+site, a release note, a talk, or a sales conversation.
+
+1. **No entry, no claim.** Every published adoption number traces to named
+   rows in this file. If it cannot be traced to rows here, it is not published.
+2. **Every number carries its as-of date.** Counts are quoted with the date in
+   [Counts](#counts), never bare.
+3. **External and dogfooding are never summed.** They are published as two
+   numbers. A dogfooding entry cannot satisfy an external adoption claim or an
+   external repeat-use claim, and a claim about "adopters" without a qualifier
+   means the external count.
+4. **An entry is a dated statement, not a measurement.** It says a party made
+   a claim on a day. It does not say they still run it, that a review went
+   well, or how much they run it.
+5. **The tier is self-reported and never upgraded.** Publish the tier the row
+   states, or publish the breakdown; never aggregate three tiers into a
+   stronger word like "in production" or "gating".
+6. **A badge is not an entry.** Nothing is inferred from a badge — not
+   adoption, not a tier.
+7. **The pilot ledger stays separate.** The design-partner denominators in
+   [`docs/design-partner-pilot-results.md`](docs/design-partner-pilot-results.md)
+   answer a different question under different consents. The two are never
+   combined, and neither is added to stars, downloads or dependents, which
+   measure caches and sentiment rather than use. Neither is participation in
+   the historical-case corpus
+   ([#511](https://github.com/ThreeMoonsLab/agents-shipgate/issues/511)) an
+   adoption denominator: reviewing whether a past change should have been
+   stopped is a judgement about the corpus, not a statement about running the
+   gate.
+8. **Removal is unconditional.** An entry leaves on request; numbers published
+   before it left are not retracted, they are restated at the next as-of date.
+
+## How this file is checked
+
+`tests/test_adopters_registry.py` runs in CI on every change. It parses both
+tables, fails on a row missing a field, an unknown `Use` value, a
+non-ISO or future `Since`, an `Entry` link that does not point into this
+repository, this repository appearing as an external adopter, counts that
+disagree with the rows, an as-of date older than the newest entry, a claims
+rule quietly dropped, a second badge variant, an issue form that has drifted
+from the tier vocabulary or stopped requiring consent, and an adoption number
+stated elsewhere in the repository that these rows cannot source. The registry
+is small enough to check by eye, which is exactly why it is worth checking
+mechanically: the
+failure mode is not a typo, it is a number that drifts upward one edit at a
+time.

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -101,18 +101,25 @@ A valid entry has all six fields:
 | Field | What goes in it |
 | --- | --- |
 | `Adopter` | The organization, project or person being counted. |
-| `Repository` | `owner/repo` as a link, or the single word `private`. A private-repo entry names the organization and nothing else — no repository name, no counts, no internal detail. |
+| `Repository` | A link to the public repository, on whichever host it lives — GitHub, GitLab, Codeberg, self-hosted — or the single word `private`. A private-repo entry names the organization and nothing else: no repository name, no counts, no internal detail. |
 | `What it gates` | One clause: which capability surface the gate reviews. |
 | `Use` | One of the three values above, as they are defined above. |
 | `Since` | `YYYY-MM-DD`, the date the entry is added. It is not a start date and not a renewal — an entry is never automatically re-confirmed. |
 | `Entry` | A link to the issue, discussion or pull request in this repository where you asked to be listed. |
 
+**One row per adopter per repository.** A second repository is a second row;
+the same repository twice is one adoption counted twice, and a guard rejects
+it. An organization holds at most one `private` row, because `private` is all
+the registry knows about it and two of them cannot be told apart. If your use
+differs between repositories, that is what the extra row is for.
+
 **Only you may add you.** An entry submitted by someone who does not speak for
 the adopter is removed on sight, and a maintainer who cannot tell will ask
-before merging. Before merging any row a maintainer checks four things: that
+before merging. Before merging any row a maintainer checks five things: that
 the requester speaks for the adopter, that the `Use` value matches what the
 requester actually wrote, that the repository link resolves or the row says
-`private`, and that the counts and as-of date moved with the row.
+`private`, that no row already covers that adopter and repository, and that the
+counts and as-of date moved with the row.
 
 **Removing yourself** takes an issue, a comment, or an email to
 `help@threemoonslab.com` saying so. No reason is required, none will be asked
@@ -195,8 +202,10 @@ site, a release note, a talk, or a sales conversation.
 
 `tests/test_adopters_registry.py` runs in CI on every change. It parses both
 tables, fails on a row missing a field, an unknown `Use` value, a
-non-ISO or future `Since`, an `Entry` link that does not point into this
-repository, this repository appearing as an external adopter, counts that
+non-ISO or future `Since`, a `Repository` that is neither one resolvable public
+link nor `private`, an `Entry` link that does not point into this repository,
+two rows covering the same adopter and repository, this repository appearing as
+an external adopter, counts that
 disagree with the rows, an as-of date older than the newest entry, a claims
 rule quietly dropped, a second badge variant, an issue form that has drifted
 from the tier vocabulary or stopped requiring consent, and an adoption number

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -51,9 +51,13 @@ never counted as external adoption.
 
 That row says `advisory CI`, not `blocking CI`, and the difference is worth
 reading. Both workflows do fail the run on `blocked` and `unknown` — but
-`main` carries no required status check, so a red run stops no merge. Under
-the definitions below that is advisory, and writing anything stronger in our
-own row would be the exact failure this file exists to prevent.
+`main` carries no required status check, so a red run stops no merge. Anyone
+can re-check that claim the way it was made: the branch ruleset on `main`
+(`gh api repos/ThreeMoonsLab/agents-shipgate/rulesets`) protects against
+deletion and non-linear history and requires a pull request, and carries no
+`required_status_checks` rule. Under the definitions below that is advisory,
+and writing anything stronger in our own row would be the exact failure this
+file exists to prevent.
 
 ## What the Use column means
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,22 @@
 
   The policy is enforced rather than promised. `tests/test_adopters_registry.py`
   parses both tables and fails on a row missing a field, an undefined tier, a
-  non-ISO or future date, an entry link that does not point into this
-  repository, this repository listed as an *external* adopter, counts that
-  disagree with the rows, an as-of date older than the newest entry, a claims
-  rule quietly dropped, a second badge variant, an issue form that drifts from
-  the registry's vocabulary or stops requiring consent — and any adopter number
-  stated anywhere in the repository's prose that these rows cannot source. A
-  45-case perturbation sweep confirmed every one of those fails on the
-  weakening it exists to catch, and that a correctly added adopter — or a
-  second maintainer row, or a grammatically singular count — still passes.
+  non-ISO or future date, a `Repository` that is neither one resolvable public
+  link — on any host, so a GitLab or self-hosted adopter is not pushed into
+  writing `private` about a public repository — nor `private` itself, an entry
+  link that does not point into this repository, **two rows covering the same
+  adopter and repository**, this repository listed as an *external* adopter,
+  counts that disagree with the rows, an as-of date older than the newest
+  entry, a claims rule quietly dropped, a second badge variant, an issue form
+  that drifts from the registry's vocabulary or stops requiring consent — and
+  any adopter number stated anywhere in the repository's prose that these rows
+  cannot source. That last check reads the claim's **own sentence**: a
+  neighbouring sentence about dogfooding does not qualify it, and a claim that
+  calls itself external never borrows the maintainer count. A 50-case
+  perturbation sweep confirmed every one of those fails on the weakening it
+  exists to catch, and that the legitimate edits — a correctly added adopter, a
+  GitLab-hosted one, a second maintainer row, a grammatically singular count —
+  still pass.
 
 - **The zero-install detector refuses an oversized candidate instead of
   reading it.** `tools/shipgate-detect.py` is fetched over `curl | python3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+- **Adoption evidence now has a counting mechanism, and its first published
+  number is a zero.** (#475) This project collects nothing — local-first and
+  static by default, no telemetry, no account — and the price of that stance is
+  that it cannot count its own users. Downloads measure CI caches and stars
+  measure sentiment, so neither is adoption. The new root-level
+  [`ADOPTERS.md`](ADOPTERS.md) is the opt-in registry that pays the price
+  honestly: one row per adopter, added by the adopter through an
+  [issue form](.github/ISSUE_TEMPLATE/adopter_entry.yml) or a pull request,
+  naming what they gate, whether it runs as local evaluation, advisory CI or
+  blocking CI, the date, and a link to the public act where they asked. Private
+  repositories are listed at organization granularity — the word `private` and
+  nothing else. An entry is removed on request, without a reason.
+
+  It ships with an eight-rule **claims policy** (no entry, no claim; every
+  number carries its as-of date; external and dogfooding are never summed; an
+  entry is a dated statement rather than a measurement; a tier is self-reported
+  and never upgraded; a badge is not an entry; the design-partner ledger stays
+  separate; removal is unconditional), an optional tier-neutral README badge
+  that links back to the registry, and the maintainer dogfooding entry the
+  acceptance asks for — which reads `advisory CI`, not `blocking CI`, because
+  `main` requires no status check and a red run there stops no merge.
+
+  The policy is enforced rather than promised. `tests/test_adopters_registry.py`
+  parses both tables and fails on a row missing a field, an undefined tier, a
+  non-ISO or future date, an entry link that does not point into this
+  repository, this repository listed as an *external* adopter, counts that
+  disagree with the rows, an as-of date older than the newest entry, a claims
+  rule quietly dropped, a second badge variant, an issue form that drifts from
+  the registry's vocabulary or stops requiring consent — and any adopter number
+  stated anywhere in the repository's prose that these rows cannot source. A
+  42-case perturbation sweep confirmed every one of those fails on the
+  weakening it exists to catch, and that a correctly added adopter still
+  passes.
+
 - **The zero-install detector refuses an oversized candidate instead of
   reading it.** `tools/shipgate-detect.py` is fetched over `curl | python3`
   and run against repositories nobody has inspected, and it read every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@
   rule quietly dropped, a second badge variant, an issue form that drifts from
   the registry's vocabulary or stops requiring consent — and any adopter number
   stated anywhere in the repository's prose that these rows cannot source. A
-  42-case perturbation sweep confirmed every one of those fails on the
-  weakening it exists to catch, and that a correctly added adopter still
-  passes.
+  45-case perturbation sweep confirmed every one of those fails on the
+  weakening it exists to catch, and that a correctly added adopter — or a
+  second maintainer row, or a grammatically singular count — still passes.
 
 - **The zero-install detector refuses an oversized candidate instead of
   reading it.** `tools/shipgate-detect.py` is fetched over `curl | python3`

--- a/README.md
+++ b/README.md
@@ -892,10 +892,10 @@ Agents Shipgate is local-first and static by default, and it collects nothing:
 no telemetry, no analytics, no account. It therefore cannot count its own
 users. [`ADOPTERS.md`](ADOPTERS.md) is the opt-in public registry that stands
 in for that: one line per adopter, added by the adopter, naming what they gate
-and whether it runs locally, as advisory CI, or as blocking CI. There is **no automatic collection of any kind** behind it —
-every entry is user-initiated and consenting, private repositories are listed
-at organization granularity, and an entry is removed on request without a
-reason. Private design-partner observations are a separate ledger under
+and whether it runs locally, as advisory CI, or as blocking CI. There is **no
+automatic collection of any kind** behind it — every entry is user-initiated
+and consenting, private repositories are listed at organization granularity,
+and an entry is removed on request without a reason. Private design-partner observations are a separate ledger under
 separate consent and never become public entries on their own.
 
 Every adoption number this project publishes traces to a named entry there —

--- a/README.md
+++ b/README.md
@@ -886,6 +886,26 @@ evidence). What the pilot has actually observed, including the counts that are
 still zero, is published in
 [`docs/design-partner-pilot-results.md`](docs/design-partner-pilot-results.md).
 
+## Adopters
+
+Agents Shipgate is local-first and static by default, and it collects nothing:
+no telemetry, no analytics, no account. It therefore cannot count its own
+users. [`ADOPTERS.md`](ADOPTERS.md) is the opt-in public registry that stands
+in for that: one line per adopter, added by the adopter, naming what they gate
+and whether it runs locally, as advisory CI, or as blocking CI. There is **no automatic collection of any kind** behind it —
+every entry is user-initiated and consenting, private repositories are listed
+at organization granularity, and an entry is removed on request without a
+reason. Private design-partner observations are a separate ledger under
+separate consent and never become public entries on their own.
+
+Every adoption number this project publishes traces to a named entry there —
+no entry, no claim — and maintainer dogfooding is counted apart from external
+adoption. Today that is **0 external adopter entries and 1 maintainer
+dogfooding entry** (as of 2026-09-06). If you run it,
+[add yourself](ADOPTERS.md#add-yourself); there is an optional
+[badge](ADOPTERS.md#badge) that links back to the registry, and it implies
+nothing about which tier you run.
+
 ## Docs
 
 The marketing site at [threemoonslab.com](https://threemoonslab.com/) carries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,8 +79,9 @@ release qualification or to complete every open issue in that window.
    remain visible. [#475](https://github.com/ThreeMoonsLab/agents-shipgate/issues/475)
    records public consenting adopters separately, in
    [ADOPTERS.md](ADOPTERS.md) — opt-in, one row per adopter, with an
-   eight-rule claims policy and a published external count of zero;
-   dogfooding, stars and downloads do not prove external repeat use. Pilot preparation need not wait for the
+   eight-rule claims policy and a dated external count published in the file
+   itself rather than restated here; dogfooding, stars and downloads do not
+   prove external repeat use. Pilot preparation need not wait for the
    historical-corpus outreach in
    [#511](https://github.com/ThreeMoonsLab/agents-shipgate/issues/511). The
    counts, the dated enrollment shortfall and the standing continue/narrow/stop

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,8 +77,10 @@ release qualification or to complete every open issue in that window.
    decision, and use on a second eligible change. Ten minutes to first value is
    an experiment target. Failed attempts and repositories with no second change
    remain visible. [#475](https://github.com/ThreeMoonsLab/agents-shipgate/issues/475)
-   records public consenting adopters separately; dogfooding, stars and downloads
-   do not prove external repeat use. Pilot preparation need not wait for the
+   records public consenting adopters separately, in
+   [ADOPTERS.md](ADOPTERS.md) — opt-in, one row per adopter, with an
+   eight-rule claims policy and a published external count of zero;
+   dogfooding, stars and downloads do not prove external repeat use. Pilot preparation need not wait for the
    historical-corpus outreach in
    [#511](https://github.com/ThreeMoonsLab/agents-shipgate/issues/511). The
    counts, the dated enrollment shortfall and the standing continue/narrow/stop

--- a/docs/design-partner-pilot-results.md
+++ b/docs/design-partner-pilot-results.md
@@ -24,6 +24,14 @@ sections below say why, in denominators rather than adjectives.
 
 Dogfooding is reported separately below and never enters these counts.
 
+These six counts are this experiment's, not the project's adopter count.
+Public, consenting adopters are listed and counted in
+[`ADOPTERS.md`](../ADOPTERS.md). The two ledgers answer different questions
+under different consents — a pilot row is an observation we made, an adopter
+entry is a statement someone else chose to publish — so they are never added
+together, and a pilot participant appears in the registry only by adding
+themselves.
+
 ## Enrollment and opportunity shortfall — 2026-09-05
 
 Zero invitations have gone out. The first version of this section, dated

--- a/docs/design-partner-verifier-pilot.md
+++ b/docs/design-partner-verifier-pilot.md
@@ -211,6 +211,11 @@ gitignored in this repository for exactly this. Only the aggregate ledger in
 [`design-partner-pilot-results.md`](design-partner-pilot-results.md) is
 public.
 
+None of the three consents lists a partner in
+[`ADOPTERS.md`](../ADOPTERS.md). That registry is opt-in and self-served: a
+partner who wants to be counted there adds themselves, as a separate decision,
+and being in this pilot never creates an entry.
+
 ## Evidence to preserve
 
 Preserve a real before/after artifact or a redacted decision note for **every

--- a/tests/test_adopters_registry.py
+++ b/tests/test_adopters_registry.py
@@ -1,0 +1,767 @@
+"""Guards for the opt-in adopters registry.
+
+This project collects nothing, so `ADOPTERS.md` is the only source for any
+adoption number it publishes. That makes the file's failure mode specific: not
+a typo, but a number that drifts upward one edit at a time — a dogfooding row
+counted as external, a count left behind when a row was removed, a tier raised
+from "we ran it once" to "it gates our merges", a badge read as an adoption
+claim, or a marketing number that no row can source.
+
+Each of those is pinned here, mechanically rather than by review attention. The
+tier vocabulary, the entry shape and the claims-policy rules live in this file
+and in the registry at once, so neither can be weakened alone.
+
+Issue #475.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = REPO_ROOT / "ADOPTERS.md"
+README = REPO_ROOT / "README.md"
+TEMPLATE = REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "adopter_entry.yml"
+PILOT_RESULTS = REPO_ROOT / "docs" / "design-partner-pilot-results.md"
+PILOT_RUNBOOK = REPO_ROOT / "docs" / "design-partner-verifier-pilot.md"
+
+REPO_URL = "https://github.com/ThreeMoonsLab/agents-shipgate"
+BADGE_TARGET = f"{REPO_URL}/blob/main/ADOPTERS.md"
+
+#: The closed vocabulary for the ``Use`` column. Three tiers, ordered by what
+#: the gate can do — not by how much anyone likes it. Adding a fourth means
+#: changing the registry's definitions, this tuple and the issue form together,
+#: which is the point: a tier nobody defined is a tier nobody can check.
+USE_TIERS = ("local evaluation", "advisory CI", "blocking CI")
+
+#: Every entry has all six. ``Since`` and ``Entry`` are deliberately absent
+#: from the issue form: the date is when the row lands, not when the requester
+#: wrote it, and the entry link is the request itself.
+COLUMNS = ("Adopter", "Repository", "What it gates", "Use", "Since", "Entry")
+REQUESTER_COLUMNS = ("Adopter", "Repository", "What it gates", "Use")
+
+#: The claims policy, keyed by the bold lead-in of each rule. Wording inside a
+#: rule may be improved; a rule may not quietly disappear.
+CLAIMS_RULES = (
+    "No entry, no claim.",
+    "Every number carries its as-of date.",
+    "External and dogfooding are never summed.",
+    "An entry is a dated statement, not a measurement.",
+    "The tier is self-reported and never upgraded.",
+    "A badge is not an entry.",
+    "The pilot ledger stays separate.",
+    "Removal is unconditional.",
+)
+
+EXTERNAL_HEADING = "## External adopters"
+DOGFOOD_HEADING = "## Maintainer dogfooding"
+EMPTY_MARKER = "No external entries yet."
+
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+# --------------------------------------------------------------------------
+# Reading the registry
+# --------------------------------------------------------------------------
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _flat(text: str) -> str:
+    """Markdown here is hard-wrapped, so any phrase asserted on below is
+    usually split across lines. Compare against the unwrapped form."""
+    return " ".join(text.split())
+
+
+def _section(text: str, heading: str) -> str:
+    """The body under ``heading``, up to the next same-or-higher heading.
+
+    Fences are tracked: a ``#`` in column one inside a fenced block is a shell
+    comment, not a heading, and truncating there would make every assertion
+    past it vacuous (the same defect found in the pilot guards, #521).
+    """
+    level = len(heading) - len(heading.lstrip("#"))
+    assert text.count(heading + "\n") == 1, f"{heading!r} must appear exactly once"
+    start = text.index(heading + "\n")
+    body = text[start + len(heading) :]
+    pattern = re.compile(rf"#{{1,{level}}} ")
+    fenced = False
+    offset = 0
+    for line in body.splitlines(keepends=True):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+        elif not fenced and pattern.match(line):
+            return body[:offset]
+        offset += len(line)
+    return body
+
+
+def _table(section: str) -> tuple[tuple[str, ...], list[list[str]]]:
+    """The pipe table in ``section`` as (header, raw rows).
+
+    Deliberately total: a row with the wrong number of cells comes back as-is
+    rather than raising, so it fails :func:`test_every_row_has_the_columns_it
+    _claims` by name instead of breaking collection with a ``zip()`` error that
+    names neither the file nor the row.
+    """
+    lines = [line.strip() for line in section.splitlines() if line.strip().startswith("|")]
+    if not lines:
+        return (), []
+    cells = [[cell.strip() for cell in line.strip("|").split("|")] for line in lines]
+    header = tuple(cells[0])
+    assert len(cells) > 1 and all(set(cell) <= set("-: ") for cell in cells[1]), (
+        f"expected a separator row under {header}"
+    )
+    return header, cells[2:]
+
+
+def _raw_rows(heading: str) -> list[list[str]]:
+    return _table(_section(_read(REGISTRY), heading))[1]
+
+
+def _entries(heading: str) -> list[dict[str, str]]:
+    """Well-formed rows only; malformed ones are reported by their own test."""
+    header, rows = _table(_section(_read(REGISTRY), heading))
+    return [dict(zip(header, row, strict=False)) for row in rows if len(row) == len(header)]
+
+
+def _all_entries() -> list[tuple[str, dict[str, str]]]:
+    return [
+        (heading, row)
+        for heading in (EXTERNAL_HEADING, DOGFOOD_HEADING)
+        for row in _entries(heading)
+    ]
+
+
+def _entry_ids() -> list[str]:
+    return [
+        f"{heading.strip('# ').replace(' ', '-')}::{row.get('Adopter', '?')}"
+        for heading, row in _all_entries()
+    ]
+
+
+def _counts() -> dict[str, str]:
+    """The labelled numbers in ``## Counts``, by label."""
+    section = _section(_read(REGISTRY), "## Counts")
+    return {
+        m.group(1): m.group(2)
+        for m in re.finditer(r"\*\*([A-Z][A-Za-z ]+): ([^*]+?)\.\*\*", section)
+    }
+
+
+def _slug(heading: str) -> str:
+    text = heading.lstrip("# ").strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    return re.sub(r"\s+", "-", text)
+
+
+def _headings(text: str) -> set[str]:
+    return {_slug(line) for line in text.splitlines() if line.startswith("#")}
+
+
+def _template() -> dict:
+    return yaml.safe_load(_read(TEMPLATE))
+
+
+def _template_fields() -> dict[str, dict]:
+    return {
+        block["attributes"]["label"]: block
+        for block in _template()["body"]
+        if "label" in block.get("attributes", {})
+    }
+
+
+# --------------------------------------------------------------------------
+# The file exists, and the README carries the stance
+# --------------------------------------------------------------------------
+
+
+def test_registry_exists_and_the_readme_links_it():
+    """A registry nobody can find counts nobody."""
+    assert REGISTRY.is_file(), "ADOPTERS.md must exist at the repository root"
+    assert "](ADOPTERS.md)" in _read(README), "README.md must link ADOPTERS.md"
+
+
+def test_readme_links_into_the_registry_resolve():
+    """The README sends readers to `#add-yourself` and `#badge`. A renamed
+    heading turns both into a scroll to the top of a file about counting."""
+    headings = _headings(_read(REGISTRY))
+    targets = {
+        href.split("#", 1)[1]
+        for href in LINK_RE.findall(_read(README))
+        if href.startswith("ADOPTERS.md#")
+    }
+    assert targets, "README.md must deep-link the registry's how-to sections"
+    assert targets <= headings, f"README links dead registry anchors: {sorted(targets - headings)}"
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    (
+        "no automatic collection",
+        "user-initiated and consenting",
+        "removed on request",
+        "no entry, no claim",
+    ),
+)
+def test_readme_states_the_privacy_and_claims_stance(phrase: str):
+    """The stance has to be readable where adoption is discussed, not only in
+    the file being defended. A README that links the registry without saying
+    nothing is collected leaves a reader to assume the usual thing."""
+    section = _flat(_section(_read(README), "## Adopters")).lower()
+    assert phrase in section, f"README § Adopters must state {phrase!r}"
+
+
+def test_readme_separates_public_entries_from_private_pilot_observations():
+    """Acceptance §3: a private observation must never read as a public entry."""
+    section = _flat(_section(_read(README), "## Adopters")).lower()
+    assert "separate ledger" in section and "separate consent" in section, (
+        "README § Adopters must say private pilot observations are a separate "
+        "ledger under separate consent"
+    )
+
+
+def test_readme_counts_match_the_registry():
+    """Two places publishing the same number is how one of them goes stale.
+    The registry is the source; the README is checked against it."""
+    counts = _counts()
+    section = _flat(_section(_read(README), "## Adopters"))
+    external = counts["External adopter entries"]
+    dogfood = counts["Maintainer dogfooding entries"]
+    assert f"{external} external adopter entries" in section, (
+        f"README § Adopters must state the registry's external count ({external})"
+    )
+    assert re.search(rf"\b{re.escape(dogfood)} maintainer dogfooding entr(?:y|ies)\b", section), (
+        f"README § Adopters must state the registry's dogfooding count ({dogfood})"
+    )
+    assert counts["Counts as of"] in section, (
+        "README § Adopters must carry the registry's as-of date beside its numbers"
+    )
+
+
+# --------------------------------------------------------------------------
+# Entry shape
+# --------------------------------------------------------------------------
+
+
+def test_both_tables_use_the_same_columns():
+    """One row shape, one parser. Two tables that drift apart are two
+    definitions of what an entry is, and the weaker one wins by accident."""
+    text = _read(REGISTRY)
+    for heading in (EXTERNAL_HEADING, DOGFOOD_HEADING):
+        header, _ = _table(_section(text, heading))
+        assert header == COLUMNS, f"{heading} columns are {header}, expected {COLUMNS}"
+
+
+@pytest.mark.parametrize("heading", (EXTERNAL_HEADING, DOGFOOD_HEADING))
+def test_every_row_has_the_columns_it_claims(heading: str):
+    """A stray `|` in a description silently shifts every later cell, so a
+    date lands in `Use` and a link lands in `Since`. Cell count is checked
+    before any cell is read, and the rest of this file only ever sees rows
+    that survived it."""
+    for row in _raw_rows(heading):
+        assert len(row) == len(COLUMNS), (
+            f"{heading} has a row with {len(row)} cells, expected {len(COLUMNS)}: {row}. "
+            "Escape any literal '|' in a cell as '\\|'."
+        )
+
+
+@pytest.mark.parametrize(("heading", "row"), _all_entries(), ids=_entry_ids())
+def test_every_field_of_every_entry_is_filled(heading: str, row: dict[str, str]):
+    """A blank cell is an unstated claim, and an unstated claim gets read
+    generously later."""
+    for column in COLUMNS:
+        assert row.get(column, "").strip(), f"{heading} row {row} has an empty {column!r}"
+
+
+@pytest.mark.parametrize(("heading", "row"), _all_entries(), ids=_entry_ids())
+def test_every_entry_states_a_defined_use_tier(heading: str, row: dict[str, str]):
+    """`Use` is the only field anyone will quote. It comes from the closed
+    vocabulary or the row does not merge."""
+    assert row["Use"] in USE_TIERS, (
+        f"{heading} row {row['Adopter']!r} states Use={row['Use']!r}; "
+        f"the defined tiers are {USE_TIERS}"
+    )
+
+
+@pytest.mark.parametrize(("heading", "row"), _all_entries(), ids=_entry_ids())
+def test_every_entry_is_dated_in_the_past(heading: str, row: dict[str, str]):
+    """The date is what every published number is quoted against. A free-text
+    date ("2026", "since launch") cannot be compared, and a future one cannot
+    be true."""
+    since = row["Since"]
+    assert DATE_RE.match(since), f"{heading} row {row['Adopter']!r} has Since={since!r}, want YYYY-MM-DD"
+    assert dt.date.fromisoformat(since) <= dt.date.today(), (
+        f"{heading} row {row['Adopter']!r} is dated in the future: {since}"
+    )
+
+
+@pytest.mark.parametrize(("heading", "row"), _all_entries(), ids=_entry_ids())
+def test_every_entry_links_the_public_act_that_created_it(heading: str, row: dict[str, str]):
+    """Consent is what the count rests on, so every row names where it was
+    given — an issue, discussion or PR in this repository, not a private
+    conversation somebody remembers."""
+    hrefs = LINK_RE.findall(row["Entry"])
+    assert len(hrefs) == 1, f"{heading} row {row['Adopter']!r} must link exactly one entry record"
+    href = hrefs[0]
+    assert re.fullmatch(rf"{re.escape(REPO_URL)}/(issues|pull|discussions)/\d+", href), (
+        f"{heading} row {row['Adopter']!r} links {href!r}; the entry record must be an "
+        "issue, pull request or discussion in this repository"
+    )
+
+
+@pytest.mark.parametrize(("heading", "row"), _all_entries(), ids=_entry_ids())
+def test_every_entry_names_a_repository_or_says_private(heading: str, row: dict[str, str]):
+    """Acceptance §1: private-repo entries are allowed at organization
+    granularity. `private` is the whole vocabulary for that — a half-named
+    private repository ("internal monorepo") discloses without being checkable."""
+    repository = row["Repository"]
+    if repository == "private":
+        return
+    hrefs = LINK_RE.findall(repository)
+    assert len(hrefs) == 1 and re.fullmatch(
+        r"https://github\.com/[\w.-]+/[\w.-]+", hrefs[0]
+    ), (
+        f"{heading} row {row['Adopter']!r} has Repository={repository!r}; "
+        "expected a linked github.com/owner/repo or the single word 'private'"
+    )
+
+
+# --------------------------------------------------------------------------
+# Counts
+# --------------------------------------------------------------------------
+
+
+def test_the_counts_are_the_row_counts():
+    """The whole mechanism in one assertion: a published number equals rows
+    somebody consented to. Removing a row without touching the count, or
+    raising a count without a row, fails here."""
+    counts = _counts()
+    assert counts["External adopter entries"] == str(len(_entries(EXTERNAL_HEADING)))
+    assert counts["Maintainer dogfooding entries"] == str(len(_entries(DOGFOOD_HEADING)))
+
+
+def test_the_counts_section_publishes_exactly_two_numbers_and_a_date():
+    """A third labelled number — a total, a "teams", a trend — is a claim with
+    no denominator. There are two counts here and they are never summed."""
+    assert set(_counts()) == {
+        "Counts as of",
+        "External adopter entries",
+        "Maintainer dogfooding entries",
+    }
+
+
+def test_the_as_of_date_is_not_older_than_the_newest_entry():
+    """Adding a row without re-dating the counts publishes yesterday's number
+    as today's. This is the coupling that makes that impossible."""
+    as_of = dt.date.fromisoformat(_counts()["Counts as of"])
+    for heading, row in _all_entries():
+        assert dt.date.fromisoformat(row["Since"]) <= as_of, (
+            f"{heading} row {row['Adopter']!r} is dated {row['Since']}, after the "
+            f"stated as-of date {as_of}. Re-date § Counts in the same change."
+        )
+    assert as_of <= dt.date.today(), f"§ Counts is dated in the future: {as_of}"
+
+
+def test_the_empty_external_table_says_so_in_words():
+    """An empty table renders as nothing much and reads as an oversight. The
+    zero is a result, so it is stated — and the sentence has to go when the
+    first row arrives, or the file contradicts itself."""
+    section = _flat(_section(_read(REGISTRY), EXTERNAL_HEADING))
+    if _entries(EXTERNAL_HEADING):
+        assert EMPTY_MARKER not in section, (
+            "§ External adopters has rows but still says there are none"
+        )
+    else:
+        assert EMPTY_MARKER in section, (
+            f"§ External adopters is empty and must say so: {EMPTY_MARKER!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Dogfooding stays out of the external count
+# --------------------------------------------------------------------------
+
+
+def test_this_repository_is_never_an_external_adopter():
+    """Acceptance §5. The self-entry is allowed and useful; counting it as
+    external adoption is the single most tempting error this file can make."""
+    for row in _entries(EXTERNAL_HEADING):
+        blob = _flat(f"{row['Adopter']} {row['Repository']}").lower()
+        assert "threemoonslab" not in blob and "three moons lab" not in blob, (
+            f"{row['Adopter']!r} is a maintainer entry listed as external; "
+            f"it belongs under {DOGFOOD_HEADING}"
+        )
+
+
+def test_the_registry_says_a_dogfood_entry_cannot_carry_an_external_claim():
+    """Acceptance §5 again, in the file itself: the separation has to survive
+    somebody reading only the counts."""
+    flat = _flat(_read(REGISTRY)).lower()
+    assert "never added together" in flat
+    assert "cannot satisfy an external adoption claim or an external repeat-use claim" in flat
+
+
+def test_the_maintainer_row_agrees_with_the_paragraph_that_explains_it():
+    """The self-entry states `advisory CI` and the paragraph under it explains
+    why that is the honest tier when `main` requires no check. Raising the row
+    without rewriting the explanation would leave the file arguing against its
+    own table — so it fails instead."""
+    section = _flat(_section(_read(REGISTRY), DOGFOOD_HEADING))
+    for row in _entries(DOGFOOD_HEADING):
+        assert f"That row says `{row['Use']}`" in section, (
+            f"the maintainer row states Use={row['Use']!r}, which the prose "
+            "beside it does not explain. State the tier and say why it is that one."
+        )
+
+
+def test_the_dogfood_section_is_marked_as_maintainer_operated():
+    section = _flat(_section(_read(REGISTRY), DOGFOOD_HEADING)).lower()
+    assert "operated by the maintainers" in section
+    assert "never counted as external" in section
+
+
+# --------------------------------------------------------------------------
+# The tier vocabulary, defined once
+# --------------------------------------------------------------------------
+
+
+def test_the_registry_defines_exactly_the_tiers_the_guard_knows():
+    """Two tables of tiers eventually disagree, and the disagreement is always
+    resolved in the flattering direction."""
+    section = _section(_read(REGISTRY), "## What the Use column means")
+    defined = tuple(re.findall(r"\*\*`([^`]+)`\*\*", section))
+    assert defined == USE_TIERS, f"registry defines {defined}, guard knows {USE_TIERS}"
+
+
+def test_the_blocking_tier_requires_a_required_check():
+    """`blocking CI` is the claim worth having and therefore the one worth
+    defining tightly: failing a run that nothing requires blocks nothing. This
+    repository's own row is `advisory CI` for exactly that reason."""
+    section = _flat(_section(_read(REGISTRY), "## What the Use column means")).lower()
+    assert "required on the protected branch" in section
+    assert "fails on at least one merge verdict" in section
+
+
+def test_the_registry_refuses_to_infer_a_tier():
+    """Acceptance: do not infer a stronger tier from a badge."""
+    flat = _flat(_read(REGISTRY)).lower()
+    assert "self-reported" in flat
+    assert "not from a badge" in flat
+
+
+# --------------------------------------------------------------------------
+# The issue form: the low-friction path, and the one that records consent
+# --------------------------------------------------------------------------
+
+
+def test_the_issue_form_offers_exactly_the_registry_tiers():
+    """A form offering a tier the registry does not define produces rows that
+    cannot be merged — and a form missing one silently discourages the honest
+    answer."""
+    dropdowns = [
+        block for block in _template()["body"] if block.get("type") == "dropdown"
+    ]
+    assert len(dropdowns) == 1, "the adopter form has exactly one tier dropdown"
+    assert tuple(dropdowns[0]["attributes"]["options"]) == USE_TIERS
+
+
+def test_the_issue_form_asks_for_every_field_the_requester_owns():
+    """`Since` and `Entry` are not asked for on purpose: the date is when the
+    row lands and the entry link is this issue. Every other column is the
+    requester's to state, so the form must ask for it."""
+    fields = _template_fields()
+    asked = tuple(label for label in fields if label != "Consent")
+    assert asked == REQUESTER_COLUMNS, f"form asks {asked}, expected {REQUESTER_COLUMNS}"
+    assert set(COLUMNS) - set(REQUESTER_COLUMNS) == {"Since", "Entry"}
+    for label in REQUESTER_COLUMNS:
+        assert fields[label].get("validations", {}).get("required") is True, (
+            f"{label!r} is part of every row, so the form must require it"
+        )
+
+
+def test_the_issue_form_takes_consent_and_requires_it():
+    """An optional consent box is not consent. Both statements — speaking for
+    the adopter, and understanding what publication means — are required."""
+    consent = _template_fields()["Consent"]
+    assert consent["type"] == "checkboxes"
+    options = consent["attributes"]["options"]
+    assert len(options) == 2 and all(option.get("required") is True for option in options)
+    joined = _flat(" ".join(option["label"] for option in options)).lower()
+    assert "speak for" in joined
+    assert "public" in joined and "removed on request" in joined
+
+
+def test_the_issue_form_states_the_private_repository_route():
+    """Somebody with a private repository must be able to see, before typing,
+    that they can be counted without naming it."""
+    markdown = _flat(
+        " ".join(
+            block["attributes"]["value"]
+            for block in _template()["body"]
+            if block.get("type") == "markdown"
+        )
+    ).lower()
+    assert "private" in markdown and "organization granularity" in markdown
+
+
+# --------------------------------------------------------------------------
+# The badge
+# --------------------------------------------------------------------------
+
+
+def test_the_badge_snippet_links_back_to_the_registry():
+    """Acceptance §2. A badge pointing anywhere else is decoration; pointing
+    here it is at least a route to the rules it does not itself prove."""
+    section = _section(_read(REGISTRY), "## Badge")
+    fences = re.findall(r"```markdown\n(.*?)```", section, flags=re.DOTALL)
+    assert len(fences) == 1, "§ Badge must offer exactly one snippet"
+    snippet = fences[0].strip()
+    match = re.fullmatch(r"\[!\[[^\]]+\]\((https://img\.shields\.io/[^)]+)\)\]\(([^)]+)\)", snippet)
+    assert match, f"§ Badge snippet is not a linked shields.io badge: {snippet!r}"
+    assert match.group(2) == BADGE_TARGET, (
+        f"badge links {match.group(2)!r}, expected the registry at {BADGE_TARGET!r}"
+    )
+
+
+def test_the_badge_claims_no_tier_and_creates_no_entry():
+    """The badge is the one artifact that travels without its context, so the
+    rules that keep it from becoming evidence live beside it — and there is
+    exactly one badge, because a second one would be a tier variant."""
+    section = _flat(_section(_read(REGISTRY), "## Badge"))
+    lowered = section.lower()
+    assert "tier-neutral" in lowered
+    assert "a badge is not an entry" in lowered
+    badges = re.findall(r"https://img\.shields\.io/\S+", section)
+    assert len(badges) == 1, (
+        f"§ Badge offers {len(badges)} badges: {badges}. One, deliberately — a "
+        "second is a tier variant, and a tier variant is an unverifiable claim."
+    )
+    for tier in USE_TIERS:
+        token = tier.replace(" ", "%20").lower()
+        assert token not in lowered, (
+            f"a {tier!r} badge variant invites exactly the inference the policy forbids"
+        )
+
+
+# --------------------------------------------------------------------------
+# Claims policy
+# --------------------------------------------------------------------------
+
+
+def test_every_claims_rule_is_present_and_numbered():
+    """The policy is the deliverable; the rows are only its input. A rule that
+    disappears takes its constraint with it and nothing else changes."""
+    section = _section(_read(REGISTRY), "## Claims policy")
+    found = tuple(re.findall(r"^\d+\. \*\*(.+?)\*\*", section, flags=re.MULTILINE))
+    assert found == CLAIMS_RULES, f"claims rules are {found}, expected {CLAIMS_RULES}"
+
+
+def test_the_registry_and_the_pilot_ledger_point_at_each_other():
+    """Two public counting mechanisms, two consents, one reader. Whichever page
+    that reader lands on has to say the other exists and is not addable to it."""
+    assert "ADOPTERS.md" in _read(PILOT_RESULTS), (
+        "the pilot ledger must name the adopters registry"
+    )
+    assert "ADOPTERS.md" in _read(PILOT_RUNBOOK), (
+        "the pilot runbook must say enrollment does not create an entry"
+    )
+    assert "design-partner-pilot-results.md" in _read(REGISTRY)
+    assert "never added together" in _flat(_read(PILOT_RESULTS)).lower()
+
+
+# --------------------------------------------------------------------------
+# No entry, no claim — enforced across the repository
+# --------------------------------------------------------------------------
+
+#: What makes a number an adoption claim. Getting this wrong in either
+#: direction is fatal: too loose and it fires on "5 sentences of user
+#: instructions" and "27 national company registries" — both real lines in
+#: this repository — after which somebody deletes the guard rather than the
+#: claim. Too tight and it is decoration. So a number counts as a claim only
+#: when it reads as one: a use verb in front of it ("used by 40 teams"), a use
+#: verb behind it ("40 teams run the gate"), or a noun that has no other
+#: meaning here ("40 adopters").
+_NUMBER = r"(\d[\d,]*)\+?\s+"
+#: Up to two intervening words, but never a preposition or conjunction — that
+#: is what separates "40 happy adopters" from "5 sentences of user".
+_FILLER = r"(?:(?!of\b|in\b|for\b|to\b|from\b|with\b|per\b|and\b|or\b)\w+\s+){0,2}"
+_UNAMBIGUOUS_NOUNS = r"(?:adopters?|customers?|users?)"
+_NOUNS = rf"(?:{_UNAMBIGUOUS_NOUNS}|teams?|comp(?:any|anies)|organi[sz]ations?|orgs?)"
+_USE_BEFORE = r"(?:used|run|adopted|trusted|deployed|gated)\s+by\s+"
+_USE_AFTER = (
+    r"\s+(?:use|uses|using|run|runs|running|gate|gates|rely|relies|ship|ships|"
+    r"have\s+adopted|has\s+adopted|are\s+on)\b"
+)
+
+_CLAIM_RES = (
+    re.compile(rf"\b{_USE_BEFORE}{_NUMBER}{_FILLER}{_NOUNS}\b", re.IGNORECASE),
+    re.compile(rf"\b{_NUMBER}{_FILLER}{_NOUNS}{_USE_AFTER}", re.IGNORECASE),
+    re.compile(rf"\b{_NUMBER}{_FILLER}{_UNAMBIGUOUS_NOUNS}\b", re.IGNORECASE),
+)
+
+
+def _claims(text: str):
+    """Every adoption-claim match in ``text``, deduplicated by position."""
+    seen: dict[int, re.Match[str]] = {}
+    for pattern in _CLAIM_RES:
+        for match in pattern.finditer(text):
+            seen.setdefault(match.start(), match)
+    return [seen[start] for start in sorted(seen)]
+
+
+#: How much text around a number counts as its context when deciding whether
+#: it is talking about dogfooding.
+_CONTEXT = 120
+
+
+def _untraceable_claims(text: str) -> list[str]:
+    """Adoption numbers in ``text`` that the registry cannot source.
+
+    An unqualified adopter number must equal the **external** count. The
+    dogfooding count only sources a number that says it is dogfooding — rule 3
+    is that the two are never summed, and "used by 1 team" borrowing the
+    maintainer row would be exactly that sum, one row large.
+    """
+    counts = _counts()
+    external = counts["External adopter entries"]
+    dogfood = counts["Maintainer dogfooding entries"]
+    flat = _flat(text)
+    untraceable = []
+    for match in _claims(flat):
+        number = match.group(1).replace(",", "")
+        if number == external:
+            continue
+        context = flat[max(0, match.start() - _CONTEXT) : match.end() + _CONTEXT].lower()
+        if number == dogfood and ("dogfood" in context or "maintainer" in context):
+            continue
+        untraceable.append(match.group(0))
+    return untraceable
+
+
+def _prose_files() -> list[Path]:
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split("\0")
+    return [
+        REPO_ROOT / rel
+        for rel in tracked
+        if rel.endswith((".md", ".txt")) and not rel.startswith("tests/")
+    ]
+
+
+def test_no_published_adoption_number_is_larger_than_the_registry():
+    """Rule 1, enforced rather than promised. Any adopter count stated anywhere
+    in the repository's prose must be one the rows can source."""
+    offenders = {
+        str(path.relative_to(REPO_ROOT)): claims
+        for path in _prose_files()
+        if (claims := _untraceable_claims(_read(path)))
+    }
+    assert not offenders, (
+        f"adoption numbers with no rows behind them: {offenders}. Add the "
+        "consenting entries to ADOPTERS.md, or do not publish the number."
+    )
+
+
+#: Claim shapes the scanner must catch. The number is filled in at run time
+#: from :func:`_untraceable_number` — hard-coding one would quietly stop being
+#: a control the day the registry's own count reached it, which is exactly what
+#: happened to an earlier draft of this file when a test adopter was added.
+UNTRACEABLE_CLAIM_SHAPES = (
+    "Agents Shipgate is used by {n} teams in production.",
+    "Trusted by {n} organizations.",
+    "More than {n} adopters run the gate on every PR.",
+    "Now with {n} users.",
+    "Agents Shipgate is used by {n} team.",
+    "{n} companies gate their agent changes with it.",
+)
+
+
+def _untraceable_number() -> str:
+    """A count no row in the registry can source, whatever the rows say."""
+    published = {int(value) for label, value in _counts().items() if value.isdigit()}
+    return str(max(published, default=0) + 41)
+
+
+@pytest.mark.parametrize("shape", UNTRACEABLE_CLAIM_SHAPES)
+def test_the_claim_scanner_catches_an_untraceable_number(shape: str):
+    """Negative control. The guard above passes today because nobody has
+    written such a sentence; this is what proves it would fail if they did."""
+    claim = shape.format(n=_untraceable_number())
+    assert _untraceable_claims(claim), f"the scanner missed {claim!r}"
+
+
+def test_the_claim_scanner_accepts_a_number_the_rows_can_source():
+    """The other half of the control: a sourced number is not an offence, or
+    the registry could never publish its own count."""
+    counts = _counts()
+    sourced = f"{counts['External adopter entries']} external adopter entries are listed."
+    assert _untraceable_claims(sourced) == []
+
+
+def test_a_dogfooding_number_only_sources_a_dogfooding_sentence():
+    """Rule 3, at the scanner. The maintainer row is a real row, so its count
+    is publishable — as dogfooding. Lent to an unqualified sentence it becomes
+    the sum the policy forbids, and the last test case above is that sentence."""
+    counts = _counts()
+    dogfood = counts["Maintainer dogfooding entries"]
+    if dogfood == counts["External adopter entries"]:
+        pytest.skip("the two counts are equal, so this number is traceable either way")
+    assert _untraceable_claims(f"{dogfood} maintainer dogfooding adopters are listed.") == []
+    assert _untraceable_claims(f"Agents Shipgate is run by {dogfood} teams.")
+
+
+def test_the_claim_scanner_ignores_this_repositorys_other_denominators():
+    """Benchmark and pilot prose count repositories, PRs and servers. Those are
+    measurements with their own denominators, not adoption claims, and a guard
+    that swept them in would be disabled rather than obeyed."""
+    for benign in (
+        "across 361 mined rows from 8 distinct real agent repos",
+        "the 30-server survey behind the registry",
+        "19 unique labeled engine-engaged PRs",
+        # Both of these are real lines elsewhere in the repository, and both
+        # were false positives until the pattern stopped accepting a
+        # preposition as filler.
+        "the first 5 sentences of user instructions are preserved",
+        "27 national company registries",
+    ):
+        assert _untraceable_claims(benign) == []
+
+
+# --------------------------------------------------------------------------
+# Internal links
+# --------------------------------------------------------------------------
+
+
+def test_registry_links_resolve():
+    """A registry that links a moved doc or a renamed anchor teaches the reader
+    that its rules are decorative."""
+    text = _read(REGISTRY)
+    headings = _headings(text)
+    for href in LINK_RE.findall(text):
+        if href.startswith(("http://", "https://", "mailto:")):
+            continue
+        if href.startswith("#"):
+            assert href[1:] in headings, f"ADOPTERS.md links dead anchor {href}"
+            continue
+        path, _, anchor = href.partition("#")
+        target = (REPO_ROOT / path).resolve()
+        assert target.exists(), f"ADOPTERS.md links non-existent {href}"
+        if anchor:
+            assert anchor in _headings(target.read_text(encoding="utf-8")), (
+                f"ADOPTERS.md links dead anchor {href}"
+            )

--- a/tests/test_adopters_registry.py
+++ b/tests/test_adopters_registry.py
@@ -311,18 +311,54 @@ def test_every_entry_is_dated_in_the_past(heading: str, row: dict[str, str]):
     )
 
 
+#: A public repository link: any host, because Shipgate runs on a checkout and
+#: not on an API. Requiring github.com would have told a GitLab, Codeberg or
+#: self-hosted adopter to write `private` about a repository that is not — a
+#: registry that mislabels its own rows to fit its validator.
+PUBLIC_REPOSITORY_RE = re.compile(r"https?://[\w.-]+\.[a-z]{2,}(?::\d+)?/[\w./~-]*[\w~-]", re.I)
+ENTRY_RECORD_RE = re.compile(rf"{re.escape(REPO_URL)}/(?:issues|pull|discussions)/\d+")
+
+
+def _repository_problem(cell: str) -> str | None:
+    """Why ``cell`` is not a usable ``Repository`` value, or ``None``."""
+    cell = cell.strip()
+    if cell == "private":
+        return None
+    hrefs = LINK_RE.findall(cell)
+    if len(hrefs) != 1:
+        return "expected one linked public repository, or the single word 'private'"
+    if not PUBLIC_REPOSITORY_RE.fullmatch(hrefs[0]):
+        return (
+            f"{hrefs[0]!r} is not a public repository URL; link the repository on "
+            "whichever host it lives, or write 'private'"
+        )
+    return None
+
+
+def _entry_record_problem(cell: str) -> str | None:
+    """Why ``cell`` is not a usable ``Entry`` value, or ``None``.
+
+    Deliberately narrower than the repository check above: a repository can
+    live anywhere, but the *consent* has to be an act in this project that
+    anyone can open and read.
+    """
+    hrefs = LINK_RE.findall(cell.strip())
+    if len(hrefs) != 1:
+        return "expected exactly one linked entry record"
+    if not ENTRY_RECORD_RE.fullmatch(hrefs[0]):
+        return (
+            f"{hrefs[0]!r} is not an issue, pull request or discussion in this repository"
+        )
+    return None
+
+
 @pytest.mark.parametrize(("heading", "row"), _all_entries(), ids=_entry_ids())
 def test_every_entry_links_the_public_act_that_created_it(heading: str, row: dict[str, str]):
     """Consent is what the count rests on, so every row names where it was
     given — an issue, discussion or PR in this repository, not a private
     conversation somebody remembers."""
-    hrefs = LINK_RE.findall(row["Entry"])
-    assert len(hrefs) == 1, f"{heading} row {row['Adopter']!r} must link exactly one entry record"
-    href = hrefs[0]
-    assert re.fullmatch(rf"{re.escape(REPO_URL)}/(issues|pull|discussions)/\d+", href), (
-        f"{heading} row {row['Adopter']!r} links {href!r}; the entry record must be an "
-        "issue, pull request or discussion in this repository"
-    )
+    problem = _entry_record_problem(row["Entry"])
+    assert problem is None, f"{heading} row {row['Adopter']!r}: {problem}"
 
 
 @pytest.mark.parametrize(("heading", "row"), _all_entries(), ids=_entry_ids())
@@ -330,16 +366,57 @@ def test_every_entry_names_a_repository_or_says_private(heading: str, row: dict[
     """Acceptance §1: private-repo entries are allowed at organization
     granularity. `private` is the whole vocabulary for that — a half-named
     private repository ("internal monorepo") discloses without being checkable."""
-    repository = row["Repository"]
-    if repository == "private":
-        return
-    hrefs = LINK_RE.findall(repository)
-    assert len(hrefs) == 1 and re.fullmatch(
-        r"https://github\.com/[\w.-]+/[\w.-]+", hrefs[0]
-    ), (
-        f"{heading} row {row['Adopter']!r} has Repository={repository!r}; "
-        "expected a linked github.com/owner/repo or the single word 'private'"
-    )
+    problem = _repository_problem(row["Repository"])
+    assert problem is None, f"{heading} row {row['Adopter']!r}: {problem}"
+
+
+@pytest.mark.parametrize(
+    "cell",
+    (
+        "private",
+        "[acme/agent](https://github.com/acme/agent)",
+        "[acme/agent](https://gitlab.com/acme/agent)",
+        "[acme/agent](https://codeberg.org/acme/agent)",
+        "[acme/agent](https://git.acme.example/acme/agent)",
+        "[acme/agent](https://git.acme.example:8443/team/acme/agent)",
+    ),
+)
+def test_a_public_repository_on_any_host_is_accepted(cell: str):
+    """An adopter whose code is on GitLab or a self-hosted forge follows the
+    same documented path as everyone else. Rejecting them would leave writing
+    `private` about a public repository as the only way to be counted."""
+    assert _repository_problem(cell) is None, f"{cell!r} should be a valid Repository"
+
+
+@pytest.mark.parametrize(
+    "cell",
+    (
+        "",
+        "internal monorepo",
+        "acme/agent",
+        "[acme/agent](notes/acme.md)",
+        "[a](https://gitlab.com/x) and [b](https://gitlab.com/y)",
+    ),
+)
+def test_an_unlinked_or_half_named_repository_is_rejected(cell: str):
+    """The other half: a cell that is neither `private` nor one resolvable
+    public link cannot be checked by a reader, which is the whole point."""
+    assert _repository_problem(cell) is not None, f"{cell!r} should be rejected"
+
+
+@pytest.mark.parametrize(
+    "cell",
+    (
+        "[#600](https://gitlab.com/acme/agent/-/issues/2)",
+        "[#600](https://github.com/acme/agent/issues/600)",
+        "[ask](mailto:help@threemoonslab.com)",
+        "asked in a call",
+    ),
+)
+def test_a_consent_record_outside_this_repository_is_rejected(cell: str):
+    """The repository may live anywhere; the consent may not. An entry record
+    nobody outside the maintainers can open is not attributable."""
+    assert _entry_record_problem(cell) is not None, f"{cell!r} should be rejected"
 
 
 # --------------------------------------------------------------------------
@@ -354,6 +431,36 @@ def test_the_counts_are_the_row_counts():
     counts = _counts()
     assert counts["External adopter entries"] == str(len(_entries(EXTERNAL_HEADING)))
     assert counts["Maintainer dogfooding entries"] == str(len(_entries(DOGFOOD_HEADING)))
+
+
+def _entry_identity(row: dict[str, str]) -> tuple[str, str]:
+    """What makes two rows the same adoption.
+
+    The repository link, when there is one, is the identity — two rows can
+    describe the same repository in different words. A `private` row is
+    identified by its adopter alone, which is all the registry knows about it,
+    and is exactly why one organization cannot hold two of them.
+    """
+    hrefs = LINK_RE.findall(row["Repository"])
+    repository = hrefs[0] if hrefs else row["Repository"]
+    return (_flat(row["Adopter"]).casefold(), _flat(repository).casefold())
+
+
+def test_no_adopter_is_counted_twice():
+    """The counts are row counts, so a duplicated row is a duplicated adopter:
+    one adoption and one consent record, counted twice, with every other guard
+    still green. Identity is checked across both tables — the same party listed
+    as external and as dogfooding would inflate the headline number the same
+    way, from the one place the policy says it never may."""
+    seen: dict[tuple[str, str], str] = {}
+    for heading, row in _all_entries():
+        identity = _entry_identity(row)
+        assert identity not in seen, (
+            f"{heading} row {row['Adopter']!r} repeats an adoption already listed under "
+            f"{seen[identity]} ({identity[0]!r} / {identity[1]!r}). One row per adopter "
+            "per repository; an adopter with a second repository lists that repository."
+        )
+        seen[identity] = heading
 
 
 def test_the_counts_section_publishes_exactly_two_numbers_and_a_date():
@@ -631,9 +738,26 @@ def _claims(text: str):
     return [seen[start] for start in sorted(seen)]
 
 
-#: How much text around a number counts as its context when deciding whether
-#: it is talking about dogfooding.
-_CONTEXT = 120
+#: Words that qualify a claim as being about maintainer dogfooding, and words
+#: that qualify it as being about external adoption. A claim carrying the
+#: second kind can never borrow the dogfooding count, whatever the sentence
+#: around it says.
+_DOGFOOD_WORDS = ("dogfood", "maintainer")
+_EXTERNAL_WORDS = ("external", "outside")
+_SENTENCE_ENDS = (". ", "? ", "! ", "; ")
+
+
+def _sentence_around(flat: str, start: int, end: int) -> str:
+    """The sentence containing ``flat[start:end]``.
+
+    A character window is the wrong unit: with a 120-character one, "used by 1
+    external team. Maintainer dogfooding is counted separately." had its
+    *neighbour* authorize it. A qualifier only qualifies the sentence it is in.
+    """
+    left = max((flat.rfind(mark, 0, start) for mark in _SENTENCE_ENDS), default=-1)
+    rights = [pos for pos in (flat.find(mark, end) for mark in _SENTENCE_ENDS) if pos != -1]
+    right = min(rights) if rights else len(flat)
+    return flat[left + 1 : right].strip()
 
 
 def _untraceable_claims(text: str, counts: dict[str, str] | None = None) -> list[str]:
@@ -643,6 +767,14 @@ def _untraceable_claims(text: str, counts: dict[str, str] | None = None) -> list
     dogfooding count only sources a number that says it is dogfooding — rule 3
     is that the two are never summed, and "used by 1 team" borrowing the
     maintainer row would be exactly that sum, one row large.
+
+    Two things bound that exemption, because prose about adoption routinely
+    discusses both counts in adjacent sentences:
+
+    * the dogfooding qualifier must be in the claim's **own sentence**, not
+      merely nearby; and
+    * a claim that qualifies *itself* as external never takes the exemption,
+      whatever the rest of the sentence says.
 
     ``counts`` is accepted so a caller sweeping hundreds of files parses the
     registry once rather than once per file.
@@ -656,8 +788,11 @@ def _untraceable_claims(text: str, counts: dict[str, str] | None = None) -> list
         number = match.group(1).replace(",", "")
         if number == external:
             continue
-        context = flat[max(0, match.start() - _CONTEXT) : match.end() + _CONTEXT].lower()
-        if number == dogfood and ("dogfood" in context or "maintainer" in context):
+        claim = match.group(0).lower()
+        sentence = _sentence_around(flat, match.start(), match.end()).lower()
+        says_external = any(word in claim for word in _EXTERNAL_WORDS)
+        says_dogfood = any(word in sentence for word in _DOGFOOD_WORDS)
+        if number == dogfood and says_dogfood and not says_external:
             continue
         untraceable.append(match.group(0))
     return untraceable
@@ -739,6 +874,39 @@ def test_a_dogfooding_number_only_sources_a_dogfooding_sentence():
         pytest.skip("the two counts are equal, so this number is traceable either way")
     assert _untraceable_claims(f"{dogfood} maintainer dogfooding adopters are listed.") == []
     assert _untraceable_claims(f"Agents Shipgate is run by {dogfood} teams.")
+
+
+def test_a_neighbouring_dogfooding_sentence_authorizes_nothing():
+    """The reported case, pinned. With counts 0 external / 1 maintainer, this
+    passed: the scanner read the *next* sentence as the claim's qualifier and
+    let an explicitly external `1` borrow the maintainer row — the sum rule 3
+    forbids, produced by a character window rather than a sentence."""
+    counts = _counts()
+    dogfood = counts["Maintainer dogfooding entries"]
+    if dogfood == counts["External adopter entries"]:
+        pytest.skip("the two counts are equal, so this number is traceable either way")
+    reported = (
+        f"Agents Shipgate is used by {dogfood} external team. "
+        "Maintainer dogfooding is counted separately."
+    )
+    assert _untraceable_claims(reported), "a neighbouring sentence must not qualify a claim"
+    # …and the same number, unqualified, is not rescued by the neighbour either.
+    assert _untraceable_claims(
+        f"Agents Shipgate is used by {dogfood} teams. Maintainer dogfooding is separate."
+    )
+
+
+def test_an_externally_qualified_claim_never_borrows_the_dogfooding_count():
+    """Even inside a sentence that is otherwise about dogfooding. "Beside our
+    own maintainer entry, 1 external adopter runs it" is a claim about the
+    external count, and the external count is what has to source it."""
+    counts = _counts()
+    dogfood = counts["Maintainer dogfooding entries"]
+    if dogfood == counts["External adopter entries"]:
+        pytest.skip("the two counts are equal, so this number is traceable either way")
+    assert _untraceable_claims(
+        f"Beside our maintainer dogfooding row, {dogfood} external adopters run it."
+    )
 
 
 def test_the_claim_scanner_ignores_this_repositorys_other_denominators():

--- a/tests/test_adopters_registry.py
+++ b/tests/test_adopters_registry.py
@@ -66,6 +66,11 @@ EMPTY_MARKER = "No external entries yet."
 LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
+#: Dates are compared against the runner's local today plus one day. The guard
+#: is here to catch "2027-03-01", not to fail a contributor in Auckland whose
+#: today is still tomorrow in the UTC runner that reviews their pull request.
+CLOCK_SKEW = dt.timedelta(days=1)
+
 
 # --------------------------------------------------------------------------
 # Reading the registry
@@ -237,12 +242,13 @@ def test_readme_counts_match_the_registry():
     section = _flat(_section(_read(README), "## Adopters"))
     external = counts["External adopter entries"]
     dogfood = counts["Maintainer dogfooding entries"]
-    assert f"{external} external adopter entries" in section, (
-        f"README § Adopters must state the registry's external count ({external})"
-    )
-    assert re.search(rf"\b{re.escape(dogfood)} maintainer dogfooding entr(?:y|ies)\b", section), (
-        f"README § Adopters must state the registry's dogfooding count ({dogfood})"
-    )
+    # Both counts accept "entry" and "entries": the first real adopter makes
+    # the external count 1, and a guard that demanded "1 external adopter
+    # entries" would meet that contributor with a red build over grammar.
+    for count, noun in ((external, "external adopter"), (dogfood, "maintainer dogfooding")):
+        assert re.search(rf"\b{re.escape(count)} {noun} entr(?:y|ies)\b", section), (
+            f"README § Adopters must state the registry's {noun} count ({count})"
+        )
     assert counts["Counts as of"] in section, (
         "README § Adopters must carry the registry's as-of date beside its numbers"
     )
@@ -300,7 +306,7 @@ def test_every_entry_is_dated_in_the_past(heading: str, row: dict[str, str]):
     be true."""
     since = row["Since"]
     assert DATE_RE.match(since), f"{heading} row {row['Adopter']!r} has Since={since!r}, want YYYY-MM-DD"
-    assert dt.date.fromisoformat(since) <= dt.date.today(), (
+    assert dt.date.fromisoformat(since) <= dt.date.today() + CLOCK_SKEW, (
         f"{heading} row {row['Adopter']!r} is dated in the future: {since}"
     )
 
@@ -369,7 +375,9 @@ def test_the_as_of_date_is_not_older_than_the_newest_entry():
             f"{heading} row {row['Adopter']!r} is dated {row['Since']}, after the "
             f"stated as-of date {as_of}. Re-date § Counts in the same change."
         )
-    assert as_of <= dt.date.today(), f"§ Counts is dated in the future: {as_of}"
+    assert as_of <= dt.date.today() + CLOCK_SKEW, (
+        f"§ Counts is dated in the future: {as_of}"
+    )
 
 
 def test_the_empty_external_table_says_so_in_words():
@@ -418,7 +426,11 @@ def test_the_maintainer_row_agrees_with_the_paragraph_that_explains_it():
     own table — so it fails instead."""
     section = _flat(_section(_read(REGISTRY), DOGFOOD_HEADING))
     for row in _entries(DOGFOOD_HEADING):
-        assert f"That row says `{row['Use']}`" in section, (
+        # "That row says `x`" today; "the Acme row says `x`" once there are
+        # two. What is pinned is the claim-plus-tier, not one sentence opener —
+        # a guard that only fit one row would be rewritten out on the day a
+        # second one arrived.
+        assert re.search(rf"row says `{re.escape(row['Use'])}`", section), (
             f"the maintainer row states Use={row['Use']!r}, which the prose "
             "beside it does not explain. State the tier and say why it is that one."
         )
@@ -624,15 +636,18 @@ def _claims(text: str):
 _CONTEXT = 120
 
 
-def _untraceable_claims(text: str) -> list[str]:
+def _untraceable_claims(text: str, counts: dict[str, str] | None = None) -> list[str]:
     """Adoption numbers in ``text`` that the registry cannot source.
 
     An unqualified adopter number must equal the **external** count. The
     dogfooding count only sources a number that says it is dogfooding — rule 3
     is that the two are never summed, and "used by 1 team" borrowing the
     maintainer row would be exactly that sum, one row large.
+
+    ``counts`` is accepted so a caller sweeping hundreds of files parses the
+    registry once rather than once per file.
     """
-    counts = _counts()
+    counts = counts if counts is not None else _counts()
     external = counts["External adopter entries"]
     dogfood = counts["Maintainer dogfooding entries"]
     flat = _flat(text)
@@ -666,10 +681,11 @@ def _prose_files() -> list[Path]:
 def test_no_published_adoption_number_is_larger_than_the_registry():
     """Rule 1, enforced rather than promised. Any adopter count stated anywhere
     in the repository's prose must be one the rows can source."""
+    counts = _counts()
     offenders = {
         str(path.relative_to(REPO_ROOT)): claims
         for path in _prose_files()
-        if (claims := _untraceable_claims(_read(path)))
+        if (claims := _untraceable_claims(_read(path), counts))
     }
     assert not offenders, (
         f"adoption numbers with no rows behind them: {offenders}. Add the "

--- a/tests/test_distribution_surface_parity.py
+++ b/tests/test_distribution_surface_parity.py
@@ -283,6 +283,7 @@ NOT_A_DISTRIBUTION_SURFACE: dict[str, str] = {
     ".gitignore": "repository mechanics",
     ".pre-commit-hooks.yaml": "repository mechanics",
     ".well-known": "the channel metadata this registry reads; the source of truth for executable_pin, not a restatement of it",
+    "ADOPTERS.md": "the opt-in public adopters registry; it publishes self-reported adopter claims, not an engine answer, and is pinned by tests/test_adopters_registry.py",
     "AGENTS.md": "repository documentation, pinned by tests/test_public_surface_contract.py",
     "CHANGELOG.md": "repository documentation, pinned by tests/test_public_surface_contract.py",
     "CLAUDE.md": "repository documentation, pinned by tests/test_public_surface_contract.py",

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -3605,6 +3605,7 @@ TRUST_QUALIFIER_WINDOW = 400  # ~one paragraph; matches CONTEXT_WINDOW
 
 TRUST_CLAIM_SURFACES = (
     "README.md",
+    "ADOPTERS.md",
     "AGENTS.md",
     "STABILITY.md",
     "llms.txt",


### PR DESCRIPTION
## Summary

Closes #475.

Shipgate collects nothing, deliberately. The price is that it cannot count its
own users: downloads measure CI caches, stars measure sentiment, and the repos
that quietly run the gate every day are invisible. This adds the counting
mechanism that stance requires — **[`ADOPTERS.md`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/claude/issue-475-review-360ece/ADOPTERS.md)**,
opt-in and self-served, plus the rule that every adoption number this project
publishes comes from it.

- **One row per adopter**, added by the adopter — through the new
  [Adopter entry issue form](.github/ISSUE_TEMPLATE/adopter_entry.yml) or a
  pull request. Six fields: who, which repository (or the single word
  `private`), what it gates, the tier, the date, and a link to the public act
  where they asked. That link is the consent record, and it is what the count
  rests on.
- **Three tiers, defined tightly**: `local evaluation`, `advisory CI`,
  `blocking CI` — the last one meaning the job fails on a verdict *and* the
  check is required on the protected branch.
- **An eight-rule claims policy.** No entry, no claim; every number carries its
  as-of date; external and dogfooding are never summed; an entry is a dated
  statement rather than a measurement; a tier is self-reported and never
  upgraded; a badge is not an entry; the design-partner ledger (#521) and the
  historical corpus (#511) stay separate; removal is unconditional.
- **One optional badge**, deliberately tier-neutral, linking back to the
  registry. There is no blocking-CI variant and the file says why.
- **Today's numbers, published rather than omitted**: 0 external entries, 1
  maintainer dogfooding entry.

### The self-entry says `advisory CI`

Both self-gate workflows do fail the run on `blocked` and `unknown` — but
`main` carries no required status check, so a red run stops no merge. Under the
file's own definitions that is advisory, and a guard fails the build if the row
is ever raised without rewriting the paragraph that explains it. It is the
smallest available demonstration of the rule the registry runs on: the tier is
what is true, not what is flattering.

## Type

- [x] Documentation only

**Surface discipline.** Not a new surface under
[CONTRIBUTING §Surface discipline](CONTRIBUTING.md#surface-discipline) — no CLI
command, schema, report block, discovery surface or adapter, and no data
collection of any kind. `ADOPTERS.md` is registered in
`NOT_A_DISTRIBUTION_SURFACE` with its reason (it publishes self-reported
adopter claims, not an engine answer), which is what the top-level classifier
requires of any new root entry. Headline metric: attributable public adoption
claims, with dogfooding and external entries separated.

## Verification

Local, all green: `ruff check .`; the full `pytest -n auto -m "not perf"` gate;
`tests/test_adapter_static_only.py` and `tests/test_latency_budget.py -m perf`
in their own runs, as CI splits them.

`tests/test_adopters_registry.py` (46 tests) is the "and verify" half of the
issue title. It fails on a row missing a field, a row whose cell count is wrong
(reported by name rather than as a `zip()` error during collection), an
undefined tier, a non-ISO or future date, an entry link that does not point
into this repository, this repository listed as an *external* adopter, counts
that disagree with the rows, an as-of date older than the newest entry, an
empty table that stops saying it is empty, a claims rule quietly dropped, a
second badge variant, a README that drops the privacy stance or drifts from the
registry's counts, an issue form that offers an undefined tier or stops
requiring consent — and any adopter number stated anywhere in the repository's
prose that these rows cannot source.

**A 50-case perturbation sweep** drove every one of those mutations against the
suite and confirmed each fails, that the legitimate edits still pass (adding a
real adopter correctly, adding a second maintainer row *with* its explanation,
writing the grammatically singular "1 external adopter entry"), and — via a
no-op detector — that every mutation string actually matched something. It
found two real defects while I was writing it, both fixed here:

1. The badge guard folded case before looking for a tier token, so a
   `blocking%20CI` badge variant slipped through. It now also requires the
   section to carry exactly one shields.io URL.
2. The claim scanner's first draft misfired on real prose in this repository —
   "5 sentences of user instructions", "27 national company registries" —
   because it accepted a preposition as filler. A number now counts as a claim
   only when it reads as one: a use verb in front of it, a use verb behind it,
   or a noun with no other meaning here. Both strings are pinned as
   must-not-fire cases.

A third came out of the sweep's own failure: the negative controls hard-coded
the number `1`, which silently stopped being a control the moment a test
adopter row made `1` traceable. They now derive an unsourceable number from the
published counts.

**Two review rounds followed, both with findings** (commits 2 and 3):

- Round 1, on the guards: the README count assertion demanded the plural
  "entries", so the first real adopter had to write "1 external adopter
  entries" or take a red build over grammar; the self-entry agreement guard
  hard-coded a sentence opener that cannot be written naturally once there are
  two maintainer rows; dates were compared against the runner's local `today`,
  failing a contributor east of UTC; and the claim scanner re-parsed
  `ADOPTERS.md` once per scanned file (294 today).
- Round 2, on the prose: **the self-entry's `advisory CI` claim had been
  checked against the wrong mechanism.** Classic branch protection reports
  `main` as unprotected, but an active *ruleset* governs it. It requires a pull
  request and linear history and carries no `required_status_checks` rule — so
  the tier stands, and the file now names the command that shows it. ROADMAP.md
  was also restating the external count in prose, which is rule 2's staleness
  trap one file over; it points at the registry now instead.
- Round 3, on review feedback (three P2s, all reproduced before and after, in
  `5789ef07`): a **neighbouring** sentence about dogfooding could authorize an
  explicitly external number — the exemption is now scoped to the claim's own
  sentence, and a claim that calls itself external never takes it at all;
  **duplicate rows inflated the counts**, since counts were compared to
  `len()` — rows now carry an adopter+repository identity checked across both
  tables; and **only GitHub repositories were accepted**, which would have told
  a GitLab or self-hosted adopter to write `private` about a public repository
  — repository host and consent record are now validated independently.

## Not done here

**The site half of the acceptance is not in this repository.** "Linked from the
README and the site" — the README is done; threemoonslab.com is built from the
private `ThreeMoonsLab/web` repo, so the site link needs a change there. Happy
to file that as a tracking issue in `web` on request; it is the one acceptance
box this PR cannot tick.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] New or changed check IDs are documented in `docs/checks.md` — n/a, no check changes
- [x] Report/schema changes are additive or documented in `STABILITY.md` — n/a, no schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
