### PR TITLE
Scope the unresolvable-root rejection to its own project (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   exists to catch, and that the legitimate edits — a correctly added adopter, a
   GitLab-hosted one, a second maintainer row, a grammatically singular count —
   still pass.
+
 - **One unreadable application root no longer rejects every agent name in the
   repository.** (#398) A declared root whose identity cannot be established
   statically makes nothing selectable — the #324 rule, and a sound one, because
@@ -54,6 +55,15 @@
   publishes, now computed once and read by both — and the sentence names that
   project. A name several projects declare is still rejected when any of them
   is blocked; that direction is the fail-closed one.
+
+  "Which project" is resolved against the projects that grouping actually
+  *established*, not against the nearest project marker. The two are not the
+  same, and reading the marker fails open: a utilities package carrying its own
+  `pyproject.toml` but no agent evidence is not a manifest scope, so a bare
+  `Agent(name="CrmHelper")` found there was exempt from the workspace's refusal
+  and plain `init --write` wrote a helper class's argument as the reviewed
+  identity of a repository whose real application root could not be read at
+  all. A name under no established project belongs to the scope enclosing it.
 
   Scoping alone would not have unblocked the reproduction, because one of the
   two observed culprits was `eval/test_eval_arize.py` *inside* the project
@@ -85,13 +95,25 @@
   `0.6.0`): `agent_name_candidates` is the field the zero-install path pins
   byte for byte, so a script that scoped the rejection differently would name a
   different agent than `init` does. Putting the grouping behind one object on
-  each side surfaced a parity break that predates this issue — where no marker
-  was found above the evidence at all, the script named the workspace's
-  `requirements.txt` as the project marker while the CLI reported `null`. A
-  weak marker only draws a boundary in a directory that already holds agent
-  evidence, so one that unlocked nothing is not the boundary the project rests
-  on. Every sample carries a `pyproject.toml`, which is why the per-sample
-  parity check never reached the fallback; a test does now.
+  each side surfaced two parity breaks that predate this issue.
+
+  The script counted **every** `Agent(name=…)` literal as project evidence,
+  where the CLI counts only framework-attributed ones. A module defining its
+  own `Agent` class and constructing `Agent(name="crm")` is not an agent
+  project (#363 review), so the script drew a boundary the CLI does not: a
+  phantom entry in `agent_project_candidates` and, through it, `agent_scope:
+  "ambiguous"` on a workspace the CLI calls `"single"` — a *verdict*
+  disagreement on the surface whose whole contract is verdict parity. The
+  script now qualifies those literals the same way, snapshotting each Python
+  file's framework attribution right after the Python pass, which is exactly
+  what `_score_python_signals` records on the CLI side.
+
+  And where no marker was found above the evidence at all, the script named the
+  workspace's `requirements.txt` as the project marker while the CLI reported
+  `null`. A weak marker only draws a boundary in a directory that already holds
+  agent evidence, so one that unlocked nothing is not the boundary the project
+  rests on. Every sample carries a `pyproject.toml` and one readable root,
+  which is why the per-sample parity check reached neither; tests do now.
 
 - **The zero-install detector refuses an oversized candidate instead of
   reading it.** `tools/shipgate-detect.py` is fetched over `curl | python3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,43 @@
   exists to catch, and that the legitimate edits — a correctly added adopter, a
   GitLab-hosted one, a second maintainer row, a grammatically singular count —
   still pass.
+- **One unreadable application root no longer rejects every agent name in the
+  repository.** (#398) A declared root whose identity cannot be established
+  statically makes nothing selectable — the #324 rule, and a sound one, because
+  every name still standing is by construction *not* that root. It was being
+  applied with repository scope. On adk-samples that meant one file rejected
+  roughly 55 candidates across 25 projects, `financial_coordinator` and
+  `cyber_guardian_orchestrator` among them, and told the reader so by naming a
+  file in a project they were not adopting. The rejection is now scoped to the
+  project the root sits in — the same grouping `agent_project_candidates`
+  publishes, now computed once and read by both — and the sentence names that
+  project. A name several projects declare is still rejected when any of them
+  is blocked; that direction is the fail-closed one.
+
+  Scoping alone would not have unblocked the reproduction, because one of the
+  two observed culprits was `eval/test_eval_arize.py` *inside* the project
+  being adopted and the other was
+  `.agents/skills/**/resources/templates/app/agent.py`. Neither is the
+  application a project ships: a fixture that builds an `App` is a fixture, and
+  a scaffolding template is what a generator copies. The ranker already said so
+  for *selection* and said the opposite for *rejection* — one predicate now
+  answers both, so a scaffolding template is demoted exactly as a test fixture
+  is instead of standing in for the product. The template rule is the directory
+  pair `resources/templates/`, not a bare `templates/`, which real packages
+  use; an unreadable root anywhere else still stops selection, and a project
+  whose own product root is unreadable still refuses with `CHANGE_ME`.
+
+  `tools/shipgate-detect.py` carries the same change (`script_version`
+  `0.6.0`): `agent_name_candidates` is the field the zero-install path pins
+  byte for byte, so a script that scoped the rejection differently would name a
+  different agent than `init` does. Putting the grouping behind one object on
+  each side surfaced a parity break that predates this issue — where no marker
+  was found above the evidence at all, the script named the workspace's
+  `requirements.txt` as the project marker while the CLI reported `null`. A
+  weak marker only draws a boundary in a directory that already holds agent
+  evidence, so one that unlocked nothing is not the boundary the project rests
+  on. Every sample carries a `pyproject.toml`, which is why the per-sample
+  parity check never reached the fallback; a test does now.
 
 - **The zero-install detector refuses an oversized candidate instead of
   reading it.** `tools/shipgate-detect.py` is fetched over `curl | python3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,19 @@
   use; an unreadable root anywhere else still stops selection, and a project
   whose own product root is unreadable still refuses with `CHANGE_ME`.
 
+  One consequence is worth stating rather than discovering: where the *only*
+  agent evidence in a workspace is non-product code, an unreadable root there
+  used to force `CHANGE_ME`, and now the fixture or template name is written.
+  That guard was accidental — a readable root in the same file already had its
+  name written before this change — so what this does is make the two cases
+  agree, not open a new one. The general rule it points at, that a name only
+  non-product code declares should never be asserted as the reviewed identity,
+  is [#533](https://github.com/ThreeMoonsLab/agents-shipgate/issues/533); it
+  would close the readable case too and is a wider decision than this fix. The
+  same widening reaches `init --write --allow-unresolved-scope`, whose whole
+  contract is already "adopt the first agent name it parsed" on a workspace
+  with several unrelated projects.
+
   `tools/shipgate-detect.py` carries the same change (`script_version`
   `0.6.0`): `agent_name_candidates` is the field the zero-install path pins
   byte for byte, so a script that scoped the rejection differently would name a

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -122,6 +122,12 @@ Consume the response to decide whether to proceed. Key fields:
   `agent_project_candidates[]` stay selectable. A name two projects declare
   is rejected when either one is blocked.
 
+  "Which project" means an entry of `agent_project_candidates[]`, not the
+  nearest directory carrying a project marker. A marker directory that holds
+  no agent evidence — a utilities package with its own `pyproject.toml` — is
+  not a manifest scope, and a name found there belongs to the scope that
+  encloses it.
+
   The same product/not-product split above decides *which* roots block: a
   root declared only by test code or by a scaffolding template is not the
   application a project ships, so it does not disable selection for the

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -101,21 +101,31 @@ Consume the response to decide whether to proceed. Key fields:
     `sub_agent` (named inside another agent's `sub_agents=[…]` /
     `handoffs=[…]`). `workspace_dir` is the directory-name fallback and is
     never selectable.
-  - `path` — a name declared in product code outranks one declared in test
-    code, which names fixtures. This dominates: a test fixture that builds
-    an `App(root_agent=…)` still ranks below a plain agent the shipped code
-    declares.
+  - `path` — a name declared in product code outranks one that is not the
+    product's: test code, which names fixtures, and a scaffolding template
+    under a `resources/templates/` directory, which names an example. This
+    dominates: either one building an `App(root_agent=…)` still ranks below
+    a plain agent the shipped code declares.
   - corroboration — a value the project name independently agrees with
     ranks above one only a single site declares.
   - a quality floor — values under three significant characters, and
     generic scaffolding names (`agent`, `foo`, `test`, …), are ranked last
     and marked `selectable: false`.
 
-  One rule overrides all four: if the workspace declares an application root
+  One rule overrides all four: if a **project** declares an application root
   whose name cannot be resolved statically — a dynamic expression, a factory
-  call, a symbol bound more than once — then **nothing** is selectable, and
-  the `rationale[]` says why. Anything still ranked is by construction not
-  the root, so writing it would declare a worker as the reviewed identity.
+  call, a symbol bound more than once — then nothing that project declares
+  is selectable, and the `rationale[]` names the project and says why.
+  Anything still ranked there is by construction not the root, so writing it
+  would declare a worker as the reviewed identity. The scope is the project,
+  not the repository: on a monorepo, agents in the other entries of
+  `agent_project_candidates[]` stay selectable. A name two projects declare
+  is rejected when either one is blocked.
+
+  The same product/not-product split above decides *which* roots block: a
+  root declared only by test code or by a scaffolding template is not the
+  application a project ships, so it does not disable selection for the
+  rest of the project (#398).
 
   `rationale[]` states which of those applied, so a ranking change is
   visible in the output rather than silently changing what the manifest

--- a/docs/zero-install.md
+++ b/docs/zero-install.md
@@ -35,7 +35,7 @@ The script's output is a **structural subset** of `agents-shipgate detect --json
   "python_parse_truncated": false,
   "next_action": "agents-shipgate init --workspace .",
   "workspace_signals": {...},
-  "script_version": "0.5.0"
+  "script_version": "0.6.0"
 }
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1059,21 +1059,31 @@ Consume the response to decide whether to proceed. Key fields:
     `sub_agent` (named inside another agent's `sub_agents=[…]` /
     `handoffs=[…]`). `workspace_dir` is the directory-name fallback and is
     never selectable.
-  - `path` — a name declared in product code outranks one declared in test
-    code, which names fixtures. This dominates: a test fixture that builds
-    an `App(root_agent=…)` still ranks below a plain agent the shipped code
-    declares.
+  - `path` — a name declared in product code outranks one that is not the
+    product's: test code, which names fixtures, and a scaffolding template
+    under a `resources/templates/` directory, which names an example. This
+    dominates: either one building an `App(root_agent=…)` still ranks below
+    a plain agent the shipped code declares.
   - corroboration — a value the project name independently agrees with
     ranks above one only a single site declares.
   - a quality floor — values under three significant characters, and
     generic scaffolding names (`agent`, `foo`, `test`, …), are ranked last
     and marked `selectable: false`.
 
-  One rule overrides all four: if the workspace declares an application root
+  One rule overrides all four: if a **project** declares an application root
   whose name cannot be resolved statically — a dynamic expression, a factory
-  call, a symbol bound more than once — then **nothing** is selectable, and
-  the `rationale[]` says why. Anything still ranked is by construction not
-  the root, so writing it would declare a worker as the reviewed identity.
+  call, a symbol bound more than once — then nothing that project declares
+  is selectable, and the `rationale[]` names the project and says why.
+  Anything still ranked there is by construction not the root, so writing it
+  would declare a worker as the reviewed identity. The scope is the project,
+  not the repository: on a monorepo, agents in the other entries of
+  `agent_project_candidates[]` stay selectable. A name two projects declare
+  is rejected when either one is blocked.
+
+  The same product/not-product split above decides *which* roots block: a
+  root declared only by test code or by a scaffolding template is not the
+  application a project ships, so it does not disable selection for the
+  rest of the project (#398).
 
   `rationale[]` states which of those applied, so a ranking change is
   visible in the output rather than silently changing what the manifest

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1080,6 +1080,12 @@ Consume the response to decide whether to proceed. Key fields:
   `agent_project_candidates[]` stay selectable. A name two projects declare
   is rejected when either one is blocked.
 
+  "Which project" means an entry of `agent_project_candidates[]`, not the
+  nearest directory carrying a project marker. A marker directory that holds
+  no agent evidence — a utilities package with its own `pyproject.toml` — is
+  not a manifest scope, and a name found there belongs to the scope that
+  encloses it.
+
   The same product/not-product split above decides *which* roots block: a
   root declared only by test code or by a scaffolding template is not the
   application a project ships, so it does not disable selection for the

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -211,19 +211,28 @@ ROOT_AGENT_SYMBOL = "root_agent"
 CHILD_AGENT_KEYWORDS = ("sub_agents", "handoffs")
 # Score adjustments. Hierarchy and corroboration move a candidate within
 # its origin; origin itself is meant to dominate, because the documented
-# contract is that product code outranks test code — full stop, not "unless
-# the test one happens to be a root". ORIGIN_TEST_PENALTY is therefore
-# strictly greater than the whole spread of the other signals
+# contract is that product code outranks code that is not the product —
+# full stop, not "unless the fixture happens to be a root".
+# ORIGIN_NON_PRODUCT_PENALTY is therefore strictly greater than the whole
+# spread of the other signals
 # (ROOT_BONUS + CORROBORATION_BONUS − SUB_AGENT_PENALTY = 5.5), which keeps
 # the published rank_score the single ordering key instead of needing a
 # separate tier the score cannot explain.
 # Conventional test module filenames that carry no ``test_`` prefix, so the
 # prefix rule alone reads them as product code.
 TEST_MODULE_NAMES = frozenset({"conftest.py", "test.py", "tests.py"})
+#: Consecutive directory names that mark code shipped as *material* rather
+#: than as the running application. A ``templates/`` directory nested inside
+#: a ``resources/`` one is the scaffolding convention #398 found: the file it
+#: holds is what a generator copies into a new project, not what this
+#: repository runs. The pair is required rather than a bare ``templates/``,
+#: which web frameworks use for a directory of real modules — every name
+#: added here widens what fails *open*, so it is kept to the shape observed.
+NON_PRODUCT_DIR_SEQUENCES: tuple[tuple[str, ...], ...] = (("resources", "templates"),)
 ROOT_AGENT_BONUS = 3.0
 SUB_AGENT_PENALTY = 1.5
 CORROBORATION_BONUS = 1.0
-ORIGIN_TEST_PENALTY = 6.0
+ORIGIN_NON_PRODUCT_PENALTY = 6.0
 QUALITY_FLOOR_PENALTY = 3.0
 
 # Quality floor for a value that may be written as ``agent.name``. A
@@ -377,11 +386,8 @@ def detect_workspace(
     detections.sort(key=lambda d: (-d.score, d.type))
 
     project_name_candidates = _project_name_candidates(workspace)
-    agent_name_candidates = _rank_agent_name_candidates(
-        py_facts, workspace, project_name_candidates
-    )
     codex_plugin_candidates = _codex_plugin_candidates(workspace, inventory)
-    agent_project_candidates = _agent_project_candidates(
+    evidence_paths = _agent_evidence_paths(
         py_facts,
         detections,
         # An artifact-only project — an OpenAPI spec, an MCP export, a Codex
@@ -394,6 +400,16 @@ def detect_workspace(
         + [candidate.path for candidate in codex_plugin_candidates]
         + _nested_manifest_paths(inventory, workspace),
         workspace,
+    )
+    attribution = _ProjectAttribution(workspace, evidence_paths)
+    agent_project_candidates = _agent_project_candidates(
+        py_facts, evidence_paths, attribution
+    )
+    # Ranking runs after the grouping because it reads the same attribution:
+    # an application root it cannot resolve disqualifies the names in *that
+    # project* and no others (#398).
+    agent_name_candidates = _rank_agent_name_candidates(
+        py_facts, workspace, project_name_candidates, attribution
     )
     project_root_count = _project_root_count(inventory, workspace)
     python_file_total = sum(1 for path in inventory if path.suffix == ".py")
@@ -1934,6 +1950,78 @@ def _safe_resolve(path: Path) -> Path:
         return path
 
 
+def _non_product_origin(rel_path: str) -> str | None:
+    """Why ``rel_path`` is not the product's own code, or ``None``.
+
+    One predicate, two uses, because #398 is what an asymmetry between them
+    costs: the ranker discounted a fixture for *selection* while still
+    letting the same file disable selection for every other name in the
+    repository. Both readings go through this function —
+    :func:`_score_agent_name` for the penalty and
+    :func:`_can_declare_application_root` for the block — so a file cannot
+    be product code for one and material for the other.
+
+    Two kinds of file declare agents that are not the product's:
+
+    * **Test code.** A fixture that builds an ``App`` is a fixture. #398
+      found one ``eval/test_*.py`` rejecting every real product agent in the
+      repository.
+    * **Scaffolding templates.** :data:`NON_PRODUCT_DIR_SEQUENCES` names the
+      directory shape that holds what a generator copies. Only the
+      *directory* part is examined, because the sequence is about where a
+      file sits rather than what it is called.
+
+    The return value is the rationale line the penalty publishes, so the
+    reason a name was demoted and the reason its file cannot speak for the
+    project are the same sentence.
+    """
+
+    if _is_test_path(rel_path):
+        return "declared in test code, which names fixtures rather than the product"
+    parts = Path(rel_path).parts[:-1]
+    if any(
+        parts[index : index + len(sequence)] == sequence
+        for sequence in NON_PRODUCT_DIR_SEQUENCES
+        for index in range(len(parts))
+    ):
+        return (
+            "declared under a scaffolding template directory, which names an "
+            "example rather than the product"
+        )
+    return None
+
+
+def _can_declare_application_root(rel_path: str) -> bool:
+    """Whether a root declared in ``rel_path`` speaks for the product.
+
+    The unresolvable-root rule is a statement about the application a
+    project ships: if that root cannot be identified, no other name in the
+    project may stand in for it (#324). A root declared by code that is not
+    the product (:func:`_non_product_origin`) is not that root, and reading
+    it as one disables name selection over files neither ``init`` nor the
+    runtime would ever reach.
+    """
+
+    return _non_product_origin(rel_path) is None
+
+
+def _unresolvable_root_rejection(scope: str, detail: str) -> str:
+    """Why no name a project declares may be written as its identity.
+
+    ``scope`` is the project's workspace-relative path, so the sentence
+    names the project the unreadable root belongs to. #398's report was that
+    it named only a file — one in a project the reader was not adopting.
+    """
+
+    where = "this workspace" if scope == "." else f"project `{scope}`"
+    return (
+        f"{where} declares an application root whose name is not statically "
+        f"resolvable ({detail}); every other name it declares is by "
+        "construction not that root, so none of them can be the reviewed "
+        "identity"
+    )
+
+
 def _is_test_path(rel_path: str) -> bool:
     """Whether ``rel_path`` is test code rather than product code.
 
@@ -2059,7 +2147,10 @@ class _RankedName:
 
 
 def _rank_agent_name_candidates(
-    facts: list[_PyFacts], workspace: Path, project_names: Sequence[NameCandidate]
+    facts: list[_PyFacts],
+    workspace: Path,
+    project_names: Sequence[NameCandidate],
+    attribution: _ProjectAttribution,
 ) -> list[AgentNameCandidate]:
     """Rank ``Agent(name=…)`` evidence best-first.
 
@@ -2078,17 +2169,40 @@ def _rank_agent_name_candidates(
       is ranked last and made unselectable, so ``init`` writes CHANGE_ME and
       asks for review rather than asserting something unreliable.
 
-    One rule overrides all four: if a workspace declares an application root
-    whose identity cannot be established statically, *nothing* is
-    selectable. Any name still standing is by construction not the root, so
-    writing it would declare a worker as the reviewed identity — the exact
-    failure #324 asks to fail closed on.
+    One rule overrides all four: a *project* that declares an application
+    root whose identity cannot be established statically has nothing
+    selectable. Any name still standing in it is by construction not the
+    root, so writing one would declare a worker as the reviewed identity —
+    the exact failure #324 asks to fail closed on.
+
+    That rule is scoped to the project, not to the repository. Applied with
+    repository scope it read one unresolvable root in a scaffolding template
+    as grounds for rejecting all 55 real product agents in a monorepo, and
+    told the reader so by naming a file with no relationship to the project
+    they were adopting (#398). ``attribution`` supplies the same grouping
+    :func:`_agent_project_candidates` publishes, so "which project" has one
+    answer here and there. A name several projects declare is rejected when
+    *any* of them is blocked: it is a worker in that project whatever it is
+    elsewhere, so this direction is the fail-closed one.
+
+    Only a root the product itself declares blocks a project — see
+    :func:`_can_declare_application_root`.
 
     Scores are published so a reordering regression is visible in
     ``detect --json`` instead of silently changing what the manifest claims.
     """
     by_path = {_safe_resolve(fact.path): fact for fact in facts}
-    unresolved_roots = [fact.unresolved_root for fact in facts if fact.unresolved_root]
+    # Project directory → the first unreadable application root found in it.
+    blocked_projects: dict[Path, str] = {}
+
+    def _block(fact: _PyFacts, detail: str) -> None:
+        if not _can_declare_application_root(fact.rel_path):
+            return
+        blocked_projects.setdefault(attribution.of(fact.path)[0], detail)
+
+    for fact in facts:
+        if fact.unresolved_root:
+            _block(fact, fact.unresolved_root)
     # A root whose *name* is a symbol that fails the cross-module resolution
     # below is just as unresolved as one whose name is an f-string. The
     # failure surfaces here rather than at parse time because resolution
@@ -2098,9 +2212,10 @@ def _rank_agent_name_candidates(
             if evidence.role != "root_agent" or evidence.literal is not None:
                 continue
             if _resolve_agent_name_evidence(evidence, fact, by_path, workspace) is None:
-                unresolved_roots.append(
+                _block(
+                    fact,
                     f"{evidence.rel_path}: the application root's name comes from "
-                    f"`{evidence.symbol}`, which does not resolve to a static value"
+                    f"`{evidence.symbol}`, which does not resolve to a static value",
                 )
     project_forms = {
         _normalise_name(candidate.value) for candidate in project_names if candidate.value
@@ -2109,6 +2224,10 @@ def _rank_agent_name_candidates(
     project_forms.discard("")
 
     best: dict[str, _RankedName] = {}
+    # Every project a value is declared in, not only the site that scored
+    # best: the rejection below asks whether *any* of them is blocked, and
+    # `best` keeps one entry per value.
+    declared_in: dict[str, list[Path]] = {}
     order = 0
     for fact in facts:
         for evidence in fact.agent_names:
@@ -2127,19 +2246,27 @@ def _rank_agent_name_candidates(
                 order=order,
             )
             order += 1
+            project = attribution.of(fact.path)[0]
+            projects = declared_in.setdefault(value, [])
+            if project not in projects:
+                projects.append(project)
             previous = best.get(value)
             if previous is None or ranked.score > previous.score:
                 best[value] = ranked
 
-    if unresolved_roots:
-        blocked = (
-            "an application root is declared here but its name is not statically "
-            f"resolvable ({unresolved_roots[0]}); any other name would declare a "
-            "worker as the reviewed identity"
+    for value, ranked in best.items():
+        blocking = [
+            project for project in declared_in[value] if project in blocked_projects
+        ]
+        if not blocking:
+            continue
+        ranked.selectable = False
+        ranked.rationale.append(
+            "rejected: "
+            + _unresolvable_root_rejection(
+                attribution.relative(blocking[0]), blocked_projects[blocking[0]]
+            )
         )
-        for ranked in best.values():
-            ranked.selectable = False
-            ranked.rationale.append(f"rejected: {blocked}")
 
     ordered = sorted(best.values(), key=lambda r: (not r.selectable, -r.score, r.order))
     candidates = [
@@ -2205,12 +2332,14 @@ def _score_agent_name(
             root_evidence or "declared as a child of another agent, not the root"
         )
 
-    if _is_test_path(rel_path):
-        # Deliberately larger than every other signal combined: a fixture
-        # that happens to build an App root is still a fixture, and must not
-        # outrank a plain agent the shipped code declares.
-        score -= ORIGIN_TEST_PENALTY
-        rationale.append("declared in test code, which names fixtures rather than the product")
+    origin = _non_product_origin(rel_path)
+    if origin is not None:
+        # Deliberately larger than every other signal combined: a fixture or
+        # a scaffolding template that happens to build an App root is still
+        # not the product, and must not outrank a plain agent the shipped
+        # code declares.
+        score -= ORIGIN_NON_PRODUCT_PENALTY
+        rationale.append(origin)
 
     normalised = _normalise_name(value)
     if normalised and normalised in project_forms:
@@ -2325,44 +2454,89 @@ def _project_root_count(inventory: list[Path], workspace: Path) -> int:
     return len(roots)
 
 
-def _agent_project_candidates(
+class _ProjectAttribution:
+    """Which project each path in the workspace belongs to.
+
+    A file's project is the nearest directory at or above it that carries a
+    project marker, bounded by the workspace; a file with no marker above it
+    belongs to the workspace itself.
+
+    One rule, two readers, one object — because the two readers must not
+    drift apart about where a project ends.
+    :func:`_agent_project_candidates` groups agent evidence by project to
+    decide whether one manifest can describe the workspace (#363).
+    :func:`_rank_agent_name_candidates` asks the same question for a
+    different reason: an application root whose identity cannot be
+    established disqualifies the names declared *in that project*, and one
+    unresolvable root in an unrelated corner of a monorepo must not disable
+    name selection everywhere (#398).
+
+    ``evidence_dirs`` is derived here from the same evidence paths the
+    grouping reads, so a weak marker (a bare ``requirements.txt``) draws a
+    boundary in exactly the directories agent evidence was found in — see
+    :func:`find_project_root`.
+    """
+
+    def __init__(self, workspace: Path, evidence_paths: Sequence[Path]) -> None:
+        self._workspace = workspace
+        self._evidence_dirs = frozenset(
+            path if path.is_dir() else path.parent for path in evidence_paths
+        )
+        self._by_directory: dict[Path, tuple[Path, str | None]] = {}
+
+    def of(self, path: Path) -> tuple[Path, str | None]:
+        """``(project directory, marker)`` for the file or directory ``path``.
+
+        A Codex plugin package is named by its directory, not by a file
+        inside it; everything else is a file whose directory we want. A
+        source reached through a symlink out of the workspace cannot name a
+        project inside it, so it is attributed to the workspace rather than
+        to a directory nobody asked about.
+        """
+
+        directory = path if path.is_dir() else path.parent
+        cached = self._by_directory.get(directory)
+        if cached is not None:
+            return cached
+        try:
+            directory.relative_to(self._workspace)
+        except ValueError:
+            found = None
+        else:
+            found = find_project_root(
+                directory, root=self._workspace, evidence_dirs=self._evidence_dirs
+            )
+        resolved = (
+            (found.directory, found.marker)
+            if found is not None
+            else (self._workspace, project_marker(self._workspace))
+        )
+        self._by_directory[directory] = resolved
+        return resolved
+
+    def relative(self, project: Path) -> str:
+        """``project`` as a workspace-relative POSIX path; ``"."`` for the root."""
+
+        if project == self._workspace:
+            return "."
+        return project.relative_to(self._workspace).as_posix()
+
+
+def _agent_evidence_paths(
     facts: list[_PyFacts],
     detections: list[FrameworkDetection],
     artifact_paths: list[str],
     workspace: Path,
-) -> list[AgentProjectCandidate]:
-    """Group the agent evidence in this workspace by the project it sits in.
+) -> list[Path]:
+    """Everything ``init`` would turn into a manifest, as absolute paths.
 
-    A file's project is the nearest directory at or above it that carries a
-    project marker, bounded by the workspace; a file with no marker above it
-    belongs to the workspace itself. Several agents inside *one* project are
-    one manifest's business — a crew, a router and its sub-agents. Agents in
-    *separate* projects are not: one ``agent.name``, one ``declared_purpose``,
-    and one ``tool_sources`` list cannot describe both, which is what makes
-    the scope ambiguous (#363).
-
-    Evidence is everything ``init`` would turn into a manifest: the file set
-    the frameworks fired on, every framework-attributed ``Agent(name=…)``
-    literal, and the artifact paths (``suggested_sources``, Codex plugin
-    packages and marketplaces) that become ``tool_sources`` on their own. No
-    single one of those is enough. The literal is the value ``init`` adopts
-    for ``agent.name`` without asking — but the #363 agent is constructed as
-    ``LlmAgent(name=CONFIG.agent_name)`` and has none. The framework file
-    set covers that — but an OpenAPI- or MCP-only project fires no framework
-    detection at all, and two of those under one root is the same
-    one-manifest-for-two-agents outcome with none of the Python evidence.
-
-    *Framework-attributed* is the operative word for the literals. A file
-    with no supported framework import that happens to construct its own
-    ``Agent(name="crm")`` is not an agent project, and reading it as one
-    would refuse ``init`` on a repository that has exactly one (#363
-    review). Those literals stay in ``agent_name_candidates`` as name
-    suggestions; they just do not draw a boundary.
+    The file set the frameworks fired on, the artifact paths
+    (``suggested_sources``, Codex plugin packages and marketplaces, nested
+    manifests) that become ``tool_sources`` on their own, and every file
+    carrying a framework-attributed ``Agent(name=…)`` literal. No single one
+    of those is enough — see :func:`_agent_project_candidates`.
     """
 
-    # Directories holding agent evidence, which is what lets a weak marker
-    # (a bare ``requirements.txt``) count as a project root there and only
-    # there. Collected before attribution because the walk up needs it.
     evidence_paths: list[Path] = [
         workspace / relative
         for detection in detections
@@ -2372,50 +2546,59 @@ def _agent_project_candidates(
     evidence_paths.extend(
         fact.path for fact in facts if fact.name_literals() and fact.framework
     )
-    evidence_dirs = frozenset(
-        path if path.is_dir() else path.parent for path in evidence_paths
-    )
+    return evidence_paths
+
+
+def _agent_project_candidates(
+    facts: list[_PyFacts],
+    evidence_paths: Sequence[Path],
+    attribution: _ProjectAttribution,
+) -> list[AgentProjectCandidate]:
+    """Group the agent evidence in this workspace by the project it sits in.
+
+    Several agents inside *one* project are one manifest's business — a
+    crew, a router and its sub-agents. Agents in *separate* projects are
+    not: one ``agent.name``, one ``declared_purpose``, and one
+    ``tool_sources`` list cannot describe both, which is what makes the
+    scope ambiguous (#363).
+
+    Evidence is everything ``init`` would turn into a manifest
+    (:func:`_agent_evidence_paths`), and no single kind of it is enough. The
+    literal is the value ``init`` adopts for ``agent.name`` without asking —
+    but the #363 agent is constructed as ``LlmAgent(name=CONFIG.agent_name)``
+    and has none. The framework file set covers that — but an OpenAPI- or
+    MCP-only project fires no framework detection at all, and two of those
+    under one root is the same one-manifest-for-two-agents outcome with none
+    of the Python evidence.
+
+    *Framework-attributed* is the operative word for the literals. A file
+    with no supported framework import that happens to construct its own
+    ``Agent(name="crm")`` is not an agent project, and reading it as one
+    would refuse ``init`` on a repository that has exactly one (#363
+    review). Those literals stay in ``agent_name_candidates`` as name
+    suggestions; they just do not draw a boundary.
+    """
 
     names: dict[Path, set[str]] = {}
     markers: dict[Path, str | None] = {}
 
-    def _project_of(path: Path) -> Path:
-        # A Codex plugin package is named by its directory, not by a file
-        # inside it; everything else is a file whose directory we want.
-        directory = path if path.is_dir() else path.parent
-        try:
-            directory.relative_to(workspace)
-        except ValueError:
-            # A source reached through a symlink out of the workspace cannot
-            # name a project inside it, so attribute it to the workspace
-            # rather than to a directory nobody asked about.
-            found = None
-        else:
-            found = find_project_root(
-                directory, root=workspace, evidence_dirs=evidence_dirs
-            )
-        project = found.directory if found is not None else workspace
+    def _claim(path: Path) -> Path:
+        project, marker = attribution.of(path)
         if project not in markers:
-            markers[project] = (
-                found.marker if found is not None else project_marker(workspace)
-            )
+            markers[project] = marker
             names.setdefault(project, set())
         return project
 
     for path in evidence_paths:
-        _project_of(path)
+        _claim(path)
     for fact in facts:
         literals = fact.name_literals()
         if literals and fact.framework:
-            names[_project_of(fact.path)].update(literals)
+            names[_claim(fact.path)].update(literals)
 
     candidates = [
         AgentProjectCandidate(
-            path=(
-                project.relative_to(workspace).as_posix()
-                if project != workspace
-                else "."
-            ),
+            path=attribution.relative(project),
             marker=markers[project],
             agent_names=sorted(found_names),
         )

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -1978,7 +1978,10 @@ def _non_product_origin(rel_path: str) -> str | None:
 
     if _is_test_path(rel_path):
         return "declared in test code, which names fixtures rather than the product"
-    parts = Path(rel_path).parts[:-1]
+    # Case-folded: `Resources/Templates` and `resources/templates` are the
+    # same directory on a case-insensitive checkout, and an exact match let
+    # the #398 symptom survive the spelling difference.
+    parts = tuple(part.lower() for part in Path(rel_path).parts[:-1])
     if any(
         parts[index : index + len(sequence)] == sequence
         for sequence in NON_PRODUCT_DIR_SEQUENCES
@@ -2005,17 +2008,28 @@ def _can_declare_application_root(rel_path: str) -> bool:
     return _non_product_origin(rel_path) is None
 
 
-def _unresolvable_root_rejection(scope: str, detail: str) -> str:
+def _unresolvable_root_rejection(
+    scope: str, detail: str, *, declared_elsewhere: bool
+) -> str:
     """Why no name a project declares may be written as its identity.
 
     ``scope`` is the project's workspace-relative path, so the sentence
     names the project the unreadable root belongs to. #398's report was that
     it named only a file — one in a project the reader was not adopting.
+
+    ``declared_elsewhere`` covers the case that leaves: a value whose
+    best-ranked site sits in a *clean* project and which some blocked
+    project also declares. Every other published field then points at the
+    clean project, and without this clause the reader sees exactly the #398
+    complaint again — a rejection naming a project their candidate has no
+    visible relationship to. The relationship is the whole justification, so
+    it is stated.
     """
 
     where = "this workspace" if scope == "." else f"project `{scope}`"
+    opening = f"this name is also declared in {where}, which" if declared_elsewhere else where
     return (
-        f"{where} declares an application root whose name is not statically "
+        f"{opening} declares an application root whose name is not statically "
         f"resolvable ({detail}); every other name it declares is by "
         "construction not that root, so none of them can be the reviewed "
         "identity"
@@ -2226,10 +2240,16 @@ def _rank_agent_name_candidates(
     best: dict[str, _RankedName] = {}
     # Every project a value is declared in, not only the site that scored
     # best: the rejection below asks whether *any* of them is blocked, and
-    # `best` keeps one entry per value.
+    # `best` keeps one entry per value. `best_project` is the project of the
+    # site `best` kept, which is the one every other published field of the
+    # candidate points at.
     declared_in: dict[str, list[Path]] = {}
+    best_project: dict[str, Path] = {}
     order = 0
     for fact in facts:
+        # Invariant across the evidence in one file, and `of()` pays a stat
+        # before it reaches its cache, so it is asked once per file.
+        project = attribution.of(fact.path)[0]
         for evidence in fact.agent_names:
             resolved = _resolve_agent_name_evidence(evidence, fact, by_path, workspace)
             if resolved is None:
@@ -2246,25 +2266,35 @@ def _rank_agent_name_candidates(
                 order=order,
             )
             order += 1
-            project = attribution.of(fact.path)[0]
             projects = declared_in.setdefault(value, [])
             if project not in projects:
                 projects.append(project)
             previous = best.get(value)
             if previous is None or ranked.score > previous.score:
                 best[value] = ranked
+                best_project[value] = project
 
     for value, ranked in best.items():
-        blocking = [
-            project for project in declared_in[value] if project in blocked_projects
-        ]
+        # The candidate's own project first when it is blocked, so the
+        # sentence names the project every other field already points at;
+        # declaration order decides the rest.
+        blocking = sorted(
+            (
+                project
+                for project in declared_in[value]
+                if project in blocked_projects
+            ),
+            key=lambda project: project != best_project[value],
+        )
         if not blocking:
             continue
         ranked.selectable = False
         ranked.rationale.append(
             "rejected: "
             + _unresolvable_root_rejection(
-                attribution.relative(blocking[0]), blocked_projects[blocking[0]]
+                attribution.relative(blocking[0]),
+                blocked_projects[blocking[0]],
+                declared_elsewhere=blocking[0] != best_project[value],
             )
         )
 

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -2214,7 +2214,7 @@ def _rank_agent_name_candidates(
     def _block(fact: _PyFacts, detail: str) -> None:
         if not _can_declare_application_root(fact.rel_path):
             return
-        blocked_projects.setdefault(attribution.of(fact.path)[0], detail)
+        blocked_projects.setdefault(attribution.scope_of(fact.path), detail)
 
     for fact in facts:
         if fact.unresolved_root:
@@ -2257,7 +2257,7 @@ def _rank_agent_name_candidates(
         # Invariant across the evidence in one file, and `of()` pays a stat
         # before it reaches its cache, so it is asked once per file rather
         # than once per name.
-        project = attribution.of(fact.path)[0]
+        project = attribution.scope_of(fact.path)
         for evidence in fact.agent_names:
             resolved = _resolve_agent_name_evidence(evidence, fact, by_path, workspace)
             if resolved is None:
@@ -2521,6 +2521,9 @@ class _ProjectAttribution:
             path if path.is_dir() else path.parent for path in evidence_paths
         )
         self._by_directory: dict[Path, tuple[Path, str | None]] = {}
+        self._agent_projects: frozenset[Path] = frozenset()
+        self._established = False
+        self._scope_by_directory: dict[Path, Path] = {}
 
     def of(self, path: Path) -> tuple[Path, str | None]:
         """``(project directory, marker)`` for the file or directory ``path``.
@@ -2551,6 +2554,65 @@ class _ProjectAttribution:
         )
         self._by_directory[directory] = resolved
         return resolved
+
+    def establish(self, projects: Iterable[Path]) -> None:
+        """Record which projects the grouping actually published.
+
+        Called by :func:`_agent_project_candidates`, whose grouping keys
+        *are* the answer, and which is the only thing entitled to say what
+        an agent project is in this workspace.
+        """
+
+        self._agent_projects = frozenset(projects)
+        self._established = True
+        self._scope_by_directory.clear()
+
+    def scope_of(self, path: Path) -> Path:
+        """The nearest *established* agent project at or above ``path``.
+
+        :meth:`of` answers with the nearest project *marker*, which is the
+        right boundary for grouping evidence: it is what decides whether two
+        agents are one manifest's business. It is the wrong one for deciding
+        whether a name is disqualified. A marker directory holding no agent
+        evidence is not a manifest scope at all — a utilities package with
+        its own ``pyproject.toml`` — so a name found there belongs to the
+        scope that encloses it, which is the scope ``init`` would write.
+
+        Reading the marker directly is how a workspace whose only
+        application root was unreadable still wrote ``agent.name`` from a
+        bare ``Agent(name="CrmHelper")`` sitting under such a package: the
+        candidate's marker directory was not the blocked project, so nothing
+        rejected it (#532 review). The refusal has to be decided against the
+        projects that were actually established.
+
+        The workspace is the fallback: a name under no established project
+        belongs to no scope of its own, and attributing it to the enclosing
+        workspace is the fail-closed reading.
+        """
+
+        if not self._established:  # pragma: no cover - programming error
+            raise RuntimeError(
+                "scope_of() read before _agent_project_candidates established "
+                "the projects; it would attribute every name to the workspace"
+            )
+        directory = path if path.is_dir() else path.parent
+        cached = self._scope_by_directory.get(directory)
+        if cached is not None:
+            return cached
+        current = directory
+        scope = self._workspace
+        while True:
+            if current in self._agent_projects:
+                scope = current
+                break
+            if current == self._workspace:
+                break
+            parent = current.parent
+            if parent == current:  # defensive: never climb past a filesystem root
+                break
+            current = parent
+        self._scope_by_directory[directory] = scope
+        return scope
 
     def relative(self, project: Path) -> str:
         """``project`` as a workspace-relative POSIX path; ``"."`` for the root."""
@@ -2633,6 +2695,11 @@ def _agent_project_candidates(
         literals = fact.name_literals()
         if literals and fact.framework:
             names[_claim(fact.path)].update(literals)
+
+    # These keys are the workspace's agent projects, and ranking resolves a
+    # name's scope against them rather than against the nearest marker —
+    # see :meth:`_ProjectAttribution.scope_of`.
+    attribution.establish(names)
 
     candidates = [
         AgentProjectCandidate(

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -228,6 +228,8 @@ TEST_MODULE_NAMES = frozenset({"conftest.py", "test.py", "tests.py"})
 #: repository runs. The pair is required rather than a bare ``templates/``,
 #: which web frameworks use for a directory of real modules — every name
 #: added here widens what fails *open*, so it is kept to the shape observed.
+#: Entries must be lowercase: the path is case-folded before the comparison,
+#: so a capitalised entry here would match nothing at all.
 NON_PRODUCT_DIR_SEQUENCES: tuple[tuple[str, ...], ...] = (("resources", "templates"),)
 ROOT_AGENT_BONUS = 3.0
 SUB_AGENT_PENALTY = 1.5
@@ -2247,8 +2249,14 @@ def _rank_agent_name_candidates(
     best_project: dict[str, Path] = {}
     order = 0
     for fact in facts:
+        if not fact.agent_names:
+            # Most files in a repository declare no agent. Attributing them
+            # to a project is a stat and a walk for an answer nothing below
+            # reads.
+            continue
         # Invariant across the evidence in one file, and `of()` pays a stat
-        # before it reaches its cache, so it is asked once per file.
+        # before it reaches its cache, so it is asked once per file rather
+        # than once per name.
         project = attribution.of(fact.path)[0]
         for evidence in fact.agent_names:
             resolved = _resolve_agent_name_evidence(evidence, fact, by_path, workspace)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -878,6 +878,73 @@ def test_the_rejection_quotes_the_parse_time_root_over_a_symbol_failure(
     assert "a_symbol.py" not in _rejection(worker)
 
 
+#: A module that defines its own, unrelated ``Agent`` class. Its
+#: ``Agent(name=…)`` literal is a *name suggestion* and nothing more: it draws
+#: no project boundary, because a file with no supported framework import is
+#: not an agent project (#363 review).
+UNRELATED_AGENT_CLASS = "class Agent:\n    def __init__(self, name):\n        self.name = name\n"
+
+
+def test_a_name_under_a_non_agent_marker_cannot_escape_the_blocked_scope(
+    tmp_path: Path,
+) -> None:
+    """Which project a name belongs to is decided against the projects
+    `agent_project_candidates` established, not against the nearest marker.
+
+    A utilities package carries its own `pyproject.toml` but no agent
+    evidence, so it is not a manifest scope — `agent_scope` is `single` and
+    the only project is `.`. Attributing its bare `Agent(name="CrmHelper")`
+    to `util/` exempted it from the workspace's refusal, and `init` wrote a
+    helper class's argument as the reviewed identity of a repository whose
+    real application root could not be read at all (#532 review)."""
+    workspace = _write_files(
+        tmp_path / "repo",
+        {
+            "agent.py": ADK_HEADER + UNREADABLE_ROOT,
+            "domain.py": UNRELATED_AGENT_CLASS,
+            "util/pyproject.toml": '[project]\nname = "util"\n',
+            "util/agent.py": 'from domain import Agent\n\nhelper = Agent(name="CrmHelper")\n',
+        },
+    )
+    result = detect_workspace(workspace)
+    # The premise: `util` is not one of the workspace's agent projects.
+    assert result.agent_scope == "single"
+    assert [c.path for c in result.agent_project_candidates] == ["."]
+
+    helper = next(c for c in result.agent_name_candidates if c.value == "CrmHelper")
+    assert helper.path == "util/agent.py"
+    assert helper.selectable is False
+    assert "this workspace declares an application root" in _rejection(helper)
+    assert select_agent_name(result.agent_name_candidates) is None
+
+
+def test_init_write_refuses_a_name_under_a_non_agent_marker(tmp_path: Path) -> None:
+    """The same shape through the command an adopter actually runs. No
+    `--allow-unresolved-scope`, no test or template code: plain `init
+    --write` on a single-scope workspace has to keep `CHANGE_ME` when the
+    only application root it found cannot be read."""
+    from typer.testing import CliRunner
+
+    from agents_shipgate.cli.main import app
+
+    workspace = _write_files(
+        tmp_path / "repo",
+        {
+            "agent.py": ADK_HEADER + UNREADABLE_ROOT,
+            "domain.py": UNRELATED_AGENT_CLASS,
+            "util/pyproject.toml": '[project]\nname = "util"\n',
+            "util/agent.py": 'from domain import Agent\n\nhelper = Agent(name="CrmHelper")\n',
+        },
+    )
+    written = CliRunner().invoke(
+        app, ["init", "--workspace", str(workspace), "--write", "--json"]
+    )
+    assert written.exit_code == 0, written.output
+    manifest = (workspace / "shipgate.yaml").read_text(encoding="utf-8")
+    assert "name: CHANGE_ME" in manifest
+    assert "CrmHelper" not in manifest
+
+
 def test_a_name_two_projects_declare_is_rejected_when_either_is_blocked(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -816,6 +816,66 @@ def test_a_bare_templates_directory_still_blocks_selection(tmp_path: Path) -> No
     )
     result = detect_workspace(project)
     assert select_agent_name(result.agent_name_candidates) is None
+    # Asserting only "nothing is selectable" would pass on any other reason —
+    # the quality floor, a future rule — while the property this test names
+    # had quietly gone. The rejection has to be *this* one.
+    real_root = next(c for c in result.agent_name_candidates if c.value == "RealRoot")
+    assert "templates/agent.py" in _rejection(real_root)
+
+
+def test_case_folded_template_directory_is_still_scaffolding(
+    tmp_path: Path,
+) -> None:
+    """`Resources/Templates` and `resources/templates` are the same directory
+    on a case-insensitive checkout. Matching the sequence exactly let the
+    #398 symptom survive a spelling difference the filesystem does not
+    make."""
+    project = _write_files(
+        tmp_path / "repo",
+        {
+            "agent.py": ADK_HEADER + 'root_agent = LlmAgent(name="RealRoot")\n',
+            "Skills/Recipe/Resources/Templates/app/agent.py": (
+                ADK_HEADER + UNREADABLE_ROOT
+            ),
+        },
+    )
+    result = detect_workspace(project)
+    selected = select_agent_name(result.agent_name_candidates)
+    assert selected is not None and selected.value == "RealRoot"
+
+
+def test_the_rejection_quotes_the_parse_time_root_over_a_symbol_failure(
+    tmp_path: Path,
+) -> None:
+    """Two unreadable roots in one project: one found while parsing, one only
+    when cross-module resolution fails. The published sentence quotes the
+    parse-time one, which is what the repository-scoped list did before the
+    rejection was scoped. `rationale[]` is pinned byte for byte against the
+    zero-install script, so this precedence is a contract between two
+    implementations, not an implementation detail."""
+    project = _write_files(
+        tmp_path / "both",
+        {
+            "pyproject.toml": '[project]\nname = "both"\n',
+            # Resolution-time, and *first* in walk order on purpose: the
+            # root's name is a symbol that never resolves, which only the
+            # cross-module pass can see. Merging the two passes into one
+            # walk-order loop would make this file win, so the filenames are
+            # what make the assertion about precedence rather than order.
+            "a_symbol.py": (
+                ADK_HEADER
+                + 'NAME = "One"\nNAME = "Two"\n'
+                + 'worker = LlmAgent(name="WorkerAgent")\n'
+                + "root_agent = LlmAgent(name=NAME, sub_agents=[worker])\n"
+            ),
+            # Parse-time: the module symbol is bound to a factory call.
+            "z_parse_time.py": ADK_HEADER + UNREADABLE_ROOT,
+        },
+    )
+    result = detect_workspace(project)
+    worker = next(c for c in result.agent_name_candidates if c.value == "WorkerAgent")
+    assert "z_parse_time.py" in _rejection(worker)
+    assert "a_symbol.py" not in _rejection(worker)
 
 
 def test_a_name_two_projects_declare_is_rejected_when_either_is_blocked(
@@ -839,7 +899,14 @@ def test_a_name_two_projects_declare_is_rejected_when_either_is_blocked(
     result = detect_workspace(workspace)
     shared = next(c for c in result.agent_name_candidates if c.value == "SharedName")
     assert shared.selectable is False
-    assert "project `blocked`" in _rejection(shared)
+    # Every other field of this candidate points at `clean` — the site that
+    # ranked best. Naming `blocked` without saying the value is declared
+    # there too is the #398 complaint again, one project narrower.
+    assert shared.path == "clean/agent.py"
+    assert _rejection(shared).startswith(
+        "rejected: this name is also declared in project `blocked`, which "
+        "declares an application root"
+    )
 
 
 def test_weak_marker_siblings_are_scoped_independently(tmp_path: Path) -> None:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -645,6 +645,225 @@ def test_unresolvable_root_name_blocks_selection_entirely(tmp_path: Path) -> Non
     assert "name: CHANGE_ME" in render_auto_manifest(project, result).text
 
 
+ADK_HEADER = "from google.adk.agents import LlmAgent\nfrom google.adk.apps import App\n\n"
+#: A module-level `root_agent` bound to a factory call. Statically the root
+#: exists and its identity is unreadable — the shape #398 found poisoning a
+#: whole repository from one file.
+UNREADABLE_ROOT = "def build():\n    return LlmAgent(name='inner')\n\nroot_agent = build()\n"
+
+
+def _write_files(root: Path, files: dict[str, str]) -> Path:
+    for relative, body in files.items():
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+    return root
+
+
+def _rejection(candidate) -> str:
+    """The unresolvable-root rejection on ``candidate``, or ``""``."""
+    return next(
+        (
+            reason
+            for reason in candidate.rationale
+            if "declares an application root" in reason
+        ),
+        "",
+    )
+
+
+def test_unresolvable_root_is_scoped_to_its_own_project(tmp_path: Path) -> None:
+    """#398. One application root that cannot be read used to reject every
+    agent name in the repository — on adk-samples, 55 candidates across 25
+    projects, blamed on one file none of them had any relationship to. The
+    rule is sound inside a project and meaningless across projects: a name
+    in `python/agents/financial-advisor` is not a worker of whatever root
+    `python/agents/RAG` failed to declare."""
+    workspace = _write_files(
+        tmp_path / "adk-samples",
+        {
+            "python/agents/financial-advisor/pyproject.toml": (
+                '[project]\nname = "financial-advisor"\n'
+            ),
+            "python/agents/financial-advisor/agent.py": (
+                ADK_HEADER
+                + 'worker = LlmAgent(name="market_watcher")\n'
+                + "root_agent = LlmAgent("
+                + 'name="financial_coordinator", sub_agents=[worker])\n'
+            ),
+            "python/agents/RAG/pyproject.toml": '[project]\nname = "rag"\n',
+            "python/agents/RAG/agent.py": ADK_HEADER + UNREADABLE_ROOT,
+        },
+    )
+    result = detect_workspace(workspace)
+    by_value = {c.value: c for c in result.agent_name_candidates}
+
+    coordinator = by_value["financial_coordinator"]
+    assert coordinator.selectable is True
+    assert _rejection(coordinator) == ""
+    assert by_value["market_watcher"].selectable is True
+
+    # The project that actually declared the unreadable root keeps its
+    # refusal, and the sentence now names the project rather than only a
+    # file the reader has no reason to recognise.
+    inner = by_value["inner"]
+    assert inner.selectable is False
+    assert "project `python/agents/RAG`" in _rejection(inner)
+    assert "python/agents/RAG/agent.py" in _rejection(inner)
+
+
+def test_scoped_init_on_the_unresolvable_project_still_refuses(
+    tmp_path: Path,
+) -> None:
+    """The other half of #398's product note. Narrowing the blast radius must
+    not narrow the rule: run against the project whose own root is
+    unreadable, nothing is selectable and the manifest keeps CHANGE_ME."""
+    project = _write_files(
+        tmp_path / "rag",
+        {
+            "pyproject.toml": '[project]\nname = "rag"\n',
+            "agent.py": (
+                ADK_HEADER + 'worker = LlmAgent(name="WorkerAgent")\n' + UNREADABLE_ROOT
+            ),
+        },
+    )
+    result = detect_workspace(project)
+    assert result.agent_scope == "single"
+    assert select_agent_name(result.agent_name_candidates) is None
+    worker = next(c for c in result.agent_name_candidates if c.value == "WorkerAgent")
+    assert "this workspace declares an application root" in _rejection(worker)
+    assert "name: CHANGE_ME" in render_auto_manifest(project, result).text
+
+
+def test_a_test_only_root_does_not_reject_the_product_agent(tmp_path: Path) -> None:
+    """#398's second culprit, and the one scoping alone cannot fix: the file
+    that could not declare a root is `eval/test_eval_arize.py`, inside the
+    very project being adopted. A fixture that builds an App is a fixture —
+    the ranker already says so for selection, and saying the opposite for
+    rejection is what left `init` with no name at the correct scope."""
+    project = _write_files(
+        tmp_path / "rag",
+        {
+            "pyproject.toml": '[project]\nname = "rag"\n',
+            "rag/agent.py": ADK_HEADER + 'root_agent = LlmAgent(name="rag_root_agent")\n',
+            "eval/test_eval_arize.py": ADK_HEADER + UNREADABLE_ROOT,
+        },
+    )
+    result = detect_workspace(project)
+    selected = select_agent_name(result.agent_name_candidates)
+    assert selected is not None and selected.value == "rag_root_agent"
+    assert "name: rag_root_agent" in render_auto_manifest(project, result).text
+
+
+def test_a_scaffolding_template_root_does_not_reject_the_product_agent(
+    tmp_path: Path,
+) -> None:
+    """#398's first culprit: `.agents/skills/**/resources/templates/app/agent.py`
+    is what a generator copies into a new project, not what this repository
+    runs, so the root it declares is not this project's root."""
+    project = _write_files(
+        tmp_path / "repo",
+        {
+            "agent.py": ADK_HEADER + 'root_agent = LlmAgent(name="RealRoot")\n',
+            ".agents/skills/scaffold-python-recipe/resources/templates/app/agent.py": (
+                ADK_HEADER + UNREADABLE_ROOT
+            ),
+        },
+    )
+    result = detect_workspace(project)
+    selected = select_agent_name(result.agent_name_candidates)
+    assert selected is not None and selected.value == "RealRoot"
+
+
+def test_a_template_declared_name_ranks_below_the_product_name(
+    tmp_path: Path,
+) -> None:
+    """The exclusion is one predicate used twice, so a template that *can* be
+    read is demoted for selection exactly as a fixture is. Excluding it from
+    rejection while still letting it win the ranking would move the failure
+    rather than fix it: `init` would write the example's name."""
+    project = _write_files(
+        tmp_path / "repo",
+        {
+            "agent.py": ADK_HEADER + 'helper = LlmAgent(name="ProductHelper")\n',
+            "skills/recipe/resources/templates/app/agent.py": (
+                ADK_HEADER
+                + 'root_agent = LlmAgent(name="TemplateRoot")\n'
+                + 'app = App(name="t", root_agent=root_agent)\n'
+            ),
+        },
+    )
+    result = detect_workspace(project)
+    selected = select_agent_name(result.agent_name_candidates)
+    assert selected is not None and selected.value == "ProductHelper"
+    template = next(
+        c for c in result.agent_name_candidates if c.value == "TemplateRoot"
+    )
+    assert any("scaffolding template" in reason for reason in template.rationale)
+
+
+def test_a_bare_templates_directory_still_blocks_selection(tmp_path: Path) -> None:
+    """The template rule is a directory *pair*, deliberately. A bare
+    `templates/` is a real package name — Django and Flask both ship one —
+    and every name added to the exclusion widens what fails open. A root
+    this reader cannot prove is scaffolding still stops selection."""
+    project = _write_files(
+        tmp_path / "repo",
+        {
+            "agent.py": ADK_HEADER + 'root_agent = LlmAgent(name="RealRoot")\n',
+            "templates/agent.py": ADK_HEADER + UNREADABLE_ROOT,
+        },
+    )
+    result = detect_workspace(project)
+    assert select_agent_name(result.agent_name_candidates) is None
+
+
+def test_a_name_two_projects_declare_is_rejected_when_either_is_blocked(
+    tmp_path: Path,
+) -> None:
+    """Scoping decides which project a *name* belongs to, and a name can
+    belong to two. In the blocked one it is a worker whatever it is
+    elsewhere, so the union — not the best-scoring site — is what the
+    rejection reads. Fail-closed is the only safe direction here."""
+    workspace = _write_files(
+        tmp_path / "monorepo",
+        {
+            "clean/pyproject.toml": '[project]\nname = "clean"\n',
+            "clean/agent.py": ADK_HEADER + 'root_agent = LlmAgent(name="SharedName")\n',
+            "blocked/pyproject.toml": '[project]\nname = "blocked"\n',
+            "blocked/agent.py": (
+                ADK_HEADER + 'helper = LlmAgent(name="SharedName")\n' + UNREADABLE_ROOT
+            ),
+        },
+    )
+    result = detect_workspace(workspace)
+    shared = next(c for c in result.agent_name_candidates if c.value == "SharedName")
+    assert shared.selectable is False
+    assert "project `blocked`" in _rejection(shared)
+
+
+def test_weak_marker_siblings_are_scoped_independently(tmp_path: Path) -> None:
+    """The grouping is the one `agent_project_candidates` publishes, weak
+    markers included. Two sibling agents whose only boundary is a
+    `requirements.txt` beside an `agent.py` are two projects (#363), so an
+    unreadable root in one must not reject the other — a second, weaker
+    implementation of "which project" here would have missed that."""
+    workspace = _write_files(
+        tmp_path / "monorepo",
+        {
+            "one/requirements.txt": "google-adk\n",
+            "one/agent.py": ADK_HEADER + 'root_agent = LlmAgent(name="OneRoot")\n',
+            "two/requirements.txt": "google-adk\n",
+            "two/agent.py": ADK_HEADER + UNREADABLE_ROOT,
+        },
+    )
+    result = detect_workspace(workspace)
+    assert [c.path for c in result.agent_project_candidates] == ["one", "two"]
+    by_value = {c.value: c for c in result.agent_name_candidates}
+    assert by_value["OneRoot"].selectable is True
+    assert "project `two`" in _rejection(by_value["inner"])
+
+
 def test_root_reference_resolves_to_the_reaching_assignment(tmp_path: Path) -> None:
     """`App(root_agent=agent)` names the binding live at that point, not
     every construction that ever used the identifier. Classifying both as
@@ -1200,21 +1419,22 @@ def test_origin_penalty_dominates_the_other_signals_by_construction(
     tmp_path: Path,
 ) -> None:
     """Pins the arithmetic the contract rests on. If a future signal widens
-    the spread past ORIGIN_TEST_PENALTY, a test fixture can outrank product
-    code again and only this assertion would notice."""
+    the spread past ORIGIN_NON_PRODUCT_PENALTY, a test fixture can outrank
+    product code again and only this assertion would notice."""
     from agents_shipgate.cli.discovery import signals
 
-    best_test_score = (
+    best_non_product_score = (
         1.0
         + signals.ROOT_AGENT_BONUS
         + signals.CORROBORATION_BONUS
-        - signals.ORIGIN_TEST_PENALTY
+        - signals.ORIGIN_NON_PRODUCT_PENALTY
     )
     worst_product_score = 1.0 - signals.SUB_AGENT_PENALTY
-    assert best_test_score < worst_product_score, (
-        "ORIGIN_TEST_PENALTY must exceed the whole spread of the hierarchy "
-        "and corroboration signals, or 'product code outranks test code' "
-        "stops being true for the best-placed fixture."
+    assert best_non_product_score < worst_product_score, (
+        "ORIGIN_NON_PRODUCT_PENALTY must exceed the whole spread of the "
+        "hierarchy and corroboration signals, or 'product code outranks code "
+        "that is not the product' stops being true for the best-placed "
+        "fixture."
     )
 
 

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -1009,6 +1009,148 @@ def test_script_agent_name_ranking_matches_cli(script_module, tmp_path):
     ] == ["t", "smart_closer"]
 
 
+_ADK_HEADER = "from google.adk.agents import LlmAgent\nfrom google.adk.apps import App\n\n"
+_UNREADABLE_ROOT = "def build():\n    return LlmAgent(name='inner')\n\nroot_agent = build()\n"
+
+#: Workspaces where a declared application root cannot be read statically.
+#: Which names that rejects is scoped to the project the root sits in, and
+#: skipped entirely for code that is not the product (#398) — a rule the two
+#: implementations have to apply identically, because
+#: ``agent_name_candidates`` is the field pinned byte for byte.
+_UNREADABLE_ROOT_SCOPES: dict[str, dict[str, str]] = {
+    # Two projects, one blocked. The other keeps every name selectable.
+    "monorepo": {
+        "clean/pyproject.toml": '[project]\nname = "clean"\n',
+        "clean/agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="CleanRoot")\n',
+        "blocked/pyproject.toml": '[project]\nname = "blocked"\n',
+        "blocked/agent.py": _ADK_HEADER + _UNREADABLE_ROOT,
+    },
+    # Sibling projects whose only boundary is a weak marker beside an agent.
+    "weak_markers": {
+        "one/requirements.txt": "google-adk\n",
+        "one/agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="OneRoot")\n',
+        "two/requirements.txt": "google-adk\n",
+        "two/agent.py": _ADK_HEADER + _UNREADABLE_ROOT,
+    },
+    # One name declared in both a clean and a blocked project: rejected.
+    "shared_name": {
+        "clean/pyproject.toml": '[project]\nname = "clean"\n',
+        "clean/agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="SharedName")\n',
+        "blocked/pyproject.toml": '[project]\nname = "blocked"\n',
+        "blocked/agent.py": (
+            _ADK_HEADER + 'helper = LlmAgent(name="SharedName")\n' + _UNREADABLE_ROOT
+        ),
+    },
+    # A fixture that builds a root is a fixture, at the correct scope.
+    "eval_test_file": {
+        "pyproject.toml": '[project]\nname = "rag"\n',
+        "rag/agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="RagRoot")\n',
+        "eval/test_eval_arize.py": _ADK_HEADER + _UNREADABLE_ROOT,
+    },
+    # Scaffolding material: what a generator copies, not what this repo runs.
+    "scaffolding_template": {
+        "agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="RealRoot")\n',
+        ".agents/skills/recipe/resources/templates/app/agent.py": (
+            _ADK_HEADER + _UNREADABLE_ROOT
+        ),
+    },
+    # A readable template root is demoted, not excluded, by the same rule.
+    "readable_template": {
+        "agent.py": _ADK_HEADER + 'helper = LlmAgent(name="ProductHelper")\n',
+        "skills/recipe/resources/templates/app/agent.py": (
+            _ADK_HEADER
+            + 'root_agent = LlmAgent(name="TemplateRoot")\n'
+            + 'app = App(name="t", root_agent=root_agent)\n'
+        ),
+    },
+    # A bare `templates/` is a real package name, so it still blocks.
+    "bare_templates": {
+        "agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="RealRoot")\n',
+        "templates/agent.py": _ADK_HEADER + _UNREADABLE_ROOT,
+    },
+    # The project's own product root is unreadable: refusal is preserved.
+    "own_root": {
+        "pyproject.toml": '[project]\nname = "rag"\n',
+        "agent.py": (
+            _ADK_HEADER + 'worker = LlmAgent(name="WorkerAgent")\n' + _UNREADABLE_ROOT
+        ),
+    },
+}
+
+
+@pytest.mark.parametrize("label", sorted(_UNREADABLE_ROOT_SCOPES))
+def test_script_scopes_an_unreadable_root_like_the_cli(script_module, tmp_path, label):
+    """An application root the reader cannot resolve rejects the names in
+    *its own project*, and only where the product itself declared it (#398).
+    The samples all have one project and one readable root, so the per-sample
+    parity check cannot see any of this — and a script that scoped the
+    rejection differently would tell an agent no name is safe on a repository
+    where `init` names one, or the reverse."""
+    project = tmp_path / label
+    for relative, body in _UNREADABLE_ROOT_SCOPES[label].items():
+        target = project / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+
+    script_result = script_module.detect(project)
+    cli_result = detect_workspace(project.resolve()).model_dump(mode="json")
+    assert (
+        script_result["agent_name_candidates"] == cli_result["agent_name_candidates"]
+    ), f"{label}: unreadable-root scoping diverged from the CLI"
+    assert (
+        script_result["agent_project_candidates"]
+        == cli_result["agent_project_candidates"]
+    ), f"{label}: project grouping diverged from the CLI"
+
+    # Both readers must land on the same *verdict*, not merely the same
+    # bytes: a shared bug that rejected everything would satisfy equality.
+    selectable = {
+        candidate["value"]
+        for candidate in cli_result["agent_name_candidates"]
+        if candidate["selectable"]
+    }
+    expected = {
+        "monorepo": {"CleanRoot"},
+        "weak_markers": {"OneRoot"},
+        "shared_name": set(),
+        "eval_test_file": {"RagRoot", "inner"},
+        "scaffolding_template": {"RealRoot", "inner"},
+        "readable_template": {"ProductHelper", "TemplateRoot"},
+        "bare_templates": set(),
+        "own_root": set(),
+    }[label]
+    assert selectable == expected
+
+
+def test_script_names_the_workspace_fallback_marker_like_the_cli(
+    script_module, tmp_path
+):
+    """A weak marker at the workspace root that unlocked no boundary must not
+    be reported as the project's marker. `find_project_root` only honours
+    `requirements.txt` in a directory it already found agent evidence in, so
+    a root that holds one while the agent lives a level down carries no
+    marker at all — and the script named it anyway. Every sample has a
+    `pyproject.toml`, so the per-sample parity check never reached the
+    fallback."""
+    project = tmp_path / "weak_root"
+    (project / "sub").mkdir(parents=True)
+    (project / "requirements.txt").write_text("google-adk\n", encoding="utf-8")
+    (project / "sub" / "agent.py").write_text(
+        'from google.adk.agents import LlmAgent\n\nroot_agent = LlmAgent(name="SubRoot")\n',
+        encoding="utf-8",
+    )
+
+    script_result = script_module.detect(project)
+    cli_result = detect_workspace(project.resolve()).model_dump(mode="json")
+    assert cli_result["agent_project_candidates"] == [
+        {"path": ".", "marker": None, "agent_names": ["SubRoot"]}
+    ]
+    assert (
+        script_result["agent_project_candidates"]
+        == cli_result["agent_project_candidates"]
+    )
+
+
 def _git_init(root: Path) -> None:
     subprocess.run(["git", "init", "-q", str(root)], check=True, capture_output=True)
     for key, value in (("user.email", "t@example.test"), ("user.name", "T")):

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -1068,6 +1068,28 @@ _UNREADABLE_ROOT_SCOPES: dict[str, dict[str, str]] = {
         "agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="RealRoot")\n',
         "templates/agent.py": _ADK_HEADER + _UNREADABLE_ROOT,
     },
+    # The same directory pair, spelled the way a case-insensitive checkout
+    # may hold it.
+    "case_folded_template": {
+        "agent.py": _ADK_HEADER + 'root_agent = LlmAgent(name="RealRoot")\n',
+        "Skills/Recipe/Resources/Templates/app/agent.py": (
+            _ADK_HEADER + _UNREADABLE_ROOT
+        ),
+    },
+    # Two unreadable roots in one project, found by the two different passes.
+    # Which one the published sentence quotes is a contract between the two
+    # implementations, and the filenames put the resolution-time one first in
+    # walk order so the assertion is about precedence, not order.
+    "two_unreadable_roots": {
+        "pyproject.toml": '[project]\nname = "both"\n',
+        "a_symbol.py": (
+            _ADK_HEADER
+            + 'NAME = "One"\nNAME = "Two"\n'
+            + 'worker = LlmAgent(name="WorkerAgent")\n'
+            + "root_agent = LlmAgent(name=NAME, sub_agents=[worker])\n"
+        ),
+        "z_parse_time.py": _ADK_HEADER + _UNREADABLE_ROOT,
+    },
     # The project's own product root is unreadable: refusal is preserved.
     "own_root": {
         "pyproject.toml": '[project]\nname = "rag"\n',
@@ -1117,9 +1139,42 @@ def test_script_scopes_an_unreadable_root_like_the_cli(script_module, tmp_path, 
         "scaffolding_template": {"RealRoot", "inner"},
         "readable_template": {"ProductHelper", "TemplateRoot"},
         "bare_templates": set(),
+        "case_folded_template": {"RealRoot", "inner"},
+        "two_unreadable_roots": set(),
         "own_root": set(),
     }[label]
     assert selectable == expected
+
+    if label == "shared_name":
+        # Every other field of this candidate names `clean`. Both readers
+        # have to say why `blocked` is the one being quoted.
+        shared = next(
+            candidate
+            for candidate in cli_result["agent_name_candidates"]
+            if candidate["value"] == "SharedName"
+        )
+        assert shared["path"] == "clean/agent.py"
+        assert any(
+            reason.startswith(
+                "rejected: this name is also declared in project `blocked`,"
+            )
+            for reason in shared["rationale"]
+        )
+    if label == "two_unreadable_roots":
+        worker = next(
+            candidate
+            for candidate in cli_result["agent_name_candidates"]
+            if candidate["value"] == "WorkerAgent"
+        )
+        # The rejection line only: `a_symbol.py` is legitimately named by the
+        # *declaration* line above it.
+        rejection = next(
+            reason
+            for reason in worker["rationale"]
+            if "declares an application root" in reason
+        )
+        assert "z_parse_time.py" in rejection
+        assert "a_symbol.py" not in rejection
 
 
 def test_script_names_the_workspace_fallback_marker_like_the_cli(

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -1011,6 +1011,9 @@ def test_script_agent_name_ranking_matches_cli(script_module, tmp_path):
 
 _ADK_HEADER = "from google.adk.agents import LlmAgent\nfrom google.adk.apps import App\n\n"
 _UNREADABLE_ROOT = "def build():\n    return LlmAgent(name='inner')\n\nroot_agent = build()\n"
+#: A module defining its own, unrelated `Agent` class. Its `Agent(name=…)`
+#: literal is a name suggestion that draws no project boundary.
+_UNRELATED_AGENT_CLASS = "class Agent:\n    def __init__(self, name):\n        self.name = name\n"
 
 #: Workspaces where a declared application root cannot be read statically.
 #: Which names that rejects is scoped to the project the root sits in, and
@@ -1090,6 +1093,24 @@ _UNREADABLE_ROOT_SCOPES: dict[str, dict[str, str]] = {
         ),
         "z_parse_time.py": _ADK_HEADER + _UNREADABLE_ROOT,
     },
+    # A name in a marker directory that holds no *framework* evidence. The
+    # literal is a name suggestion and draws no boundary, so the directory
+    # is not an agent project and the name cannot escape the workspace's
+    # refusal. Both markers are covered: the script counted the literal as
+    # project evidence, which activated the weak one and put a phantom entry
+    # in `agent_project_candidates` under the strong one.
+    "non_agent_strong_marker": {
+        "agent.py": _ADK_HEADER + _UNREADABLE_ROOT,
+        "domain.py": _UNRELATED_AGENT_CLASS,
+        "util/pyproject.toml": '[project]\nname = "util"\n',
+        "util/agent.py": 'from domain import Agent\n\nhelper = Agent(name="CrmHelper")\n',
+    },
+    "non_agent_weak_marker": {
+        "agent.py": _ADK_HEADER + _UNREADABLE_ROOT,
+        "domain.py": _UNRELATED_AGENT_CLASS,
+        "util/requirements.txt": "requests\n",
+        "util/agent.py": 'from domain import Agent\n\nhelper = Agent(name="CrmHelper")\n',
+    },
     # The project's own product root is unreadable: refusal is preserved.
     "own_root": {
         "pyproject.toml": '[project]\nname = "rag"\n',
@@ -1141,6 +1162,8 @@ def test_script_scopes_an_unreadable_root_like_the_cli(script_module, tmp_path, 
         "bare_templates": set(),
         "case_folded_template": {"RealRoot", "inner"},
         "two_unreadable_roots": set(),
+        "non_agent_strong_marker": set(),
+        "non_agent_weak_marker": set(),
         "own_root": set(),
     }[label]
     assert selectable == expected
@@ -1160,6 +1183,14 @@ def test_script_scopes_an_unreadable_root_like_the_cli(script_module, tmp_path, 
             )
             for reason in shared["rationale"]
         )
+    if label.startswith("non_agent_"):
+        # The premise both halves rest on: the marker directory holds no
+        # framework evidence, so it is not one of the workspace's agent
+        # projects and `init` has one scope to write.
+        assert cli_result["agent_scope"] == "single"
+        assert [
+            candidate["path"] for candidate in cli_result["agent_project_candidates"]
+        ] == ["."]
     if label == "two_unreadable_roots":
         worker = next(
             candidate

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -3153,7 +3153,10 @@ def _non_product_origin(rel: str) -> str | None:
     """
     if _is_test_path(rel):
         return "declared in test code, which names fixtures rather than the product"
-    parts = Path(rel).parts[:-1]
+    # Case-folded: `Resources/Templates` is the same directory on a
+    # case-insensitive checkout, and an exact match let the symptom survive
+    # the spelling difference.
+    parts = tuple(part.lower() for part in Path(rel).parts[:-1])
     if any(
         parts[index:index + len(sequence)] == sequence
         for sequence in NON_PRODUCT_DIR_SEQUENCES
@@ -3174,11 +3177,20 @@ def _can_declare_application_root(rel: str) -> bool:
     return _non_product_origin(rel) is None
 
 
-def _unresolvable_root_rejection(scope: str, detail: str) -> str:
-    """Why no name a project declares may be written as its identity."""
+def _unresolvable_root_rejection(scope: str, detail: str, *,
+                                 declared_elsewhere: bool) -> str:
+    """Why no name a project declares may be written as its identity.
+
+    ``declared_elsewhere`` covers a value whose best-ranked site sits in a
+    clean project while a blocked project also declares it: every other
+    published field points at the clean project, so the relationship that
+    justifies the rejection has to be stated.
+    """
     where = "this workspace" if scope == "." else f"project `{scope}`"
+    opening = (f"this name is also declared in {where}, which"
+               if declared_elsewhere else where)
     return (
-        f"{where} declares an application root whose name is not statically "
+        f"{opening} declares an application root whose name is not statically "
         f"resolvable ({detail}); every other name it declares is by "
         "construction not that root, so none of them can be the reviewed "
         "identity"
@@ -3302,10 +3314,15 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
 
     best: dict[str, dict[str, Any]] = {}
     # Every project a value is declared in, not only its best-scoring site.
+    # `best_project` is the project of the site `best` kept — the one every
+    # other published field of the candidate points at.
     declared_in: dict[str, list[str]] = {}
+    best_project: dict[str, str] = {}
     order = 0
     for path, facts in py_facts:
         rel = _rel(path, workspace)
+        # Invariant across the evidence in one file, so it is asked once.
+        project = attribution.of(path)[0]
         for evidence in facts["names"]:
             resolved = _resolve_agent_name(evidence, path, facts, by_path, workspace)
             if resolved is None:
@@ -3363,13 +3380,13 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
                 "_order": order,
             }
             order += 1
-            project = attribution.of(path)[0]
             projects = declared_in.setdefault(value, [])
             if project not in projects:
                 projects.append(project)
             previous = best.get(value)
             if previous is None or ranked["rank_score"] > previous["rank_score"]:
                 best[value] = ranked
+                best_project[value] = project
 
     # A root whose *name* is a symbol that fails cross-module resolution is
     # just as unresolved as one whose name is an f-string; it surfaces here
@@ -3388,15 +3405,22 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
                     "static value",
                 )
     for value, ranked in best.items():
-        blocking = [
-            project for project in declared_in[value] if project in blocked_projects
-        ]
+        # The candidate's own project first when it is blocked, so the
+        # sentence names the project every other field already points at.
+        blocking = sorted(
+            (p for p in declared_in[value] if p in blocked_projects),
+            key=lambda p: p != best_project[value],
+        )
         if not blocking:
             continue
         ranked["selectable"] = False
         ranked["rationale"].append(
             "rejected: "
-            + _unresolvable_root_rejection(blocking[0], blocked_projects[blocking[0]])
+            + _unresolvable_root_rejection(
+                blocking[0],
+                blocked_projects[blocking[0]],
+                declared_elsewhere=blocking[0] != best_project[value],
+            )
         )
 
     ordered = sorted(

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -224,6 +224,7 @@ TEST_MODULE_NAMES = frozenset({"conftest.py", "test.py", "tests.py"})
 # as the running application: a `templates/` directory nested in a
 # `resources/` one holds what a generator copies. The pair is required, not a
 # bare `templates/` — every name added here widens what fails open (#398).
+# Entries must be lowercase: the path is case-folded before the comparison.
 NON_PRODUCT_DIR_SEQUENCES: tuple[tuple[str, ...], ...] = (("resources", "templates"),)
 ROOT_AGENT_BONUS = 3.0
 SUB_AGENT_PENALTY = 1.5
@@ -3320,8 +3321,13 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
     best_project: dict[str, str] = {}
     order = 0
     for path, facts in py_facts:
+        if not facts["names"]:
+            # Most files declare no agent; attributing them to a project is
+            # a stat and a walk for an answer nothing below reads.
+            continue
         rel = _rel(path, workspace)
-        # Invariant across the evidence in one file, so it is asked once.
+        # Invariant across the evidence in one file, so it is asked once
+        # per file rather than once per name.
         project = attribution.of(path)[0]
         for evidence in facts["names"]:
             resolved = _resolve_agent_name(evidence, path, facts, by_path, workspace)

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -104,7 +104,7 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-SCRIPT_VERSION = "0.5.0"
+SCRIPT_VERSION = "0.6.0"
 MAX_STRUCTURED_FILE_BYTES = 10 * 1024 * 1024
 # Matches ``detect_workspace``'s ``max_python_files``. The bound is on
 # parses, not on the inventory: capping the inventory lets an asset-heavy
@@ -215,14 +215,20 @@ AGENT_FRAMEWORK_MODULE_PREFIXES = (
 )
 ROOT_AGENT_SYMBOL = "root_agent"
 CHILD_AGENT_KEYWORDS = ("sub_agents", "handoffs")
-# Origin is meant to dominate hierarchy and corroboration, so the test
-# penalty is strictly greater than their whole spread (3.0 + 1.0 + 1.5).
+# Origin is meant to dominate hierarchy and corroboration, so the
+# non-product penalty is strictly greater than their whole spread
+# (3.0 + 1.0 + 1.5).
 # Conventional test module filenames that carry no `test_` prefix.
 TEST_MODULE_NAMES = frozenset({"conftest.py", "test.py", "tests.py"})
+# Consecutive directory names that hold code shipped as material rather than
+# as the running application: a `templates/` directory nested in a
+# `resources/` one holds what a generator copies. The pair is required, not a
+# bare `templates/` — every name added here widens what fails open (#398).
+NON_PRODUCT_DIR_SEQUENCES: tuple[tuple[str, ...], ...] = (("resources", "templates"),)
 ROOT_AGENT_BONUS = 3.0
 SUB_AGENT_PENALTY = 1.5
 CORROBORATION_BONUS = 1.0
-ORIGIN_TEST_PENALTY = 6.0
+ORIGIN_NON_PRODUCT_PENALTY = 6.0
 QUALITY_FLOOR_PENALTY = 3.0
 AGENT_NAME_MIN_LENGTH = 3
 GENERIC_AGENT_NAME_VALUES = frozenset({
@@ -516,10 +522,53 @@ def _project_of(
         directory = parent
 
 
+class _ProjectAttribution:
+    """Which project each path in the workspace belongs to — mirror of
+    ``cli/discovery/signals.py:_ProjectAttribution``.
+
+    One rule, two readers. ``_agent_project_candidates`` groups agent
+    evidence by project to decide whether one manifest can describe the
+    workspace; ``_rank_agent_names`` asks the same question because an
+    application root whose identity cannot be established disqualifies the
+    names declared *in that project* and no others (#398).
+    """
+
+    def __init__(self, workspace: Path, evidence_paths: list[str]) -> None:
+        self._workspace = workspace
+        self._evidence_dirs = frozenset(
+            (workspace / rel) if (workspace / rel).is_dir() else (workspace / rel).parent
+            for rel in evidence_paths
+        )
+        self._by_directory: dict[Path, tuple[str, str | None]] = {}
+
+    def of(self, path: Path) -> tuple[str, str | None]:
+        """``(project relative path, marker)``; ``"."`` for the workspace."""
+        directory = path if path.is_dir() else path.parent
+        cached = self._by_directory.get(directory)
+        if cached is not None:
+            return cached
+        found = _project_of(path, self._workspace, self._evidence_dirs)
+        # No marker anywhere above: the workspace is the project by default,
+        # not because a marker said so. The fallback marker is therefore the
+        # workspace's *strong* marker only, matching
+        # `signals.py:_ProjectAttribution.of`. Passing WEAK_PROJECT_MARKERS
+        # here reported `marker: "requirements.txt"` where the CLI reported
+        # `marker: null` — a weak marker that unlocks nowhere it was found
+        # is not the boundary this project rests on.
+        resolved = (
+            found
+            if found is not None
+            else (".", _project_marker(self._workspace))
+        )
+        self._by_directory[directory] = resolved
+        return resolved
+
+
 def _agent_project_candidates(
     workspace: Path,
     evidence_paths: list[str],
     literals_by_path: dict[str, list[str]],
+    attribution: _ProjectAttribution,
 ) -> list[dict[str, Any]]:
     """Group agent evidence by the project each piece of it sits in.
 
@@ -528,17 +577,8 @@ def _agent_project_candidates(
     """
     names: dict[str, set[str]] = {}
     markers: dict[str, str | None] = {}
-    evidence_dirs = frozenset(
-        (workspace / rel) if (workspace / rel).is_dir() else (workspace / rel).parent
-        for rel in evidence_paths
-    )
     for rel in evidence_paths:
-        found = _project_of(workspace / rel, workspace, evidence_dirs)
-        project, marker = (
-            found
-            if found is not None
-            else (".", _project_marker(workspace, WEAK_PROJECT_MARKERS))
-        )
+        project, marker = attribution.of(workspace / rel)
         names.setdefault(project, set()).update(literals_by_path.get(rel, []))
         markers.setdefault(project, marker)
     return [
@@ -3101,6 +3141,50 @@ def _is_test_path(rel: str) -> bool:
             or stem.endswith("_test.py"))
 
 
+def _non_product_origin(rel: str) -> str | None:
+    """Why ``rel`` is not the product's own code, or ``None`` — mirror of
+    ``cli/discovery/signals.py:_non_product_origin``.
+
+    One predicate, two uses: the score penalty below and the
+    application-root block. A test fixture that builds an ``App`` is a
+    fixture, and a file under a scaffolding ``resources/templates/``
+    directory is what a generator copies. The returned string is the
+    rationale line the penalty publishes.
+    """
+    if _is_test_path(rel):
+        return "declared in test code, which names fixtures rather than the product"
+    parts = Path(rel).parts[:-1]
+    if any(
+        parts[index:index + len(sequence)] == sequence
+        for sequence in NON_PRODUCT_DIR_SEQUENCES
+        for index in range(len(parts))
+    ):
+        return ("declared under a scaffolding template directory, which names "
+                "an example rather than the product")
+    return None
+
+
+def _can_declare_application_root(rel: str) -> bool:
+    """Whether a root declared in ``rel`` speaks for the product.
+
+    Neither a fixture nor a template is the application whose identity the
+    project ships, and reading either as one rejected every real agent in
+    the repository (#398).
+    """
+    return _non_product_origin(rel) is None
+
+
+def _unresolvable_root_rejection(scope: str, detail: str) -> str:
+    """Why no name a project declares may be written as its identity."""
+    where = "this workspace" if scope == "." else f"project `{scope}`"
+    return (
+        f"{where} declares an application root whose name is not statically "
+        f"resolvable ({detail}); every other name it declares is by "
+        "construction not that root, so none of them can be the reviewed "
+        "identity"
+    )
+
+
 def _constant_module_paths(importer: Path, module: str, level: int,
                            workspace: Path) -> list[Path]:
     """Every in-workspace file the import could refer to. All of them, not
@@ -3175,7 +3259,8 @@ def _resolve_agent_name(evidence: dict[str, Any], path: Path, facts: dict[str, A
 
 
 def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Path,
-                      project_names: list[dict[str, str]]) -> list[dict[str, Any]]:
+                      project_names: list[dict[str, str]],
+                      attribution: _ProjectAttribution) -> list[dict[str, Any]]:
     """Rank ``Agent(name=…)`` evidence best-first — mirror of
     ``cli/discovery/signals.py:_rank_agent_name_candidates``.
 
@@ -3184,6 +3269,12 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
     corroboration by the project name decide the order; a value too short or
     too generic to be an identity is ranked last and made unselectable so
     ``init`` writes CHANGE_ME rather than asserting something unreliable.
+
+    A project whose application root cannot be resolved has nothing
+    selectable, and that rule is scoped to the project: with repository
+    scope one unresolvable root in a scaffolding template rejected every
+    real agent in a monorepo (#398). A name several projects declare is
+    rejected when any of them is blocked — the fail-closed direction.
     """
     by_path: dict[Path, dict[str, Any]] = {}
     for path, facts in py_facts:
@@ -3195,7 +3286,23 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
     project_forms.add(_normalise_name(workspace.name))
     project_forms.discard("")
 
+    # Project → the first unreadable application root found in it. Only a
+    # root the product itself declares blocks a project.
+    blocked_projects: dict[str, str] = {}
+
+    def _block(path: Path, rel: str, detail: str) -> None:
+        if not _can_declare_application_root(rel):
+            return
+        blocked_projects.setdefault(attribution.of(path)[0], detail)
+
+    for path, facts in py_facts:
+        if facts["unresolved_root"]:
+            rel = _rel(path, workspace)
+            _block(path, rel, f"{rel}: {facts['unresolved_root']}")
+
     best: dict[str, dict[str, Any]] = {}
+    # Every project a value is declared in, not only its best-scoring site.
+    declared_in: dict[str, list[str]] = {}
     order = 0
     for path, facts in py_facts:
         rel = _rel(path, workspace)
@@ -3222,13 +3329,13 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
                 rationale.append(
                     evidence["why"] or "declared as a child of another agent, not the root"
                 )
-            if _is_test_path(rel):
-                # Larger than every other signal combined: a fixture that
-                # happens to build an App root is still a fixture.
-                score -= ORIGIN_TEST_PENALTY
-                rationale.append(
-                    "declared in test code, which names fixtures rather than the product"
-                )
+            origin = _non_product_origin(rel)
+            if origin is not None:
+                # Larger than every other signal combined: a fixture or a
+                # scaffolding template that happens to build an App root is
+                # still not the product.
+                score -= ORIGIN_NON_PRODUCT_PENALTY
+                rationale.append(origin)
             normalised = _normalise_name(value)
             if normalised and normalised in project_forms:
                 score += CORROBORATION_BONUS
@@ -3256,15 +3363,14 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
                 "_order": order,
             }
             order += 1
+            project = attribution.of(path)[0]
+            projects = declared_in.setdefault(value, [])
+            if project not in projects:
+                projects.append(project)
             previous = best.get(value)
             if previous is None or ranked["rank_score"] > previous["rank_score"]:
                 best[value] = ranked
 
-    unresolved = [
-        f"{_rel(p, workspace)}: {f['unresolved_root']}"
-        for p, f in py_facts
-        if f["unresolved_root"]
-    ]
     # A root whose *name* is a symbol that fails cross-module resolution is
     # just as unresolved as one whose name is an f-string; it surfaces here
     # because resolution needs every file's constants.
@@ -3273,23 +3379,25 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
             if evidence["role"] != "root_agent" or evidence["literal"] is not None:
                 continue
             if _resolve_agent_name(evidence, path, facts, by_path, workspace) is None:
-                unresolved.append(
-                    f"{_rel(path, workspace)}: the application root's name comes "
-                    f"from `{evidence['symbol']}`, which does not resolve to a "
-                    "static value"
+                rel = _rel(path, workspace)
+                _block(
+                    path,
+                    rel,
+                    f"{rel}: the application root's name comes from "
+                    f"`{evidence['symbol']}`, which does not resolve to a "
+                    "static value",
                 )
-    if unresolved:
-        # A declared application root whose identity is not statically
-        # resolvable. Anything still standing is by construction not the
-        # root, so nothing may be selected.
-        blocked = (
-            "an application root is declared here but its name is not statically "
-            f"resolvable ({unresolved[0]}); any other name would declare a worker "
-            "as the reviewed identity"
+    for value, ranked in best.items():
+        blocking = [
+            project for project in declared_in[value] if project in blocked_projects
+        ]
+        if not blocking:
+            continue
+        ranked["selectable"] = False
+        ranked["rationale"].append(
+            "rejected: "
+            + _unresolvable_root_rejection(blocking[0], blocked_projects[blocking[0]])
         )
-        for ranked in best.values():
-            ranked["selectable"] = False
-            ranked["rationale"].append(f"rejected: {blocked}")
 
     ordered = sorted(
         best.values(),
@@ -3601,8 +3709,6 @@ def detect(workspace: Path) -> dict[str, Any]:
             project_names.append({"value": m.group(1).strip(), "source": "pyproject"})
     project_names.append({"value": workspace.name, "source": "workspace_dir"})
 
-    name_candidates = _rank_agent_names(py_facts, workspace, project_names)
-
     marketplace_paths = [
         path
         for path in files
@@ -3691,8 +3797,15 @@ def detect(workspace: Path) -> dict[str, Any]:
             + list(literals_by_path)
         )
     )
+    attribution = _ProjectAttribution(workspace, evidence_paths)
     agent_project_candidates = _agent_project_candidates(
-        workspace, evidence_paths, literals_by_path
+        workspace, evidence_paths, literals_by_path, attribution
+    )
+    # Ranking runs after the grouping because it reads the same attribution:
+    # an application root it cannot resolve disqualifies the names in *that
+    # project* and no others (#398).
+    name_candidates = _rank_agent_names(
+        py_facts, workspace, project_names, attribution
     )
     # The workspace is always a candidate scope, marker or not: agent evidence
     # under no marker is attributed to it as ".", so an unmarked root agent in

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -100,6 +100,7 @@ import re
 import subprocess
 import sys
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -541,6 +542,9 @@ class _ProjectAttribution:
             for rel in evidence_paths
         )
         self._by_directory: dict[Path, tuple[str, str | None]] = {}
+        self._agent_projects: frozenset[str] = frozenset()
+        self._established = False
+        self._scope_by_directory: dict[Path, str] = {}
 
     def of(self, path: Path) -> tuple[str, str | None]:
         """``(project relative path, marker)``; ``"."`` for the workspace."""
@@ -564,6 +568,47 @@ class _ProjectAttribution:
         self._by_directory[directory] = resolved
         return resolved
 
+    def establish(self, projects: Iterable[str]) -> None:
+        """Record which projects the grouping actually published."""
+        self._agent_projects = frozenset(projects)
+        self._established = True
+        self._scope_by_directory.clear()
+
+    def scope_of(self, path: Path) -> str:
+        """The nearest *established* agent project at or above ``path``.
+
+        `of()` answers with the nearest project *marker*, which is the right
+        boundary for grouping evidence and the wrong one for deciding
+        whether a name is disqualified: a marker directory holding no agent
+        evidence is not a manifest scope, so a name found there belongs to
+        the scope enclosing it. Mirror of
+        ``signals.py:_ProjectAttribution.scope_of``.
+        """
+        if not self._established:
+            raise RuntimeError(
+                "scope_of() read before _agent_project_candidates established "
+                "the projects; it would attribute every name to the workspace"
+            )
+        directory = path if path.is_dir() else path.parent
+        cached = self._scope_by_directory.get(directory)
+        if cached is not None:
+            return cached
+        current = directory
+        scope = "."
+        while True:
+            rel = "." if current == self._workspace else _rel(current, self._workspace)
+            if rel in self._agent_projects:
+                scope = rel
+                break
+            if current == self._workspace:
+                break
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+        self._scope_by_directory[directory] = scope
+        return scope
+
 
 def _agent_project_candidates(
     workspace: Path,
@@ -582,6 +627,9 @@ def _agent_project_candidates(
         project, marker = attribution.of(workspace / rel)
         names.setdefault(project, set()).update(literals_by_path.get(rel, []))
         markers.setdefault(project, marker)
+    # These keys are the workspace's agent projects, and ranking resolves a
+    # name's scope against them rather than against the nearest marker.
+    attribution.establish(names)
     return [
         {"path": project, "marker": markers[project], "agent_names": sorted(found)}
         for project, found in sorted(names.items())
@@ -3306,7 +3354,7 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
     def _block(path: Path, rel: str, detail: str) -> None:
         if not _can_declare_application_root(rel):
             return
-        blocked_projects.setdefault(attribution.of(path)[0], detail)
+        blocked_projects.setdefault(attribution.scope_of(path), detail)
 
     for path, facts in py_facts:
         if facts["unresolved_root"]:
@@ -3328,7 +3376,7 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
         rel = _rel(path, workspace)
         # Invariant across the evidence in one file, so it is asked once
         # per file rather than once per name.
-        project = attribution.of(path)[0]
+        project = attribution.scope_of(path)
         for evidence in facts["names"]:
             resolved = _resolve_agent_name(evidence, path, facts, by_path, workspace)
             if resolved is None:
@@ -3624,6 +3672,13 @@ def detect(workspace: Path) -> dict[str, Any]:
             _add(scores, "openai_agents_sdk", 2.0, "strong",
                  f"{rel}: @function_tool decorator", rel)
 
+    # Mirror of `_PyFacts.framework`: whether any framework's scoring claimed
+    # this file. Snapshotted here, before package tokens, glob hits and the
+    # MCP source add candidates of their own, because a Python file's
+    # *framework* attribution is exactly what `_score_python_signals` records
+    # on the CLI side and nothing later touches it there.
+    framework_files = {rel for st in scores.values() for rel in st["candidate_files"]}
+
     for token in _package_tokens(workspace):
         for fw, hints in PACKAGE_HINTS.items():
             if token.lower() in {h.lower() for h in hints}:
@@ -3799,6 +3854,15 @@ def detect(workspace: Path) -> dict[str, Any]:
     # name that needs cross-module resolution is not available per-file, and
     # a project boundary is about *where* agents live, not what they are
     # called.
+    #
+    # *Framework-attributed* literals only, matching the CLI's
+    # `if literals and fact.framework`. A module that defines its own
+    # `Agent` class and constructs `Agent(name="crm")` is not an agent
+    # project; counting it drew a boundary the CLI does not draw, which put
+    # a phantom entry in `agent_project_candidates` and flipped `agent_scope`
+    # to "ambiguous" on a workspace the CLI calls "single". Those literals
+    # stay in `agent_name_candidates` as name suggestions either way — they
+    # just do not draw a boundary (#532 review).
     literals_by_path = {
         rel: literals
         for rel, literals in (
@@ -3812,7 +3876,7 @@ def detect(workspace: Path) -> dict[str, Any]:
             )
             for p, f in py_facts
         )
-        if literals
+        if literals and rel in framework_files
     }
     evidence_paths = list(
         dict.fromkeys(


### PR DESCRIPTION
Closes #398.

## The bug

A declared application root whose identity cannot be established statically makes **nothing** selectable — the #324 rule, and a sound one: every name still standing is by construction *not* that root, so writing one would declare a worker as the reviewed identity.

It was applied with **repository** scope. On adk-samples that meant one file rejected roughly 55 candidates across 25 projects — `financial_coordinator`, `cyber_guardian_orchestrator`, `data_science_root_agent` — and told the reader so by naming a file in a project they were not adopting.

Reproduced both halves before touching anything:

```
--- whole repository ---
  'financial_coordinator'   selectable=False
      rejected: an application root is declared here but its name is not statically resolvable
      (.agents/skills/scaffold-python-recipe/resources/templates/app/agent.py: ...)
--- scoped: python/agents/RAG ---
  'rag_root_agent'          selectable=False
      rejected: ... (eval/test_eval_arize.py: ...)
```

The second line matters: scoping alone would **not** have fixed the reproduction, because that culprit sits *inside* the project being adopted.

## The change

**1. The rejection is scoped to the project the root sits in.** That is the grouping `agent_project_candidates` already publishes, now computed once behind a `_ProjectAttribution` object that both readers share — a second, weaker "which project" here would have missed weak markers (two sibling agents whose only boundary is `requirements.txt` beside `agent.py` are two projects, #363). The rationale sentence now names the project. A name several projects declare is rejected when **any** of them is blocked; that is the fail-closed direction.

**2. Only a root the *product* declares blocks a project.** A fixture that builds an `App` is a fixture; a file under `resources/templates/` is what a generator copies. The ranker already said so for *selection* (`ORIGIN_TEST_PENALTY`) and said the opposite for *rejection* — one predicate (`_non_product_origin`) now answers both, so a scaffolding template is demoted exactly as a fixture is instead of standing in for the product. Without that symmetry the fix would have moved the failure rather than closed it: `init` would write the example's name.

The template rule is the directory **pair** `resources/templates/`, not a bare `templates/` — Django and Flask both ship a real one, and every name added to the exclusion widens what fails *open*.

## What is deliberately preserved

- A project whose own product root is unreadable still refuses, and the manifest keeps `CHANGE_ME`.
- An unreadable root under a bare `templates/` still blocks.
- Truncated discovery is untouched (`agent_scope_truncated` / `python_parse_truncated`).
- No candidate is auto-asserted and no deployment binding is inferred.

## Zero-install parity

`agent_name_candidates` is the one field `tools/shipgate-detect.py` pins **byte for byte** (`docs/zero-install.md`), so the script carries the same change (`script_version` `0.6.0`), covered by eight parametrised parity cases that also assert the *verdict* — a shared bug rejecting everything would satisfy equality alone.

Restructuring both sides surfaced a parity break that **predates this issue**: where no marker was found above the evidence, the script named the workspace's `requirements.txt` as the project marker while the CLI reported `null`. A weak marker only draws a boundary in a directory that already holds agent evidence, so one that unlocked nothing is not the boundary the project rests on. Fixed to match the CLI, with a test — every sample carries a `pyproject.toml`, which is why the per-sample parity check never reached the fallback.

## Verification

Full CI gate green (`ruff`, `pytest -n auto -m "not perf"`, `test_adapter_static_only.py`, `test_latency_budget.py -m perf`).

Every new guard was replayed against `origin/main`: 13 of them fail there and pass here. The four that pass on both are the deliberate preserved-behaviour cases (`bare_templates`, `own_root`, `shared_name`, `readable_template`), where the parity assertion is doing the work.

No new surface: `detect`'s schema is unchanged, and `zero_install_detector`'s row in `docs/distribution-surfaces.md` still claims exactly `agent_project_verdict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)