### PR TITLE
Read the Python `@mcp.tool` decorator, in both detectors (#484)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,7 +508,7 @@ Do NOT use it for:
 | Trigger in this PR | Run Shipgate? |
 |---|---|
 | Adds/changes MCP exports, OpenAPI specs, or `tools/*openai*tools*.json` | Yes |
-| Adds/changes an MCP tool registration written in TypeScript or Go source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`) | Yes |
+| Adds/changes an MCP tool registration written in TypeScript, Go or Python source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`, `@mcp.tool`) | Yes |
 | Adds/changes Codex repo config, hooks, or permission profiles | Yes |
 | Adds/changes coding-agent host config, hooks, permissions, MCP servers, or workflows | Yes |
 | Adds/changes Codex plugin manifests, marketplace files, `.app.json`, `.mcp.json`, or `SKILL.md` files | Yes |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## Unreleased
 
+- **Python MCP servers get the route the survey said they needed most.**
+  (#484) #431 shipped a built-in registry of tool-registration idioms covering
+  TypeScript and Go, and its own 30-server survey named what it left out:
+  Python's `@mcp.tool` decorator, the largest single shape by both repositories
+  and call sites. `redis/mcp-redis`, `chroma-core/chroma-mcp` and
+  `neo4j-contrib/mcp-neo4j` were all in the state MongoDB and Grafana were in
+  before #431 — `detect` returned `is_agent_project: false` for a first-party
+  server publishing dozens of tools. All three are now read, and so is the one
+  the survey measured as the largest of all: `awslabs/mcp` yields **334 tools**
+  with 107 registrations recorded as unenumerable.
+
+  It is a sixth idiom (`py_fastmcp_decorator`) and a different **extraction
+  mechanism**, which is why it waited for its own increment and its own probe
+  list. Three facts about the shape are why it could not be a sixth pattern:
+  the name is usually *not written down* — `@mcp.tool()` on `def dbsize()`
+  registers `dbsize`, which is all 53 of `redis/mcp-redis`'s registrations; the
+  input schema is the **annotated signature**, so this idiom publishes one
+  where the lexical idioms genuinely have nothing to publish; and whether the
+  decorator registers anything at all is a **binding fact**, since `@app.tool`
+  is a tool registration when `app` is a server and somebody else's decorator
+  otherwise. So it is read with the standard library's parser, it follows the
+  decorated name back to a server construction — across modules, because
+  `redis/mcp-redis` constructs its server in `src/common/server.py` and
+  decorates in `src/tools/*.py` — and it refuses out loud when it cannot.
+
+  Two findings changed the design after it was measured rather than before.
+  The official Python SDK's v2 **renamed `FastMCP` to `MCPServer`** and left
+  `mcp.server.fastmcp` as a module that only raises; 41 of `awslabs/mcp`'s
+  servers had already moved, and a reader that knew one name read 105 tools
+  where there are 334. And every one of `neo4j-contrib/mcp-neo4j`'s 40 tools is
+  registered as `name=namespace_prefix + "…"`, so the rule the lexical idioms
+  use — offer no route without a resolved name — would have reported that
+  repository as "not an agent project" *because* its names are dynamic. A
+  Python site carries its own provenance, having already been followed back to
+  a server construction, so the route is offered and the evidence says "40
+  registration(s), none of which this reader can name". A committed export
+  cannot displace such a route either: containment is the test, and an export
+  contains an empty set of names vacuously.
+
+  Nothing is claimed more loudly for having been read more closely. The
+  ceiling stays `medium`, a name built at run time stays an omission the
+  exclusion ledger accounts for, and a decorator on an object this reader
+  cannot follow — `@self.mcp.tool` on an injected server, `app =
+  create_server()` on a factory's result, both measured in `awslabs/mcp` — is
+  recorded rather than guessed at or silently dropped. `IDIOM_REGISTRY_VERSION`
+  is `2` and `TRIGGER-MCP-TOOL-REGISTRATION-SOURCE` routes `@mcp.tool`.
+
+  The zero-install detector moved in the same commit, to `0.6.0`: #485 made
+  `tools/shipgate-detect.py` a second implementation of this reader, and
+  `tests/mcp_idiom_corpus.py` is what keeps it from becoming a different one —
+  every case either reader has been asked about lives there once, the whole
+  Python probe list and the cross-module trees included, and both are driven
+  through all of it and compared site by site, span by span. Both detectors
+  return identical verdicts, sources and evidence on all four live
+  repositories.
+
 - **The zero-install detector refuses an oversized candidate instead of
   reading it.** `tools/shipgate-detect.py` is fetched over `curl | python3`
   and run against repositories nobody has inspected, and it read every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@
   recorded rather than guessed at or silently dropped. `IDIOM_REGISTRY_VERSION`
   is `2` and `TRIGGER-MCP-TOOL-REGISTRATION-SOURCE` routes `@mcp.tool`.
 
+  Every dependency table the gate names is reachable, which took a second
+  pass to be true: the walker read a Poetry table's *constraint* where the
+  distribution is the key, so `mcp = "^1.6.0"` produced `^1.6.0` and never
+  `mcp` — three of the five tables named in the constant were dead, and a
+  Poetry-managed server got no route at all. Both halves of a table are
+  admitted now, and all five are exercised.
+
   The zero-install detector moved in the same commit, to `0.6.0`: #485 made
   `tools/shipgate-detect.py` a second implementation of this reader, and
   `tests/mcp_idiom_corpus.py` is what keeps it from becoming a different one —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
   `neo4j-contrib/mcp-neo4j` were all in the state MongoDB and Grafana were in
   before #431 — `detect` returned `is_agent_project: false` for a first-party
   server publishing dozens of tools. All three are now read, and so is the one
-  the survey measured as the largest of all: `awslabs/mcp` yields **334 tools**
-  with 107 registrations recorded as unenumerable.
+  the survey measured as the largest of all: `awslabs/mcp` yields **262 tools**
+  with 179 registrations recorded as unenumerable.
 
   It is a sixth idiom (`py_fastmcp_decorator`) and a different **extraction
   mechanism**, which is why it waited for its own increment and its own probe
@@ -42,12 +42,22 @@
   contains an empty set of names vacuously.
 
   Nothing is claimed more loudly for having been read more closely. The
-  ceiling stays `medium`, a name built at run time stays an omission the
-  exclusion ledger accounts for, and a decorator on an object this reader
-  cannot follow — `@self.mcp.tool` on an injected server, `app =
-  create_server()` on a factory's result, both measured in `awslabs/mcp` — is
-  recorded rather than guessed at or silently dropped. `IDIOM_REGISTRY_VERSION`
-  is `2` and `TRIGGER-MCP-TOOL-REGISTRATION-SOURCE` routes `@mcp.tool`.
+  ceiling stays `medium`, and every way the registered identity can differ
+  from the one on the page is a recorded omission rather than a guess: a name
+  built at run time, a `**options` unpacking that can carry `name`, a
+  decorator *below* the registration whose return value is what the server
+  actually receives, and an object this reader cannot follow to a server at
+  all — `@self.mcp.tool` on an injected server, `app = create_server()` on a
+  factory's result. All four are measured in `awslabs/mcp`.
+  `IDIOM_REGISTRY_VERSION` is `2` and `TRIGGER-MCP-TOOL-REGISTRATION-SOURCE`
+  routes `@mcp.tool`.
+
+  A committed export displaces this route only when it accounts for
+  *everything* the route found, unreadable registrations included. An export
+  naming every tool the reader could read looks like containment and is not:
+  withholding the route then sends the reader to the export and never to
+  `scan`, so the registration nobody could name reaches no exclusion ledger —
+  a measured miss turning back into a silent one.
 
   Every dependency table the gate names is reachable, which took a second
   pass to be true: the walker read a Poetry table's *constraint* where the

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ Run Agents Shipgate when a PR adds or changes agent tool surfaces or the policy
 evidence around them:
 
 - MCP exports, OpenAPI specs, or local tool inventories.
-- An MCP server whose tool surface exists only as code — TypeScript or Go
+- An MCP server whose tool surface exists only as code — TypeScript, Go or Python
   registration sites, read through a built-in idiom registry.
 - OpenAI Agents SDK, Google ADK, LangChain/LangGraph, CrewAI, Anthropic
   Messages API, or OpenAI API artifact tool definitions.

--- a/docs/determinism-boundary.json
+++ b/docs/determinism-boundary.json
@@ -159,7 +159,31 @@
           "surface": "enumerated",
           "surface_complete": true,
           "surface_flags": [],
-          "variant": null,
+          "variant": "literal name at a registration site",
+          "verdict": "Every action from this route raises `low_confidence_tool` and either `unattested_surface` (when its set was enumerated) or `incomplete_surface` (when it was not), so none can be pass-eligible. Only the latter adds an exclusion-ledger row for an unread remainder. Semantic evidence gaps are zero-tolerance, so **one** such action is already enough to put the run below the evidence threshold and withhold a verdict. A reviewed tool inventory is the route out."
+        },
+        {
+          "ceiling": "medium",
+          "emits": [
+            "mcp_server_source"
+          ],
+          "evidence_gaps": [
+            "low_confidence_tool",
+            "unattested_surface"
+          ],
+          "exclusion_detail": null,
+          "exclusion_reason": null,
+          "extraction_complete": false,
+          "extraction_permits_pass": false,
+          "outcome": "low_confidence",
+          "raises": [],
+          "reads": "A `@mcp.tool` decorator on a Python function, where `mcp` is followed back to a `FastMCP(...)` construction \u2014 in the same module or in one this walk also read. The name is the `name=` literal or, where the framework's own default applies, the function's; the description is the `description=` literal or the docstring; the input schema is the annotated signature.",
+          "shape": "literal_registration",
+          "status": "extracted",
+          "surface": "enumerated",
+          "surface_complete": true,
+          "surface_flags": [],
+          "variant": "FastMCP decorator",
           "verdict": "Every action from this route raises `low_confidence_tool` and either `unattested_surface` (when its set was enumerated) or `incomplete_surface` (when it was not), so none can be pass-eligible. Only the latter adds an exclusion-ledger row for an unread remainder. Semantic evidence gaps are zero-tolerance, so **one** such action is already enough to put the run below the evidence threshold and withhold a verdict. A reviewed tool inventory is the route out."
         },
         {
@@ -191,13 +215,32 @@
           "extraction_permits_pass": false,
           "outcome": "not_extracted",
           "raises": [],
+          "reads": "A `.tool` decorator whose object does not resolve to a `FastMCP(...)` construction \u2014 `@self.mcp.tool` on a server handed in as an argument is the measured shape \u2014 registers something this reader can neither name nor confirm is a tool at all. It enters no catalog and is recorded as an unenumerated subject in the exclusion ledger.",
+          "shape": "dynamic_construction",
+          "status": "not_extracted",
+          "surface": null,
+          "surface_complete": false,
+          "surface_flags": [],
+          "variant": "decorator on an object this reader cannot follow",
+          "verdict": "No action enters the catalog, so nothing here carries an action-level ceiling. That is not the same as unseen: the scan records that it read this construct and refused to guess what it produces, and a framework check may raise a finding on the record itself \u2014 see the row's own `Raises` column."
+        },
+        {
+          "ceiling": null,
+          "emits": [],
+          "evidence_gaps": [],
+          "exclusion_detail": null,
+          "exclusion_reason": null,
+          "extraction_complete": false,
+          "extraction_permits_pass": false,
+          "outcome": "not_extracted",
+          "raises": [],
           "reads": "A registration whose name is a variable, a concatenation, or a template substitution names no tool this reader can check. It enters no catalog and is recorded as an unenumerated subject in the exclusion ledger, which holds its file's surface at `partial`.",
           "shape": "dynamic_construction",
           "status": "not_extracted",
           "surface": null,
           "surface_complete": false,
           "surface_flags": [],
-          "variant": null,
+          "variant": "name built at runtime",
           "verdict": "No action enters the catalog, so nothing here carries an action-level ceiling. That is not the same as unseen: the scan records that it read this construct and refused to guess what it produces, and a framework check may raise a finding on the record itself \u2014 see the row's own `Raises` column."
         }
       ],
@@ -208,7 +251,7 @@
       "label": "MCP server source",
       "manifest_section": null,
       "manifest_section_role": "activates",
-      "reads": "The TypeScript or Go source of an MCP server that does not commit an export, through a built-in registry of registration idioms."
+      "reads": "The TypeScript, Go or Python source of an MCP server that does not commit an export, through a built-in registry of registration idioms."
     },
     {
       "adapter": "openapi",

--- a/docs/determinism-boundary.md
+++ b/docs/determinism-boundary.md
@@ -76,7 +76,7 @@ Where an input shows more than one answer for a shape, the table shows the best 
 
 ### MCP server source
 
-*Configured as a `tool_sources[]` entry of type `mcp_server_source`.* The TypeScript or Go source of an MCP server that does not commit an export, through a built-in registry of registration idioms.
+*Configured as a `tool_sources[]` entry of type `mcp_server_source`.* The TypeScript, Go or Python source of an MCP server that does not commit an export, through a built-in registry of registration idioms.
 
 **Can a verdict rest on it?**
 
@@ -85,14 +85,16 @@ Where an input shows more than one answer for a shape, the table shows the best 
 **Getting to `proven` here:** no route on this input reaches `proven`. Publish the actions through an input that does, or accept that a verdict cannot rest on this surface alone.
 
 <details>
-<summary>Every route this input has, in full (4)</summary>
+<summary>Every route this input has, in full (6)</summary>
 
 | Declaration shape | What is read | Emits | Ceiling | Outcome | Evidence gaps | Raises |
 | --- | --- | --- | --- | --- | --- | --- |
 | `export_artifact` | A committed export is the server's own contract and is read by the MCP tool-export input at `high`, which stays the better route wherever one exists. | — | — | `not_applicable` | — | — |
-| `literal_registration` | A tool name written as a string literal at a registration site — `static toolName = "…"`, `.registerTool("…"`, `MustTool("…"`, `NewTool("…"`, `Tool{Name: "…"}` — plus the sibling operation-class literal where the idiom defines one. | `mcp_server_source` | `medium` | `low_confidence` | `low_confidence_tool`, `unattested_surface` | — |
+| `literal_registration — literal name at a registration site` | A tool name written as a string literal at a registration site — `static toolName = "…"`, `.registerTool("…"`, `MustTool("…"`, `NewTool("…"`, `Tool{Name: "…"}` — plus the sibling operation-class literal where the idiom defines one. | `mcp_server_source` | `medium` | `low_confidence` | `low_confidence_tool`, `unattested_surface` | — |
+| `literal_registration — FastMCP decorator` | A `@mcp.tool` decorator on a Python function, where `mcp` is followed back to a `FastMCP(...)` construction — in the same module or in one this walk also read. The name is the `name=` literal or, where the framework's own default applies, the function's; the description is the `description=` literal or the docstring; the input schema is the annotated signature. | `mcp_server_source` | `medium` | `low_confidence` | `low_confidence_tool`, `unattested_surface` | — |
 | `factory` | A helper that registers a table of tools contributes nothing on its own: resolving what it registers would mean evaluating it. Any registration site inside the helper is read on its own terms. | — | — | `not_extracted` | — | — |
-| `dynamic_construction` | A registration whose name is a variable, a concatenation, or a template substitution names no tool this reader can check. It enters no catalog and is recorded as an unenumerated subject in the exclusion ledger, which holds its file's surface at `partial`. | — | — | `not_extracted` | — | — |
+| `dynamic_construction — decorator on an object this reader cannot follow` | A `.tool` decorator whose object does not resolve to a `FastMCP(...)` construction — `@self.mcp.tool` on a server handed in as an argument is the measured shape — registers something this reader can neither name nor confirm is a tool at all. It enters no catalog and is recorded as an unenumerated subject in the exclusion ledger. | — | — | `not_extracted` | — | — |
+| `dynamic_construction — name built at runtime` | A registration whose name is a variable, a concatenation, or a template substitution names no tool this reader can check. It enters no catalog and is recorded as an unenumerated subject in the exclusion ledger, which holds its file's surface at `partial`. | — | — | `not_extracted` | — | — |
 
 </details>
 

--- a/docs/mcp-registration-idioms.md
+++ b/docs/mcp-registration-idioms.md
@@ -35,19 +35,18 @@ test files are included in these raw counts and excluded by the shipped reader
 
 | idiom | repositories | largest single repo | shipped |
 |---|---|---|---|
-| Python `@mcp.tool` (FastMCP decorator) | 5 | `awslabs/mcp` (488) | **no — next increment** |
+| Python `@mcp.tool` (server decorator) | 5 | `awslabs/mcp` (488) | yes (`py_fastmcp_decorator`) |
 | Go `Tool{Name: "…"}` | 3 | `github/github-mcp-server` (135) | yes (`go_tool_struct`) |
 | TS `.tool(` / `.registerTool("…"` | 3 | `cloudflare/mcp-server-cloudflare` (85) | yes (`ts_sdk_register_tool`) |
 | Go `NewTool("…"` | 2 | `hashicorp/terraform-mcp-server` (63) | yes (`go_new_tool`) |
 | Go `MustTool("…"` | 1 | `grafana/mcp-grafana` (132) | yes (`go_must_tool`) |
 | TS `static toolName = "…"` | 1 | `mongodb-js/mongodb-mcp-server` (77) | yes (`ts_static_tool_name`) |
 
-The five shipped idioms cover every surveyed server whose tools are declared in
-TypeScript or Go, including all three walked vendors. Measured against the
-current heads of the three vendor repositories, the reader finds 61, 114, and
-110 tool names respectively, with 3, 1, and 3 registrations whose names are
-built at runtime — each recorded as an unenumerated subject rather than
-dropped.
+The six shipped idioms cover every surveyed server. Measured against the
+current heads of the three walked vendor repositories, the reader finds 61,
+114, and 110 tool names respectively, with 3, 1, and 3 registrations whose
+names are built at runtime — each recorded as an unenumerated subject rather
+than dropped.
 
 One shape was measured and deliberately rejected: an object literal carrying
 `name:` and `description:` keys, which appears in 14 of the surveyed
@@ -55,25 +54,91 @@ repositories. It matches any object with those two keys, which is most
 configuration in a TypeScript codebase, and a reader resting on it would invent
 tools rather than find them.
 
-## Why Python FastMCP is not in this increment
+## Python: a different mechanism, not a sixth pattern
 
-It is the largest single shape in the survey, and it is a **different
-extraction mechanism**: the name defaults to the decorated function's, the
-schema comes from the signature, and the provenance gate is an import binding
-rather than a declared dependency. Per [#393](https://github.com/ThreeMoonsLab/agents-shipgate/issues/393),
-the mechanism is reusable but each one needs its own adversarial probe list
-before it can claim anything — the lexical reader shipped here had eight
-fail-open constructs in its first draft, all found by writing that list. Python
-gets its own increment, its own probes, and a real AST rather than a masking
-lexer — filed as
-[#484](https://github.com/ThreeMoonsLab/agents-shipgate/issues/484).
+Python was deliberately held back from the first increment and shipped in
+[#484](https://github.com/ThreeMoonsLab/agents-shipgate/issues/484) with its
+own adversarial probe list, because per
+[#393](https://github.com/ThreeMoonsLab/agents-shipgate/issues/393) an
+extraction mechanism can only claim what its probes have been run against. The
+lexical reader had eight fail-open constructs in its first draft, all found by
+writing that list.
+
+Three facts make it a mechanism rather than a pattern, and each was measured
+before it was designed for:
+
+- **The name is usually not written down.** `@mcp.tool()` on `def dbsize()`
+  registers `dbsize`. All 53 of `redis/mcp-redis`'s registrations are the bare
+  form, so a reader looking for a literal beside the call would find none of
+  them. The name is the `name=` literal where one is given and the decorated
+  function's otherwise.
+- **The schema is the signature.** The server builds the tool's input schema
+  from the annotated parameters, so this idiom publishes one where the
+  TypeScript and Go idioms genuinely have nothing to publish. The request
+  `Context` parameter is dropped, because the server drops it too.
+- **Whether it registers anything is a binding fact.** `@app.tool()` registers
+  an MCP tool when `app` is a server and is somebody else's decorator
+  otherwise. The reader follows the decorated name back to a server
+  construction and refuses out loud when it cannot: `awslabs/mcp` writes
+  `@self.mcp.tool()` on a server passed in as a constructor argument, and
+  `app = create_server()` on the result of a factory. Both are recorded as
+  unenumerated subjects — 107 of them across that monorepo, against 334 tools
+  it does read.
+
+The binding is followed **across modules**, because the population requires it:
+`redis/mcp-redis` constructs its server in `src/common/server.py` and applies
+every decorator in `src/tools/*.py`. An import is resolved by matching path
+segments against the modules the walk read, and only when exactly one module
+matches — the scanned root can sit anywhere along the import path, so neither
+end is anchored, and two candidates mean the reader cannot tell which module
+was imported.
+
+### Three server classes, because all three are live
+
+The class whose instance carries `.tool` has been spelled three ways, and the
+reader knows the `(module, class)` pairs rather than one name:
+
+| import | shipped in |
+|---|---|
+| `from fastmcp import FastMCP` | the standalone `fastmcp` package (2.x) |
+| `from mcp.server.fastmcp import FastMCP` | the official Python SDK, v1 |
+| `from mcp.server.mcpserver import MCPServer` | the official Python SDK, v2 |
+
+The v2 rename is not a detail. `mcp.server.fastmcp` in the v2 SDK is a module
+that exists only to raise `ModuleNotFoundError` with a migration hint, and 41
+of `awslabs/mcp`'s servers had already moved when this shipped. A reader that
+knew only `FastMCP` reported every one of their registrations as unenumerable —
+105 tools read where there are 334.
+
+### A route for a server whose tool names are all dynamic
+
+The lexical idioms need a **resolved name** before discovery offers a route,
+because they match a spelling and a spelling in a client repository is a
+coincidence. The Python idiom does not: its site is only emitted after the
+decorator has been followed back to a server construction, and a client does
+not construct a server.
+
+That distinction is load-bearing rather than theoretical.
+`neo4j-contrib/mcp-neo4j` registers 40 tools and writes every single name as
+`name=namespace_prefix + "…"`. Requiring a readable name would report the
+repository as *not an agent project* precisely because its tool names are
+built at run time, which is the silent miss this whole input exists to end.
+`detect` offers the route, the evidence says "40 registration(s), none of which
+this reader can name", and every one of them reaches the exclusion ledger.
+
+For the same reason a committed export cannot displace such a route:
+containment is the test, and an export contains an empty set of names
+vacuously.
 
 ## What the reader does and does not read
 
 It reads a name, an operation-class literal where the idiom defines one, and a
-description literal where one sits beside the name. It runs no code, evaluates
-no schema library (Zod included), infers no type, and reads no annotation the
-source declares about itself.
+description literal where one sits beside the name — plus, for the Python
+idiom, the decorated function's docstring and signature, because that is where
+the server itself takes them from. It runs no code, evaluates no schema library
+(Zod and Pydantic included), resolves no type, and reads no annotation the
+source declares about itself: a parameter's annotation is mapped to a JSON
+Schema type by spelling, never by import resolution.
 
 Escape sequences are decoded with **each language's own grammar**, and anything
 either grammar does not define is refused rather than guessed. Go writes an
@@ -94,12 +159,16 @@ untrusted source has an incentive to make.
 
 ### What the reader excludes
 
-- **Test files** — `*_test.go`, `*.test.ts`, `*.spec.ts`, and files under
-  `test/`, `tests/`, `__tests__/`, `testdata/`, `fixtures/`. A test's fake tool
-  is not the published surface. Excluding them drops 14 phantom tools from the
-  MongoDB repository and 8 from Grafana.
-- **Vendored and built code** — `node_modules/`, `vendor/`, `dist/`, `build/`.
-  Somebody else's registrations are not this repository's surface.
+- **Test files** — `*_test.go`, `*.test.ts`, `*.spec.ts`, `test_*.py`,
+  `*_test.py`, `conftest.py`, and files under `test/`, `tests/`, `__tests__/`,
+  `testdata/`, `fixtures/`. A test's fake tool is not the published surface.
+  Excluding them drops 14 phantom tools from the MongoDB repository and 8 from
+  Grafana. Python is the reason the prefix rule exists at all: `pytest`
+  collects `test_*.py`, so a suffix-only rule read `test_server.py` as the
+  server.
+- **Vendored and built code** — `node_modules/`, `vendor/`, `dist/`, `build/`,
+  `.venv/`, `site-packages/`, `.tox/`. Somebody else's registrations are not
+  this repository's surface.
 - **JSX** (`.tsx`, `.jsx`) — JSX puts prose in code position, so an apostrophe
   in `<p>don't</p>` opens a string that never closes and the file reads as
   unreadable. That is the fail-closed direction, which is exactly why it is
@@ -109,13 +178,15 @@ untrusted source has an incentive to make.
 
 ## Confidence, and where an export still wins
 
-A literal at a registration site is `medium`. A committed export stays `high`
-and remains the better route wherever one exists: it is the server's own
-published contract and it carries the input schemas this input does not read.
-`detect` therefore withholds the source route when a committed export **names
-every tool the source route resolved**, and records the withheld route in
-`excluded_sources` with the export that displaced it — named and visible, never
-silently dropped.
+A registration read out of source is `medium`, including the Python one that
+carries a signature: a signature is what the author wrote, not what the server
+publishes, and the ceiling is about the route rather than about how much of it
+was read. A committed export stays `high` and remains the better route wherever
+one exists, because it is the server's own contract in the shape a client
+receives it. `detect` therefore withholds the source route when a committed
+export **names every tool the source route resolved**, and records the withheld
+route in `excluded_sources` with the export that displaced it — named and
+visible, never silently dropped.
 
 Containment is the test, not location and not mere existence. "Any export in
 the workspace wins" deleted real actions in two ways: in a repository holding
@@ -144,11 +215,13 @@ reach. The over-broad route is visible in the manifest `init` writes and an
 adopter narrows it in one line; the withheld one leaves them where they
 started, which is the state #431 was filed about.
 
-The zero-install detector (`tools/shipgate-detect.py`) does not read registration
-sites at all, so it still answers "not an agent project" for these repositories
-while the installed CLI does not. That divergence is named in the script's own
-"intentional simplifications" list, pinned by a test, and filed as
-[#485](https://github.com/ThreeMoonsLab/agents-shipgate/issues/485).
+The zero-install detector (`tools/shipgate-detect.py`) carries a port of this
+reader, so it answers these repositories the same way the installed CLI does —
+[#485](https://github.com/ThreeMoonsLab/agents-shipgate/issues/485) closed the
+divergence, and `tests/mcp_idiom_corpus.py` is what keeps the two from becoming
+different implementations: every case either reader has ever been asked about
+lives there once and both are driven through all of it, site by site and span
+by span.
 
 ## Routing a diff
 
@@ -156,9 +229,12 @@ while the installed CLI does not. That divergence is named in the script's own
 `diff_tokens`. Those are deliberately narrower than what the reader matches: a
 matched capability rule overrides the workspace stop condition, so a router
 firing on `.tool(` or a bare `Tool{` would turn "this is not an agent project"
-into "run" for any diff containing that substring. The router's job is to stop
-the *silent* miss; the reader's is to read the surface once the repository is
-adopted.
+into "run" for any diff containing that substring. `@mcp.tool` is the Python
+token for the same reason: it is the spelling four of the five surveyed servers
+use and 329 of `awslabs/mcp`'s call sites, while `@app.tool` — which the reader
+does read — is a decorator name a non-MCP repository can plausibly carry. The
+router's job is to stop the *silent* miss; the reader's is to read the surface
+once the repository is adopted.
 
 ## Adding an idiom
 
@@ -168,7 +244,8 @@ Idioms live in `agents_shipgate.inputs.mcp_idioms`. Adding one means:
    invisible without it, in the survey's terms.
 2. An entry in `IDIOMS` with its `diff_tokens`, and a positive sample in
    `tests/test_mcp_idioms.py` (the sample is what proves the tokens are real).
-3. Adversarial cases in the same file for every way the shape can be faked or
-   built at runtime.
+3. Adversarial cases in `tests/mcp_idiom_corpus.py` for every way the shape can
+   be faked or built at runtime — the corpus, not one test file, because the
+   zero-install detector is driven through the same cases.
 4. A bump of `IDIOM_REGISTRY_VERSION`, because the trigger catalog's token list
    is derived from this registry.

--- a/docs/mcp-registration-idioms.md
+++ b/docs/mcp-registration-idioms.md
@@ -42,11 +42,14 @@ test files are included in these raw counts and excluded by the shipped reader
 | Go `MustTool("…"` | 1 | `grafana/mcp-grafana` (132) | yes (`go_must_tool`) |
 | TS `static toolName = "…"` | 1 | `mongodb-js/mongodb-mcp-server` (77) | yes (`ts_static_tool_name`) |
 
-The six shipped idioms cover every surveyed server. Measured against the
-current heads of the three walked vendor repositories, the reader finds 61,
-114, and 110 tool names respectively, with 3, 1, and 3 registrations whose
+The six shipped idioms cover every surveyed server. Re-measured against the
+current heads of the three walked vendor repositories when #484 shipped, the
+reader finds 61, 115 and 114 tool names, with 3, 0 and 3 registrations whose
 names are built at runtime — each recorded as an unenumerated subject rather
-than dropped.
+than dropped. (#431 published 61/114/110 with 3/1/3 against the heads of the
+day; the same clones give the same numbers to the reader before and after
+#484, so the difference is those servers gaining tools, not this reader
+changing its mind.)
 
 One shape was measured and deliberately rejected: an object literal carrying
 `name:` and `description:` keys, which appears in 14 of the surveyed

--- a/docs/mcp-registration-idioms.md
+++ b/docs/mcp-registration-idioms.md
@@ -85,8 +85,42 @@ before it was designed for:
   construction and refuses out loud when it cannot: `awslabs/mcp` writes
   `@self.mcp.tool()` on a server passed in as a constructor argument, and
   `app = create_server()` on the result of a factory. Both are recorded as
-  unenumerated subjects — 107 of them across that monorepo, against 334 tools
+  unenumerated subjects — 107 of them across that monorepo, against 262 tools
   it does read.
+
+### Three ways the registered identity is not the one on the page
+
+The name and the schema come from the object the decorator receives, and three
+constructs put something else there. Each is a recorded omission rather than a
+guess, because #431 settled that direction for the Go octal escape: an action
+id nobody serves is worse than a measured gap.
+
+- **A decorator below the registration.** Decorators apply bottom-up, so
+  `@mcp.tool()` over `@audited` registers `audited(fn)` — whose `__name__` and
+  `inspect.signature` need not be the decorated function's. A `functools.wraps`
+  wrapper does preserve both (`inspect.signature` follows `__wrapped__`), and
+  every one of the 72 such sites in `awslabs/mcp` is that shape or a plain
+  `return func`. But that is a fact about the decorator's *body*, in another
+  module for most of them, and this reader does not read bodies across
+  modules — seeing `@audited` at the use site proves nothing. The site keeps
+  its provenance and loses its name. Proving the wrapper is the increment this
+  defers; the 72 names are the evidence for whether it is worth it.
+- **An unpacked mapping.** `@mcp.tool(**options)` can carry `name`, decided at
+  run time, so the framework's default no longer provably applies and reading
+  the function's name would publish `harmless` for a tool registered as
+  whatever the mapping said.
+- **A `name=` this reader cannot resolve**, which is the `mcp-neo4j` shape.
+
+### What the request context is, and is not
+
+The server injects its `Context` on the parameter's **annotation**, so this
+reader drops a parameter only when it is annotated `Context` — including
+`Context | None` and `Context[ServerSession, None]`, and not `list[Context]`.
+The conventional-name list this package's other Python adapters share holds
+`config`, `context` and `runtime`, which are ordinary user-supplied inputs to
+an MCP tool: dropping them by name published an empty schema for a
+three-argument tool and hid a real parameter inventory from every schema and
+policy consumer downstream.
 
 The binding is followed **across modules**, because the population requires it:
 `redis/mcp-redis` constructs its server in `src/common/server.py` and applies
@@ -94,7 +128,12 @@ every decorator in `src/tools/*.py`. An import is resolved by matching path
 segments against the modules the walk read, and only when exactly one module
 matches — the scanned root can sit anywhere along the import path, so neither
 end is anchored, and two candidates mean the reader cannot tell which module
-was imported.
+was imported. *Every* scanned module is in that universe, including the ones
+that construct no server: holding only the servers takes the conflicting
+candidate out before the uniqueness check runs, so a `src/common/server.py`
+binding `mcp` to something else, beside an `archive/src/common/server.py` that
+really does build one, would resolve uniquely to the archive and lend a
+decorator binding evidence from a module the import demonstrably did not name.
 
 ### Three server classes, because all three are live
 
@@ -130,8 +169,16 @@ built at run time, which is the silent miss this whole input exists to end.
 this reader can name", and every one of them reaches the exclusion ledger.
 
 For the same reason a committed export cannot displace such a route:
-containment is the test, and an export contains an empty set of names
-vacuously.
+containment is the test, and an export cannot be shown to contain a
+registration **nobody could name**. That is one rule with two readings, and
+both matter. With no readable name the comparison is vacuous — `names <=
+covered` is true for the empty set, so any export would displace all 40 of
+`mcp-neo4j`'s registrations. With *some* readable, an export naming exactly
+those looks like containment and is not: withholding the route sends the
+reader to the export and never to `scan`, so the registration nobody could
+name reaches no exclusion ledger at all — a measured miss turning back into a
+silent one. So the export displaces the source route only when the route has
+nothing the export left out, unreadable registrations included.
 
 ## What the reader does and does not read
 

--- a/docs/triggers.json
+++ b/docs/triggers.json
@@ -97,10 +97,11 @@
     {
       "id": "TRIGGER-MCP-TOOL-REGISTRATION-SOURCE",
       "surface_class": "capability",
-      "agents_md_row": "Adds/changes an MCP tool registration written in TypeScript or Go source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`)",
+      "agents_md_row": "Adds/changes an MCP tool registration written in TypeScript, Go or Python source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`, `@mcp.tool`)",
       "when": {
         "any_of": [
           {"diff_contains": ".registerTool("},
+          {"diff_contains": "@mcp.tool"},
           {"diff_contains": "MustTool("},
           {"diff_contains": "NewTool("},
           {"diff_contains": "mcp.Tool{"},
@@ -108,7 +109,7 @@
         ]
       },
       "action": "run_shipgate",
-      "rationale": "Most MCP servers never emit their tool list: the official MongoDB and Grafana servers declare every tool as a string literal at a registration site in TypeScript or Go, and no filename or schema-content rule matches such a diff. These five tokens are the high-precision subset of the built-in idiom registry (`agents_shipgate.inputs.mcp_idioms.DIFF_TOKENS`), narrower than what that reader matches because a matched capability rule overrides the workspace stop condition. Routing this diff stops the silent miss; the `mcp_server_source` input reads the whole surface once the repository is adopted.",
+      "rationale": "Most MCP servers never emit their tool list: the official MongoDB and Grafana servers declare every tool as a string literal at a registration site in TypeScript or Go, and the largest measured shape is a Python `@mcp.tool` decorator whose name is usually not written down at all. No filename or schema-content rule matches such a diff. These six tokens are the high-precision subset of the built-in idiom registry (`agents_shipgate.inputs.mcp_idioms.DIFF_TOKENS`), narrower than what that reader matches because a matched capability rule overrides the workspace stop condition. Routing this diff stops the silent miss; the `mcp_server_source` input reads the whole surface once the repository is adopted.",
       "command": "agents-shipgate verify --preview --json"
     },
     {

--- a/docs/zero-install.md
+++ b/docs/zero-install.md
@@ -35,7 +35,7 @@ The script's output is a **structural subset** of `agents-shipgate detect --json
   "python_parse_truncated": false,
   "next_action": "agents-shipgate init --workspace .",
   "workspace_signals": {...},
-  "script_version": "0.5.0"
+  "script_version": "0.6.0"
 }
 ```
 
@@ -43,7 +43,7 @@ Like the canonical CLI, the script parse-probes each glob-matched MCP/OpenAPI ca
 
 One rejection needs no parser and so applies to every candidate, JSON or YAML: a file larger than 10 MB is refused unread. The input adapters apply that same bound before their own parse, so such a file cannot be scanned whatever it contains — suggesting it would hand you a `tool_sources` entry `scan` rejects, and reading it to find out is exactly what a script you piped from `curl` should not do to a repository it knows nothing about. It appears under `excluded_sources` with the reason the CLI gives it.
 
-An MCP server whose tool surface exists **only as TypeScript or Go registration sites** — `mongodb-js/mongodb-mcp-server`, `grafana/mcp-grafana`, `github/github-mcp-server` — is detected here too, and suggested as `{"type": "mcp_server_source", "path": "..."}`. That is 100% of the population this script is pointed at: a repository that has not adopted Shipgate. Until v0.5.0 of the script the reader lived only in the installed CLI, so the documented first command answered "Stop, not an agent project" on exactly the repositories the CLI reported as agent projects with 61, 110 and 114 tools.
+An MCP server whose tool surface exists **only as registration sites in its own source** — `mongodb-js/mongodb-mcp-server`, `grafana/mcp-grafana`, `github/github-mcp-server` in TypeScript and Go, `redis/mcp-redis`, `chroma-core/chroma-mcp` and `neo4j-contrib/mcp-neo4j` in Python — is detected here too, and suggested as `{"type": "mcp_server_source", "path": "..."}`. That is 100% of the population this script is pointed at: a repository that has not adopted Shipgate. Until v0.5.0 of the script the reader lived only in the installed CLI, so the documented first command answered "Stop, not an agent project" on exactly the repositories the CLI reported as agent projects with 61, 110 and 114 tools; v0.6.0 added the Python idiom on both sides at once.
 
 Porting it means a second implementation of the load-bearing matcher — the masking lexer and the five registration idioms. It is held to the CLI's answers by a shared conformance corpus rather than by inspection: every positive sample, the whole adversarial sweep, the path predicate and both escape grammars live once in [`tests/mcp_idiom_corpus.py`](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/tests/mcp_idiom_corpus.py) and are driven through both readers, compared site by site with the byte span of each. Neither reader can change its answer on a case either of them has ever been asked about without the other following.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -533,7 +533,7 @@ Do NOT use it for:
 | Trigger in this PR | Run Shipgate? |
 |---|---|
 | Adds/changes MCP exports, OpenAPI specs, or `tools/*openai*tools*.json` | Yes |
-| Adds/changes an MCP tool registration written in TypeScript or Go source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`) | Yes |
+| Adds/changes an MCP tool registration written in TypeScript, Go or Python source (`static toolName`, `.registerTool(`, `MustTool(`, `NewTool(`, `mcp.Tool{`, `@mcp.tool`) | Yes |
 | Adds/changes Codex repo config, hooks, or permission profiles | Yes |
 | Adds/changes coding-agent host config, hooks, permissions, MCP servers, or workflows | Yes |
 | Adds/changes Codex plugin manifests, marketplace files, `.app.json`, `.mcp.json`, or `SKILL.md` files | Yes |

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import json
 import tomllib
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 
@@ -61,7 +61,10 @@ from agents_shipgate.inputs.mcp_idioms import (
     language_for_path,
     scan_source,
 )
-from agents_shipgate.inputs.mcp_server_source import SOURCE_TYPE
+from agents_shipgate.inputs.mcp_server_source import (
+    MAX_CACHED_SOURCE_BYTES,
+    SOURCE_TYPE,
+)
 
 #: How many source files discovery reads before it stops. Discovery runs on an
 #: unknown workspace with no manifest and has to stay bounded; the scan-time
@@ -182,7 +185,7 @@ def discover_mcp_server_source(
     scannable.sort(key=lambda pair: pair[1])
     truncated = len(scannable) > max_source_files
     read = scannable[:max_source_files]
-    server_index = _python_server_index(read)
+    server_index, python_texts = _python_server_index(read)
     names: set[str] = set()
     languages: set[SourceLanguage] = set()
     unresolved_by_file: dict[str, int] = {}
@@ -191,7 +194,7 @@ def discover_mcp_server_source(
         language = language_for_path(path)
         if language is None:  # pragma: no cover - filtered above
             continue
-        text = _source_text(path)
+        text = python_texts.pop(path, None) or _source_text(path)
         if text is None:
             continue
         result = scan_source(
@@ -296,15 +299,18 @@ def discover_mcp_server_source(
         unresolved_count=unresolved,
         evidence=evidence,
         framework_evidence=tuple(sorted(framework.reasons)),
-        candidate_files=tuple(sorted(candidate_files)),
+        # De-duplicated: one module can prove the binding for every file
+        # that imports it, so a plain sort repeated `src/common/server.py`
+        # once per decorating module.
+        candidate_files=tuple(sorted(set(candidate_files))),
         truncated=truncated,
     )
 
 
 def _python_server_index(
     scannable: Sequence[tuple[Path, str]]
-) -> PythonServerIndex:
-    """Index every Python module in the walk that constructs a FastMCP server.
+) -> tuple[PythonServerIndex, dict[Path, str]]:
+    """Index every Python module in the walk that constructs an MCP server.
 
     Built ahead of the scan for the same reason the adapter builds one:
     ``redis/mcp-redis`` constructs the server in ``src/common/server.py`` and
@@ -314,17 +320,30 @@ def _python_server_index(
     The keys are workspace-relative here and root-relative in the adapter, and
     that is not a divergence: both are the path *inside the tree being read*,
     which is what an import's segments are matched against.
+
+    Returns the texts it read alongside the index, up to
+    :data:`MAX_CACHED_SOURCE_BYTES`, so the scan pass reads each Python file
+    once. Past the bound a file is read twice rather than held, which changes
+    no answer.
     """
 
-    return PythonServerIndex.build(
-        (relative, text)
-        for relative, text in (
-            (relative, _source_text(path))
-            for path, relative in scannable
-            if language_for_path(path) == "python"
-        )
-        if text is not None
-    )
+    texts: dict[Path, str] = {}
+    cached = 0
+
+    def _modules() -> Iterator[tuple[str, str]]:
+        nonlocal cached
+        for path, relative in scannable:
+            if language_for_path(path) != "python":
+                continue
+            text = _source_text(path)
+            if text is None:
+                continue
+            if cached + len(text) <= MAX_CACHED_SOURCE_BYTES:
+                texts[path] = text
+                cached += len(text)
+            yield relative, text
+
+    return PythonServerIndex.build(_modules()), texts
 
 
 def _source_text(path: Path) -> str | None:
@@ -461,12 +480,21 @@ def _pyproject_requirements(text: str) -> list[str]:
 
 
 def _toml_requirements(node: object, depth: int = 0) -> list[str]:
-    """Requirement strings inside a dependency list, table, or table of lists.
+    """Every string in a dependency table that could name a distribution.
 
-    One walker for three shapes, because they are three spellings of one fact:
-    PEP 621 writes a list of requirement strings, PEP 735 and Poetry's groups
-    write a table of them, and Poetry's own table writes the *name* as the key
-    with a constraint as the value.
+    Four spellings of one fact, and the walker admits **both** halves of a
+    table rather than choosing between them: PEP 621 writes a list of
+    requirement strings, PEP 735 and Poetry's groups write a table of such
+    lists, and Poetry's own table writes the *name as the key* with a
+    constraint as the value — sometimes an inline table (``{version = "^2"}``)
+    rather than a string.
+
+    Choosing was the bug. A first draft emitted the key only when the value
+    yielded nothing, so ``mcp = "^1.6.0"`` produced ``^1.6.0`` and never
+    ``mcp`` — every Poetry table in the list above was dead, and the gate
+    withheld the route from a Poetry-managed server. Emitting the key too
+    costs nothing: a group name like ``dev`` is not a distribution this gate
+    looks for, and :func:`normalized_distribution` drops ``^1.6.0`` anyway.
     """
 
     if depth > 3:  # pragma: no cover - a dependency table is never this deep
@@ -478,12 +506,8 @@ def _toml_requirements(node: object, depth: int = 0) -> list[str]:
     if isinstance(node, dict):
         found: list[str] = []
         for key, value in node.items():
-            nested = _toml_requirements(value, depth + 1)
-            # A Poetry table maps ``name -> constraint``, so the *key* is the
-            # requirement; a group table maps ``group -> [requirements]``, so
-            # the values are. Both are admitted, and the key only when the
-            # value was not itself a requirement list.
-            found.extend(nested if nested else [str(key)])
+            found.append(str(key))
+            found.extend(_toml_requirements(value, depth + 1))
         return found
     return []
 

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -195,7 +195,9 @@ def discover_mcp_server_source(
         if language is None:  # pragma: no cover - filtered above
             continue
         # ``is None``, not ``or``: an empty module caches as ``""``, which is
-        # the right answer and a falsy one, so ``or`` would read it again.
+        # the right answer and a falsy one, so ``or`` would read it again. The
+        # re-read returns the same text, so this costs a read and never an
+        # answer — a perturbation sweep reports it untested and is right to.
         text = python_texts.pop(path, None)
         if text is None:
             text = _source_text(path)

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -194,7 +194,11 @@ def discover_mcp_server_source(
         language = language_for_path(path)
         if language is None:  # pragma: no cover - filtered above
             continue
-        text = python_texts.pop(path, None) or _source_text(path)
+        # ``is None``, not ``or``: an empty module caches as ``""``, which is
+        # the right answer and a falsy one, so ``or`` would read it again.
+        text = python_texts.pop(path, None)
+        if text is None:
+            text = _source_text(path)
         if text is None:
             continue
         result = scan_source(

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -5,7 +5,7 @@ agent project". Both publish dozens of tools — ``drop-database``,
 ``delete-many``, ``update_incident`` — and neither commits an export, so every
 route discovery had was filename-shaped and found nothing. This module supplies
 the missing route: it asks whether a workspace *is* an MCP server written in
-TypeScript or Go, and if so which directory holds the registrations.
+TypeScript, Go or Python, and if so which directory holds the registrations.
 
 Two facts have to hold together before the route is offered, and the pairing is
 the whole design.
@@ -14,26 +14,35 @@ the whole design.
 is not an MCP server just because a class of its own happens to spell a field
 ``toolName``. #393's lesson is that a proof resting on a spelling is the
 fail-open shape, so the dependency — ``@modelcontextprotocol/*`` in a
-``package.json``, an MCP module in a ``go.mod`` — is what turns a spelling into
-provenance. It is also the cheap half: a workspace with no such dependency is
-answered without reading a single source file.
+``package.json``, an MCP module in a ``go.mod``, ``mcp`` or ``fastmcp`` in a
+``pyproject.toml`` — is what turns a spelling into provenance. It is also the
+cheap half: a workspace with no such dependency is answered without reading a
+single source file.
 
-**A resolved registration.** Dependency evidence alone says the repository
-*uses* MCP, which every client does too. At least one tool name has to be
-readable at a registration site before this claims a tool surface.
+**A registration this reader can stand behind.** Dependency evidence alone says
+the repository *uses* MCP, which every client does too. For the lexical idioms
+the second fact is a **resolved name**: they match a spelling, and a spelling
+is all `.registerTool(` in a client repository ever is. The Python idiom
+already carries the second fact in the site itself — it is only emitted after
+the decorator has been followed back to a server construction, and a client
+does not construct a server — so there the route is offered for a registration
+whose *name* is built at run time. That is not a corner: all 40 of
+``neo4j-contrib/mcp-neo4j``'s tools are ``name=namespace_prefix + "…"``, and
+requiring a readable name would report the repository as "not an agent project"
+precisely because its names are dynamic.
 
 Where both hold and the workspace *also* has a parseable MCP export, the export
-wins: it is the server's own published contract, it carries the input schemas
-this route deliberately does not read, and it is ``high`` confidence against
-``medium``. The source route is then withheld and recorded in
-``excluded_sources`` — named and visible, never silently dropped, because a
-route that vanishes without a reason is indistinguishable from one nobody
-implemented.
+wins: it is the server's own published contract, published in the shape a
+client receives it, and it is ``high`` confidence against ``medium``. The
+source route is then withheld and recorded in ``excluded_sources`` — named and
+visible, never silently dropped, because a route that vanishes without a reason
+is indistinguishable from one nobody implemented.
 """
 
 from __future__ import annotations
 
 import json
+import tomllib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
@@ -45,7 +54,9 @@ from agents_shipgate.inputs.mcp_idioms import (
     MAX_SOURCE_FILE_BYTES,
     SKIP_DIRECTORY_NAMES,
     TYPESCRIPT_FRAMEWORK_PACKAGES,
+    PythonServerIndex,
     SourceLanguage,
+    declares_python_mcp_framework,
     is_scannable_path,
     language_for_path,
     scan_source,
@@ -73,6 +84,24 @@ _PACKAGE_JSON_DEPENDENCY_KEYS = (
     "optionalDependencies",
 )
 
+#: Python project files read for the language gate. ``setup.py`` is absent on
+#: purpose: its dependencies are an argument to a function call, so reading them
+#: is either running the file or grepping it, and a grep for ``mcp`` in a Python
+#: module is the spelling-shaped proof #393 rules out.
+_PYTHON_PROJECT_FILES: frozenset[str] = frozenset({"pyproject.toml"})
+
+#: Dependency tables of a ``pyproject.toml`` that count. PEP 621's own list,
+#: PEP 735's dependency groups, and Poetry's table — a server declares its SDK
+#: in whichever one its build backend reads, and all three are live in the
+#: surveyed servers' ecosystems.
+_PYPROJECT_DEPENDENCY_PATHS: tuple[tuple[str, ...], ...] = (
+    ("project", "dependencies"),
+    ("project", "optional-dependencies"),
+    ("dependency-groups",),
+    ("tool", "poetry", "dependencies"),
+    ("tool", "poetry", "group"),
+)
+
 
 @dataclass(frozen=True)
 class McpSourceDiscovery:
@@ -81,9 +110,10 @@ class McpSourceDiscovery:
     #: Workspace-relative directory to point ``tool_sources[].path`` at, or
     #: ``None`` when no route was found.
     path: str | None = None
-    #: Languages whose idioms resolved at least one name.
+    #: Languages that contributed a registration this route rests on.
     languages: tuple[SourceLanguage, ...] = ()
-    #: Distinct resolved tool names, sorted.
+    #: Distinct resolved tool names, sorted. Empty is a real answer: a server
+    #: can register 40 tools and name none of them where a reader can read it.
     tool_names: tuple[str, ...] = ()
     #: Registration sites whose name could not be resolved to a literal.
     unresolved_count: int = 0
@@ -94,7 +124,8 @@ class McpSourceDiscovery:
     #: lines are ordered for a human and gain conditional entries at the end,
     #: so "the dependency reason" was a list position rather than a fact.
     framework_evidence: tuple[str, ...] = ()
-    #: Workspace-relative files that carried a resolved registration.
+    #: Workspace-relative files the route has to cover — the ones that carried
+    #: a registration, plus the modules whose server construction proved one.
     candidate_files: tuple[str, ...] = ()
     #: ``{type, path, reason}`` rows for a route discovery found and withheld.
     excluded: tuple[dict[str, str], ...] = ()
@@ -150,40 +181,50 @@ def discover_mcp_server_source(
     # published "this count is a lower bound" for a count that was exact.
     scannable.sort(key=lambda pair: pair[1])
     truncated = len(scannable) > max_source_files
+    read = scannable[:max_source_files]
+    server_index = _python_server_index(read)
     names: set[str] = set()
     languages: set[SourceLanguage] = set()
     unresolved_by_file: dict[str, int] = {}
     candidate_files: list[str] = []
-    unreadable = 0
-    for path, relative in scannable[:max_source_files]:
+    for path, relative in read:
         language = language_for_path(path)
         if language is None:  # pragma: no cover - filtered above
             continue
-        try:
-            if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
-                continue
-            # The adapter's own reader, not a lenient copy of it. Decoding here
-            # with `errors="replace"` let `detect` resolve a registration out of
-            # a file `load_mcp_server_source` then refuses as `unreadable_file`,
-            # so the route this promised enumerated fewer tools than it named —
-            # the detect/scan agreement is the whole point of sharing
-            # `is_scannable_path`, and the read has to be shared too.
-            text = load_text_file(path)
-        except (OSError, InputParseError):
-            unreadable += 1
+        text = _source_text(path)
+        if text is None:
             continue
-        result = scan_source(text, language)
+        result = scan_source(
+            text, language, module_path=relative, server_index=server_index
+        )
         resolved = [site.name for site in result.sites if site.name is not None]
         opaque = sum(1 for site in result.sites if site.name is None)
         if opaque:
             unresolved_by_file[relative] = opaque
-        if not resolved:
+        # A site that proves a server counts even when its name does not
+        # resolve. For the lexed idioms nothing does — they match a spelling,
+        # and a spelling in a repository that merely *uses* MCP is the
+        # coincidence the dependency gate exists to reject. The Python idiom
+        # has already followed the decorator back to a `FastMCP(...)`
+        # construction before it emits anything, and a client does not
+        # construct a server. Requiring a *name* on top of that would withhold
+        # the route from `neo4j-contrib/mcp-neo4j`, whose 40 registrations are
+        # every one of them `name=namespace_prefix + "…"` — the repository
+        # would stay "not an agent project" because its tool names are built at
+        # run time, which is the state this input exists to end.
+        if not resolved and not any(site.proves_server for site in result.sites):
             continue
         languages.add(language)
         names.update(resolved)
         candidate_files.append(relative)
+        # The module that constructed the server is part of the route even
+        # though it registers nothing: `redis/mcp-redis` builds its server in
+        # `src/common/server.py` and decorates in `src/tools/*.py`, and a route
+        # covering only the decorators is one on which `scan` cannot repeat the
+        # proof `detect` just published.
+        candidate_files.extend(result.server_modules)
 
-    if not names:
+    if not candidate_files:
         return McpSourceDiscovery(
             unresolved_count=sum(unresolved_by_file.values()), truncated=truncated
         )
@@ -201,8 +242,15 @@ def discover_mcp_server_source(
     evidence = _evidence_lines(
         framework, languages, names, root, truncated, unresolved
     )
-    covering_export, uncovered = _covering_export(
-        workspace, exported_source_paths, names
+    covering_export, uncovered = (
+        _covering_export(workspace, exported_source_paths, names)
+        if names
+        # An export cannot be shown to *contain* a surface with no names in it.
+        # `names <= covered` is vacuously true for the empty set, so asking the
+        # question here would let any readable export displace a route whose
+        # whole content is "40 registrations nobody can enumerate" — the one
+        # case where the source route says something no export restates.
+        else (None, set())
     )
     if covering_export is not None:
         return McpSourceDiscovery(
@@ -253,12 +301,60 @@ def discover_mcp_server_source(
     )
 
 
+def _python_server_index(
+    scannable: Sequence[tuple[Path, str]]
+) -> PythonServerIndex:
+    """Index every Python module in the walk that constructs a FastMCP server.
+
+    Built ahead of the scan for the same reason the adapter builds one:
+    ``redis/mcp-redis`` constructs the server in ``src/common/server.py`` and
+    decorates in ``src/tools/*.py``, so resolving bindings as the walk went
+    would prove or refuse the same decorator depending on file order.
+
+    The keys are workspace-relative here and root-relative in the adapter, and
+    that is not a divergence: both are the path *inside the tree being read*,
+    which is what an import's segments are matched against.
+    """
+
+    return PythonServerIndex.build(
+        (relative, text)
+        for relative, text in (
+            (relative, _source_text(path))
+            for path, relative in scannable
+            if language_for_path(path) == "python"
+        )
+        if text is not None
+    )
+
+
+def _source_text(path: Path) -> str | None:
+    """One source file's text, or ``None`` when this walk will not read it.
+
+    The adapter's own reader, not a lenient copy of it. Decoding here with
+    ``errors="replace"`` let ``detect`` resolve a registration out of a file
+    ``load_mcp_server_source`` then refuses as ``unreadable_file``, so the
+    route this promised enumerated fewer tools than it named — the detect/scan
+    agreement is the whole point of sharing ``is_scannable_path``, and the read
+    has to be shared too.
+    """
+
+    try:
+        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+            return None
+        return load_text_file(path)
+    except (OSError, InputParseError):
+        return None
+
+
 def _framework_evidence(
     workspace: Path, files: Sequence[Path]
 ) -> _FrameworkEvidence:
     evidence = _FrameworkEvidence()
     for path in files:
         name = path.name
+        if name in _PYTHON_PROJECT_FILES or _is_requirements_file(name):
+            _record_python_evidence(workspace, path, evidence)
+            continue
         if name not in {"package.json", "go.mod"}:
             continue
         relative = _relative(path, workspace)
@@ -294,6 +390,118 @@ def _framework_evidence(
                 evidence.reasons.append(f"{relative} depends on {dependency}")
                 break
     return evidence
+
+
+def _is_requirements_file(name: str) -> bool:
+    """Whether ``name`` is a pip requirements file.
+
+    The glob rather than the exact name: ``requirements-dev.txt`` and
+    ``requirements/base.txt`` are both ordinary, and a repository that pins its
+    SDK in one of them has declared it just as plainly.
+    """
+
+    lowered = name.lower()
+    return lowered.startswith("requirements") and lowered.endswith(".txt")
+
+
+def _record_python_evidence(
+    workspace: Path, path: Path, evidence: _FrameworkEvidence
+) -> None:
+    """Admit Python when a project file declares ``mcp`` or ``fastmcp``.
+
+    Weaker than its Go and TypeScript counterparts, and knowingly so: a Python
+    *client* declares ``mcp`` too. It buys the same thing the others buy — a
+    workspace with no such dependency is answered without parsing a single
+    module — while the load-bearing half of the pairing moves into the reader,
+    which will not emit a Python site at all until it has followed the
+    decorated object back to a ``FastMCP(...)`` construction.
+    """
+
+    relative = _relative(path, workspace)
+    if relative is None:
+        return
+    if any(part in SKIP_DIRECTORY_NAMES for part in PurePosixPath(relative).parts):
+        return
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    requirements = (
+        _pyproject_requirements(text)
+        if path.name in _PYTHON_PROJECT_FILES
+        else _requirements_txt(text)
+    )
+    dependency = declares_python_mcp_framework(requirements)
+    if dependency is None:
+        return
+    evidence.languages.add("python")
+    evidence.reasons.append(f"{relative} depends on {dependency}")
+
+
+def _pyproject_requirements(text: str) -> list[str]:
+    """Every requirement string a ``pyproject.toml`` declares.
+
+    Parsed with ``tomllib`` rather than scanned line by line. The general
+    package-token scan in discovery does the latter and drops
+    ``mcp[cli]>=1.26.0,<2`` — the requirement two of the five surveyed servers
+    declare — because an extras marker is not a bare token.
+    """
+
+    try:
+        data = tomllib.loads(text)
+    except (tomllib.TOMLDecodeError, ValueError, RecursionError):
+        return []
+    requirements: list[str] = []
+    for path in _PYPROJECT_DEPENDENCY_PATHS:
+        node: object = data
+        for key in path:
+            node = node.get(key) if isinstance(node, dict) else None
+        requirements.extend(_toml_requirements(node))
+    return requirements
+
+
+def _toml_requirements(node: object, depth: int = 0) -> list[str]:
+    """Requirement strings inside a dependency list, table, or table of lists.
+
+    One walker for three shapes, because they are three spellings of one fact:
+    PEP 621 writes a list of requirement strings, PEP 735 and Poetry's groups
+    write a table of them, and Poetry's own table writes the *name* as the key
+    with a constraint as the value.
+    """
+
+    if depth > 3:  # pragma: no cover - a dependency table is never this deep
+        return []
+    if isinstance(node, str):
+        return [node]
+    if isinstance(node, list):
+        return [item for item in node if isinstance(item, str)]
+    if isinstance(node, dict):
+        found: list[str] = []
+        for key, value in node.items():
+            nested = _toml_requirements(value, depth + 1)
+            # A Poetry table maps ``name -> constraint``, so the *key* is the
+            # requirement; a group table maps ``group -> [requirements]``, so
+            # the values are. Both are admitted, and the key only when the
+            # value was not itself a requirement list.
+            found.extend(nested if nested else [str(key)])
+        return found
+    return []
+
+
+def _requirements_txt(text: str) -> list[str]:
+    """Requirement lines from a pip requirements file.
+
+    Option lines (``-r``, ``--index-url``, ``-e``) are dropped rather than
+    followed: a requirements file that includes another one names a path, and
+    resolving it is a second file read for a gate whose whole value is that it
+    is cheap.
+    """
+
+    return [
+        line
+        for raw in text.splitlines()
+        if (line := raw.strip()) and not line.startswith(("-", "#"))
+    ]
 
 
 def _package_dependencies(text: str) -> set[str]:
@@ -421,14 +629,24 @@ def _evidence_lines(
     if len(names) > len(sample):
         shown += ", …"
     lines = [
-        f"MCP tool registrations in {'/'.join(sorted(languages))} source under "
-        f"{root}/: {len(names)} tool name(s) — {shown}",
+        (
+            f"MCP tool registrations in {'/'.join(sorted(languages))} source "
+            f"under {root}/: {len(names)} tool name(s) — {shown}"
+        )
+        if names
+        else (
+            f"MCP tool registrations in {'/'.join(sorted(languages))} source "
+            f"under {root}/: {unresolved} registration(s), none of which this "
+            "reader can name"
+        ),
     ]
     lines.extend(sorted(framework.reasons)[:_EVIDENCE_NAME_LIMIT])
-    if unresolved:
+    if unresolved and names:
         # Named here because this is what a human reads when deciding whether
         # to adopt, and "61 tools" without "and 3 more this reader cannot name"
-        # is the over-claim the whole input is built to avoid.
+        # is the over-claim the whole input is built to avoid. Suppressed when
+        # there are no names at all, because the headline above already is the
+        # unresolved count and saying it twice reads as two findings.
         lines.append(
             f"{unresolved} registration(s) name themselves at runtime and are "
             "not enumerated"

--- a/src/agents_shipgate/cli/discovery/mcp_source.py
+++ b/src/agents_shipgate/cli/discovery/mcp_source.py
@@ -251,16 +251,32 @@ def discover_mcp_server_source(
     evidence = _evidence_lines(
         framework, languages, names, root, truncated, unresolved
     )
-    covering_export, uncovered = (
-        _covering_export(workspace, exported_source_paths, names)
-        if names
-        # An export cannot be shown to *contain* a surface with no names in it.
-        # `names <= covered` is vacuously true for the empty set, so asking the
-        # question here would let any readable export displace a route whose
-        # whole content is "40 registrations nobody can enumerate" — the one
-        # case where the source route says something no export restates.
-        else (None, set())
+    covering_export, uncovered = _covering_export(
+        workspace, exported_source_paths, names
     )
+    if covering_export is not None and unresolved:
+        # Containment is the test, and an export cannot be shown to contain a
+        # registration *nobody could name*. Withholding the route here is what
+        # sends the reader to the export and never to `scan`, so the unreadable
+        # registration reaches no exclusion ledger at all — it stops being a
+        # measured miss and becomes a silent one, which is the state this whole
+        # input exists to end.
+        #
+        # One rule for two readings. With no readable name at all the
+        # comparison is vacuous — `names <= covered` is true for the empty set,
+        # so any export would displace `neo4j-contrib/mcp-neo4j`'s 40
+        # unenumerable registrations. With *some* readable, an export naming
+        # exactly those looks complete and is not. Both are "the export does
+        # not account for everything this route found", and both are answered
+        # by the unresolved count rather than by a special case.
+        evidence = (
+            *evidence,
+            f"An MCP tool export ({covering_export}) names every registration "
+            f"this reader could read and none of the {unresolved} it could "
+            "not; both routes are suggested, so the unreadable ones still "
+            "reach the exclusion ledger",
+        )
+        covering_export = None
     if covering_export is not None:
         return McpSourceDiscovery(
             unresolved_count=unresolved,

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -575,7 +575,7 @@ def _initial_framework_scores() -> dict[str, _FrameworkScore]:
         "openai_api": _FrameworkScore(),
         # mcp_server_source is not a Python framework and scores from neither
         # the AST pass nor a filename glob: it is the workspace's own
-        # TypeScript or Go registration sites, scored by
+        # TypeScript, Go or Python registration sites, scored by
         # :func:`discover_mcp_server_source` (#431). It keeps an entry here
         # because the detection loop reads this sheet, and a framework absent
         # from it is a framework that can never be reported.

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -31,11 +31,14 @@ the first need is met the settled way.
 treadmill and proves nothing transferable. An idiom is a registration *shape*:
 the 30-server survey behind this module found five shapes covering every server
 whose tools are declared in TypeScript or Go, including all three walked
-vendors. Python's FastMCP decorator is the largest single shape in that survey
-and is deliberately absent: it is a different extraction mechanism (a real AST,
-a name that defaults to the function's, a schema that comes from the signature)
-and per #393 each mechanism needs its own adversarial probe list before it can
-claim anything.
+vendors. Python's ``@mcp.tool`` decorator was the largest single shape in that
+survey and shipped one increment later (#484), with its own probe list, because
+it is a different **extraction mechanism** rather than a sixth pattern: the
+name defaults to the decorated function's, the input schema comes from the
+signature, and whether the decorator registers anything at all depends on what
+its object is bound to. None of those is a lexical fact, so that idiom is read
+with the standard library's parser and the rest of this module's machinery does
+not apply to it.
 
 **Honest about what it proved.** Every observation records which idiom matched.
 A literal at a registration site is ``medium`` confidence — a committed export
@@ -44,18 +47,22 @@ reader cannot resolve to a literal is reported as *unenumerated*, never dropped:
 it becomes a typed omission that the exclusion ledger (#403) accounts for and
 that holds the whole file's surface at ``partial``.
 
-Reading is done over a **masked** copy of the source, in which comments and
-string bodies have been overwritten (see :func:`mask_source`). A registration
-site can therefore never be found inside a comment or inside another string,
-and a name is a name only when the masking pass recorded a real literal at that
-offset. Where masking cannot complete — an unterminated string or block comment
-— the file is reported partial rather than read as though the rest were code.
+Reading a *lexed* language is done over a **masked** copy of the source, in
+which comments and string bodies have been overwritten (see :func:`mask_source`).
+A registration site can therefore never be found inside a comment or inside
+another string, and a name is a name only when the masking pass recorded a real
+literal at that offset. Where masking cannot complete — an unterminated string
+or block comment — the file is reported partial rather than read as though the
+rest were code. Python is parsed instead, and a file that does not parse is
+reported partial for the same reason.
 """
 
 from __future__ import annotations
 
+import ast
 import re
-from dataclasses import dataclass
+from collections.abc import Iterable
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Literal
 
@@ -64,9 +71,9 @@ from typing import Literal
 #: pinning an idiom id would have to change; adding an idiom bumps it, because
 #: the trigger catalog's token list is derived from this registry and a consumer
 #: that mirrors the list has to re-read it.
-IDIOM_REGISTRY_VERSION = "1"
+IDIOM_REGISTRY_VERSION = "2"
 
-SourceLanguage = Literal["typescript", "go"]
+SourceLanguage = Literal["typescript", "go", "python"]
 
 #: File suffixes each language's idioms are read from. TypeScript's list covers
 #: JavaScript too: the TS SDK is published as JavaScript and a server written
@@ -81,7 +88,17 @@ SourceLanguage = Literal["typescript", "go"]
 LANGUAGE_EXTENSIONS: dict[SourceLanguage, tuple[str, ...]] = {
     "typescript": (".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"),
     "go": (".go",),
+    "python": (".py",),
 }
+
+#: The languages read with a masking lexer rather than a parser. Python is
+#: absent because it has a real parser in the standard library, and #484's
+#: measurement is why that matters: a FastMCP tool's name defaults to the
+#: *decorated function's*, its schema comes from the *signature*, and whether
+#: `@app.tool` registers anything at all depends on what `app` is bound to.
+#: None of those are lexical facts, and a masking reader asked for them would
+#: be guessing at each one.
+LEXED_LANGUAGES: frozenset[SourceLanguage] = frozenset({"typescript", "go"})
 
 #: Declared-dependency tokens that establish an MCP framework for a language.
 #: Used by ``detect`` as the provenance gate: an idiom hit in a repository that
@@ -103,17 +120,68 @@ GO_FRAMEWORK_MODULES: tuple[str, ...] = (
     "github.com/thinkinaixyz/go-mcp",
     "github.com/ktr0731/go-mcp",
 )
+#: Distribution names, normalised per PEP 503, that establish an MCP framework
+#: for Python. ``mcp`` is the official SDK (whose ``mcp.server.fastmcp``
+#: subpackage is FastMCP 1.x) and ``fastmcp`` is the standalone 2.x package;
+#: every one of the five servers in the #431 survey declares one of the two.
+#:
+#: The gate is weaker here than in the other two languages — a *client* also
+#: depends on ``mcp`` — and that is on purpose: for Python the load-bearing
+#: half of the pairing is not the dependency but the **import binding** the
+#: reader itself requires, which is a fact about the same file as the
+#: registration. See :func:`python_server_exports`.
+PYTHON_FRAMEWORK_PACKAGES: tuple[str, ...] = ("mcp", "fastmcp")
+
+#: ``(module prefix, class)`` pairs whose construction is an MCP server. All
+#: three are live and all three were measured, which is why this is a table
+#: rather than one module and one class name:
+#:
+#: * ``fastmcp`` — the standalone 2.x package, and the most common of the
+#:   three: 175 modules of ``awslabs/mcp`` import from it, and
+#:   ``neo4j-contrib/mcp-neo4j`` from ``fastmcp.server``.
+#: * ``mcp.server.fastmcp`` — FastMCP as it shipped inside the official SDK's
+#:   v1, which is what ``redis/mcp-redis`` and ``chroma-core/chroma-mcp``
+#:   import.
+#: * ``mcp.server.mcpserver`` — the same class in the official SDK's v2, where
+#:   it was **renamed** to ``MCPServer`` and the old module was replaced by one
+#:   that raises ``ModuleNotFoundError``. 41 of ``awslabs/mcp``'s servers had
+#:   already moved when this was written, and a reader that knew only the old
+#:   name reported every one of their registrations as unenumerable.
+PYTHON_SERVER_CONSTRUCTORS: tuple[tuple[str, str], ...] = (
+    ("fastmcp", "FastMCP"),
+    ("mcp.server.fastmcp", "FastMCP"),
+    ("mcp.server.mcpserver", "MCPServer"),
+)
+
+#: The cheap gate for the index pass, the same idea as :data:`PREFILTER_TOKEN`
+#: and *derived from the table above*, because the two must not drift: a
+#: hand-written ``"fastmcp"`` skipped every module built on the SDK's v2 class,
+#: which is the largest single shape after the standalone package.
+PYTHON_SERVER_PREFILTER_TOKENS: tuple[str, ...] = tuple(
+    sorted({symbol.lower() for _module, symbol in PYTHON_SERVER_CONSTRUCTORS})
+)
+
+#: The decorator attribute that registers a tool. ``@mcp.resource`` and
+#: ``@mcp.prompt`` are the sibling decorators on the same object and register
+#: other things; reading either as a tool would put a resource into the action
+#: catalog.
+PYTHON_TOOL_DECORATOR_ATTR = "tool"
 
 #: Directory names never walked for registration sites. Vendored dependencies
 #: and build output contain other people's registrations, and reporting them as
 #: this repository's surface is the same over-claim as reading a lockfile.
 SKIP_DIRECTORY_NAMES: frozenset[str] = frozenset(
     {
+        ".eggs",
         ".git",
         ".hg",
-        ".svn",
+        ".mypy_cache",
         ".next",
         ".nuxt",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".svn",
+        ".tox",
         ".turbo",
         ".venv",
         "__pycache__",
@@ -124,6 +192,7 @@ SKIP_DIRECTORY_NAMES: frozenset[str] = frozenset(
         "node_modules",
         "obj",
         "out",
+        "site-packages",
         "target",
         "vendor",
         "venv",
@@ -149,6 +218,7 @@ TEST_DIRECTORY_NAMES: frozenset[str] = frozenset(
 )
 _TEST_FILE_SUFFIXES: tuple[str, ...] = (
     "_test.go",
+    "_test.py",
     ".test.ts",
     ".test.js",
     ".test.mts",
@@ -158,6 +228,12 @@ _TEST_FILE_SUFFIXES: tuple[str, ...] = (
     ".spec.mts",
     ".spec.mjs",
 )
+#: Python spells a test file with a *prefix*, and it is the dominant spelling:
+#: ``pytest`` collects ``test_*.py`` by default, so a suffix-only rule reads
+#: ``test_server.py`` as the server. ``conftest.py`` is matched whole because
+#: it is neither.
+_TEST_FILE_PREFIXES: tuple[str, ...] = ("test_",)
+_TEST_FILE_NAMES: frozenset[str] = frozenset({"conftest.py"})
 
 #: Every idiom's pattern requires these four characters, in some case, at the
 #: registration site: ``toolName``, ``.tool(``, ``.registerTool(``,
@@ -227,6 +303,15 @@ OMISSION_REASONS: dict[str, str] = {
     "unreadable_file": (
         "The file could not be decoded as UTF-8 source, so it was not read; "
         "any tool registered in it is absent from this catalog."
+    ),
+    "server_binding_not_proven": (
+        "The object this decorator registers on is not one this reader can "
+        "follow to an MCP server, so whether it registers a tool — "
+        "and under what name — cannot be read from the source."
+    ),
+    "unparseable_python": (
+        "The file is not valid Python, so it was not read; any tool "
+        "registered in it is absent from this catalog."
     ),
 }
 
@@ -303,6 +388,20 @@ IDIOMS: tuple[RegistrationIdiom, ...] = (
         ),
         diff_tokens=("mcp.Tool{",),
     ),
+    RegistrationIdiom(
+        id="py_fastmcp_decorator",
+        language="python",
+        label="Python MCP server tool decorator",
+        reads=(
+            "A `@mcp.tool` decorator on a function, where `mcp` is bound to a "
+            "server construction this reader can follow. The name is "
+            "the `name=` literal when one is given and the decorated "
+            "function's otherwise, the description is the `description=` "
+            "literal or the docstring, and the parameters come from the "
+            "signature."
+        ),
+        diff_tokens=("@mcp.tool",),
+    ),
 )
 
 IDIOMS_BY_ID: dict[str, RegistrationIdiom] = {idiom.id: idiom for idiom in IDIOMS}
@@ -334,21 +433,63 @@ class RegistrationSite:
     description: str | None = None
     operation_type: str | None = None
     unresolved_reason: str | None = None
+    #: The decorated function's signature, for an idiom that reads one.
+    #: ``None`` means the idiom does not read signatures at all, which is a
+    #: different statement from a tool that takes no parameters (``()``).
+    parameters: tuple[SignatureParameter, ...] | None = None
+    #: The return annotation, rendered back to source. ``None`` when the
+    #: function is unannotated or the idiom reads no signature.
+    returns: str | None = None
+    #: Whether *this site alone* is evidence that the repository is an MCP
+    #: server, independently of whether its name could be read.
+    #:
+    #: For the lexical idioms it is always False: they match a *spelling*, and
+    #: `.registerTool(` in a repository that declares no MCP dependency is a
+    #: coincidence until the dependency says otherwise. The Python idiom only
+    #: emits a site at all once it has followed the decorated object back to a
+    #: ``FastMCP(...)`` construction, and a client does not construct a server
+    #: — so the site carries its own provenance, and discovery can offer the
+    #: route for a server whose every tool name is built at runtime.
+    #: ``neo4j-contrib/mcp-neo4j`` is exactly that server: 40 registrations,
+    #: every one of them ``name=namespace_prefix + "…"``.
+    proves_server: bool = False
+
+
+@dataclass(frozen=True)
+class SignatureParameter:
+    """One parameter of a decorated function, as written.
+
+    ``annotation`` is the annotation rendered back to source, never a resolved
+    type: resolving one means following imports into libraries this reader does
+    not read. The caller maps it to a JSON Schema type.
+    """
+
+    name: str
+    annotation: str | None = None
+    required: bool = True
 
 
 @dataclass(frozen=True)
 class SourceScanResult:
     """What one file yielded.
 
-    ``anomalies`` are masking failures — an unterminated string or block
-    comment. They are separate from an unresolved site because they are a fact
-    about the *file*, not about one registration: past the anomaly this reader
-    cannot tell code from content, so a site it did not find there proves
-    nothing.
+    ``anomalies`` are failures that hold the whole file — a masking failure for
+    a lexed language, a syntax error for Python. They are separate from an
+    unresolved site because they are a fact about the *file*, not about one
+    registration: past the anomaly this reader cannot tell code from content,
+    so a site it did not find there proves nothing.
+
+    ``server_modules`` are the other modules this file's proofs *depended on* —
+    the module ``from src.common.server import mcp`` resolved to. They are
+    reported because a route that covers the registrations but not the module
+    that constructs the server is a route on which ``scan`` proves less than
+    ``detect`` did, which is the detect/scan disagreement this input's shared
+    path predicate exists to prevent.
     """
 
     sites: tuple[RegistrationSite, ...] = ()
     anomalies: tuple[str, ...] = ()
+    server_modules: tuple[str, ...] = ()
 
 
 def language_for_path(path: Path | PurePosixPath | str) -> SourceLanguage | None:
@@ -379,6 +520,8 @@ def is_scannable_path(relative_path: Path | PurePosixPath | str) -> bool:
     if any(part.lower() in TEST_DIRECTORY_NAMES for part in parts[:-1]):
         return False
     name = path.name.lower()
+    if name in _TEST_FILE_NAMES or name.startswith(_TEST_FILE_PREFIXES):
+        return False
     return not name.endswith(_TEST_FILE_SUFFIXES)
 
 
@@ -521,6 +664,11 @@ class MaskedSource:
 def mask_source(text: str, language: SourceLanguage) -> MaskedSource:
     """Overwrite comments and string bodies, recording every string literal."""
 
+    if language not in LEXED_LANGUAGES:
+        # Refused rather than defaulted. The dispatch below has no third
+        # branch, so a language added to the registry without a masker would
+        # otherwise be read with JavaScript's grammar and answer confidently.
+        raise ValueError(f"{language!r} is not read with the masking lexer")
     if language == "go":
         return _mask_go(text)
     return _mask_typescript(text)
@@ -1402,7 +1550,814 @@ def _brace_depth(masked: str, open_brace: int, index: int) -> int:
     return depth
 
 
-def scan_source(text: str, language: SourceLanguage) -> SourceScanResult:
+# --- Python: the FastMCP decorator (#484) ------------------------------------
+#
+# The largest single shape in the #431 survey, and a different extraction
+# mechanism from the four idioms above. Three facts drive the design, and all
+# three were measured on the surveyed servers rather than assumed:
+#
+# 1. **The name is usually not written down.** `@mcp.tool()` on `def dbsize()`
+#    registers `dbsize`; only `@mcp.tool(name="…")` writes it as a literal. So
+#    the name comes from the *decorated function*, and a reader that only
+#    looked for a string beside the call would find nothing at all in
+#    `redis/mcp-redis` — 55 of 55 registrations.
+# 2. **The schema is the signature.** FastMCP builds the tool's input schema
+#    out of the annotated parameters, which is real information the TypeScript
+#    and Go idioms genuinely do not have.
+# 3. **Whether it registers anything is a binding fact.** `@app.tool()` is a
+#    tool registration when `app` is a `FastMCP`, and is somebody else's
+#    decorator otherwise. Nothing lexical separates the two, so this reader
+#    follows the name back to a `FastMCP(...)` construction and refuses — out
+#    loud, as a recorded omission — when it cannot. `awslabs/mcp` writes
+#    `@self.mcp.tool()` 20 times, on a server passed in as a constructor
+#    argument, and that is exactly the shape a proof must decline.
+#
+# The binding is followed **across modules** because the population requires
+# it: `redis/mcp-redis` constructs its server in `src/common/server.py` and
+# decorates in `src/tools/*.py`, so a per-file reader proves nothing about the
+# repository #484's acceptance criteria name. :class:`PythonServerIndex`
+# carries the module-scope constructions of the whole scanned tree, and an
+# import is resolved against it by matching path segments — never by importing
+# or executing anything.
+
+
+def _is_python_server_constructor(module: str, symbol: str) -> bool:
+    """Whether ``module.symbol`` names a class whose instance is an MCP server."""
+
+    return any(
+        symbol == known_symbol
+        and (module == known_module or module.startswith(f"{known_module}."))
+        for known_module, known_symbol in PYTHON_SERVER_CONSTRUCTORS
+    )
+
+
+def _names_a_python_server_class(text: str) -> bool:
+    """Whether ``text`` could construct a server at all.
+
+    A module that constructs one has to name the class, and the class is only
+    ever bound by an import this reader checks — so a file naming none of them
+    cannot contribute a construction and is never parsed.
+    """
+
+    lowered = text.lower()
+    return any(token in lowered for token in PYTHON_SERVER_PREFILTER_TOKENS)
+
+
+def normalized_distribution(requirement: str) -> str | None:
+    """The PEP 503 name a requirement string declares, or ``None``.
+
+    Written here rather than reused from discovery's general package-token
+    scan because that scan drops exactly the spelling this gate needs:
+    ``mcp[cli]>=1.26.0,<2`` — the requirement ``redis/mcp-redis`` and
+    ``chroma-core/chroma-mcp`` both declare — carries an extras marker, and a
+    token rule admitting only ``[A-Za-z0-9_.-]+`` throws the whole line away.
+    """
+
+    text = requirement.strip()
+    if not text or text.startswith("#"):
+        return None
+    match = re.match(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?", text)
+    if match is None:
+        return None
+    rest = text[match.end() :].lstrip()
+    # Anything may follow a distribution name — extras, a version specifier, a
+    # direct reference, an environment marker, a comment — except another word
+    # character, which would mean the match stopped inside a token this reader
+    # does not understand and the leading run is not the whole name.
+    if rest[:1] not in {"", "[", "(", "@", ";", "=", "<", ">", "!", "~", ",", "#"}:
+        return None
+    return re.sub(r"[-_.]+", "-", match.group(0)).lower()
+
+
+def declares_python_mcp_framework(requirements: Iterable[str]) -> str | None:
+    """The first requirement in ``requirements`` that names an MCP framework."""
+
+    for requirement in requirements:
+        name = normalized_distribution(requirement)
+        if name is not None and name in PYTHON_FRAMEWORK_PACKAGES:
+            return name
+    return None
+
+
+@dataclass(frozen=True)
+class _ImportBinding:
+    """What one imported name refers to.
+
+    ``symbol`` is ``None`` for ``import a.b`` and ``import a.b as c``, where
+    the bound name is an alias for a *module* rather than for something inside
+    one.
+    """
+
+    module: str
+    symbol: str | None
+    level: int
+
+
+class _PythonModule:
+    """One parsed module, with every name binding recorded per scope.
+
+    The binding table follows ``google_adk``'s rule (#400 review): a name means
+    what the module appears to say only when the module binds it **exactly
+    once** in the scope in effect. Two bindings make any resolution a guess
+    about which one ran, and a guess is not a proof — so the site becomes a
+    recorded omission instead of a catalogued tool.
+
+    Comprehension targets are deliberately not recorded. In Python 3 they bind
+    in the comprehension's own scope and cannot shadow the enclosing one, and a
+    ``def`` cannot appear inside a comprehension, so there is no decorator for
+    them to be in scope for either way.
+    """
+
+    def __init__(self, tree: ast.Module) -> None:
+        self.tree = tree
+        self._scopes: dict[int, ast.AST] = {}
+        self._bindings: dict[tuple[int, str], list[ast.AST]] = {}
+        self._imports: dict[tuple[int, str], _ImportBinding] = {}
+        #: A ``from x import *`` can rebind any name in the module, so nothing
+        #: in it is singly bound any more — including the ``FastMCP`` symbol a
+        #: construction rests on. Recorded once and consulted by every
+        #: resolution rather than approximated per name (#400 review).
+        self.star_import = False
+        self._visit(tree, tree)
+
+    # -- Construction ---------------------------------------------------
+
+    def _bind(self, scope: ast.AST, name: str, statement: ast.AST) -> None:
+        self._bindings.setdefault((id(scope), name), []).append(statement)
+
+    def _bind_target(
+        self, node: ast.AST | None, scope: ast.AST, statement: ast.AST
+    ) -> None:
+        if isinstance(node, ast.Name):
+            self._bind(scope, node.id, statement)
+        elif isinstance(node, ast.Tuple | ast.List):
+            for element in node.elts:
+                self._bind_target(element, scope, statement)
+        elif isinstance(node, ast.Starred):
+            self._bind_target(node.value, scope, statement)
+
+    def _visit(self, node: ast.AST, scope: ast.AST) -> None:
+        self._scopes[id(node)] = scope
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            self._visit_function(node, scope)
+            return
+        if isinstance(node, ast.ClassDef):
+            self._bind(scope, node.name, node)
+            for child in (*node.decorator_list, *node.bases):
+                self._visit(child, scope)
+            for keyword in node.keywords:
+                self._visit(keyword.value, scope)
+            for statement in node.body:
+                self._visit(statement, node)
+            return
+        self._record_bindings(node, scope)
+        for child in ast.iter_child_nodes(node):
+            self._visit(child, scope)
+
+    def _visit_function(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda, scope: ast.AST
+    ) -> None:
+        # A decorator, a default and an annotation are all evaluated where the
+        # ``def`` is written, not inside it. Reading them in the function's own
+        # scope would let a parameter named ``mcp`` shadow the module-level
+        # server for the very decorator that names it.
+        arguments = node.args
+        if not isinstance(node, ast.Lambda):
+            self._bind(scope, node.name, node)
+            for decorator in node.decorator_list:
+                self._visit(decorator, scope)
+            if node.returns is not None:
+                self._visit(node.returns, scope)
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self._visit(default, scope)
+        for argument in _python_arguments(arguments):
+            self._bind(node, argument.arg, argument)
+            if argument.annotation is not None:
+                self._visit(argument.annotation, scope)
+        body = node.body if isinstance(node.body, list) else [node.body]
+        for statement in body:
+            self._visit(statement, node)
+
+    def _record_bindings(self, node: ast.AST, scope: ast.AST) -> None:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                self._bind_target(target, scope, node)
+        elif isinstance(node, ast.AnnAssign | ast.AugAssign | ast.NamedExpr):
+            self._bind_target(node.target, scope, node)
+        elif isinstance(node, ast.For | ast.AsyncFor):
+            self._bind_target(node.target, scope, node)
+        elif isinstance(node, ast.withitem):
+            self._bind_target(node.optional_vars, scope, node)
+        elif isinstance(node, ast.ExceptHandler):
+            if node.name:
+                self._bind(scope, node.name, node)
+        elif isinstance(node, ast.Delete):
+            for target in node.targets:
+                self._bind_target(target, scope, node)
+        elif isinstance(node, ast.Global | ast.Nonlocal):
+            # Not a binding, but a declaration that the binding in effect lives
+            # in a scope this table did not build for this name. Recording it
+            # as one makes the name unprovable, which is the honest answer.
+            for name in node.names:
+                self._bind(scope, name, node)
+        elif isinstance(node, ast.MatchAs | ast.MatchStar):
+            if node.name:
+                self._bind(scope, node.name, node)
+        elif isinstance(node, ast.MatchMapping):
+            if node.rest:
+                self._bind(scope, node.rest, node)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                bound = alias.asname or alias.name.split(".", 1)[0]
+                module = alias.name if alias.asname else bound
+                self._bind(scope, bound, node)
+                self._imports[(id(scope), bound)] = _ImportBinding(
+                    module=module, symbol=None, level=0
+                )
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "*":
+                    self.star_import = True
+                    continue
+                bound = alias.asname or alias.name
+                self._bind(scope, bound, node)
+                self._imports[(id(scope), bound)] = _ImportBinding(
+                    module=node.module or "", symbol=alias.name, level=node.level
+                )
+
+    # -- Resolution -----------------------------------------------------
+
+    def _scope_chain(self, node: ast.AST) -> list[ast.AST]:
+        chain: list[ast.AST] = []
+        scope = self._scopes.get(id(node))
+        while scope is not None:
+            chain.append(scope)
+            if scope is self.tree:
+                break
+            scope = self._scopes.get(id(scope))
+        return chain
+
+    def binding_of(self, name: str, node: ast.AST) -> tuple[ast.AST, ast.AST] | None:
+        """The single binding of ``name`` in effect at ``node``, with its scope."""
+
+        if self.star_import:
+            return None
+        for scope in self._scope_chain(node):
+            bound = self._bindings.get((id(scope), name))
+            if bound is None:
+                continue
+            return (bound[0], scope) if len(bound) == 1 else None
+        return None
+
+    def import_of(self, name: str, node: ast.AST) -> _ImportBinding | None:
+        """``name``'s import binding at ``node``, when an import is what binds it."""
+
+        resolved = self.binding_of(name, node)
+        if resolved is None:
+            return None
+        binding, scope = resolved
+        if not isinstance(binding, ast.Import | ast.ImportFrom):
+            return None
+        return self._imports.get((id(scope), name))
+
+    def module_named(self, name: str, node: ast.AST) -> str | None:
+        """The dotted module ``name`` refers to, when it refers to one.
+
+        Both import forms can name a module: ``import mcp.server.fastmcp``
+        binds ``mcp``, and ``from mcp.server import fastmcp`` binds ``fastmcp``
+        to the same package one level further down.
+        """
+
+        binding = self.import_of(name, node)
+        if binding is None or binding.level:
+            return None
+        if binding.symbol is None:
+            return binding.module
+        return f"{binding.module}.{binding.symbol}" if binding.module else None
+
+    def is_fastmcp_construction(self, node: ast.AST | None) -> bool:
+        """Whether ``node`` is a call that constructs an MCP server."""
+
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        if isinstance(func, ast.Name):
+            binding = self.import_of(func.id, node)
+            return (
+                binding is not None
+                and binding.level == 0
+                and binding.symbol is not None
+                and _is_python_server_constructor(binding.module, binding.symbol)
+            )
+        dotted = _python_dotted_name(func)
+        if dotted is None:
+            return False
+        head, _, attribute = dotted.rpartition(".")
+        if not head:
+            return False
+        root, _, rest = head.partition(".")
+        module = self.module_named(root, node)
+        if module is None:
+            return False
+        return _is_python_server_constructor(
+            f"{module}.{rest}" if rest else module, attribute
+        )
+
+    def server_from_statement(self, statement: ast.AST, name: str) -> bool:
+        """Whether ``statement`` binds ``name`` to a server construction."""
+
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+        elif isinstance(statement, ast.AnnAssign):
+            targets = [statement.target]
+        else:
+            return False
+        # Only a plain ``name = FastMCP(...)``, or a chain of them. A tuple
+        # unpack binding the same name is binding it to an *element* of
+        # something this reader did not evaluate, whatever the right-hand side
+        # looks like, so the target has to be the whole left-hand side.
+        if name not in {
+            target.id for target in targets if isinstance(target, ast.Name)
+        }:
+            return False
+        return self.is_fastmcp_construction(statement.value)
+
+    def module_scope_servers(self) -> frozenset[str]:
+        """Module-scope names this module binds to a server construction.
+
+        This is what another module can import. A construction inside a factory
+        function is a server too — ``neo4j-contrib/mcp-neo4j`` builds all four
+        of its servers that way — but it is not reachable by name from outside,
+        so it never enters the index.
+        """
+
+        return frozenset(
+            name
+            for (scope_id, name), bound in self._bindings.items()
+            if scope_id == id(self.tree)
+            and len(bound) == 1
+            and self.server_from_statement(bound[0], name)
+        )
+
+
+def _python_arguments(arguments: ast.arguments) -> list[ast.arg]:
+    """Every named parameter, in signature order, variadics included."""
+
+    named = [*arguments.posonlyargs, *arguments.args]
+    if arguments.vararg is not None:
+        named.append(arguments.vararg)
+    named.extend(arguments.kwonlyargs)
+    if arguments.kwarg is not None:
+        named.append(arguments.kwarg)
+    return named
+
+
+def _python_dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _python_dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else None
+    return None
+
+
+def python_server_exports(text: str) -> frozenset[str]:
+    """Module-scope names ``text`` binds to an MCP server construction.
+
+    Answers ``frozenset()`` for a module that cannot be parsed. The caller that
+    *reads* the module reports the syntax error as an anomaly; reporting it
+    twice would put one file's problem into two vocabularies.
+    """
+
+    # A cost bound, never a decision. Deleting this line changes no answer the
+    # corpus can produce and no answer it should be able to produce: a module
+    # that constructs a server has to name the class, so a file this refuses
+    # is one the parse below would find nothing in. A perturbation sweep
+    # reports it as untested, and that is the correct result for a prefilter —
+    # one that changed an answer would be the defect.
+    if not _names_a_python_server_class(text):
+        return frozenset()
+    tree = _parse_python(text)
+    if tree is None:
+        return frozenset()
+    return _PythonModule(tree).module_scope_servers()
+
+
+def _parse_python(text: str) -> ast.Module | None:
+    try:
+        return ast.parse(text)
+    except (SyntaxError, ValueError, RecursionError, MemoryError):
+        # ``ValueError`` for source containing a NUL byte, ``RecursionError``
+        # for a deeply nested expression: both are the compiler declining to
+        # produce a tree, which is the same fact as a syntax error and has to
+        # be one recorded omission rather than an exception out of the walk.
+        return None
+
+
+@dataclass(frozen=True)
+class PythonServerIndex:
+    """Which modules in the scanned tree export an MCP server by name.
+
+    Built once per scan and consulted per file, because the population needs
+    it: ``redis/mcp-redis`` constructs its server in ``src/common/server.py``
+    and applies all 55 of its decorators in ``src/tools/*.py``.
+
+    Resolution matches *path segments* against the dotted module a file
+    imports from, and it is anchored at neither end. The scanned root is
+    wherever ``tool_sources[].path`` points, so a module reached as
+    ``src.common.server`` may sit at ``common/server.py`` when the root is
+    ``src/`` and at ``src/common/server.py`` when it is the repository — one
+    import, two path spellings, and the reader is not told which. A match
+    therefore counts when either side's segments end with the other's, and
+    only when **exactly one** module in the index matches: two candidates mean
+    this reader cannot tell which module was imported, and a guess about that
+    is a guess about whether the decorator registers a tool at all.
+    """
+
+    modules: dict[str, frozenset[str]] = field(default_factory=dict)
+
+    @classmethod
+    def build(cls, modules: Iterable[tuple[str, str]]) -> PythonServerIndex:
+        """Index ``(relative posix path, source text)`` pairs."""
+
+        indexed: dict[str, frozenset[str]] = {}
+        for path, text in modules:
+            exports = python_server_exports(text)
+            if exports:
+                indexed[path] = exports
+        return cls(indexed)
+
+    def resolve(self, module_path: str | None, module: str, level: int) -> str | None:
+        """The indexed module an import in ``module_path`` refers to."""
+
+        if not self.modules:
+            return None
+        parts = tuple(part for part in module.split(".") if part)
+        if level:
+            if module_path is None:
+                return None
+            package = PurePosixPath(module_path).parent
+            for _ in range(level - 1):
+                if package == PurePosixPath("."):
+                    return None
+                package = package.parent
+            for candidate in _python_module_paths(package, parts):
+                if candidate in self.modules:
+                    return candidate
+            return None
+        if not parts:
+            return None
+        matches = [
+            path
+            for path in sorted(self.modules)
+            if _python_module_key_matches(_python_module_key(path), parts)
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+
+def _python_module_key(path: str) -> tuple[str, ...]:
+    """The dotted-path segments a module file would be imported as."""
+
+    pure = PurePosixPath(path)
+    parts = pure.with_suffix("").parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return parts
+
+
+def _python_module_key_matches(key: tuple[str, ...], parts: tuple[str, ...]) -> bool:
+    if not key or not parts:
+        return False
+    if len(key) <= len(parts):
+        return parts[-len(key) :] == key
+    return key[-len(parts) :] == parts
+
+
+def _python_module_paths(
+    package: PurePosixPath, parts: tuple[str, ...]
+) -> tuple[str, ...]:
+    base = package.joinpath(*parts) if parts else package
+    return (
+        (base / "__init__.py").as_posix(),
+        base.with_suffix(".py").as_posix() if parts else "",
+    )
+
+
+def _python_sites(
+    text: str,
+    *,
+    module_path: str | None,
+    server_index: PythonServerIndex | None,
+) -> SourceScanResult:
+    """Every MCP server tool decorator in one module."""
+
+    tree = _parse_python(text)
+    if tree is None:
+        return SourceScanResult(anomalies=("unparseable_python",))
+    module = _PythonModule(tree)
+    offsets = _PythonOffsets(text)
+    index = server_index or PythonServerIndex()
+    sites: list[RegistrationSite] = []
+    server_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            receiver = _python_tool_receiver(decorator, module)
+            if receiver is None:
+                continue
+            proven, proving_module = _python_server_receiver(
+                module, receiver, index, module_path
+            )
+            if proving_module is not None:
+                server_modules.add(proving_module)
+            sites.append(
+                _python_site(node, decorator, receiver, offsets, proven=proven)
+            )
+    sites.sort(key=lambda site: (site.line, site.column))
+    return SourceScanResult(
+        sites=tuple(sites), server_modules=tuple(sorted(server_modules))
+    )
+
+
+def _python_tool_receiver(
+    decorator: ast.expr, module: _PythonModule
+) -> ast.expr | None:
+    """The object a ``.tool`` decorator registers on, or ``None``.
+
+    Three spellings, one meaning. FastMCP 2.x accepts a bare ``@mcp.tool``,
+    every surveyed server writes ``@mcp.tool()``, and a module may bind the
+    bound method to a name of its own first — ``register = mcp.tool`` and then
+    ``@register``. The third is followed through exactly **one** hop, the same
+    depth the zero-install detector's constant resolution uses: a chain of
+    aliases is unbounded, and each extra hop buys a shape nobody was measured
+    writing while widening what can be mistaken for a registration.
+    """
+
+    expression = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if (
+        isinstance(expression, ast.Attribute)
+        and expression.attr == PYTHON_TOOL_DECORATOR_ATTR
+    ):
+        return expression.value
+    if not isinstance(expression, ast.Name):
+        return None
+    resolved = module.binding_of(expression.id, expression)
+    if resolved is None:
+        return None
+    binding, _scope = resolved
+    # Only ``alias = <something>.tool``. Every other decorator in the language
+    # binds to something else — ``@staticmethod`` to an import, ``@deco`` to a
+    # ``def`` — so this cannot turn an ordinary decorator into a registration.
+    if not isinstance(binding, ast.Assign) or not all(
+        isinstance(target, ast.Name) for target in binding.targets
+    ):
+        return None
+    value = binding.value
+    if (
+        isinstance(value, ast.Attribute)
+        and value.attr == PYTHON_TOOL_DECORATOR_ATTR
+    ):
+        return value.value
+    return None
+
+
+def _python_server_receiver(
+    module: _PythonModule,
+    receiver: ast.expr,
+    index: PythonServerIndex,
+    module_path: str | None,
+) -> tuple[bool, str | None]:
+    """Whether ``receiver`` is a proven MCP server, and what proved it.
+
+    A bare name is the only shape a proof is attempted for. ``@self.mcp.tool``
+    reaches through an attribute this reader would have to know the type of,
+    and ``awslabs/mcp`` writes it on a server handed in as a constructor
+    argument — so the receiver is a server there and this reader still cannot
+    show it, which is what the recorded omission says.
+    """
+
+    if not isinstance(receiver, ast.Name):
+        return False, None
+    resolved = module.binding_of(receiver.id, receiver)
+    if resolved is None:
+        return False, None
+    binding, _scope = resolved
+    if module.server_from_statement(binding, receiver.id):
+        return True, None
+    # A function-local ``from .server import mcp`` binds the same name from the
+    # same module as one at the top of the file, and resolving it is the same
+    # question. Restricting the proof to module scope refused a shape the
+    # index can answer, for no reason a test could state.
+    if not isinstance(binding, ast.ImportFrom):
+        return False, None
+    imported = module.import_of(receiver.id, receiver)
+    if imported is None or imported.symbol is None:
+        return False, None
+    target = index.resolve(module_path, imported.module, imported.level)
+    if target is None or imported.symbol not in index.modules.get(target, frozenset()):
+        return False, None
+    return True, target
+
+
+def _python_site(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    decorator: ast.expr,
+    receiver: ast.expr,
+    offsets: _PythonOffsets,
+    *,
+    proven: bool,
+) -> RegistrationSite:
+    line, column = decorator.lineno, offsets.column(decorator)
+    # The span is the decorator expression, not the function it decorates.
+    # ``_contains_another_site`` drops an unresolved site that contains a
+    # resolved one, and a decorated function's body can hold a nested
+    # registration of its own — so a span covering the body would silently
+    # delete the outer omission. A decorator expression cannot contain a
+    # registration, which is what makes it the construct that registers.
+    span = (offsets.offset(decorator), offsets.end_offset(decorator))
+    if not proven:
+        return RegistrationSite(
+            idiom="py_fastmcp_decorator",
+            name=None,
+            line=line,
+            column=column,
+            span=span,
+            unresolved_reason="server_binding_not_proven",
+        )
+    del receiver
+    name, unresolved = _python_tool_name(node, decorator)
+    return RegistrationSite(
+        idiom="py_fastmcp_decorator",
+        name=name,
+        line=line,
+        column=column,
+        span=span,
+        description=_python_tool_description(node, decorator),
+        unresolved_reason=unresolved,
+        parameters=_python_signature(node),
+        returns=_python_annotation(node.returns),
+        proves_server=True,
+    )
+
+
+def _python_tool_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, decorator: ast.expr
+) -> tuple[str | None, str | None]:
+    """The registered name, or why it could not be read.
+
+    FastMCP takes the name from ``name=``, then from a single positional
+    argument, and defaults to the decorated function's. The default is not a
+    guess — it is the framework's documented rule and the spelling 55 of 55
+    ``redis/mcp-redis`` registrations use — but a ``name=`` this reader cannot
+    resolve is never *replaced* by it: ``neo4j-contrib/mcp-neo4j`` registers
+    ``namespace_prefix + "delete_instance"``, and answering ``delete_instance``
+    there would publish a name that server does not serve.
+    """
+
+    if isinstance(decorator, ast.Call):
+        given = _python_keyword(decorator, "name")
+        if given is None and decorator.args:
+            given = decorator.args[0]
+        if given is not None:
+            return _resolve_name(_python_string(given), True)
+    return _resolve_name(node.name, True)
+
+
+def _python_tool_description(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, decorator: ast.expr
+) -> str | None:
+    """The description FastMCP would register: ``description=`` or the docstring."""
+
+    if isinstance(decorator, ast.Call):
+        given = _python_keyword(decorator, "description")
+        if given is not None:
+            return _python_string(given)
+    try:
+        return ast.get_docstring(node, clean=True)
+    except (TypeError, ValueError):  # pragma: no cover - malformed docstring node
+        return None
+
+
+def _python_keyword(call: ast.Call, name: str) -> ast.expr | None:
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _python_string(node: ast.expr) -> str | None:
+    """The value of ``node`` when it is a whole string literal.
+
+    An f-string, a concatenation and a ``.format`` call all resolve to
+    something only at run time, and this returns ``None`` for each — the same
+    answer :func:`_literal_is_whole_value` gives the lexed languages when a
+    literal is only *part* of the value.
+    """
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _python_signature(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[SignatureParameter, ...]:
+    arguments = node.args
+    positional = [*arguments.posonlyargs, *arguments.args]
+    defaults: list[ast.expr | None] = [None] * (
+        len(positional) - len(arguments.defaults)
+    )
+    defaults.extend(arguments.defaults)
+    parameters = [
+        SignatureParameter(
+            name=argument.arg,
+            annotation=_python_annotation(argument.annotation),
+            required=default is None,
+        )
+        for argument, default in zip(positional, defaults, strict=True)
+    ]
+    parameters.extend(
+        SignatureParameter(
+            name=argument.arg,
+            annotation=_python_annotation(argument.annotation),
+            required=default is None,
+        )
+        for argument, default in zip(
+            arguments.kwonlyargs, arguments.kw_defaults, strict=True
+        )
+    )
+    # ``*args`` and ``**kwargs`` are deliberately absent: they are not schema
+    # properties, and a tool that has them takes arguments this reader cannot
+    # enumerate rather than one parameter named ``kwargs``.
+    return tuple(parameters)
+
+
+def _python_annotation(node: ast.expr | None) -> str | None:
+    if node is None:
+        return None
+    try:
+        return ast.unparse(node)
+    except (AttributeError, ValueError, RecursionError):  # pragma: no cover
+        return None
+
+
+class _PythonOffsets:
+    """Character offsets for ``ast`` positions.
+
+    ``col_offset`` is a **UTF-8 byte** offset into the line, while every other
+    offset this module publishes is a character offset into the text. A source
+    line containing a non-ASCII character makes the two differ, so the
+    conversion is done rather than assumed.
+    """
+
+    def __init__(self, text: str) -> None:
+        self._lines = text.splitlines(keepends=True)
+        self._starts: list[int] = []
+        offset = 0
+        for line in self._lines:
+            self._starts.append(offset)
+            offset += len(line)
+        self._length = offset
+
+    def _character_column(self, line: int, byte_column: int) -> int:
+        if not 1 <= line <= len(self._lines):
+            return 0
+        raw = self._lines[line - 1].encode("utf-8")[:byte_column]
+        return len(raw.decode("utf-8", errors="ignore"))
+
+    def offset(self, node: ast.AST) -> int:
+        line = getattr(node, "lineno", 1)
+        if not 1 <= line <= len(self._starts):
+            return self._length
+        return self._starts[line - 1] + self._character_column(
+            line, getattr(node, "col_offset", 0)
+        )
+
+    def end_offset(self, node: ast.AST) -> int:
+        line = getattr(node, "end_lineno", None)
+        if line is None or not 1 <= line <= len(self._starts):
+            return self._length
+        return self._starts[line - 1] + self._character_column(
+            line, getattr(node, "end_col_offset", 0)
+        )
+
+    def column(self, node: ast.AST) -> int:
+        """The 1-based character column, matching :meth:`MaskedSource.line_column`."""
+
+        return self._character_column(
+            getattr(node, "lineno", 1), getattr(node, "col_offset", 0)
+        ) + 1
+
+
+def scan_source(
+    text: str,
+    language: SourceLanguage,
+    *,
+    module_path: str | None = None,
+    server_index: PythonServerIndex | None = None,
+) -> SourceScanResult:
     """Find every registration site in one file.
 
     An unresolved site is dropped when a resolved one sits inside it. The
@@ -1411,10 +2366,21 @@ def scan_source(text: str, language: SourceLanguage) -> SourceScanResult:
     reporting the wrapper's non-literal first argument as an unenumerated tool
     would fill the exclusion ledger with omissions for tools the very same call
     names one argument later.
+
+    ``module_path`` and ``server_index`` are the Python idiom's cross-module
+    binding evidence and are ignored by the lexed languages, which resolve a
+    name against nothing outside the file. Omitting them is not an error: it
+    reads the module on its own, which proves every construction written in it
+    and no import of one — the reason they are optional is that most callers
+    (and every corpus case) ask about one file.
     """
 
     if PREFILTER_TOKEN not in text.lower():
         return SourceScanResult()
+    if language == "python":
+        return _python_sites(
+            text, module_path=module_path, server_index=server_index
+        )
     source = mask_source(text, language)
     sites: list[RegistrationSite] = []
     if language == "typescript":

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -232,6 +232,10 @@ _TEST_FILE_SUFFIXES: tuple[str, ...] = (
 #: ``pytest`` collects ``test_*.py`` by default, so a suffix-only rule reads
 #: ``test_server.py`` as the server. ``conftest.py`` is matched whole because
 #: it is neither.
+#:
+#: Applied to Python only. ``test_helpers.ts`` and ``test_util.go`` are
+#: ordinary module names, and an excluded path is never read — so widening
+#: this to them would drop a surface with no omission to show for it.
 _TEST_FILE_PREFIXES: tuple[str, ...] = ("test_",)
 _TEST_FILE_NAMES: frozenset[str] = frozenset({"conftest.py"})
 
@@ -520,7 +524,14 @@ def is_scannable_path(relative_path: Path | PurePosixPath | str) -> bool:
     if any(part.lower() in TEST_DIRECTORY_NAMES for part in parts[:-1]):
         return False
     name = path.name.lower()
-    if name in _TEST_FILE_NAMES or name.startswith(_TEST_FILE_PREFIXES):
+    # Scoped to Python, because the *reason* is: pytest collects `test_*.py`,
+    # so a suffix-only rule reads `test_server.py` as the server. `test_util.go`
+    # and `test_helpers.ts` are ordinary module names, and excluding one costs
+    # a surface with no omission to show for it — an excluded path is never
+    # read, so nothing records that it was skipped.
+    if language_for_path(path) == "python" and (
+        name in _TEST_FILE_NAMES or name.startswith(_TEST_FILE_PREFIXES)
+    ):
         return False
     return not name.endswith(_TEST_FILE_SUFFIXES)
 
@@ -1703,7 +1714,23 @@ class _PythonModule:
             return
         if isinstance(node, ast.ClassDef):
             self._bind(scope, node.name, node)
-            for child in (*node.decorator_list, *node.bases):
+            for child in (
+                *node.decorator_list,
+                *node.bases,
+                # PEP 695 type parameters — the one child list of a scope
+                # node this walk would otherwise skip.
+                #
+                # Inert for any module Python will run, and knowably so: the
+                # only construct that could bind a name here is a walrus, and
+                # `compile` refuses one in a TypeVar bound ("named expression
+                # cannot be used within a TypeVar bound") even though
+                # `ast.parse` accepts it. So a perturbation sweep reports this
+                # line untested and is right to. It is here because the rule is
+                # "visit every child list of a scope node", and a reader who
+                # later adds a construct to `type_params` should not have to
+                # rediscover the gap.
+                *getattr(node, "type_params", ()),
+            ):
                 self._visit(child, scope)
             for keyword in node.keywords:
                 self._visit(keyword.value, scope)
@@ -1726,6 +1753,8 @@ class _PythonModule:
             self._bind(scope, node.name, node)
             for decorator in node.decorator_list:
                 self._visit(decorator, scope)
+            for parameter in getattr(node, "type_params", ()):
+                self._visit(parameter, scope)
             if node.returns is not None:
                 self._visit(node.returns, scope)
         for default in (*arguments.defaults, *arguments.kw_defaults):
@@ -1789,10 +1818,22 @@ class _PythonModule:
     # -- Resolution -----------------------------------------------------
 
     def _scope_chain(self, node: ast.AST) -> list[ast.AST]:
+        """The scopes a name at ``node`` is looked up in, innermost first.
+
+        A class body is searched only when it is the scope the name is written
+        in. Python does not close over class scope: a function nested inside a
+        method resolves ``mcp`` to the module, never to a class attribute of
+        the same name, so keeping the class in the chain made a module-level
+        server unreachable from a decorator written one level in — and, the
+        other way round, could resolve a class attribute the interpreter never
+        consults.
+        """
+
         chain: list[ast.AST] = []
         scope = self._scopes.get(id(node))
         while scope is not None:
-            chain.append(scope)
+            if not isinstance(scope, ast.ClassDef) or not chain:
+                chain.append(scope)
             if scope is self.tree:
                 break
             scope = self._scopes.get(id(scope))
@@ -2037,10 +2078,19 @@ def _python_module_key_matches(key: tuple[str, ...], parts: tuple[str, ...]) -> 
 def _python_module_paths(
     package: PurePosixPath, parts: tuple[str, ...]
 ) -> tuple[str, ...]:
-    base = package.joinpath(*parts) if parts else package
+    if not parts:
+        # ``from . import x`` names no module path of its own: what it binds is
+        # an attribute of the package's ``__init__``, which is where a name it
+        # re-exports would be bound. That is Python's rule and not an
+        # approximation of it: after ``from . import server``, the name
+        # is the submodule *unless* ``__init__`` binds something else
+        # of that name, and a submodule has no ``.tool`` to register
+        # with — so the only case worth resolving is the re-export.
+        return ((package / "__init__.py").as_posix(),)
+    base = package.joinpath(*parts)
     return (
         (base / "__init__.py").as_posix(),
-        base.with_suffix(".py").as_posix() if parts else "",
+        base.with_suffix(".py").as_posix(),
     )
 
 
@@ -2056,8 +2106,8 @@ def _python_sites(
     if tree is None:
         return SourceScanResult(anomalies=("unparseable_python",))
     module = _PythonModule(tree)
-    offsets = _PythonOffsets(text)
     index = server_index or PythonServerIndex()
+    offsets: _PythonOffsets | None = None
     sites: list[RegistrationSite] = []
     server_modules: set[str] = set()
     for node in ast.walk(tree):
@@ -2072,8 +2122,14 @@ def _python_sites(
             )
             if proving_module is not None:
                 server_modules.add(proving_module)
+            # Built on the first site, not per file: most modules that pass the
+            # `"tool"` prefilter register nothing — a variable of that name, a
+            # word in a docstring — and the line table would be built and
+            # thrown away for every one of them.
+            if offsets is None:
+                offsets = _PythonOffsets(text)
             sites.append(
-                _python_site(node, decorator, receiver, offsets, proven=proven)
+                _python_site(node, decorator, offsets, proven=proven)
             )
     sites.sort(key=lambda site: (site.line, site.column))
     return SourceScanResult(
@@ -2164,7 +2220,6 @@ def _python_server_receiver(
 def _python_site(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     decorator: ast.expr,
-    receiver: ast.expr,
     offsets: _PythonOffsets,
     *,
     proven: bool,
@@ -2186,7 +2241,6 @@ def _python_site(
             span=span,
             unresolved_reason="server_binding_not_proven",
         )
-    del receiver
     name, unresolved = _python_tool_name(node, decorator)
     return RegistrationSite(
         idiom="py_fastmcp_decorator",

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -313,6 +313,12 @@ OMISSION_REASONS: dict[str, str] = {
         "follow to an MCP server, so whether it registers a tool — "
         "and under what name — cannot be read from the source."
     ),
+    "wrapped_before_registration": (
+        "Another decorator is applied to this function before the registration "
+        "sees it, and what that decorator returns is not readable here — so "
+        "the name and parameters the server registers may belong to some other "
+        "function entirely."
+    ),
     "unparseable_python": (
         "The file is not valid Python, so it was not read; any tool "
         "registered in it is absent from this catalog."
@@ -2014,20 +2020,29 @@ class PythonServerIndex:
     only when **exactly one** module in the index matches: two candidates mean
     this reader cannot tell which module was imported, and a guess about that
     is a guess about whether the decorator registers a tool at all.
+
+    **Every scanned module is in the index, exporting nothing where it
+    constructs nothing.** Holding only the servers would take the *conflicting*
+    candidate out of the universe before the uniqueness check runs: a
+    ``src/common/server.py`` that binds ``mcp`` to something else, beside an
+    ``archive/src/common/server.py`` that really does build one, would resolve
+    uniquely — to the archive — and lend a decorator binding evidence from a
+    module the import demonstrably did not name. Ambiguity has to be measured
+    against what is *there*, not against what happened to qualify.
     """
 
+    #: Every scanned module, mapped to the server names it exports — empty for
+    #: a module that exports none, which is what keeps it in the universe the
+    #: uniqueness check is measured against.
     modules: dict[str, frozenset[str]] = field(default_factory=dict)
 
     @classmethod
     def build(cls, modules: Iterable[tuple[str, str]]) -> PythonServerIndex:
         """Index ``(relative posix path, source text)`` pairs."""
 
-        indexed: dict[str, frozenset[str]] = {}
-        for path, text in modules:
-            exports = python_server_exports(text)
-            if exports:
-                indexed[path] = exports
-        return cls(indexed)
+        return cls(
+            {path: python_server_exports(text) for path, text in modules}
+        )
 
     def resolve(self, module_path: str | None, module: str, level: int) -> str | None:
         """The indexed module an import in ``module_path`` refers to."""
@@ -2113,7 +2128,7 @@ def _python_sites(
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
-        for decorator in node.decorator_list:
+        for position, decorator in enumerate(node.decorator_list):
             receiver = _python_tool_receiver(decorator, module)
             if receiver is None:
                 continue
@@ -2122,6 +2137,10 @@ def _python_sites(
             )
             if proving_module is not None:
                 server_modules.add(proving_module)
+            # Everything *below* the registration in the source runs first, so
+            # the object `.tool` receives is that decorator's return value and
+            # not this `def`. See :func:`_python_wrapped_before_registration`.
+            wrapped = bool(node.decorator_list[position + 1 :])
             # Built on the first site, not per file: most modules that pass the
             # `"tool"` prefilter register nothing — a variable of that name, a
             # word in a docstring — and the line table would be built and
@@ -2129,7 +2148,9 @@ def _python_sites(
             if offsets is None:
                 offsets = _PythonOffsets(text)
             sites.append(
-                _python_site(node, decorator, offsets, proven=proven)
+                _python_site(
+                    node, decorator, offsets, proven=proven, wrapped=wrapped
+                )
             )
     sites.sort(key=lambda site: (site.line, site.column))
     return SourceScanResult(
@@ -2217,12 +2238,35 @@ def _python_server_receiver(
     return True, target
 
 
+def _python_wrapped_before_registration() -> None:
+    """Why a decorator below the registration withholds the name.
+
+    Decorators apply bottom-up: ``@mcp.tool()`` over ``@replace`` registers
+    ``replace(harmless)``, so the name is that object's ``__name__`` and the
+    schema is ``inspect.signature`` of it — neither of which need be this
+    ``def``'s. A wrapper built with ``functools.wraps`` does preserve both
+    (``inspect.signature`` follows ``__wrapped__``), and every one of the 106
+    such sites measured in ``awslabs/mcp`` is that shape or a plain
+    ``return func``. But *that* is a fact about the decorator's body, in
+    another module for most of them, and this reader does not read function
+    bodies across modules. Seeing ``@audited`` at the use site proves nothing.
+
+    So the site keeps its provenance — it is still a registration, and still
+    proves a server — and loses its *name*, which is the direction #431 settled
+    for the Go octal escape: an action id nobody serves is worse than a
+    recorded omission. Measured cost: ``awslabs/mcp`` 334 → 228 named tools,
+    with the other 106 in the exclusion ledger; the four servers in #484's
+    acceptance criteria have no such site at all.
+    """
+
+
 def _python_site(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     decorator: ast.expr,
     offsets: _PythonOffsets,
     *,
     proven: bool,
+    wrapped: bool,
 ) -> RegistrationSite:
     line, column = decorator.lineno, offsets.column(decorator)
     # The span is the decorator expression, not the function it decorates.
@@ -2241,7 +2285,11 @@ def _python_site(
             span=span,
             unresolved_reason="server_binding_not_proven",
         )
-    name, unresolved = _python_tool_name(node, decorator)
+    name, unresolved = (
+        (None, "wrapped_before_registration")
+        if wrapped
+        else _python_tool_name(node, decorator)
+    )
     return RegistrationSite(
         idiom="py_fastmcp_decorator",
         name=name,
@@ -2250,8 +2298,11 @@ def _python_site(
         span=span,
         description=_python_tool_description(node, decorator),
         unresolved_reason=unresolved,
-        parameters=_python_signature(node),
-        returns=_python_annotation(node.returns),
+        # Withheld with the name: the schema comes from the same object, so a
+        # signature published beside an unreadable name would be a parameter
+        # list for a function the server may not have registered.
+        parameters=None if wrapped else _python_signature(node),
+        returns=None if wrapped else _python_annotation(node.returns),
         proves_server=True,
     )
 
@@ -2271,6 +2322,13 @@ def _python_tool_name(
     """
 
     if isinstance(decorator, ast.Call):
+        if any(keyword.arg is None for keyword in decorator.keywords):
+            # ``@mcp.tool(**options)``. A ``**`` unpacking can carry ``name``,
+            # and whether it does is decided at run time — so the framework's
+            # default is no longer known to apply, and falling back to the
+            # function's name would publish ``harmless`` for a tool the server
+            # registers as whatever the mapping said.
+            return None, "name_not_literal"
         given = _python_keyword(decorator, "name")
         if given is None and decorator.args:
             given = decorator.args[0]

--- a/src/agents_shipgate/inputs/mcp_server_source.py
+++ b/src/agents_shipgate/inputs/mcp_server_source.py
@@ -37,6 +37,7 @@ the exclusion ledger accounts for by subject.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 from typing import ClassVar, Literal
 
@@ -98,6 +99,21 @@ EXTRACTION_CONFIDENCE = "medium"
 #: contributed at ``partial``: past the cap, nothing is known about what was
 #: not read.
 MAX_SCANNED_FILES = 4000
+
+#: How many bytes of Python source the index pass keeps for the scan pass.
+#:
+#: A cost bound and never a decision: past it a file is simply read twice
+#: instead of once, so no answer moves and nothing is recorded. That is what
+#: makes it different from every other cap in this module — exceeding
+#: :data:`MAX_SCANNED_FILES` or :data:`MAX_SOURCE_FILE_BYTES` leaves a hole in
+#: the enumeration and has to be reported; exceeding this one leaves a hole in
+#: nothing.
+#:
+#: Sized against the measurement: all of ``awslabs/mcp``'s non-test Python is
+#: 12.8 MB, so the largest server in the survey is read once. The bound exists
+#: for the shape the file cap alone does not stop — 4,000 files of 8 MB each
+#: would be 32 GB held to save a second read.
+MAX_CACHED_SOURCE_BYTES = 64 * 1024 * 1024
 
 #: ``operationType``-style classifications an idiom can read, mapped to the
 #: risk-tag vocabulary. Deliberately partial, in one direction only.
@@ -176,14 +192,15 @@ def load_mcp_server_source(source: ToolSourceConfig, base_dir: Path) -> LoadedTo
             ),
         )
 
-    server_index = _python_server_index(files, root)
+    server_index, python_texts = _python_server_index(files, root)
 
     for path in files:
         language = language_for_path(path)
         assert language is not None  # guaranteed by _scannable_files
         relative = _relative_source_path(path, source.path, base_dir)
         unread = _unread_reason(path)
-        if unread is None:
+        text = python_texts.pop(path, None)
+        if unread is None and text is None:
             try:
                 text = load_text_file(path)
             except InputParseError:
@@ -287,38 +304,55 @@ def _apply_source_gaps(tools: list[Tool], gaps: list[str]) -> None:
         tool.extraction["surface_gaps"] = merged
 
 
-def _python_server_index(files: list[Path], root: Path) -> PythonServerIndex:
-    """Index every module in the walk that constructs a FastMCP server.
+def _python_server_index(
+    files: list[Path], root: Path
+) -> tuple[PythonServerIndex, dict[Path, str]]:
+    """Index every module in the walk that constructs an MCP server.
 
-    A second read of the Python files, ahead of the one that scans them, and
-    the ordering is the whole point: ``redis/mcp-redis`` applies all 55 of its
+    A pass over the Python files ahead of the one that scans them, and the
+    ordering is the whole point: ``redis/mcp-redis`` applies all 53 of its
     decorators in ``src/tools/*.py`` and constructs the server they register on
     in ``src/common/server.py``, so a reader that resolved bindings as it went
     would prove or refuse the same decorator depending on walk order.
 
-    The extra read is bounded by the prefilter inside
-    :func:`~agents_shipgate.inputs.mcp_idioms.python_server_exports`: a module
-    that never names ``fastmcp`` cannot construct one and is not parsed. What
-    is *not* bounded away is the read itself, which is why this walks only the
-    Python files — the TypeScript and Go halves of a mixed repository are read
-    once, as before.
+    The texts come back with the index so the scan pass does not read them a
+    second time — on ``awslabs/mcp`` that is 2,500 files' worth of I/O — up to
+    :data:`MAX_CACHED_SOURCE_BYTES`, past which a file is read twice rather
+    than held. Only Python files are held either way: the TypeScript and Go
+    halves of a mixed repository are streamed as before, one read each.
     """
 
-    modules: list[tuple[str, str]] = []
-    for path in files:
-        if language_for_path(path) != "python" or _unread_reason(path) is not None:
-            continue
-        relative = _root_relative(path, root)
-        if relative is None:
-            continue
-        try:
-            modules.append((relative, load_text_file(path)))
-        except InputParseError:
-            # Reported as an omission by the read loop, which is the pass that
-            # owns the file's surface. Recording it here too would put one
-            # file's problem into the ledger twice.
-            continue
-    return PythonServerIndex.build(modules)
+    texts: dict[Path, str] = {}
+    cached = 0
+
+    def _modules() -> Iterator[tuple[str, str]]:
+        # A generator, so ``build`` sees one module at a time and keeps only
+        # each one's exported names. Materialising the list would hold every
+        # file's text alive at once, which is the cost the bound above exists
+        # to refuse.
+        nonlocal cached
+        for path in files:
+            if (
+                language_for_path(path) != "python"
+                or _unread_reason(path) is not None
+            ):
+                continue
+            relative = _root_relative(path, root)
+            if relative is None:
+                continue
+            try:
+                text = load_text_file(path)
+            except InputParseError:
+                # Reported as an omission by the read loop, which is the pass
+                # that owns the file's surface. Recording it here too would put
+                # one file's problem into the ledger twice.
+                continue
+            if cached + len(text) <= MAX_CACHED_SOURCE_BYTES:
+                texts[path] = text
+                cached += len(text)
+            yield relative, text
+
+    return PythonServerIndex.build(_modules()), texts
 
 
 def _root_relative(path: Path, root: Path) -> str | None:

--- a/src/agents_shipgate/inputs/mcp_server_source.py
+++ b/src/agents_shipgate/inputs/mcp_server_source.py
@@ -14,12 +14,19 @@ is exactly such an artifact. Effect and authority still come from the
 declaration questionnaire (#410). The one thing the source is trusted to state
 is a name, which is checkable against the registration site that carries it.
 
+The Python idiom (#484) also reads the decorated function's **signature**,
+because for FastMCP that is where the input schema comes from — it is written
+in the same file, at the same site, and checking it costs no inference. That
+does not lift the ceiling: a signature is what the author wrote, not what the
+server publishes, and the ``medium`` bound is about the route, not about how
+much of it was read.
+
 Where a repository publishes a committed export, that export stays the better
-route: it is the server's own contract, it carries the input schemas this input
-deliberately does not read, and it is ``high`` confidence against this input's
-``medium``. ``detect`` therefore withholds this route wherever an export
-already covers the scope, and an adopter with both configured keeps the
-export's evidence untouched.
+route: it is the server's own contract published in the shape a client
+receives it, and it is ``high`` confidence against this input's ``medium``.
+``detect`` therefore withholds this route wherever an export already covers
+the scope, and an adopter with both configured keeps the export's evidence
+untouched.
 
 **Completeness is per file**, following #393: one unresolved registration holds
 every tool that file produced at ``partial``, and its siblings elsewhere in the
@@ -39,6 +46,7 @@ from agents_shipgate.core.domain import (
     LoadedToolSource,
     SourceSurfaceOmission,
     Tool,
+    ToolParameter,
     ToolRiskHint,
 )
 from agents_shipgate.core.errors import InputParseError
@@ -55,12 +63,18 @@ from agents_shipgate.inputs.mcp_idioms import (
     IDIOM_REGISTRY_VERSION,
     MAX_SOURCE_FILE_BYTES,
     OMISSION_REASONS,
+    PythonServerIndex,
     RegistrationSite,
+    SignatureParameter,
     is_scannable_path,
     language_for_path,
     scan_source,
 )
 from agents_shipgate.inputs.protocol import LoadedAdapterResult
+from agents_shipgate.inputs.python_static import (
+    SKIPPED_TOOL_PARAMETERS,
+    json_schema_type,
+)
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
     ToolSourceConfig,
@@ -125,7 +139,8 @@ def load_mcp_server_source(source: ToolSourceConfig, base_dir: Path) -> LoadedTo
     files, capped = _scannable_files(root)
     if not files:
         raise InputParseError(
-            f"MCP server source has no TypeScript or Go files to read: {root}. "
+            "MCP server source has no TypeScript, Go or Python files to read: "
+            f"{root}. "
             "Point tool_sources[].path at the directory holding the server's "
             "tool registrations, or at one such file."
         )
@@ -161,6 +176,8 @@ def load_mcp_server_source(source: ToolSourceConfig, base_dir: Path) -> LoadedTo
             ),
         )
 
+    server_index = _python_server_index(files, root)
+
     for path in files:
         language = language_for_path(path)
         assert language is not None  # guaranteed by _scannable_files
@@ -183,7 +200,12 @@ def load_mcp_server_source(source: ToolSourceConfig, base_dir: Path) -> LoadedTo
                 detail=OMISSION_REASONS[unread],
             )
             continue
-        result = scan_source(text, language)
+        result = scan_source(
+            text,
+            language,
+            module_path=_root_relative(path, root),
+            server_index=server_index,
+        )
 
         file_gaps: list[str] = []
         for anomaly in result.anomalies:
@@ -265,6 +287,58 @@ def _apply_source_gaps(tools: list[Tool], gaps: list[str]) -> None:
         tool.extraction["surface_gaps"] = merged
 
 
+def _python_server_index(files: list[Path], root: Path) -> PythonServerIndex:
+    """Index every module in the walk that constructs a FastMCP server.
+
+    A second read of the Python files, ahead of the one that scans them, and
+    the ordering is the whole point: ``redis/mcp-redis`` applies all 55 of its
+    decorators in ``src/tools/*.py`` and constructs the server they register on
+    in ``src/common/server.py``, so a reader that resolved bindings as it went
+    would prove or refuse the same decorator depending on walk order.
+
+    The extra read is bounded by the prefilter inside
+    :func:`~agents_shipgate.inputs.mcp_idioms.python_server_exports`: a module
+    that never names ``fastmcp`` cannot construct one and is not parsed. What
+    is *not* bounded away is the read itself, which is why this walks only the
+    Python files — the TypeScript and Go halves of a mixed repository are read
+    once, as before.
+    """
+
+    modules: list[tuple[str, str]] = []
+    for path in files:
+        if language_for_path(path) != "python" or _unread_reason(path) is not None:
+            continue
+        relative = _root_relative(path, root)
+        if relative is None:
+            continue
+        try:
+            modules.append((relative, load_text_file(path)))
+        except InputParseError:
+            # Reported as an omission by the read loop, which is the pass that
+            # owns the file's surface. Recording it here too would put one
+            # file's problem into the ledger twice.
+            continue
+    return PythonServerIndex.build(modules)
+
+
+def _root_relative(path: Path, root: Path) -> str | None:
+    """``path`` relative to the walked root, as an import-resolvable key.
+
+    Deliberately *not* the manifest-relative path the omissions and tools
+    carry. Module resolution matches path segments against a dotted import, so
+    the segments have to be the ones inside the source tree; prefixing them
+    with the manifest's own directory layout would make ``from .server import
+    mcp`` resolve against a package that does not exist.
+    """
+
+    if root.is_file():
+        return path.name if path == root else None
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
 def _unread_reason(path: Path) -> str | None:
     """Why this file was not opened, or ``None`` when it was."""
 
@@ -294,6 +368,7 @@ def _tool_from_site(
     }
     if surface_gaps:
         extraction["surface_gaps"] = surface_gaps
+    parameters = _signature_parameters(site)
     return Tool(
         id=stable_tool_id(site.name),
         name=site.name,
@@ -304,10 +379,101 @@ def _tool_from_site(
         source_path=source_path,
         source_start_line=site.line,
         source_start_column=site.column,
+        input_schema=_signature_input_schema(parameters, site),
+        output_schema=(
+            {"type": json_schema_type(site.returns)} if site.returns else {}
+        ),
+        parameters=parameters,
+        function_signature=_signature_text(site, parameters),
         risk_hints=_operation_type_hints(site),
         extraction_confidence=EXTRACTION_CONFIDENCE,
         extraction=extraction,
     )
+
+
+#: Annotations naming the framework's request context. A tool declares one to
+#: reach logging and progress reporting, and the server strips it from the
+#: schema it publishes — so a catalog that kept it would publish a required
+#: argument no caller can supply.
+#:
+#: Matched on the annotation as well as the name because the framework matches
+#: on the *type*: ``SKIPPED_TOOL_PARAMETERS`` catches the conventional ``ctx``
+#: and ``context`` spellings, and this catches the parameter that is annotated
+#: ``Context`` and called something else.
+_CONTEXT_ANNOTATIONS: frozenset[str] = frozenset({"Context"})
+
+
+def _is_context_parameter(parameter: SignatureParameter) -> bool:
+    if parameter.name in SKIPPED_TOOL_PARAMETERS:
+        return True
+    annotation = (parameter.annotation or "").strip()
+    # A forward reference is a string literal in the source and comes back from
+    # the reader with its quotes, because the reader renders the annotation
+    # rather than resolving it.
+    annotation = annotation.strip("'\"").strip()
+    # `Context`, `mcp.Context`, and the optional spellings a tool uses when the
+    # context is injected only in some transports.
+    annotation = annotation.removeprefix("Optional[").removesuffix("]")
+    annotation = annotation.split("|", 1)[0].strip()
+    return annotation.rsplit(".", 1)[-1] in _CONTEXT_ANNOTATIONS
+
+
+def _signature_parameters(site: RegistrationSite) -> list[ToolParameter]:
+    """The registered tool's parameters, for an idiom that reads a signature.
+
+    The exclusions are applied here rather than in the reader because they are
+    *framework* facts, not syntactic ones: the server drops the request context
+    from the schema it publishes, and every other Python input in this package
+    drops the same conventional parameter names. Keeping the reader purely
+    syntactic is what lets the zero-install detector mirror it without carrying
+    the catalog's vocabulary too.
+    """
+
+    if site.parameters is None:
+        return []
+    return [
+        ToolParameter(
+            name=parameter.name,
+            type=json_schema_type(parameter.annotation),
+            required=parameter.required,
+        )
+        for parameter in site.parameters
+        if not _is_context_parameter(parameter)
+    ]
+
+
+def _signature_input_schema(
+    parameters: list[ToolParameter], site: RegistrationSite
+) -> dict[str, object]:
+    """The JSON Schema the signature implies, or ``{}`` when there is no signature.
+
+    An empty schema and a schema with no properties are different claims: the
+    first says this idiom reads no signature at all, the second says the tool
+    takes no arguments. A lexical idiom must publish the first — inventing
+    "this tool takes nothing" for a TypeScript registration would be a schema
+    assertion nobody made.
+    """
+
+    if site.parameters is None:
+        return {}
+    return {
+        "type": "object",
+        "properties": {
+            parameter.name: {"type": parameter.type} for parameter in parameters
+        },
+        "required": [
+            parameter.name for parameter in parameters if parameter.required
+        ],
+    }
+
+
+def _signature_text(
+    site: RegistrationSite, parameters: list[ToolParameter]
+) -> str | None:
+    if site.parameters is None:
+        return None
+    rendered = f"{site.name}({', '.join(parameter.name for parameter in parameters)})"
+    return f"{rendered} -> {site.returns}" if site.returns else rendered
 
 
 def _operation_type_hints(site: RegistrationSite) -> list[ToolRiskHint]:
@@ -336,7 +502,8 @@ def _scannable_files(root: Path) -> tuple[list[Path], bool]:
     if root.is_file():
         if language_for_path(root) is None:
             raise InputParseError(
-                f"MCP server source is not a TypeScript or Go file: {root}"
+                "MCP server source is not a TypeScript, Go or Python file: "
+                f"{root}"
             )
         return [root], False
     candidates = [
@@ -378,8 +545,9 @@ class MCPServerSourceAdapter:
         adapter=SOURCE_TYPE,
         label="MCP server source",
         reads=(
-            "The TypeScript or Go source of an MCP server that does not commit "
-            "an export, through a built-in registry of registration idioms."
+            "The TypeScript, Go or Python source of an MCP server that does "
+            "not commit an export, through a built-in registry of "
+            "registration idioms."
         ),
         cells=(
             BoundaryCell(
@@ -394,6 +562,7 @@ class MCPServerSourceAdapter:
             BoundaryCell(
                 shape="literal_registration",
                 status="extracted",
+                variant="literal name at a registration site",
                 reads=(
                     'A tool name written as a string literal at a registration '
                     'site — `static toolName = "…"`, `.registerTool("…"`, '
@@ -403,6 +572,36 @@ class MCPServerSourceAdapter:
                 emits=(SOURCE_TYPE,),
                 ceiling=EXTRACTION_CONFIDENCE,
                 surface=SURFACE_ENUMERATED,
+            ),
+            BoundaryCell(
+                shape="literal_registration",
+                status="extracted",
+                variant="FastMCP decorator",
+                reads=(
+                    "A `@mcp.tool` decorator on a Python function, where `mcp` "
+                    "is followed back to a `FastMCP(...)` construction — in the "
+                    "same module or in one this walk also read. The name is the "
+                    "`name=` literal or, where the framework's own default "
+                    "applies, the function's; the description is the "
+                    "`description=` literal or the docstring; the input schema "
+                    "is the annotated signature."
+                ),
+                emits=(SOURCE_TYPE,),
+                ceiling=EXTRACTION_CONFIDENCE,
+                surface=SURFACE_ENUMERATED,
+            ),
+            BoundaryCell(
+                shape="dynamic_construction",
+                status="not_extracted",
+                variant="decorator on an object this reader cannot follow",
+                reads=(
+                    "A `.tool` decorator whose object does not resolve to a "
+                    "`FastMCP(...)` construction — `@self.mcp.tool` on a server "
+                    "handed in as an argument is the measured shape — registers "
+                    "something this reader can neither name nor confirm is a "
+                    "tool at all. It enters no catalog and is recorded as an "
+                    "unenumerated subject in the exclusion ledger."
+                ),
             ),
             BoundaryCell(
                 shape="factory",
@@ -417,6 +616,7 @@ class MCPServerSourceAdapter:
             BoundaryCell(
                 shape="dynamic_construction",
                 status="not_extracted",
+                variant="name built at runtime",
                 reads=(
                     "A registration whose name is a variable, a concatenation, "
                     "or a template substitution names no tool this reader can "

--- a/src/agents_shipgate/inputs/mcp_server_source.py
+++ b/src/agents_shipgate/inputs/mcp_server_source.py
@@ -72,10 +72,7 @@ from agents_shipgate.inputs.mcp_idioms import (
     scan_source,
 )
 from agents_shipgate.inputs.protocol import LoadedAdapterResult
-from agents_shipgate.inputs.python_static import (
-    SKIPPED_TOOL_PARAMETERS,
-    json_schema_type,
-)
+from agents_shipgate.inputs.python_static import json_schema_type
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
     ToolSourceConfig,
@@ -430,26 +427,42 @@ def _tool_from_site(
 #: schema it publishes — so a catalog that kept it would publish a required
 #: argument no caller can supply.
 #:
-#: Matched on the annotation as well as the name because the framework matches
-#: on the *type*: ``SKIPPED_TOOL_PARAMETERS`` catches the conventional ``ctx``
-#: and ``context`` spellings, and this catches the parameter that is annotated
-#: ``Context`` and called something else.
+#: Matched on the **annotation only**, because that is what the framework
+#: matches on. The name-based ``SKIPPED_TOOL_PARAMETERS`` this input shared
+#: with the other Python adapters is wrong here: it holds ``config``,
+#: ``context`` and ``runtime``, which are ordinary user-supplied inputs to an
+#: MCP tool, and dropping them published an empty schema for
+#: ``configure(config, context, runtime)`` — hiding a real parameter inventory
+#: from every schema and policy consumer downstream. ``self`` is not special
+#: either: a decorated method registers the plain function, and the server puts
+#: ``self`` in the schema, so this reader says what the server says.
 _CONTEXT_ANNOTATIONS: frozenset[str] = frozenset({"Context"})
 
 
-def _is_context_parameter(parameter: SignatureParameter) -> bool:
-    if parameter.name in SKIPPED_TOOL_PARAMETERS:
-        return True
-    annotation = (parameter.annotation or "").strip()
+def _context_annotation(annotation: str | None) -> str:
+    """The bare class name an annotation is written as.
+
+    Written as, never resolved: following ``Context`` to an import would mean
+    reading another module's namespace, and this input reads a signature.
+    """
+
     # A forward reference is a string literal in the source and comes back from
     # the reader with its quotes, because the reader renders the annotation
     # rather than resolving it.
-    annotation = annotation.strip("'\"").strip()
-    # `Context`, `mcp.Context`, and the optional spellings a tool uses when the
-    # context is injected only in some transports.
-    annotation = annotation.removeprefix("Optional[").removesuffix("]")
-    annotation = annotation.split("|", 1)[0].strip()
-    return annotation.rsplit(".", 1)[-1] in _CONTEXT_ANNOTATIONS
+    text = (annotation or "").strip().strip("'\"").strip()
+    # `Context | None`, the spelling a tool uses when the context is injected
+    # only in some transports.
+    text = text.split("|", 1)[0].strip()
+    if text.startswith(("Optional[", "typing.Optional[")):
+        text = text.split("[", 1)[1].rsplit("]", 1)[0].strip()
+    # `Context[ServerSession, None]` — the parameterised spelling the SDK's own
+    # examples use. Taking the head keeps `list[Context]`, which is a list.
+    text = text.split("[", 1)[0].strip()
+    return text.rsplit(".", 1)[-1]
+
+
+def _is_context_parameter(parameter: SignatureParameter) -> bool:
+    return _context_annotation(parameter.annotation) in _CONTEXT_ANNOTATIONS
 
 
 def _signature_parameters(site: RegistrationSite) -> list[ToolParameter]:

--- a/tests/mcp_idiom_corpus.py
+++ b/tests/mcp_idiom_corpus.py
@@ -1166,6 +1166,57 @@ ADVERSARIAL: list[tuple[str, str, str, list[str], list[str]]] = [
         [],
         ['server_binding_not_proven'],
     ),
+    (
+        'a class attribute does not shadow the module for a nested function',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        'class Handlers:\n'
+        '    mcp = "not a server"\n'
+        '\n'
+        '    def register(self):\n'
+        '        @mcp.tool()\n'
+        '        def nested_in_a_method() -> None:\n'
+        '            pass\n',
+        ['nested_in_a_method'],
+        [],
+    ),
+    (
+        'a class attribute is the scope a decorator in that body is written in',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        '\n'
+        'class Handlers:\n'
+        '    mcp = FastMCP("s")\n'
+        '\n'
+        '    @mcp.tool()\n'
+        '    def in_the_class_body(self) -> None:\n'
+        '        pass\n',
+        ['in_the_class_body'],
+        [],
+    ),
+    (
+        'a PEP 695 type parameter is a child list the walk must not skip',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        'class Box[T]:\n'
+        '    pass\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def generic[T](item: T) -> T:\n'
+        '    return item\n',
+        ['generic'],
+        [],
+    ),
 ]
 
 # --- Paths the reader is and is not allowed to open -------------------------
@@ -1196,6 +1247,12 @@ SCANNABLE_PATHS: list[tuple[str, bool]] = [
     ("src/tools/hash_test.py", False),
     ("conftest.py", False),
     ("src/conftest.py", False),
+    # The prefix rule exists because pytest collects `test_*.py`. It is scoped
+    # to Python: `test_helpers.ts` is an ordinary module name in the other two
+    # languages, and dropping one is a lost surface with no omission to show
+    # for it, because an excluded path is never read at all.
+    ("src/test_helpers.ts", True),
+    ("pkg/test_util.go", True),
     (".venv/lib/python3.12/site-packages/fastmcp/server.py", False),
     ("build/lib/server.py", False),
     (".tox/py312/lib/server.py", False),

--- a/tests/mcp_idiom_corpus.py
+++ b/tests/mcp_idiom_corpus.py
@@ -103,6 +103,20 @@ POSITIVE_SAMPLES: dict[str, Sample] = {
         ")\n",
         "issue_read",
     ),
+    "py_fastmcp_decorator": Sample(
+        "py_fastmcp_decorator",
+        "python",
+        "from mcp.server.fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("Redis MCP Server")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "async def dbsize() -> int:\n"
+        '    """Get the number of keys stored in the Redis database"""\n'
+        "    return 0\n",
+        "dbsize",
+    ),
 }
 
 
@@ -667,6 +681,491 @@ ADVERSARIAL: list[tuple[str, str, str, list[str], list[str]]] = [
         ["real"],
         [],
     ),
+    (
+        'a python decorator on an alias of the tool method',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        'register = mcp.tool\n'
+        '\n'
+        '\n'
+        '@register\n'
+        'def aliased() -> None:\n'
+        '    pass\n',
+        ['aliased'],
+        [],
+    ),
+    (
+        'a python tool name built at runtime',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool(name=NAMESPACE + "delete_instance")\n'
+        'def delete_instance() -> None:\n'
+        '    pass\n',
+        [],
+        ['name_not_literal'],
+    ),
+    (
+        'a python decorator applied inside a factory takes its argument',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        '\n'
+        'def register_all(server: FastMCP) -> None:\n'
+        '    @server.tool()\n'
+        '    def injected() -> None:\n'
+        '        pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python server constructed inside a factory is still a server',
+        "python",
+        'from fastmcp.server import FastMCP\n'
+        '\n'
+        '\n'
+        'def create_mcp_server(namespace: str = "") -> FastMCP:\n'
+        '    mcp: FastMCP = FastMCP("mcp-neo4j-cypher")\n'
+        '\n'
+        '    @mcp.tool()\n'
+        '    def get_neo4j_schema() -> str:\n'
+        '        return ""\n'
+        '\n'
+        '    return mcp\n',
+        ['get_neo4j_schema'],
+        [],
+    ),
+    (
+        'functools.wraps is not a registration',
+        "python",
+        'import functools\n'
+        '\n'
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        'def audited(fn):\n'
+        '    @functools.wraps(fn)\n'
+        '    def wrapper(*args, **kwargs):\n'
+        '        return fn(*args, **kwargs)\n'
+        '\n'
+        '    return wrapper\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        '@audited\n'
+        'def wrapped() -> None:\n'
+        '    pass\n',
+        ['wrapped'],
+        [],
+    ),
+    (
+        'a conditional python registration is reported like any other',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        'if FEATURE_ENABLED:\n'
+        '\n'
+        '    @mcp.tool()\n'
+        '    def gated() -> None:\n'
+        '        pass\n',
+        ['gated'],
+        [],
+    ),
+    (
+        'a re-bound python module symbol is not proven',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        'mcp = wrap(mcp)\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def rebound() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a decorator on an object that is not a FastMCP server',
+        "python",
+        'import click\n'
+        '\n'
+        'app = click.Group()\n'
+        '\n'
+        '\n'
+        '@app.tool()\n'
+        'def not_ours() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python decorator reaching through an attribute',
+        "python",
+        'from mcp.server.fastmcp import FastMCP\n'
+        '\n'
+        '\n'
+        'class RabbitMQModule:\n'
+        '    def __init__(self, mcp: FastMCP) -> None:\n'
+        '        self.mcp = mcp\n'
+        '\n'
+        '    def register(self) -> None:\n'
+        '        @self.mcp.tool()\n'
+        '        def rabbitmq_broker_list_queues() -> list:\n'
+        '            return []\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python star import makes every binding unprovable',
+        "python",
+        'from fastmcp import FastMCP\n'
+        'from plugins import *\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def shadowed() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python resource or prompt decorator is not a tool',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.resource("resource://schema/node")\n'
+        'def node_schema() -> dict:\n'
+        '    return {}\n'
+        '\n'
+        '\n'
+        '@mcp.prompt()\n'
+        'def summarise() -> str:\n'
+        '    return ""\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def real_tool() -> None:\n'
+        '    pass\n',
+        ['real_tool'],
+        [],
+    ),
+    (
+        'a python parameter shadows the module-level server',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        'def outer(mcp):\n'
+        '    @mcp.tool()\n'
+        '    def inner() -> None:\n'
+        '        pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python name a loop also binds is not proven',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        'for mcp in servers:\n'
+        '    pass\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def looped() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python function name that is not shaped like a tool name',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def _private_helper() -> None:\n'
+        '    pass\n',
+        [],
+        ['implausible_tool_name'],
+    ),
+    (
+        'a python decorator written without parentheses',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool\n'
+        'def bare() -> None:\n'
+        '    pass\n',
+        ['bare'],
+        [],
+    ),
+    (
+        'a positional python tool name',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool("explicit-name")\n'
+        'def positional() -> None:\n'
+        '    pass\n',
+        ['explicit-name'],
+        [],
+    ),
+    (
+        'a nested python registration keeps the outer omission',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool(name=RUNTIME)\n'
+        'def outer() -> None:\n'
+        '    @mcp.tool()\n'
+        '    def inner() -> None:\n'
+        '        pass\n',
+        ['inner'],
+        ['name_not_literal'],
+    ),
+    (
+        'a python alias for the FastMCP class',
+        "python",
+        'from fastmcp import FastMCP as Server\n'
+        '\n'
+        'mcp = Server("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def aliased_class() -> None:\n'
+        '    pass\n',
+        ['aliased_class'],
+        [],
+    ),
+    (
+        'a python alias for the FastMCP package',
+        "python",
+        'import fastmcp\n'
+        '\n'
+        'server = fastmcp.FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@server.tool()\n'
+        'def module_alias() -> None:\n'
+        '    pass\n',
+        ['module_alias'],
+        [],
+    ),
+    (
+        'a FastMCP-shaped class from some other package',
+        "python",
+        'from mypackage.fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def foreign() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python registration written inside a docstring',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        'def documented() -> None:\n'
+        '    """Register one like this:\n'
+        '\n'
+        '    @mcp.tool()\n'
+        '    def ghost() -> None:\n'
+        '        ...\n'
+        '    """\n',
+        [],
+        [],
+    ),
+    (
+        'a python tool decorator on a class registers nothing',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'class NotAFunction:\n'
+        '    pass\n',
+        [],
+        [],
+    ),
+    (
+        'a python server bound by tuple unpacking is not proven',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp, sidecar = FastMCP("s"), None\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def unpacked() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python global declaration is not a proof',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        '\n'
+        'def build() -> None:\n'
+        '    global mcp\n'
+        '    mcp = FastMCP("s")\n'
+        '\n'
+        '    @mcp.tool()\n'
+        '    def declared() -> None:\n'
+        '        pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'the official SDK v2 renamed the server class',
+        "python",
+        'from mcp.server.mcpserver import MCPServer\n'
+        '\n'
+        'mcp = MCPServer("awslabs.amazon-kendra-index-mcp-server")\n'
+        '\n'
+        '\n'
+        '@mcp.tool(name="KendraListIndexesTool")\n'
+        'async def kendra_list_indexes_tool(region: str = "") -> dict:\n'
+        '    """List all Amazon Kendra indexes in the specified region."""\n'
+        '    return {}\n',
+        ['KendraListIndexesTool'],
+        [],
+    ),
+    (
+        'a server built by a factory call is not proven',
+        "python",
+        'from mcp.server.mcpserver import MCPServer\n'
+        '\n'
+        '\n'
+        'def create_server() -> MCPServer:\n'
+        '    return MCPServer("s")\n'
+        '\n'
+        '\n'
+        'app = create_server()\n'
+        '\n'
+        '\n'
+        '@app.tool\n'
+        'def from_a_factory() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        "the v1 class name is not the v2 module's",
+        "python",
+        'from mcp.server.mcpserver import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def wrong_pairing() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a Context parameter is not a tool parameter',
+        "python",
+        'from mcp.server.mcpserver import Context, MCPServer\n'
+        '\n'
+        'mcp = MCPServer("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'async def with_context(x: int, ctx: Context) -> str:\n'
+        '    return str(x)\n',
+        ['with_context'],
+        [],
+    ),
+    (
+        'a python parameter named like the server does not shadow it',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def configure(mcp: str) -> None:\n'
+        '    pass\n',
+        ['configure'],
+        [],
+    ),
+    (
+        'a function-local import of a server is an import of a server',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        'def register() -> None:\n'
+        '    from elsewhere import unrelated\n'
+        '\n'
+        '    @unrelated.tool()\n'
+        '    def nested() -> None:\n'
+        '        pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
+    (
+        'a python server unpacked into two names is not proven',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp, sidecar = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        'def unpacked_from_a_call() -> None:\n'
+        '    pass\n',
+        [],
+        ['server_binding_not_proven'],
+    ),
 ]
 
 # --- Paths the reader is and is not allowed to open -------------------------
@@ -688,6 +1187,18 @@ SCANNABLE_PATHS: list[tuple[str, bool]] = [
     ("vendor/other/tools.go", False),
     ("testdata/sample.go", False),
     ("README.md", False),
+    ("src/tools/hash.py", True),
+    ("servers/cypher/src/mcp_neo4j_cypher/server.py", True),
+    # Python spells a test file with a prefix and pytest collects it that way,
+    # so a suffix-only rule read `test_server.py` as the server itself.
+    ("tests/test_server.py", False),
+    ("src/tools/test_hash.py", False),
+    ("src/tools/hash_test.py", False),
+    ("conftest.py", False),
+    ("src/conftest.py", False),
+    (".venv/lib/python3.12/site-packages/fastmcp/server.py", False),
+    ("build/lib/server.py", False),
+    (".tox/py312/lib/server.py", False),
 ]
 
 
@@ -751,6 +1262,195 @@ MASKING_FAILURES: dict[str, SourceCase] = {
 }
 
 
+# --- Source neither reader can read to the end ------------------------------
+#
+# The Python analogue of a masking failure. Nothing about the file is known
+# past a syntax error, so reporting no sites would be indistinguishable from a
+# module that registers nothing — the exact ambiguity this input removes.
+
+PARSE_FAILURES: dict[str, SourceCase] = {
+    "unparseable_python": SourceCase(
+        "unparseable_python",
+        "python",
+        "from fastmcp import FastMCP\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "@mcp.tool(\n"
+        "def truncated() -> None:\n"
+        "    pass\n",
+    ),
+}
+
+
+# --- Modules whose binding evidence lives in another file -------------------
+#
+# `redis/mcp-redis` constructs its server in `src/common/server.py` and applies
+# all 53 of its decorators in `src/tools/*.py`, so a reader that only ever
+# looked at one file at a time would prove nothing about the largest Python
+# server in the survey. These are whole trees: the index is built from every
+# module, then each is scanned against it.
+#
+# `names` and `unresolved` are keyed by module path and are exact. `depends_on`
+# is what each module reported as the module its proof rested on — the value
+# discovery adds to the route so `scan` can repeat the proof `detect` made.
+
+
+class PythonTree:
+    """One tree of modules, and what each must yield when read together."""
+
+    def __init__(
+        self,
+        case: str,
+        modules: dict[str, str],
+        names: dict[str, list[str]],
+        unresolved: dict[str, list[str]],
+        depends_on: dict[str, list[str]],
+    ) -> None:
+        self.case = case
+        self.modules = modules
+        self.names = names
+        self.unresolved = unresolved
+        self.depends_on = depends_on
+
+
+_SERVER_MODULE = (
+    "from mcp.server.fastmcp import FastMCP\n"
+    "\n"
+    'mcp = FastMCP("Redis MCP Server")\n'
+)
+_TOOL_MODULE = (
+    "from src.common.server import mcp\n"
+    "\n"
+    "\n"
+    "@mcp.tool()\n"
+    "async def dbsize() -> int:\n"
+    '    """Get the number of keys stored in the Redis database"""\n'
+    "    return 0\n"
+)
+_RELATIVE_TOOL_MODULE = (
+    "from .server import mcp\n"
+    "\n"
+    "\n"
+    "@mcp.tool()\n"
+    "def sibling() -> None:\n"
+    "    pass\n"
+)
+
+PYTHON_TREES: list[PythonTree] = [
+    PythonTree(
+        "the import path is anchored above the scanned root",
+        {"src/common/server.py": _SERVER_MODULE, "src/tools/mgmt.py": _TOOL_MODULE},
+        {"src/tools/mgmt.py": ["dbsize"]},
+        {},
+        {"src/tools/mgmt.py": ["src/common/server.py"]},
+    ),
+    PythonTree(
+        # The same repository read from `src/`, which is where `detect`'s
+        # common-ancestor route points. One import, two path spellings.
+        "the scanned root is inside the import path",
+        {"common/server.py": _SERVER_MODULE, "tools/mgmt.py": _TOOL_MODULE},
+        {"tools/mgmt.py": ["dbsize"]},
+        {},
+        {"tools/mgmt.py": ["common/server.py"]},
+    ),
+    PythonTree(
+        # The import is inside the function that registers, which is how a
+        # module avoids an import cycle with the one that builds the server.
+        "a server imported inside a function is still a server",
+        {
+            "pkg/server.py": _SERVER_MODULE,
+            "pkg/tools.py": (
+                "def register() -> None:\n"
+                "    from .server import mcp\n"
+                "\n"
+                "    @mcp.tool()\n"
+                "    def deferred() -> None:\n"
+                "        pass\n"
+            ),
+        },
+        {"pkg/tools.py": ["deferred"]},
+        {},
+        {"pkg/tools.py": ["pkg/server.py"]},
+    ),
+    PythonTree(
+        "a relative import resolves against its own package",
+        {"pkg/server.py": _SERVER_MODULE, "pkg/tools.py": _RELATIVE_TOOL_MODULE},
+        {"pkg/tools.py": ["sibling"]},
+        {},
+        {"pkg/tools.py": ["pkg/server.py"]},
+    ),
+    PythonTree(
+        # Two modules in the tree could be the one imported, and picking either
+        # is a guess about whether the decorator registers a tool at all.
+        #
+        # Both candidates have to *match*, which is the trap: a first draft
+        # used `a/common/server.py` and `b/common/server.py` against an import
+        # of `src.common.server`, where neither side's segments are a suffix of
+        # the other's — so the case proved "no match" and passed with the
+        # uniqueness rule deleted.
+        "an ambiguous import proves nothing",
+        {
+            "src/common/server.py": _SERVER_MODULE,
+            "vendored/src/common/server.py": _SERVER_MODULE,
+            "src/tools/mgmt.py": _TOOL_MODULE,
+        },
+        {},
+        {"src/tools/mgmt.py": ["server_binding_not_proven"]},
+        {},
+    ),
+    PythonTree(
+        "an import from a module that exports no server proves nothing",
+        {
+            "src/common/server.py": "mcp = object()\n",
+            "src/tools/mgmt.py": _TOOL_MODULE,
+        },
+        {},
+        {"src/tools/mgmt.py": ["server_binding_not_proven"]},
+        {},
+    ),
+    PythonTree(
+        # The module *is* indexed and does export a server — under a different
+        # name. Resolving the module is only half the question, and this is
+        # the half a case whose target module exports nothing cannot reach.
+        "an import of a name that module does not export as a server",
+        {
+            "src/common/server.py": _SERVER_MODULE,
+            "src/tools/mgmt.py": (
+                "from src.common.server import helper\n"
+                "\n"
+                "\n"
+                "@helper.tool()\n"
+                "def borrowed() -> None:\n"
+                "    pass\n"
+            ),
+        },
+        {},
+        {"src/tools/mgmt.py": ["server_binding_not_proven"]},
+        {},
+    ),
+    PythonTree(
+        # A factory's local is a server, and it is not reachable by name from
+        # another module — so it must not enter the index and lend its name to
+        # an import of something else entirely.
+        "a server built inside a factory is not an export",
+        {
+            "src/common/server.py": (
+                "from fastmcp import FastMCP\n"
+                "\n"
+                "\n"
+                "def build() -> FastMCP:\n"
+                '    mcp = FastMCP("s")\n'
+                "    return mcp\n"
+            ),
+            "src/tools/mgmt.py": _TOOL_MODULE,
+        },
+        {},
+        {"src/tools/mgmt.py": ["server_binding_not_proven"]},
+        {},
+    ),
+]
+
+
 # --- Regressions the reader carries scars from ------------------------------
 #
 # Each of these was a real defect. They are inputs, not assertions: the test
@@ -798,6 +1498,65 @@ REGRESSIONS: dict[str, SourceCase] = {
         "go",
         "package main\n\nfunc main() {}\n",
     ),
+    # `col_offset` is a UTF-8 *byte* offset into the line while every other
+    # offset this reader publishes counts characters, so a non-ASCII character
+    # before the decorator moves the two apart.
+    "python_offsets_are_characters_not_bytes": SourceCase(
+        "python_offsets_are_characters_not_bytes",
+        "python",
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        # On the decorator's *own* line: `col_offset` counts bytes within one
+        # line, so a non-ASCII character anywhere else in the file moves
+        # nothing and a case that put it three lines up passed either way.
+        '@mcp.tool(description="süß — naïve café")\n'
+        "def measured() -> None:\n"
+        "    pass\n",
+    ),
+    # An empty signature and a signature this idiom does not read are two
+    # different claims, and the adapter turns them into two different schemas.
+    # ``*args``/``**kwargs`` are not schema properties, and the adversarial
+    # sweep asserts names and omissions only — so this lives here, where a
+    # named test can state what the signature must come back as.
+    "python_variadic_signature": SourceCase(
+        "python_variadic_signature",
+        "python",
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def forwarding(query: str, *filters: str, **options: str) -> str:\n"
+        "    return query\n",
+    ),
+    "python_tool_with_no_parameters": SourceCase(
+        "python_tool_with_no_parameters",
+        "python",
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def nullary() -> None:\n"
+        "    pass\n",
+    ),
+    "python_description_beats_the_docstring": SourceCase(
+        "python_description_beats_the_docstring",
+        "python",
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        '@mcp.tool(description="What the server publishes")\n'
+        "def described() -> None:\n"
+        '    """What the author wrote for a reader."""\n',
+    ),
 }
 
 
@@ -815,6 +1574,10 @@ SOURCE_CASES: tuple[SourceCase, ...] = (
     *(
         SourceCase(f"masking:{name}", entry.language, entry.text)
         for name, entry in sorted(MASKING_FAILURES.items())
+    ),
+    *(
+        SourceCase(f"parse:{name}", entry.language, entry.text)
+        for name, entry in sorted(PARSE_FAILURES.items())
     ),
     *(
         SourceCase(f"regression:{name}", entry.language, entry.text)

--- a/tests/mcp_idiom_corpus.py
+++ b/tests/mcp_idiom_corpus.py
@@ -741,7 +741,12 @@ ADVERSARIAL: list[tuple[str, str, str, list[str], list[str]]] = [
         [],
     ),
     (
-        'functools.wraps is not a registration',
+        # An inner decorator is applied *first*, so the object the registration
+        # receives is its return value. `functools.wraps` happens to preserve
+        # the name and — through `__wrapped__` — the signature, but that is a
+        # fact about the decorator's body, which this reader does not read. So
+        # the site keeps its provenance and loses its name.
+        'a decorator below the registration withholds the name',
         "python",
         'import functools\n'
         '\n'
@@ -762,8 +767,8 @@ ADVERSARIAL: list[tuple[str, str, str, list[str], list[str]]] = [
         '@audited\n'
         'def wrapped() -> None:\n'
         '    pass\n',
-        ['wrapped'],
         [],
+        ['wrapped_before_registration'],
     ),
     (
         'a conditional python registration is reported like any other',
@@ -1217,6 +1222,59 @@ ADVERSARIAL: list[tuple[str, str, str, list[str], list[str]]] = [
         ['generic'],
         [],
     ),
+    (
+        'an inner decorator can return a different function entirely',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        'def replace(fn):\n'
+        '    def delete_all(target: str) -> str:\n'
+        '        return "unused"\n'
+        '\n'
+        '    return delete_all\n'
+        '\n'
+        '\n'
+        '@mcp.tool()\n'
+        '@replace\n'
+        'def harmless(query: int) -> str:\n'
+        '    return "unused"\n',
+        [],
+        ['wrapped_before_registration'],
+    ),
+    (
+        'a decorator above the registration is applied after it',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        '\n'
+        '@audited\n'
+        '@mcp.tool()\n'
+        'def still_readable(query: int) -> str:\n'
+        '    return ""\n',
+        ['still_readable'],
+        [],
+    ),
+    (
+        'an unpacked mapping can carry the tool name',
+        "python",
+        'from fastmcp import FastMCP\n'
+        '\n'
+        'mcp = FastMCP("s")\n'
+        '\n'
+        'options = {"name": "delete_all"}\n'
+        '\n'
+        '\n'
+        '@mcp.tool(**options)\n'
+        'def harmless() -> str:\n'
+        '    return "unused"\n',
+        [],
+        ['name_not_literal'],
+    ),
 ]
 
 # --- Paths the reader is and is not allowed to open -------------------------
@@ -1456,6 +1514,27 @@ PYTHON_TREES: list[PythonTree] = [
         {},
     ),
     PythonTree(
+        # Only one candidate exports a server, so dropping non-servers from the
+        # index leaves a *unique* match — to the archive copy the import did
+        # not name. Ambiguity has to be measured against what is there.
+        "a conflicting module that exports no server is still a conflict",
+        {
+            "src/common/server.py": (
+                "class Other:\n"
+                "    def tool(self):\n"
+                "        pass\n"
+                "\n"
+                "\n"
+                "mcp = Other()\n"
+            ),
+            "archive/src/common/server.py": _SERVER_MODULE,
+            "src/tools/mgmt.py": _TOOL_MODULE,
+        },
+        {},
+        {"src/tools/mgmt.py": ["server_binding_not_proven"]},
+        {},
+    ),
+    PythonTree(
         "an import from a module that exports no server proves nothing",
         {
             "src/common/server.py": "mcp = object()\n",
@@ -1589,6 +1668,22 @@ REGRESSIONS: dict[str, SourceCase] = {
         "@mcp.tool()\n"
         "def forwarding(query: str, *filters: str, **options: str) -> str:\n"
         "    return query\n",
+    ),
+    # A *withheld* signature and an empty one are different claims, and only a
+    # named test can tell them apart: the adversarial sweep asserts names and
+    # omissions only.
+    "python_signature_withheld_by_a_wrapper": SourceCase(
+        "python_signature_withheld_by_a_wrapper",
+        "python",
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "@replace\n"
+        "def harmless(query: int) -> str:\n"
+        '    return ""\n',
     ),
     "python_tool_with_no_parameters": SourceCase(
         "python_tool_with_no_parameters",

--- a/tests/test_distribution_surface_parity.py
+++ b/tests/test_distribution_surface_parity.py
@@ -10,7 +10,7 @@ The invariant, in both halves:
     the engine's answer, or say in the registry what it does not answer.
 
 `#485` is why this exists. After `#431` taught the CLI to read an MCP server's
-tool surface out of TypeScript or Go source, `tools/shipgate-detect.py` — the
+tool surface out of TypeScript, Go or Python source, `tools/shipgate-detect.py` — the
 documented zero-install front door — went on answering ``is_agent_project:
 false`` for the vendor MCP servers the CLI now accepts, and CI stayed green: the
 existing parity test compares the two on ``samples/``, and no sample contained

--- a/tests/test_init_scaffold_disclosure.py
+++ b/tests/test_init_scaffold_disclosure.py
@@ -4,7 +4,10 @@ Three defects, one walk of ``awslabs/mcp#4489`` (a FastMCP Python MCP server):
 
 1. ``detect`` says "not a Shipgate target"; ``init`` — the command the control
    loop routes to from ``verify --preview`` — writes a manifest anyway, and
-   reports it exactly as it reports a manifest it inferred.
+   reports it exactly as it reports a manifest it inferred. (#484 later taught
+   ``detect`` to read the ``@mcp.tool`` decorator, so *this* server is now
+   detected; the scaffold tests below moved to :func:`_undetected_server`, the
+   factory-bound shape that is still unreadable.)
 2. The manifest it writes declares ``type: openapi`` for a Python MCP server.
    ``id`` and ``path`` were flagged as placeholders; ``type`` was not, so the
    one value the tool chose without evidence was the one nothing told the
@@ -62,6 +65,33 @@ def _fastmcp_server(root: Path) -> Path:
     )
     (package / "tools" / "budget_tools.py").write_text(
         "async def budget_server(ctx):\n    return {}\n", encoding="utf-8"
+    )
+    return workspace
+
+
+def _undetected_server(root: Path) -> Path:
+    """The same server, built the one way this reader still declines to read.
+
+    #484 taught ``detect`` to read a ``@mcp.tool`` decorator, which resolves
+    :func:`_fastmcp_server` — defect 1's original reproduction is no longer a
+    workspace ``detect`` declines, and that is the fix rather than a
+    regression. The scaffold path it exercised still has to be tested, so this
+    is a workspace ``detect`` genuinely still declines, and it is a *measured*
+    shape rather than an invented one: ``app = create_server()`` is how
+    ``awslabs/mcp``'s healthimaging, s3-tables and dynamodb servers bind
+    theirs, and resolving what the factory returns would mean running it.
+    """
+
+    workspace = _fastmcp_server(root)
+    package = workspace / "awslabs" / "billing_cost_management_mcp_server"
+    (package / "server.py").write_text(
+        "from mcp.server.fastmcp import FastMCP\n\n\n"
+        "def create_server():\n"
+        "    return FastMCP(name='billing-cost-management-mcp-server')\n\n\n"
+        "app = create_server()\n\n\n"
+        "@app.tool(name='budgets', description='Get budgets')\n"
+        "async def budgets(ctx):\n    return {}\n",
+        encoding="utf-8",
     )
     return workspace
 
@@ -128,7 +158,7 @@ def test_negative_control_names_the_conventional_dir_it_found(tmp_path: Path) ->
     """The flat "no tool artifacts" list stopped being the whole truth once the
     signal read below the root: the same payload reported ``has_tools_dir``."""
 
-    workspace = _fastmcp_server(tmp_path)
+    workspace = _undetected_server(tmp_path)
     runner = CliRunner()
     result = runner.invoke(app, ["detect", "--workspace", str(workspace), "--json"])
     assert result.exit_code == 0
@@ -242,7 +272,7 @@ def test_minimal_template_scaffolds_the_same_way(tmp_path: Path) -> None:
 
 
 def test_init_states_that_the_source_block_is_a_scaffold(tmp_path: Path) -> None:
-    workspace = _fastmcp_server(tmp_path)
+    workspace = _undetected_server(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         app, ["init", "--workspace", str(workspace), "--write", "--json"]
@@ -261,7 +291,7 @@ def test_init_dry_run_control_reason_states_the_scaffold(tmp_path: Path) -> None
     """A dry run writes nothing, so no manifest placeholder outranks the
     advance and the envelope's reason is init's own."""
 
-    workspace = _fastmcp_server(tmp_path)
+    workspace = _undetected_server(tmp_path)
     runner = CliRunner()
     result = runner.invoke(app, ["init", "--workspace", str(workspace), "--json"])
     payload = json.loads(result.stdout)
@@ -271,7 +301,7 @@ def test_init_dry_run_control_reason_states_the_scaffold(tmp_path: Path) -> None
 
 
 def test_init_human_output_states_the_scaffold(tmp_path: Path) -> None:
-    workspace = _fastmcp_server(tmp_path)
+    workspace = _undetected_server(tmp_path)
     runner = CliRunner()
     result = runner.invoke(app, ["init", "--workspace", str(workspace), "--write"])
     assert DISCOVERY_SCAFFOLD_SUMMARY in result.stdout
@@ -356,7 +386,7 @@ def test_written_scaffold_publishes_the_human_declaration(tmp_path: Path) -> Non
     have to carry the scaffold fact, and why neither may be dropped.
     """
 
-    workspace = _fastmcp_server(tmp_path)
+    workspace = _undetected_server(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         app, ["init", "--workspace", str(workspace), "--write", "--json"]
@@ -374,7 +404,7 @@ def test_tool_surface_origin_is_null_when_this_run_wrote_nothing(
     """Same authority rule ``placeholders`` follows: on ``skipped_existing``
     the render was discarded, so it describes no file the caller can open."""
 
-    workspace = _fastmcp_server(tmp_path)
+    workspace = _undetected_server(tmp_path)
     runner = CliRunner()
     first = runner.invoke(
         app, ["init", "--workspace", str(workspace), "--write", "--json"]

--- a/tests/test_mcp_idioms.py
+++ b/tests/test_mcp_idioms.py
@@ -23,20 +23,26 @@ from agents_shipgate.inputs.mcp_idioms import (
     LANGUAGE_EXTENSIONS,
     OMISSION_REASONS,
     PREFILTER_TOKEN,
+    PythonServerIndex,
     SourceScanResult,
+    declares_python_mcp_framework,
     decode_literal,
     is_scannable_path,
     language_for_path,
     mask_source,
+    normalized_distribution,
     scan_source,
 )
 from tests.mcp_idiom_corpus import (
     ADVERSARIAL,
     ESCAPE_CASES,
     MASKING_FAILURES,
+    PARSE_FAILURES,
     POSITIVE_SAMPLES,
+    PYTHON_TREES,
     REGRESSIONS,
     SCANNABLE_PATHS,
+    PythonTree,
 )
 
 
@@ -312,6 +318,173 @@ def test_a_file_without_the_prefilter_token_is_answered_without_masking(monkeypa
     assert scan_source(
         POSITIVE_SAMPLES["go_must_tool"].text, "go"
     ).sites
+
+
+# --- Python: the FastMCP decorator ------------------------------------------
+
+
+def test_a_python_tool_reads_its_signature_docstring_and_position():
+    """The three facts the lexed idioms do not have.
+
+    A FastMCP tool's name defaults to the decorated function's, its
+    description to the docstring, and its input schema to the signature — so a
+    reader that stopped at "is there a literal here" would find nothing at all
+    in `redis/mcp-redis`, whose 53 registrations are 53 bare `@mcp.tool()`.
+    """
+
+    sample = POSITIVE_SAMPLES["py_fastmcp_decorator"]
+    site = scan_source(sample.text, "python").sites[0]
+    assert site.name == "dbsize"
+    assert site.description == "Get the number of keys stored in the Redis database"
+    assert site.parameters == ()
+    assert site.returns == "int"
+    assert site.proves_server is True
+    # The decorator, not the function: the line a reviewer is sent to has to be
+    # the registration, and the span is what keeps a nested registration from
+    # deleting its own enclosing omission.
+    assert site.line == 6
+    assert sample.text[slice(*site.span)] == "mcp.tool()"
+
+
+def test_a_python_description_argument_beats_the_docstring():
+    """FastMCP's own precedence, not this reader's preference."""
+
+    case = REGRESSIONS["python_description_beats_the_docstring"]
+    site = scan_source(case.text, case.language).sites[0]
+    assert site.description == "What the server publishes"
+
+
+def test_a_python_tool_with_no_parameters_is_not_one_without_a_signature():
+    """``()`` and ``None`` are different claims, and the adapter reads both.
+
+    An idiom that reads no signature must publish no input schema; one that
+    read a signature with nothing in it must publish "this tool takes no
+    arguments". Collapsing them would invent a schema assertion for every
+    TypeScript and Go registration in the catalog.
+    """
+
+    case = REGRESSIONS["python_tool_with_no_parameters"]
+    assert scan_source(case.text, case.language).sites[0].parameters == ()
+    go = POSITIVE_SAMPLES["go_tool_struct"]
+    assert scan_source(go.text, go.language).sites[0].parameters is None
+
+
+def test_a_python_variadic_is_not_a_signature_parameter():
+    """``*args`` and ``**kwargs`` name no property a caller can send.
+
+    Publishing one called ``options`` would put a parameter in the catalog
+    that no request carries — a tool taking them takes arguments this reader
+    cannot enumerate, which is a different statement from taking one more.
+    """
+
+    case = REGRESSIONS["python_variadic_signature"]
+    site = scan_source(case.text, case.language).sites[0]
+    assert site.name == "forwarding"
+    assert [parameter.name for parameter in site.parameters] == ["query"]
+
+
+def test_python_offsets_are_characters_not_bytes():
+    """``col_offset`` counts UTF-8 bytes; every offset published here counts
+    characters, and the two part company on a line carrying either.
+
+    On the decorator's *own* line, because the offset is per line: a first
+    draft put the non-ASCII text three lines above and the case passed with
+    the conversion deleted.
+    """
+
+    case = REGRESSIONS["python_offsets_are_characters_not_bytes"]
+    site = scan_source(case.text, case.language).sites[0]
+    assert (
+        case.text[slice(*site.span)] == 'mcp.tool(description="süß — naïve café")'
+    )
+    assert site.description == "süß — naïve café"
+
+
+def test_a_python_syntax_error_is_an_anomaly_not_silence():
+    case = PARSE_FAILURES["unparseable_python"]
+    result = scan_source(case.text, case.language)
+    assert result.anomalies == ("unparseable_python",)
+    assert result.sites == ()
+    assert "unparseable_python" in OMISSION_REASONS
+
+
+@pytest.mark.parametrize("tree", PYTHON_TREES, ids=[t.case for t in PYTHON_TREES])
+def test_python_bindings_resolve_across_modules(tree: PythonTree):
+    index = PythonServerIndex.build(tree.modules.items())
+    for path, text in tree.modules.items():
+        result = scan_source(
+            text, "python", module_path=path, server_index=index
+        )
+        assert sorted(
+            site.name for site in result.sites if site.name
+        ) == sorted(tree.names.get(path, [])), (tree.case, path)
+        assert sorted(
+            site.unresolved_reason for site in result.sites if site.name is None
+        ) == sorted(tree.unresolved.get(path, [])), (tree.case, path)
+        assert list(result.server_modules) == tree.depends_on.get(path, []), (
+            tree.case,
+            path,
+        )
+
+
+def test_only_a_site_that_followed_a_binding_proves_a_server():
+    """``proves_server`` is what lets a route exist with no readable names.
+
+    Every `neo4j-contrib/mcp-neo4j` tool is `name=namespace_prefix + "…"`, so
+    requiring a resolved name would leave the repository reported as "not an
+    agent project" — the state this input exists to end. It must stay false for
+    a spelling, which is all the lexed idioms ever match, and false for a
+    decorator whose object this reader could not follow.
+    """
+
+    proven, unproven = (
+        scan_source(text, "python").sites[0]
+        for text in (
+            'from fastmcp import FastMCP\n'
+            'mcp = FastMCP("s")\n'
+            "@mcp.tool(name=RUNTIME)\n"
+            "def built() -> None:\n"
+            "    pass\n",
+            "@app.tool()\ndef foreign() -> None:\n    pass\n",
+        )
+    )
+    assert proven.proves_server is True and proven.name is None
+    assert unproven.proves_server is False
+    for idiom, sample in POSITIVE_SAMPLES.items():
+        if idiom == "py_fastmcp_decorator":
+            continue
+        sites = scan_source(sample.text, sample.language).sites
+        assert not any(site.proves_server for site in sites), idiom
+
+
+@pytest.mark.parametrize(
+    ("requirement", "expected"),
+    [
+        # The spelling `redis/mcp-redis` and `chroma-core/chroma-mcp` both
+        # declare, and the one discovery's general token scan throws away.
+        ("mcp[cli]>=1.26.0,<2", "mcp"),
+        ("fastmcp>=2.10.5,<2.14", "fastmcp"),
+        ("  mcp == 1.6.0  ", "mcp"),
+        ("Mcp_Server.Extras", "mcp-server-extras"),
+        ("mcp @ https://example.invalid/mcp.whl", "mcp"),
+        ('mcp; python_version >= "3.10"', "mcp"),
+        ("# mcp", None),
+        ("", None),
+        ("-r other.txt", None),
+    ],
+)
+def test_a_requirement_resolves_to_its_distribution_name(
+    requirement: str, expected: str | None
+):
+    assert normalized_distribution(requirement) == expected
+
+
+def test_the_python_gate_names_the_dependency_it_matched():
+    assert declares_python_mcp_framework(["redis>=6", "mcp[cli]>=1.26"]) == "mcp"
+    assert declares_python_mcp_framework(["fastmcp>=2.10"]) == "fastmcp"
+    # `mcp-neo4j-cypher` is the *server's own* distribution name. A prefix
+    # match would read a server's own package as its dependency on itself.
+    assert declares_python_mcp_framework(["mcp-neo4j-cypher", "neo4j>=5"]) is None
 
 
 # --- The published token list ----------------------------------------------

--- a/tests/test_mcp_idioms.py
+++ b/tests/test_mcp_idioms.py
@@ -367,6 +367,15 @@ def test_a_python_tool_with_no_parameters_is_not_one_without_a_signature():
     assert scan_source(case.text, case.language).sites[0].parameters == ()
     go = POSITIVE_SAMPLES["go_tool_struct"]
     assert scan_source(go.text, go.language).sites[0].parameters is None
+    # And a signature *withheld* reads as the third thing, not the first: the
+    # schema comes from the same object as the name, so publishing a parameter
+    # list beside an unreadable name would describe a function the server may
+    # never have registered.
+    wrapped = REGRESSIONS["python_signature_withheld_by_a_wrapper"]
+    site = scan_source(wrapped.text, wrapped.language).sites[0]
+    assert site.unresolved_reason == "wrapped_before_registration"
+    assert site.parameters is None
+    assert site.returns is None
 
 
 def test_a_python_variadic_is_not_a_signature_parameter():

--- a/tests/test_mcp_server_source.py
+++ b/tests/test_mcp_server_source.py
@@ -24,6 +24,7 @@ from agents_shipgate.core.semantic_assessment import (
     AST_ONLY_SOURCE_TYPES,
     MCP_SOURCE_TYPES,
 )
+from agents_shipgate.inputs import mcp_server_source
 from agents_shipgate.inputs.mcp_idioms import DIFF_TOKENS
 from agents_shipgate.inputs.mcp_server_source import (
     MAX_SCANNED_FILES,
@@ -113,6 +114,10 @@ def _redis_shaped(root: Path) -> Path:
     cross-module index at all: all 53 of its registrations sit in
     ``src/tools/*.py`` and the server they register on is built in
     ``src/common/server.py``.
+
+    Two tool modules, not one, because one is the shape in which several
+    defects are invisible: a route that repeats its proving module once per
+    importer looks correct with a single importer.
     """
 
     workspace = root / "redis"
@@ -145,6 +150,16 @@ def _redis_shaped(root: Path) -> Path:
         "\n"
         "@mcp.tool(name=NAMESPACE + \'hdel\')\n"
         "async def hdel(name: str) -> str:\n"
+        '    return ""\n',
+        encoding="utf-8",
+    )
+    (workspace / "src" / "tools" / "list.py").write_text(
+        "from src.common.server import mcp\n"
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "async def lpush(name: str, value: str) -> str:\n"
+        '    """Prepend a value to a list."""\n'
         '    return ""\n',
         encoding="utf-8",
     )
@@ -914,6 +929,129 @@ def test_an_export_beside_the_source_route_keeps_its_high_confidence(tmp_path):
     assert by_provider["registrations"]["confidence"] == "medium"
 
 
+# --- The Python language gate ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "pyproject", "expected"),
+    [
+        (
+            "pep621",
+            '[project]\nname = "s"\ndependencies = ["mcp[cli]>=1.26.0,<2"]\n',
+            "mcp",
+        ),
+        (
+            "pep621_optional",
+            '[project]\nname = "s"\n'
+            "[project.optional-dependencies]\n"
+            'server = ["fastmcp>=2.10"]\n',
+            "fastmcp",
+        ),
+        (
+            "pep735_groups",
+            '[project]\nname = "s"\n'
+            "[dependency-groups]\n"
+            'dev = ["mcp[cli]>=1.0"]\n',
+            "mcp",
+        ),
+        # Poetry writes the distribution as the table *key*, so a walker that
+        # read only the values found `^1.6.0` and never `mcp` — every Poetry
+        # table below was dead, and the gate withheld the route from a
+        # Poetry-managed server entirely.
+        (
+            "poetry_table",
+            '[tool.poetry.dependencies]\npython = "^3.10"\nmcp = "^1.6.0"\n',
+            "mcp",
+        ),
+        (
+            "poetry_inline_table",
+            '[tool.poetry.dependencies]\nfastmcp = {version = "^2.10"}\n',
+            "fastmcp",
+        ),
+        (
+            "poetry_group",
+            '[tool.poetry.group.dev.dependencies]\nmcp = "^1.0"\n',
+            "mcp",
+        ),
+        # The server's *own* distribution name is not a dependency on MCP.
+        (
+            "the_servers_own_name",
+            '[project]\nname = "mcp-neo4j-cypher"\ndependencies = ["neo4j>=5"]\n',
+            None,
+        ),
+        ("unparseable", "[project\nname =\n", None),
+    ],
+)
+def test_the_python_gate_reads_every_dependency_table_it_names(
+    tmp_path, label: str, pyproject: str, expected: str | None
+):
+    """Five tables are named in the constant; all five have to be reachable.
+
+    A route table with one tested entry is the shape #485 warns about — the
+    Poetry rows shipped dead in the first draft of this input and no fixture
+    could see it, because every fixture in this file writes PEP 621.
+    """
+
+    workspace = tmp_path / label
+    (workspace / "pkg").mkdir(parents=True)
+    (workspace / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    (workspace / "pkg" / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def gated() -> None:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    discovery = discover_mcp_server_source(
+        workspace, files=sorted(workspace.rglob("*"))
+    )
+    if expected is None:
+        assert discovery.path is None, label
+        return
+    assert discovery.path == "pkg", label
+    assert discovery.tool_names == ("gated",)
+    assert any(
+        line.endswith(f"depends on {expected}")
+        for line in discovery.framework_evidence
+    ), (label, discovery.framework_evidence)
+
+
+def test_a_requirements_file_opens_the_python_gate(tmp_path):
+    """`requirements*.txt` is the pre-`pyproject.toml` spelling, and the glob
+    is deliberate: a server pinning its SDK in `requirements-dev.txt` has
+    declared it just as plainly."""
+
+    workspace = tmp_path / "reqs"
+    (workspace / "pkg").mkdir(parents=True)
+    (workspace / "requirements-dev.txt").write_text(
+        "# tooling\n-r base.txt\nfastmcp>=2.10.5\n", encoding="utf-8"
+    )
+    (workspace / "pkg" / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def gated() -> None:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    discovery = discover_mcp_server_source(
+        workspace, files=sorted(workspace.rglob("*"))
+    )
+    assert discovery.path == "pkg"
+    assert discovery.framework_evidence == (
+        "requirements-dev.txt depends on fastmcp",
+    )
+
+
 # --- Reading a Python server ------------------------------------------------
 
 
@@ -930,7 +1068,7 @@ def test_a_python_server_yields_its_tools_with_the_signature_schema(tmp_path):
     loaded = load_mcp_server_source(_source("src"), workspace)
 
     by_name = {tool.name: tool for tool in loaded.tools}
-    assert set(by_name) == {"hset"}
+    assert set(by_name) == {"hset", "lpush"}
     hset = by_name["hset"]
     assert hset.extraction["idiom"] == "py_fastmcp_decorator"
     assert hset.extraction_confidence == "medium"
@@ -969,19 +1107,18 @@ def test_a_python_binding_that_lives_in_another_module_still_resolves(tmp_path):
     """
 
     workspace = _redis_shaped(tmp_path)
-    assert [
+    assert sorted(
         tool.name
         for tool in load_mcp_server_source(_source("src"), workspace).tools
-    ] == ["hset"]
+    ) == ["hset", "lpush"]
     # Point the route at the decorators alone and the proof is gone — recorded
     # as an omission rather than silently resolved against a module this walk
     # never opened.
     narrowed = load_mcp_server_source(_source("src/tools"), workspace)
     assert narrowed.tools == []
     assert [o.reason for o in narrowed.omissions] == [
-        "server_binding_not_proven",
-        "server_binding_not_proven",
-    ]
+        "server_binding_not_proven"
+    ] * 3
 
 
 def test_the_route_covers_the_module_that_proves_the_binding(tmp_path):
@@ -1000,7 +1137,14 @@ def test_the_route_covers_the_module_that_proves_the_binding(tmp_path):
     )
 
     assert discovery.path == "src"
-    assert "src/common/server.py" in discovery.candidate_files
+    # Once, not once per importer: two modules import this server, and a route
+    # that listed its proving module twice would over-count what one manifest
+    # has to describe.
+    assert discovery.candidate_files == (
+        "src/common/server.py",
+        "src/tools/hash.py",
+        "src/tools/list.py",
+    )
     # The agreement the route exists for, asserted rather than assumed.
     assert set(discovery.tool_names) == {
         tool.name
@@ -1033,6 +1177,28 @@ def test_a_variadic_is_not_a_tool_parameter(tmp_path):
     tool = load_mcp_server_source(_source("server.py"), workspace).tools[0]
     assert [p.name for p in tool.parameters] == ["query"]
     assert tool.function_signature == "forwarding(query) -> str"
+
+
+def test_the_index_read_cache_is_a_cost_bound_and_not_a_decision(tmp_path):
+    """Past the cache bound a file is read twice, not read differently.
+
+    Every other cap in this input leaves a hole in the enumeration and is
+    reported as an omission. This one leaves a hole in nothing, so the test is
+    that turning it off entirely changes no answer — if it ever does, it has
+    stopped being a bound and started being a rule.
+    """
+
+    workspace = _redis_shaped(tmp_path)
+    cached = load_mcp_server_source(_source("src"), workspace)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(mcp_server_source, "MAX_CACHED_SOURCE_BYTES", 0)
+        uncached = load_mcp_server_source(_source("src"), workspace)
+
+    assert [tool.model_dump() for tool in uncached.tools] == [
+        tool.model_dump() for tool in cached.tools
+    ]
+    assert uncached.omissions == cached.omissions
+    assert uncached.warnings == cached.warnings
 
 
 def test_a_python_context_parameter_is_not_a_tool_parameter(tmp_path):

--- a/tests/test_mcp_server_source.py
+++ b/tests/test_mcp_server_source.py
@@ -106,6 +106,52 @@ def _source(path: str, source_id: str = "server") -> ToolSourceConfig:
     return ToolSourceConfig(id=source_id, type=SOURCE_TYPE, path=path)
 
 
+def _redis_shaped(root: Path) -> Path:
+    """A Python server that constructs in one module and decorates in another.
+
+    `redis/mcp-redis`'s shape, which is the reason the reader carries a
+    cross-module index at all: all 53 of its registrations sit in
+    ``src/tools/*.py`` and the server they register on is built in
+    ``src/common/server.py``.
+    """
+
+    workspace = root / "redis"
+    (workspace / "src" / "common").mkdir(parents=True)
+    (workspace / "src" / "tools").mkdir(parents=True)
+    (workspace / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "redis-mcp-server"\n'
+        "dependencies = [\n"
+        '    "mcp[cli]>=1.26.0,<2",\n'
+        '    "redis>=6.0.0",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+    (workspace / "src" / "common" / "server.py").write_text(
+        "from mcp.server.fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("Redis MCP Server")\n',
+        encoding="utf-8",
+    )
+    (workspace / "src" / "tools" / "hash.py").write_text(
+        "from src.common.server import mcp\n"
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "async def hset(name: str, key: str, expire_seconds: int = 0) -> str:\n"
+        '    """Set a field in a hash stored at key."""\n'
+        '    return ""\n'
+        "\n"
+        "\n"
+        "@mcp.tool(name=NAMESPACE + \'hdel\')\n"
+        "async def hdel(name: str) -> str:\n"
+        '    return ""\n',
+        encoding="utf-8",
+    )
+    return workspace
+
+
+
 # --- Registration -----------------------------------------------------------
 
 
@@ -294,16 +340,20 @@ def test_a_path_with_no_readable_source_is_a_parse_error(tmp_path):
     workspace = tmp_path / "empty"
     (workspace / "docs").mkdir(parents=True)
     (workspace / "docs" / "README.md").write_text("# hi\n", encoding="utf-8")
-    with pytest.raises(InputParseError, match="no TypeScript or Go files"):
+    with pytest.raises(
+        InputParseError, match="no TypeScript, Go or Python files"
+    ):
         load_mcp_server_source(_source("docs"), workspace)
 
 
 def test_a_single_file_in_another_language_is_a_parse_error(tmp_path):
-    workspace = tmp_path / "py"
+    workspace = tmp_path / "rb"
     workspace.mkdir()
-    (workspace / "server.py").write_text("x = 1\n", encoding="utf-8")
-    with pytest.raises(InputParseError, match="not a TypeScript or Go file"):
-        load_mcp_server_source(_source("server.py"), workspace)
+    (workspace / "server.rb").write_text("x = 1\n", encoding="utf-8")
+    with pytest.raises(
+        InputParseError, match="not a TypeScript, Go or Python file"
+    ):
+        load_mcp_server_source(_source("server.rb"), workspace)
 
 
 def test_a_missing_path_is_a_parse_error(tmp_path):
@@ -862,6 +912,273 @@ def test_an_export_beside_the_source_route_keeps_its_high_confidence(tmp_path):
     by_provider = {row["provider"]: row for row in report.tool_catalog}
     assert by_provider["exported"]["confidence"] == "high"
     assert by_provider["registrations"]["confidence"] == "medium"
+
+
+# --- Reading a Python server ------------------------------------------------
+
+
+def test_a_python_server_yields_its_tools_with_the_signature_schema(tmp_path):
+    """The three facts the lexed idioms do not have, end to end.
+
+    The name comes from the decorated function, the description from the
+    docstring, and the input schema from the annotated signature — none of
+    which is a literal beside the call, which is why this idiom needed a real
+    parser rather than a sixth pattern.
+    """
+
+    workspace = _redis_shaped(tmp_path)
+    loaded = load_mcp_server_source(_source("src"), workspace)
+
+    by_name = {tool.name: tool for tool in loaded.tools}
+    assert set(by_name) == {"hset"}
+    hset = by_name["hset"]
+    assert hset.extraction["idiom"] == "py_fastmcp_decorator"
+    assert hset.extraction_confidence == "medium"
+    assert hset.description == "Set a field in a hash stored at key."
+    assert hset.source_path == "src/tools/hash.py"
+    assert [(p.name, p.type, p.required) for p in hset.parameters] == [
+        ("name", "string", True),
+        ("key", "string", True),
+        ("expire_seconds", "number", False),
+    ]
+    assert hset.input_schema["required"] == ["name", "key"]
+    assert hset.function_signature == "hset(name, key, expire_seconds) -> str"
+    assert hset.output_schema == {"type": "string"}
+
+
+def test_a_lexical_idiom_publishes_no_input_schema(tmp_path):
+    """An idiom that reads no signature must not assert an empty one.
+
+    ``{"type": "object", "properties": {}}`` is the claim "this tool takes no
+    arguments", and inventing it for every TypeScript registration in the
+    catalog would be a schema assertion nobody made.
+    """
+
+    workspace = _mongodb_shaped(tmp_path)
+    tool = load_mcp_server_source(_source("packages"), workspace).tools[0]
+    assert tool.input_schema == {}
+    assert tool.parameters == []
+    assert tool.function_signature is None
+
+
+def test_a_python_binding_that_lives_in_another_module_still_resolves(tmp_path):
+    """The server is built in `src/common/server.py` and used in `src/tools/`.
+
+    A per-file reader proves nothing here, and "nothing" is the whole surface
+    of the largest Python server in the survey.
+    """
+
+    workspace = _redis_shaped(tmp_path)
+    assert [
+        tool.name
+        for tool in load_mcp_server_source(_source("src"), workspace).tools
+    ] == ["hset"]
+    # Point the route at the decorators alone and the proof is gone — recorded
+    # as an omission rather than silently resolved against a module this walk
+    # never opened.
+    narrowed = load_mcp_server_source(_source("src/tools"), workspace)
+    assert narrowed.tools == []
+    assert [o.reason for o in narrowed.omissions] == [
+        "server_binding_not_proven",
+        "server_binding_not_proven",
+    ]
+
+
+def test_the_route_covers_the_module_that_proves_the_binding(tmp_path):
+    """`detect` must not name a route on which `scan` proves less than it did.
+
+    The registrations are under `src/tools/`; the server they register on is
+    built in `src/common/server.py`, which registers nothing. A route computed
+    from the registration files alone is `src/tools` — and pointed there, the
+    adapter cannot open the module that proves the binding, so `detect`
+    promises 53 tools and `scan` enumerates none of them.
+    """
+
+    workspace = _redis_shaped(tmp_path)
+    discovery = discover_mcp_server_source(
+        workspace, files=sorted(workspace.rglob("*"))
+    )
+
+    assert discovery.path == "src"
+    assert "src/common/server.py" in discovery.candidate_files
+    # The agreement the route exists for, asserted rather than assumed.
+    assert set(discovery.tool_names) == {
+        tool.name
+        for tool in load_mcp_server_source(
+            _source(discovery.path), workspace
+        ).tools
+    }
+
+
+def test_a_variadic_is_not_a_tool_parameter(tmp_path):
+    """``*args`` and ``**kwargs`` are not schema properties.
+
+    A tool that takes them takes arguments this reader cannot enumerate, and
+    publishing one called ``options`` would name a property no caller sends.
+    """
+
+    workspace = tmp_path / "variadic"
+    workspace.mkdir()
+    (workspace / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def forwarding(query: str, *filters: str, **options: str) -> str:\n"
+        "    return query\n",
+        encoding="utf-8",
+    )
+    tool = load_mcp_server_source(_source("server.py"), workspace).tools[0]
+    assert [p.name for p in tool.parameters] == ["query"]
+    assert tool.function_signature == "forwarding(query) -> str"
+
+
+def test_a_python_context_parameter_is_not_a_tool_parameter(tmp_path):
+    """The server strips it from the schema it publishes, so this must too.
+
+    Matched on the annotation as well as the conventional name: a catalog that
+    kept it would publish a required argument no caller can supply.
+    """
+
+    workspace = tmp_path / "ctx"
+    workspace.mkdir()
+    (workspace / "server.py").write_text(
+        "from mcp.server.mcpserver import Context, MCPServer\n"
+        "\n"
+        'mcp = MCPServer("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "async def search(query: str, reporter: Context) -> str:\n"
+        '    return ""\n',
+        encoding="utf-8",
+    )
+    tool = load_mcp_server_source(_source("server.py"), workspace).tools[0]
+    assert [p.name for p in tool.parameters] == ["query"]
+
+
+def test_an_unparseable_python_file_holds_its_surface_partial(tmp_path):
+    """Nothing about the file is known past a syntax error.
+
+    Completeness is per file (#393), so the module beside it stays
+    ``enumerated`` — but the broken one is an omission the exclusion ledger
+    accounts for, never a file that quietly registered nothing.
+    """
+
+    workspace = tmp_path / "broken"
+    (workspace / "pkg").mkdir(parents=True)
+    (workspace / "pkg" / "good.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def readable() -> None:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    (workspace / "pkg" / "broken.py").write_text(
+        "from fastmcp import FastMCP\n"
+        'mcp = FastMCP("s")\n'
+        "@mcp.tool(\n"
+        "def truncated() -> None:\n",
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(_source("pkg"), workspace)
+
+    assert [tool.name for tool in loaded.tools] == ["readable"]
+    assert loaded.tools[0].extraction["surface"] == SURFACE_ENUMERATED
+    assert [(o.subject, o.reason) for o in loaded.omissions] == [
+        ("pkg/broken.py", "unparseable_python")
+    ]
+
+
+def test_detect_offers_the_route_for_a_server_it_cannot_name_a_tool_of(tmp_path):
+    """`neo4j-contrib/mcp-neo4j` builds every tool name at run time.
+
+    All 40 of its registrations are ``name=namespace_prefix + "…"``, so a rule
+    requiring one resolved name would report the repository as "not an agent
+    project" *because* its names are dynamic — the exact silent miss this input
+    exists to end. The Python idiom's site carries its own provenance: it was
+    only emitted after the decorator was followed back to a server
+    construction, and a client does not construct a server.
+    """
+
+    workspace = tmp_path / "neo4j"
+    (workspace / "servers" / "cypher").mkdir(parents=True)
+    (workspace / "servers" / "cypher" / "pyproject.toml").write_text(
+        '[project]\nname = "mcp-neo4j-cypher"\ndependencies = ["fastmcp>=2.10.5"]\n',
+        encoding="utf-8",
+    )
+    (workspace / "servers" / "cypher" / "server.py").write_text(
+        "from fastmcp.server import FastMCP\n"
+        "\n"
+        "\n"
+        'def create_mcp_server(namespace: str = "") -> FastMCP:\n'
+        '    mcp: FastMCP = FastMCP("mcp-neo4j-cypher")\n'
+        "    namespace_prefix = _format(namespace)\n"
+        "\n"
+        '    @mcp.tool(name=namespace_prefix + "get_neo4j_schema")\n'
+        "    async def get_neo4j_schema() -> str:\n"
+        '        return ""\n'
+        "\n"
+        "    return mcp\n",
+        encoding="utf-8",
+    )
+
+    discovery = discover_mcp_server_source(
+        workspace, files=sorted(workspace.rglob("*"))
+    )
+    assert discovery.path == "servers/cypher"
+    assert discovery.tool_names == ()
+    assert discovery.unresolved_count == 1
+    assert "none of which this reader can name" in discovery.evidence[0]
+
+    result = detect_workspace(workspace)
+    assert result.is_agent_project is True
+    assert SOURCE_TYPE in {f.type for f in result.frameworks}
+
+
+def test_a_readable_export_never_displaces_a_route_with_no_names(tmp_path):
+    """Containment is the test, and nothing contains an empty surface.
+
+    ``names <= covered`` is vacuously true for the empty set, so asking the
+    question would let any readable export withhold the one route that says
+    "40 registrations nobody can enumerate" — which is what no export restates.
+    """
+
+    workspace = tmp_path / "both"
+    (workspace / "pkg").mkdir(parents=True)
+    (workspace / "pyproject.toml").write_text(
+        '[project]\nname = "s"\ndependencies = ["fastmcp"]\n', encoding="utf-8"
+    )
+    (workspace / "pkg" / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool(name=RUNTIME)\n"
+        "def built() -> None:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    (workspace / "mcp-tools.json").write_text(
+        json.dumps({"tools": [{"name": "something_else", "description": "d"}]}),
+        encoding="utf-8",
+    )
+
+    discovery = discover_mcp_server_source(
+        workspace,
+        files=sorted(workspace.rglob("*")),
+        exported_source_paths=["mcp-tools.json"],
+    )
+    assert discovery.path == "pkg"
+    assert discovery.excluded == ()
+    assert not any("does not name" in line for line in discovery.evidence)
 
 
 # --- The trigger catalog ----------------------------------------------------

--- a/tests/test_mcp_server_source.py
+++ b/tests/test_mcp_server_source.py
@@ -1225,6 +1225,161 @@ def test_a_python_context_parameter_is_not_a_tool_parameter(tmp_path):
     assert [p.name for p in tool.parameters] == ["query"]
 
 
+def test_a_conventional_parameter_name_is_still_a_tool_input(tmp_path):
+    """The framework injects on the *annotation*, so this reader must too.
+
+    `SKIPPED_TOOL_PARAMETERS` is shared with the other Python adapters and
+    holds `config`, `context` and `runtime` — all ordinary user-supplied
+    inputs to an MCP tool. Dropping them by name published an empty schema for
+    a three-argument tool, which hides a real parameter inventory from every
+    schema and policy consumer downstream.
+    """
+
+    workspace = tmp_path / "names"
+    workspace.mkdir()
+    (workspace / "server.py").write_text(
+        "from mcp.server.fastmcp import Context, FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def configure(config: dict, context: str, runtime: str) -> str:\n"
+        '    return ""\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "async def search(\n"
+        "    query: str,\n"
+        "    reporter: Context,\n"
+        "    optional: Context | None = None,\n"
+        "    parameterised: Context[object, None] = None,\n"
+        "    holder: list[Context] = None,\n"
+        ") -> str:\n"
+        '    return ""\n',
+        encoding="utf-8",
+    )
+    by_name = {
+        tool.name: tool
+        for tool in load_mcp_server_source(_source("server.py"), workspace).tools
+    }
+
+    assert [p.name for p in by_name["configure"].parameters] == [
+        "config",
+        "context",
+        "runtime",
+    ]
+    assert by_name["configure"].input_schema["required"] == [
+        "config",
+        "context",
+        "runtime",
+    ]
+    # Only the annotated context is injected. `list[Context]` is a list.
+    assert [p.name for p in by_name["search"].parameters] == ["query", "holder"]
+
+
+def test_a_decorator_below_the_registration_withholds_the_name(tmp_path):
+    """The registration receives what the inner decorator returned.
+
+    Decorators apply bottom-up, so `@mcp.tool()` over `@replace` registers
+    `replace(harmless)` — whose name and signature need not be this `def`'s.
+    A `functools.wraps` wrapper does preserve both, but that is a fact about
+    the decorator's body, which this reader does not read. So the site keeps
+    its provenance and loses its name, rather than publishing an id nobody
+    serves.
+    """
+
+    workspace = tmp_path / "wrapped"
+    workspace.mkdir()
+    (workspace / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "def replace(fn):\n"
+        "    def delete_all(target: str) -> str:\n"
+        '        return "unused"\n'
+        "\n"
+        "    return delete_all\n"
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "@replace\n"
+        "def harmless(query: int) -> str:\n"
+        '    return "unused"\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def plain(query: int) -> str:\n"
+        '    return ""\n',
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(_source("server.py"), workspace)
+
+    assert [tool.name for tool in loaded.tools] == ["plain"]
+    assert [(o.subject, o.reason) for o in loaded.omissions] == [
+        ("server.py:13", "wrapped_before_registration")
+    ]
+    # Completeness is per file, so the readable sibling is held `partial` by
+    # its neighbour rather than published as a complete surface.
+    assert loaded.tools[0].extraction["surface"] == SURFACE_PARTIAL
+
+
+def test_an_export_cannot_displace_a_route_it_only_partly_accounts_for(tmp_path):
+    """A readable tool must not remove the protection a dynamic one has.
+
+    An export naming every registration this reader *could* read looks like
+    containment and is not: withholding the route sends the reader to the
+    export and never to `scan`, so the registration nobody could name reaches
+    no exclusion ledger at all — a measured miss turning back into a silent
+    one.
+    """
+
+    workspace = tmp_path / "mixed"
+    (workspace / "pkg").mkdir(parents=True)
+    (workspace / "pyproject.toml").write_text(
+        '[project]\nname = "s"\ndependencies = ["fastmcp"]\n', encoding="utf-8"
+    )
+    (workspace / "pkg" / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("s")\n'
+        "\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def visible() -> None:\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        '@mcp.tool(name=PREFIX + "delete_all")\n'
+        "def hidden() -> None:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    (workspace / "mcp-tools.json").write_text(
+        json.dumps({"tools": [{"name": "visible", "description": "d"}]}),
+        encoding="utf-8",
+    )
+
+    discovery = discover_mcp_server_source(
+        workspace,
+        files=sorted(workspace.rglob("*")),
+        exported_source_paths=["mcp-tools.json"],
+    )
+
+    assert discovery.path == "pkg"
+    assert discovery.excluded == ()
+    assert discovery.unresolved_count == 1
+    assert any(
+        "none of the 1 it could not" in line for line in discovery.evidence
+    )
+    # And the route it kept does reach the ledger.
+    assert [o.reason for o in load_mcp_server_source(_source("pkg"), workspace).omissions] == [
+        "name_not_literal"
+    ]
+
+
 def test_an_unparseable_python_file_holds_its_surface_partial(tmp_path):
     """Nothing about the file is known past a syntax error.
 

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -32,7 +32,12 @@ from agents_shipgate.cli.discovery import detect_workspace
 from agents_shipgate.cli.discovery import mcp_source as mcp_source_discovery
 from agents_shipgate.inputs import mcp_server_source
 from agents_shipgate.inputs.codex_plugin import resolve_local_codex_marketplace_roots
-from tests.mcp_idiom_corpus import ESCAPE_CASES, SCANNABLE_PATHS, SOURCE_CASES
+from tests.mcp_idiom_corpus import (
+    ESCAPE_CASES,
+    PYTHON_TREES,
+    SCANNABLE_PATHS,
+    SOURCE_CASES,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT_PATH = REPO_ROOT / "tools" / "shipgate-detect.py"
@@ -133,7 +138,7 @@ def test_framework_vocabulary_names_every_cli_omission(script_module):
     as the fixtures: a detection the CLI gains and the script does not is
     invisible to it until a sample exercises the difference. That is exactly
     what happened with ``mcp_server_source`` (#431) — the CLI learned to read
-    an MCP server's tool names out of TypeScript or Go registration sites, no
+    an MCP server's tool names out of TypeScript, Go or Python registration sites, no
     sample contained one, and the script went on reporting
     ``mongodb-js/mongodb-mcp-server`` as *not an agent project* for a whole
     release. #485 ported it, and ``known_omissions`` is empty again.
@@ -1399,6 +1404,21 @@ def _site_fields(site: Any) -> dict[str, Any]:
         "description": site.description,
         "operation_type": site.operation_type,
         "unresolved_reason": site.unresolved_reason,
+        # `proves_server` decides whether a route exists at all for a server
+        # whose tool names are built at run time, and the signature fields
+        # decide what schema the catalog publishes. A port that returned the
+        # dataclass defaults for all three would pass a names-only comparison
+        # while withholding `neo4j-contrib/mcp-neo4j` from one detector.
+        "parameters": (
+            None
+            if site.parameters is None
+            else [
+                (parameter.name, parameter.annotation, parameter.required)
+                for parameter in site.parameters
+            ]
+        ),
+        "returns": site.returns,
+        "proves_server": site.proves_server,
     }
 
 
@@ -1536,6 +1556,37 @@ def test_the_script_implements_every_idiom_the_cli_registry_publishes(script_mod
     assert emitted == set(script_module.IDIOM_IDS)
 
 
+@pytest.mark.parametrize("tree", PYTHON_TREES, ids=[t.case for t in PYTHON_TREES])
+def test_both_readers_follow_a_binding_across_modules_identically(
+    script_module, tree
+):
+    """The cross-module half of the Python reader, driven through both.
+
+    A per-file comparison cannot reach it: the largest Python server in the
+    survey constructs its server in one module and decorates in eleven others,
+    so the index — and the path-segment matching that resolves an import
+    against it — is what decides whether either detector sees 53 tools or none.
+    """
+
+    from agents_shipgate.inputs import mcp_idioms
+
+    cli_index = mcp_idioms.PythonServerIndex.build(tree.modules.items())
+    script_index = script_module.PythonServerIndex.build(tree.modules.items())
+    assert script_index.modules == cli_index.modules, tree.case
+
+    for path, text in tree.modules.items():
+        cli = mcp_idioms.scan_source(
+            text, "python", module_path=path, server_index=cli_index
+        )
+        script = script_module.scan_source(
+            text, "python", module_path=path, server_index=script_index
+        )
+        assert [_site_fields(site) for site in script.sites] == [
+            _site_fields(site) for site in cli.sites
+        ], (tree.case, path)
+        assert script.server_modules == cli.server_modules, (tree.case, path)
+
+
 def test_the_script_records_omissions_in_the_cli_vocabulary(script_module):
     """A reason spelled differently is a second vocabulary for one event.
 
@@ -1578,6 +1629,25 @@ def test_the_script_mirrors_the_readers_shared_vocabulary(script_module):
     assert script_module.SKIP_DIRECTORY_NAMES == mcp_idioms.SKIP_DIRECTORY_NAMES
     assert script_module.TEST_DIRECTORY_NAMES == mcp_idioms.TEST_DIRECTORY_NAMES
     assert script_module.PREFILTER_TOKEN == mcp_idioms.PREFILTER_TOKEN
+    assert (
+        script_module.PYTHON_SERVER_PREFILTER_TOKENS
+        == mcp_idioms.PYTHON_SERVER_PREFILTER_TOKENS
+    )
+    assert (
+        script_module.PYTHON_FRAMEWORK_PACKAGES
+        == mcp_idioms.PYTHON_FRAMEWORK_PACKAGES
+    )
+    assert (
+        script_module.PYTHON_SERVER_CONSTRUCTORS
+        == mcp_idioms.PYTHON_SERVER_CONSTRUCTORS
+    )
+    assert (
+        script_module.PYTHON_TOOL_DECORATOR_ATTR
+        == mcp_idioms.PYTHON_TOOL_DECORATOR_ATTR
+    )
+    assert script_module.LEXED_LANGUAGES == mcp_idioms.LEXED_LANGUAGES
+    assert script_module._TEST_FILE_PREFIXES == mcp_idioms._TEST_FILE_PREFIXES
+    assert script_module._TEST_FILE_NAMES == mcp_idioms._TEST_FILE_NAMES
     assert script_module.TOOL_NAME_RE.pattern == mcp_idioms.TOOL_NAME_RE.pattern
     assert script_module.MAX_SOURCE_FILE_BYTES == mcp_idioms.MAX_SOURCE_FILE_BYTES
     assert script_module.MCP_SOURCE_TYPE == mcp_server_source.SOURCE_TYPE
@@ -1608,6 +1678,19 @@ _TS_PACKAGE_JSON = '{"name": "srv", "dependencies": {"@modelcontextprotocol/sdk"
 _GO_MOD = "module example.com/srv\n\ngo 1.23\n\nrequire github.com/mark3labs/mcp-go v0.30.0\n"
 _TS_REGISTRATION = 'server.registerTool("search_docs", { inputSchema: shape }, handler);\n'
 _GO_REGISTRATION = 'var Incident = mcpgrafana.MustTool("update_incident", "Update", update)\n'
+_PY_PROJECT = '[project]\nname = "srv"\ndependencies = ["mcp[cli]>=1.26.0,<2"]\n'
+_PY_SERVER_MODULE = (
+    "from mcp.server.fastmcp import FastMCP\n\nmcp = FastMCP(\"Redis MCP Server\")\n"
+)
+_PY_TOOL_MODULE = (
+    "from src.common.server import mcp\n"
+    "\n"
+    "\n"
+    "@mcp.tool()\n"
+    "async def hset(name: str, key: str) -> str:\n"
+    '    """Set a field in a hash stored at key."""\n'
+    '    return ""\n'
+)
 
 _MCP_ROUTE_WORKSPACES: dict[str, dict[str, str]] = {
     # The plain TypeScript route: a declared SDK dependency and a name
@@ -1711,6 +1794,51 @@ _MCP_ROUTE_WORKSPACES: dict[str, dict[str, str]] = {
         "server.ts": _TS_REGISTRATION
         + "server.registerTool(DYNAMIC, { inputSchema: shape }, handler);\n",
     },
+    # `redis/mcp-redis`'s shape: the decorators are in one package and the
+    # server they register on is constructed in another, so the route has to
+    # widen to `src` to cover the module that proves the binding. A port that
+    # dropped the cross-module index would answer "not an agent project" here
+    # while the CLI reported the tool — and no sample has this shape.
+    "python_binding_from_another_module": {
+        "pyproject.toml": _PY_PROJECT,
+        "src/common/server.py": _PY_SERVER_MODULE,
+        "src/tools/hash.py": _PY_TOOL_MODULE,
+    },
+    # Every tool name built at run time, which is all 40 of
+    # `neo4j-contrib/mcp-neo4j`'s. The route exists because the site was
+    # followed back to a server construction, not because a name was read.
+    "python_names_are_all_dynamic": {
+        "pyproject.toml": _PY_PROJECT,
+        "pkg/server.py": (
+            "from fastmcp.server import FastMCP\n"
+            "\n"
+            'mcp = FastMCP("s")\n'
+            "\n"
+            "\n"
+            '@mcp.tool(name=PREFIX + "get_schema")\n'
+            "def get_schema() -> str:\n"
+            '    return ""\n'
+        ),
+    },
+    # A `.tool` decorator on an object this reader cannot follow proves
+    # nothing, so a repository that only ever writes that shape has no route —
+    # the fail-open both detectors have to refuse together.
+    "python_decorator_on_an_unfollowable_object": {
+        "pyproject.toml": _PY_PROJECT,
+        "pkg/module.py": (
+            "from mcp.server.fastmcp import FastMCP\n"
+            "\n"
+            "\n"
+            "class Module:\n"
+            "    def __init__(self, mcp: FastMCP) -> None:\n"
+            "        self.mcp = mcp\n"
+            "\n"
+            "    def register(self) -> None:\n"
+            "        @self.mcp.tool()\n"
+            "        def injected() -> None:\n"
+            "            pass\n"
+        ),
+    },
 }
 
 
@@ -1763,6 +1891,9 @@ def test_the_constructed_route_workspaces_actually_exercise_the_route(tmp_path):
         "both_languages_register_tools": "internal",
         "a_declared_language_that_registers_nothing": "pkg",
         "an_unresolved_site_outside_the_route": "src/tools",
+        "python_binding_from_another_module": "src",
+        "python_names_are_all_dynamic": "pkg",
+        "python_decorator_on_an_unfollowable_object": None,
     }
     assert excluded == {
         "typescript_source_only": [],
@@ -1778,6 +1909,9 @@ def test_the_constructed_route_workspaces_actually_exercise_the_route(tmp_path):
         "both_languages_register_tools": [],
         "a_declared_language_that_registers_nothing": [],
         "an_unresolved_site_outside_the_route": [],
+        "python_binding_from_another_module": [],
+        "python_names_are_all_dynamic": [],
+        "python_decorator_on_an_unfollowable_object": [],
     }
 
 

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -1883,6 +1883,10 @@ def test_the_script_mirrors_the_readers_shared_vocabulary(script_module):
         script_module.DEFAULT_MAX_SOURCE_FILES
         == mcp_source_discovery.DEFAULT_MAX_SOURCE_FILES
     )
+    assert (
+        script_module.MAX_CACHED_SOURCE_BYTES
+        == mcp_server_source.MAX_CACHED_SOURCE_BYTES
+    )
 
 
 # --- The MCP source route, on workspaces no sample has ----------------------

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -3036,7 +3036,8 @@ def _discover_mcp_server_source(
         if language is None:  # pragma: no cover - filtered above
             continue
         # ``is None``, not ``or``: an empty module caches as ``""``, which is
-        # the right answer and a falsy one.
+        # the right answer and a falsy one. The re-read returns the same text,
+        # so this costs a read and never an answer.
         text = python_texts.pop(path, None)
         if text is None:
             text = _mcp_source_text(path)

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -101,7 +101,7 @@ import subprocess
 import sys
 import threading
 import tomllib
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -2919,6 +2919,11 @@ def _contains_another_site(site: RegistrationSite, sites: list[RegistrationSite]
 #: reported, never silent.
 DEFAULT_MAX_SOURCE_FILES = 1500
 
+#: How many bytes of Python source the index pass keeps for the scan pass. A
+#: cost bound and never a decision: past it a file is read twice instead of
+#: once, so no answer moves and nothing is recorded. Mirrors the CLI's bound.
+MAX_CACHED_SOURCE_BYTES = 64 * 1024 * 1024
+
 #: How many tool names the evidence names before it summarises. The line is
 #: read by a human deciding whether to adopt, and 110 names is not evidence.
 _EVIDENCE_NAME_LIMIT = 5
@@ -3021,7 +3026,7 @@ def _discover_mcp_server_source(
     scannable.sort(key=lambda pair: pair[1])
     truncated = len(scannable) > max_source_files
     read = scannable[:max_source_files]
-    server_index = _mcp_python_server_index(read)
+    server_index, python_texts = _mcp_python_server_index(read)
     names: set[str] = set()
     languages: set[str] = set()
     unresolved_by_file: dict[str, int] = {}
@@ -3030,7 +3035,11 @@ def _discover_mcp_server_source(
         language = language_for_path(path)
         if language is None:  # pragma: no cover - filtered above
             continue
-        text = _mcp_source_text(path)
+        # ``is None``, not ``or``: an empty module caches as ``""``, which is
+        # the right answer and a falsy one.
+        text = python_texts.pop(path, None)
+        if text is None:
+            text = _mcp_source_text(path)
         if text is None:
             continue
         result = scan_source(
@@ -3131,21 +3140,38 @@ def _discover_mcp_server_source(
     )
 
 
-def _mcp_python_server_index(scannable: list[tuple[Path, str]]) -> PythonServerIndex:
-    """Index every Python module in the walk that constructs a FastMCP server.
+def _mcp_python_server_index(
+    scannable: list[tuple[Path, str]],
+) -> tuple[PythonServerIndex, dict[Path, str]]:
+    """Index every Python module in the walk that constructs an MCP server.
 
     Built ahead of the scan: `redis/mcp-redis` constructs its server in one
     module and decorates in eleven others, so resolving bindings as the walk
     went would prove or refuse the same decorator depending on file order.
+
+    Returns the texts it read alongside the index, up to
+    ``MAX_CACHED_SOURCE_BYTES``, so the scan pass reads each Python file once.
+    Past the bound a file is read twice rather than held, which changes no
+    answer. Streamed into ``build`` through a generator, so the whole tree is
+    never alive at once.
     """
-    modules: list[tuple[str, str]] = []
-    for path, relative in scannable:
-        if language_for_path(path) != "python":
-            continue
-        text = _mcp_source_text(path)
-        if text is not None:
-            modules.append((relative, text))
-    return PythonServerIndex.build(modules)
+    texts: dict[Path, str] = {}
+    cached = 0
+
+    def _modules() -> Iterator[tuple[str, str]]:
+        nonlocal cached
+        for path, relative in scannable:
+            if language_for_path(path) != "python":
+                continue
+            text = _mcp_source_text(path)
+            if text is None:
+                continue
+            if cached + len(text) <= MAX_CACHED_SOURCE_BYTES:
+                texts[path] = text
+                cached += len(text)
+            yield relative, text
+
+    return PythonServerIndex.build(_modules()), texts
 
 
 def _mcp_source_text(path: Path) -> str | None:

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -75,7 +75,7 @@ Intentional simplifications vs. the canonical CLI:
   reads them, so the two stay in step — do not bound one without the other.
 
 ``mcp_server_source`` — an MCP server whose tool surface exists only as
-TypeScript or Go registration sites (#431) — **is** detected here, through a
+TypeScript, Go or Python registration sites (#431, #484) — **is** detected here, through a
 port of the CLI's masking reader and its idiom registry (#485). That port is a
 second implementation of a load-bearing matcher, so it is held to the CLI's
 answers by a shared conformance corpus rather than by inspection: every
@@ -100,11 +100,12 @@ import re
 import subprocess
 import sys
 import threading
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-SCRIPT_VERSION = "0.5.0"
+SCRIPT_VERSION = "0.6.0"
 MAX_STRUCTURED_FILE_BYTES = 10 * 1024 * 1024
 # Matches ``detect_workspace``'s ``max_python_files``. The bound is on
 # parses, not on the inventory: capping the inventory lets an asset-heavy
@@ -149,7 +150,7 @@ FRAMEWORKS = (
     "langchain", "crewai", "google_adk", "anthropic",
     "openai_agents_sdk", "n8n", "conductor", "openai_api",
     # Not a Python framework and scored from neither the AST pass nor a
-    # filename glob: it is the workspace's own TypeScript or Go registration
+    # filename glob: it is the workspace's own TypeScript, Go or Python registration
     # sites, scored by `_discover_mcp_server_source` (#431, ported by #485).
     MCP_SOURCE_TYPE,
 )
@@ -799,7 +800,13 @@ def _probe_openapi(data: Any) -> str | None:
 LANGUAGE_EXTENSIONS: dict[str, tuple[str, ...]] = {
     "typescript": (".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"),
     "go": (".go",),
+    "python": (".py",),
 }
+
+#: The languages read with the masking lexer. Python has a real parser in the
+#: standard library, and a FastMCP tool's name, schema and very existence are
+#: binding facts rather than lexical ones.
+LEXED_LANGUAGES: frozenset[str] = frozenset({"typescript", "go"})
 
 #: Declared-dependency tokens that establish an MCP framework for a language.
 #: The provenance gate: an idiom hit in a repository that declares no MCP
@@ -818,6 +825,29 @@ GO_FRAMEWORK_MODULES: tuple[str, ...] = (
     "github.com/thinkinaixyz/go-mcp",
     "github.com/ktr0731/go-mcp",
 )
+#: Distribution names, normalised per PEP 503, that establish an MCP framework
+#: for Python. Weaker than the other two gates on purpose — a Python *client*
+#: depends on ``mcp`` too — because for Python the load-bearing half of the
+#: pairing is the import binding the reader itself requires.
+PYTHON_FRAMEWORK_PACKAGES: tuple[str, ...] = ("mcp", "fastmcp")
+#: ``(module prefix, class)`` pairs whose construction is an MCP server. Three,
+#: because all three are live: the standalone ``fastmcp`` package, ``FastMCP``
+#: as it shipped inside the official SDK's v1, and ``MCPServer`` — the same
+#: class after the SDK's v2 renamed it and replaced the old module with one
+#: that raises.
+PYTHON_SERVER_CONSTRUCTORS: tuple[tuple[str, str], ...] = (
+    ("fastmcp", "FastMCP"),
+    ("mcp.server.fastmcp", "FastMCP"),
+    ("mcp.server.mcpserver", "MCPServer"),
+)
+#: The index pass's cheap gate, derived from the table so the two cannot
+#: drift: a hand-written "fastmcp" skipped every SDK v2 server.
+PYTHON_SERVER_PREFILTER_TOKENS: tuple[str, ...] = tuple(
+    sorted({symbol.lower() for _module, symbol in PYTHON_SERVER_CONSTRUCTORS})
+)
+#: The decorator attribute that registers a tool. ``@mcp.resource`` and
+#: ``@mcp.prompt`` are siblings on the same object and register other things.
+PYTHON_TOOL_DECORATOR_ATTR = "tool"
 
 #: Directory names never walked for registration sites. Distinct from this
 #: script's own inventory-level ``SKIP_DIRS`` on purpose: this is the CLI
@@ -825,9 +855,10 @@ GO_FRAMEWORK_MODULES: tuple[str, ...] = (
 #: registrations* whatever each one's inventory already dropped.
 SKIP_DIRECTORY_NAMES: frozenset[str] = frozenset(
     {
-        ".git", ".hg", ".svn", ".next", ".nuxt", ".turbo", ".venv",
+        ".eggs", ".git", ".hg", ".mypy_cache", ".next", ".nuxt",
+        ".pytest_cache", ".ruff_cache", ".svn", ".tox", ".turbo", ".venv",
         "__pycache__", "bin", "build", "coverage", "dist", "node_modules",
-        "obj", "out", "target", "vendor", "venv",
+        "obj", "out", "site-packages", "target", "vendor", "venv",
     }
 )
 
@@ -839,10 +870,14 @@ TEST_DIRECTORY_NAMES: frozenset[str] = frozenset(
     }
 )
 _TEST_FILE_SUFFIXES: tuple[str, ...] = (
-    "_test.go",
+    "_test.go", "_test.py",
     ".test.ts", ".test.js", ".test.mts", ".test.mjs",
     ".spec.ts", ".spec.js", ".spec.mts", ".spec.mjs",
 )
+#: Python spells a test file with a *prefix* and pytest collects it that way,
+#: so a suffix-only rule reads ``test_server.py`` as the server.
+_TEST_FILE_PREFIXES: tuple[str, ...] = ("test_",)
+_TEST_FILE_NAMES: frozenset[str] = frozenset({"conftest.py"})
 
 #: Every idiom's pattern requires these four characters, in some case. A file
 #: that does not contain them cannot hold a registration, so ``scan_source``
@@ -869,6 +904,7 @@ IDIOM_IDS: frozenset[str] = frozenset(
     {
         "ts_static_tool_name",
         "ts_sdk_register_tool",
+        "py_fastmcp_decorator",
         "go_must_tool",
         "go_new_tool",
         "go_tool_struct",
@@ -896,20 +932,47 @@ class RegistrationSite:
     description: str | None = None
     operation_type: str | None = None
     unresolved_reason: str | None = None
+    #: The decorated function's signature, for an idiom that reads one.
+    #: ``None`` means the idiom reads no signature, which is a different
+    #: statement from a tool that takes no parameters (``()``).
+    parameters: tuple[SignatureParameter, ...] | None = None
+    #: The return annotation, rendered back to source.
+    returns: str | None = None
+    #: Whether *this site alone* is evidence that the repository is an MCP
+    #: server, independently of whether its name could be read. False for
+    #: every lexical idiom: those match a spelling. The Python idiom follows
+    #: the decorated object back to a ``FastMCP(...)`` construction before it
+    #: emits anything, so the route can be offered for a server whose every
+    #: tool name is built at run time.
+    proves_server: bool = False
+
+
+@dataclass(frozen=True)
+class SignatureParameter:
+    """One parameter of a decorated function, as written."""
+
+    name: str
+    annotation: str | None = None
+    required: bool = True
 
 
 @dataclass(frozen=True)
 class SourceScanResult:
     """What one file yielded.
 
-    ``anomalies`` are masking failures. They are separate from an unresolved
+    ``anomalies`` hold the whole file — a masking failure for a lexed
+    language, a syntax error for Python. They are separate from an unresolved
     site because they are a fact about the *file*: past the anomaly this reader
     cannot tell code from content, so a site it did not find there proves
     nothing.
+
+    ``server_modules`` are the other modules this file's proofs depended on, so
+    a route can be widened to cover the module that constructs the server.
     """
 
     sites: tuple[RegistrationSite, ...] = ()
     anomalies: tuple[str, ...] = ()
+    server_modules: tuple[str, ...] = ()
 
 
 def language_for_path(path: Any) -> str | None:
@@ -937,6 +1000,8 @@ def is_scannable_path(relative_path: Any) -> bool:
     if any(part.lower() in TEST_DIRECTORY_NAMES for part in parts[:-1]):
         return False
     name = path.name.lower()
+    if name in _TEST_FILE_NAMES or name.startswith(_TEST_FILE_PREFIXES):
+        return False
     return not name.endswith(_TEST_FILE_SUFFIXES)
 
 
@@ -979,9 +1044,6 @@ _GO_ESCAPES = {**_SHARED_ESCAPES, "a": "\a"}
 #: registration on one of them would answer "not an agent project" for a
 #: line-ending translation (#485 review).
 _TYPESCRIPT_LINE_TERMINATORS = frozenset("\n\r")
-#: Go adds the bell and has no line continuation and no bare ``\0``.
-_GO_ESCAPES = {**_SHARED_ESCAPES, "a": "\a"}
-
 
 _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _OCTAL_DIGITS = frozenset("01234567")
@@ -1029,6 +1091,11 @@ class MaskedSource:
 
 def mask_source(text: str, language: str) -> MaskedSource:
     """Overwrite comments and string bodies, recording every string literal."""
+    if language not in LEXED_LANGUAGES:
+        # Refused rather than defaulted: the dispatch below has no third
+        # branch, so a language added without a masker would be read with
+        # JavaScript's grammar and answer confidently.
+        raise ValueError(f"{language!r} is not read with the masking lexer")
     if language == "go":
         return _mask_go(text)
     return _mask_typescript(text)
@@ -1860,7 +1927,794 @@ def _brace_depth(masked: str, open_brace: int, index: int) -> int:
     return depth
 
 
-def scan_source(text: str, language: str) -> SourceScanResult:
+# --- Python: the FastMCP decorator (mirror of the CLI's #484 reader) --------
+#
+# Copied from `agents_shipgate.inputs.mcp_idioms`, function for function, for
+# the reason the masking lexer above was: the zero-install detector is the
+# documented first command run against a repository that has not adopted
+# Shipgate, and every vendor MCP server is one. A detector that answered "not
+# an agent project" for `redis/mcp-redis` while the CLI reported 53 tools
+# would be #485 happening a second time.
+#
+# The duplication is affordable only because it is not allowed to become a
+# *different* implementation: `tests/mcp_idiom_corpus.py` holds every case
+# either reader has been asked about — the whole Python probe list and the
+# cross-module trees included — and `tests/test_zero_install_detector.py`
+# drives both through all of it, comparing every field of every site.
+
+
+#: The cheap gate for the index pass, the same idea as :data:`PREFILTER_TOKEN`.
+#: A module that constructs a server has to name the class, and the class only
+#: comes from a module whose dotted path contains ``fastmcp``, so a file
+#: without this substring cannot contribute a construction and is never parsed.
+def _is_python_server_constructor(module: str, symbol: str) -> bool:
+    """Whether ``module.symbol`` names a class whose instance is an MCP server."""
+
+    return any(
+        symbol == known_symbol
+        and (module == known_module or module.startswith(f"{known_module}."))
+        for known_module, known_symbol in PYTHON_SERVER_CONSTRUCTORS
+    )
+
+
+def _names_a_python_server_class(text: str) -> bool:
+    """Whether ``text`` could construct a server at all."""
+
+    lowered = text.lower()
+    return any(token in lowered for token in PYTHON_SERVER_PREFILTER_TOKENS)
+
+
+def normalized_distribution(requirement: str) -> str | None:
+    """The PEP 503 name a requirement string declares, or ``None``.
+
+    Written here rather than reused from discovery's general package-token
+    scan because that scan drops exactly the spelling this gate needs:
+    ``mcp[cli]>=1.26.0,<2`` — the requirement ``redis/mcp-redis`` and
+    ``chroma-core/chroma-mcp`` both declare — carries an extras marker, and a
+    token rule admitting only ``[A-Za-z0-9_.-]+`` throws the whole line away.
+    """
+
+    text = requirement.strip()
+    if not text or text.startswith("#"):
+        return None
+    match = re.match(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?", text)
+    if match is None:
+        return None
+    rest = text[match.end() :].lstrip()
+    # Anything may follow a distribution name — extras, a version specifier, a
+    # direct reference, an environment marker, a comment — except another word
+    # character, which would mean the match stopped inside a token this reader
+    # does not understand and the leading run is not the whole name.
+    if rest[:1] not in {"", "[", "(", "@", ";", "=", "<", ">", "!", "~", ",", "#"}:
+        return None
+    return re.sub(r"[-_.]+", "-", match.group(0)).lower()
+
+
+def declares_python_mcp_framework(requirements: Any) -> str | None:
+    """The first requirement in ``requirements`` that names an MCP framework."""
+
+    for requirement in requirements:
+        name = normalized_distribution(requirement)
+        if name is not None and name in PYTHON_FRAMEWORK_PACKAGES:
+            return name
+    return None
+
+
+@dataclass(frozen=True)
+class _ImportBinding:
+    """What one imported name refers to.
+
+    ``symbol`` is ``None`` for ``import a.b`` and ``import a.b as c``, where
+    the bound name is an alias for a *module* rather than for something inside
+    one.
+    """
+
+    module: str
+    symbol: str | None
+    level: int
+
+
+class _PythonModule:
+    """One parsed module, with every name binding recorded per scope.
+
+    The binding table follows ``google_adk``'s rule (#400 review): a name means
+    what the module appears to say only when the module binds it **exactly
+    once** in the scope in effect. Two bindings make any resolution a guess
+    about which one ran, and a guess is not a proof — so the site becomes a
+    recorded omission instead of a catalogued tool.
+
+    Comprehension targets are deliberately not recorded. In Python 3 they bind
+    in the comprehension's own scope and cannot shadow the enclosing one, and a
+    ``def`` cannot appear inside a comprehension, so there is no decorator for
+    them to be in scope for either way.
+    """
+
+    def __init__(self, tree: ast.Module) -> None:
+        self.tree = tree
+        self._scopes: dict[int, ast.AST] = {}
+        self._bindings: dict[tuple[int, str], list[ast.AST]] = {}
+        self._imports: dict[tuple[int, str], _ImportBinding] = {}
+        #: A ``from x import *`` can rebind any name in the module, so nothing
+        #: in it is singly bound any more — including the ``FastMCP`` symbol a
+        #: construction rests on. Recorded once and consulted by every
+        #: resolution rather than approximated per name (#400 review).
+        self.star_import = False
+        self._visit(tree, tree)
+
+    # -- Construction ---------------------------------------------------
+
+    def _bind(self, scope: ast.AST, name: str, statement: ast.AST) -> None:
+        self._bindings.setdefault((id(scope), name), []).append(statement)
+
+    def _bind_target(
+        self, node: ast.AST | None, scope: ast.AST, statement: ast.AST
+    ) -> None:
+        if isinstance(node, ast.Name):
+            self._bind(scope, node.id, statement)
+        elif isinstance(node, ast.Tuple | ast.List):
+            for element in node.elts:
+                self._bind_target(element, scope, statement)
+        elif isinstance(node, ast.Starred):
+            self._bind_target(node.value, scope, statement)
+
+    def _visit(self, node: ast.AST, scope: ast.AST) -> None:
+        self._scopes[id(node)] = scope
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            self._visit_function(node, scope)
+            return
+        if isinstance(node, ast.ClassDef):
+            self._bind(scope, node.name, node)
+            for child in (*node.decorator_list, *node.bases):
+                self._visit(child, scope)
+            for keyword in node.keywords:
+                self._visit(keyword.value, scope)
+            for statement in node.body:
+                self._visit(statement, node)
+            return
+        self._record_bindings(node, scope)
+        for child in ast.iter_child_nodes(node):
+            self._visit(child, scope)
+
+    def _visit_function(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda, scope: ast.AST
+    ) -> None:
+        # A decorator, a default and an annotation are all evaluated where the
+        # ``def`` is written, not inside it. Reading them in the function's own
+        # scope would let a parameter named ``mcp`` shadow the module-level
+        # server for the very decorator that names it.
+        arguments = node.args
+        if not isinstance(node, ast.Lambda):
+            self._bind(scope, node.name, node)
+            for decorator in node.decorator_list:
+                self._visit(decorator, scope)
+            if node.returns is not None:
+                self._visit(node.returns, scope)
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self._visit(default, scope)
+        for argument in _python_arguments(arguments):
+            self._bind(node, argument.arg, argument)
+            if argument.annotation is not None:
+                self._visit(argument.annotation, scope)
+        body = node.body if isinstance(node.body, list) else [node.body]
+        for statement in body:
+            self._visit(statement, node)
+
+    def _record_bindings(self, node: ast.AST, scope: ast.AST) -> None:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                self._bind_target(target, scope, node)
+        elif isinstance(node, ast.AnnAssign | ast.AugAssign | ast.NamedExpr):
+            self._bind_target(node.target, scope, node)
+        elif isinstance(node, ast.For | ast.AsyncFor):
+            self._bind_target(node.target, scope, node)
+        elif isinstance(node, ast.withitem):
+            self._bind_target(node.optional_vars, scope, node)
+        elif isinstance(node, ast.ExceptHandler):
+            if node.name:
+                self._bind(scope, node.name, node)
+        elif isinstance(node, ast.Delete):
+            for target in node.targets:
+                self._bind_target(target, scope, node)
+        elif isinstance(node, ast.Global | ast.Nonlocal):
+            # Not a binding, but a declaration that the binding in effect lives
+            # in a scope this table did not build for this name. Recording it
+            # as one makes the name unprovable, which is the honest answer.
+            for name in node.names:
+                self._bind(scope, name, node)
+        elif isinstance(node, ast.MatchAs | ast.MatchStar):
+            if node.name:
+                self._bind(scope, node.name, node)
+        elif isinstance(node, ast.MatchMapping):
+            if node.rest:
+                self._bind(scope, node.rest, node)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                bound = alias.asname or alias.name.split(".", 1)[0]
+                module = alias.name if alias.asname else bound
+                self._bind(scope, bound, node)
+                self._imports[(id(scope), bound)] = _ImportBinding(
+                    module=module, symbol=None, level=0
+                )
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "*":
+                    self.star_import = True
+                    continue
+                bound = alias.asname or alias.name
+                self._bind(scope, bound, node)
+                self._imports[(id(scope), bound)] = _ImportBinding(
+                    module=node.module or "", symbol=alias.name, level=node.level
+                )
+
+    # -- Resolution -----------------------------------------------------
+
+    def _scope_chain(self, node: ast.AST) -> list[ast.AST]:
+        chain: list[ast.AST] = []
+        scope = self._scopes.get(id(node))
+        while scope is not None:
+            chain.append(scope)
+            if scope is self.tree:
+                break
+            scope = self._scopes.get(id(scope))
+        return chain
+
+    def binding_of(self, name: str, node: ast.AST) -> tuple[ast.AST, ast.AST] | None:
+        """The single binding of ``name`` in effect at ``node``, with its scope."""
+
+        if self.star_import:
+            return None
+        for scope in self._scope_chain(node):
+            bound = self._bindings.get((id(scope), name))
+            if bound is None:
+                continue
+            return (bound[0], scope) if len(bound) == 1 else None
+        return None
+
+    def import_of(self, name: str, node: ast.AST) -> _ImportBinding | None:
+        """``name``'s import binding at ``node``, when an import is what binds it."""
+
+        resolved = self.binding_of(name, node)
+        if resolved is None:
+            return None
+        binding, scope = resolved
+        if not isinstance(binding, ast.Import | ast.ImportFrom):
+            return None
+        return self._imports.get((id(scope), name))
+
+    def module_named(self, name: str, node: ast.AST) -> str | None:
+        """The dotted module ``name`` refers to, when it refers to one.
+
+        Both import forms can name a module: ``import mcp.server.fastmcp``
+        binds ``mcp``, and ``from mcp.server import fastmcp`` binds ``fastmcp``
+        to the same package one level further down.
+        """
+
+        binding = self.import_of(name, node)
+        if binding is None or binding.level:
+            return None
+        if binding.symbol is None:
+            return binding.module
+        return f"{binding.module}.{binding.symbol}" if binding.module else None
+
+    def is_fastmcp_construction(self, node: ast.AST | None) -> bool:
+        """Whether ``node`` is a call that constructs an MCP server."""
+
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        if isinstance(func, ast.Name):
+            binding = self.import_of(func.id, node)
+            return (
+                binding is not None
+                and binding.level == 0
+                and binding.symbol is not None
+                and _is_python_server_constructor(binding.module, binding.symbol)
+            )
+        dotted = _python_dotted_name(func)
+        if dotted is None:
+            return False
+        head, _, attribute = dotted.rpartition(".")
+        if not head:
+            return False
+        root, _, rest = head.partition(".")
+        module = self.module_named(root, node)
+        if module is None:
+            return False
+        return _is_python_server_constructor(
+            f"{module}.{rest}" if rest else module, attribute
+        )
+
+    def server_from_statement(self, statement: ast.AST, name: str) -> bool:
+        """Whether ``statement`` binds ``name`` to a server construction."""
+
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+        elif isinstance(statement, ast.AnnAssign):
+            targets = [statement.target]
+        else:
+            return False
+        # Only a plain ``name = FastMCP(...)``, or a chain of them. A tuple
+        # unpack binding the same name is binding it to an *element* of
+        # something this reader did not evaluate, so the target has to be the
+        # whole left-hand side.
+        if name not in {
+            target.id for target in targets if isinstance(target, ast.Name)
+        }:
+            return False
+        return self.is_fastmcp_construction(statement.value)
+
+    def module_scope_servers(self) -> frozenset[str]:
+        """Module-scope names this module binds to a server construction.
+
+        This is what another module can import. A construction inside a factory
+        function is a server too — ``neo4j-contrib/mcp-neo4j`` builds all four
+        of its servers that way — but it is not reachable by name from outside,
+        so it never enters the index.
+        """
+
+        return frozenset(
+            name
+            for (scope_id, name), bound in self._bindings.items()
+            if scope_id == id(self.tree)
+            and len(bound) == 1
+            and self.server_from_statement(bound[0], name)
+        )
+
+
+def _python_arguments(arguments: ast.arguments) -> list[ast.arg]:
+    """Every named parameter, in signature order, variadics included."""
+
+    named = [*arguments.posonlyargs, *arguments.args]
+    if arguments.vararg is not None:
+        named.append(arguments.vararg)
+    named.extend(arguments.kwonlyargs)
+    if arguments.kwarg is not None:
+        named.append(arguments.kwarg)
+    return named
+
+
+def _python_dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _python_dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else None
+    return None
+
+
+def python_server_exports(text: str) -> frozenset[str]:
+    """Module-scope names ``text`` binds to an MCP server construction.
+
+    Answers ``frozenset()`` for a module that cannot be parsed. The caller that
+    *reads* the module reports the syntax error as an anomaly; reporting it
+    twice would put one file's problem into two vocabularies.
+    """
+
+    # A cost bound, never a decision: a module that constructs a server has to
+    # name the class, so a file this refuses is one the parse below would find
+    # nothing in. A perturbation sweep reports it untested, which is the
+    # correct result for a prefilter.
+    if not _names_a_python_server_class(text):
+        return frozenset()
+    tree = _parse_python(text)
+    if tree is None:
+        return frozenset()
+    return _PythonModule(tree).module_scope_servers()
+
+
+def _parse_python(text: str) -> ast.Module | None:
+    try:
+        return ast.parse(text)
+    except (SyntaxError, ValueError, RecursionError, MemoryError):
+        # ``ValueError`` for source containing a NUL byte, ``RecursionError``
+        # for a deeply nested expression: both are the compiler declining to
+        # produce a tree, which is the same fact as a syntax error and has to
+        # be one recorded omission rather than an exception out of the walk.
+        return None
+
+
+@dataclass(frozen=True)
+class PythonServerIndex:
+    """Which modules in the scanned tree export an MCP server by name.
+
+    Built once per scan and consulted per file, because the population needs
+    it: ``redis/mcp-redis`` constructs its server in ``src/common/server.py``
+    and applies all 55 of its decorators in ``src/tools/*.py``.
+
+    Resolution matches *path segments* against the dotted module a file
+    imports from, and it is anchored at neither end. The scanned root is
+    wherever ``tool_sources[].path`` points, so a module reached as
+    ``src.common.server`` may sit at ``common/server.py`` when the root is
+    ``src/`` and at ``src/common/server.py`` when it is the repository — one
+    import, two path spellings, and the reader is not told which. A match
+    therefore counts when either side's segments end with the other's, and
+    only when **exactly one** module in the index matches: two candidates mean
+    this reader cannot tell which module was imported, and a guess about that
+    is a guess about whether the decorator registers a tool at all.
+    """
+
+    modules: dict[str, frozenset[str]] = field(default_factory=dict)
+
+    @classmethod
+    def build(cls, modules: Any) -> PythonServerIndex:
+        """Index ``(relative posix path, source text)`` pairs."""
+
+        indexed: dict[str, frozenset[str]] = {}
+        for path, text in modules:
+            exports = python_server_exports(text)
+            if exports:
+                indexed[path] = exports
+        return cls(indexed)
+
+    def resolve(self, module_path: str | None, module: str, level: int) -> str | None:
+        """The indexed module an import in ``module_path`` refers to."""
+
+        if not self.modules:
+            return None
+        parts = tuple(part for part in module.split(".") if part)
+        if level:
+            if module_path is None:
+                return None
+            package = PurePosixPath(module_path).parent
+            for _ in range(level - 1):
+                if package == PurePosixPath("."):
+                    return None
+                package = package.parent
+            for candidate in _python_module_paths(package, parts):
+                if candidate in self.modules:
+                    return candidate
+            return None
+        if not parts:
+            return None
+        matches = [
+            path
+            for path in sorted(self.modules)
+            if _python_module_key_matches(_python_module_key(path), parts)
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+
+def _python_module_key(path: str) -> tuple[str, ...]:
+    """The dotted-path segments a module file would be imported as."""
+
+    pure = PurePosixPath(path)
+    parts = pure.with_suffix("").parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return parts
+
+
+def _python_module_key_matches(key: tuple[str, ...], parts: tuple[str, ...]) -> bool:
+    if not key or not parts:
+        return False
+    if len(key) <= len(parts):
+        return parts[-len(key) :] == key
+    return key[-len(parts) :] == parts
+
+
+def _python_module_paths(
+    package: PurePosixPath, parts: tuple[str, ...]
+) -> tuple[str, ...]:
+    base = package.joinpath(*parts) if parts else package
+    return (
+        (base / "__init__.py").as_posix(),
+        base.with_suffix(".py").as_posix() if parts else "",
+    )
+
+
+def _python_sites(
+    text: str,
+    *,
+    module_path: str | None,
+    server_index: PythonServerIndex | None,
+) -> SourceScanResult:
+    """Every MCP server tool decorator in one module."""
+
+    tree = _parse_python(text)
+    if tree is None:
+        return SourceScanResult(anomalies=("unparseable_python",))
+    module = _PythonModule(tree)
+    offsets = _PythonOffsets(text)
+    index = server_index or PythonServerIndex()
+    sites: list[RegistrationSite] = []
+    server_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            receiver = _python_tool_receiver(decorator, module)
+            if receiver is None:
+                continue
+            proven, proving_module = _python_server_receiver(
+                module, receiver, index, module_path
+            )
+            if proving_module is not None:
+                server_modules.add(proving_module)
+            sites.append(
+                _python_site(node, decorator, receiver, offsets, proven=proven)
+            )
+    sites.sort(key=lambda site: (site.line, site.column))
+    return SourceScanResult(
+        sites=tuple(sites), server_modules=tuple(sorted(server_modules))
+    )
+
+
+def _python_tool_receiver(
+    decorator: ast.expr, module: _PythonModule
+) -> ast.expr | None:
+    """The object a ``.tool`` decorator registers on, or ``None``.
+
+    Three spellings, one meaning. FastMCP 2.x accepts a bare ``@mcp.tool``,
+    every surveyed server writes ``@mcp.tool()``, and a module may bind the
+    bound method to a name of its own first — ``register = mcp.tool`` and then
+    ``@register``. The third is followed through exactly **one** hop, the same
+    depth the zero-install detector's constant resolution uses: a chain of
+    aliases is unbounded, and each extra hop buys a shape nobody was measured
+    writing while widening what can be mistaken for a registration.
+    """
+
+    expression = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if (
+        isinstance(expression, ast.Attribute)
+        and expression.attr == PYTHON_TOOL_DECORATOR_ATTR
+    ):
+        return expression.value
+    if not isinstance(expression, ast.Name):
+        return None
+    resolved = module.binding_of(expression.id, expression)
+    if resolved is None:
+        return None
+    binding, _scope = resolved
+    # Only ``alias = <something>.tool``. Every other decorator in the language
+    # binds to something else — ``@staticmethod`` to an import, ``@deco`` to a
+    # ``def`` — so this cannot turn an ordinary decorator into a registration.
+    if not isinstance(binding, ast.Assign) or not all(
+        isinstance(target, ast.Name) for target in binding.targets
+    ):
+        return None
+    value = binding.value
+    if (
+        isinstance(value, ast.Attribute)
+        and value.attr == PYTHON_TOOL_DECORATOR_ATTR
+    ):
+        return value.value
+    return None
+
+
+def _python_server_receiver(
+    module: _PythonModule,
+    receiver: ast.expr,
+    index: PythonServerIndex,
+    module_path: str | None,
+) -> tuple[bool, str | None]:
+    """Whether ``receiver`` is a proven MCP server, and what proved it.
+
+    A bare name is the only shape a proof is attempted for. ``@self.mcp.tool``
+    reaches through an attribute this reader would have to know the type of,
+    and ``awslabs/mcp`` writes it on a server handed in as a constructor
+    argument — so the receiver is a server there and this reader still cannot
+    show it, which is what the recorded omission says.
+    """
+
+    if not isinstance(receiver, ast.Name):
+        return False, None
+    resolved = module.binding_of(receiver.id, receiver)
+    if resolved is None:
+        return False, None
+    binding, _scope = resolved
+    if module.server_from_statement(binding, receiver.id):
+        return True, None
+    # A function-local ``from .server import mcp`` binds the same name from the
+    # same module as one at the top of the file, and resolving it is the same
+    # question.
+    if not isinstance(binding, ast.ImportFrom):
+        return False, None
+    imported = module.import_of(receiver.id, receiver)
+    if imported is None or imported.symbol is None:
+        return False, None
+    target = index.resolve(module_path, imported.module, imported.level)
+    if target is None or imported.symbol not in index.modules.get(target, frozenset()):
+        return False, None
+    return True, target
+
+
+def _python_site(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    decorator: ast.expr,
+    receiver: ast.expr,
+    offsets: _PythonOffsets,
+    *,
+    proven: bool,
+) -> RegistrationSite:
+    line, column = decorator.lineno, offsets.column(decorator)
+    # The span is the decorator expression, not the function it decorates.
+    # ``_contains_another_site`` drops an unresolved site that contains a
+    # resolved one, and a decorated function's body can hold a nested
+    # registration of its own — so a span covering the body would silently
+    # delete the outer omission. A decorator expression cannot contain a
+    # registration, which is what makes it the construct that registers.
+    span = (offsets.offset(decorator), offsets.end_offset(decorator))
+    if not proven:
+        return RegistrationSite(
+            idiom="py_fastmcp_decorator",
+            name=None,
+            line=line,
+            column=column,
+            span=span,
+            unresolved_reason="server_binding_not_proven",
+        )
+    del receiver
+    name, unresolved = _python_tool_name(node, decorator)
+    return RegistrationSite(
+        idiom="py_fastmcp_decorator",
+        name=name,
+        line=line,
+        column=column,
+        span=span,
+        description=_python_tool_description(node, decorator),
+        unresolved_reason=unresolved,
+        parameters=_python_signature(node),
+        returns=_python_annotation(node.returns),
+        proves_server=True,
+    )
+
+
+def _python_tool_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, decorator: ast.expr
+) -> tuple[str | None, str | None]:
+    """The registered name, or why it could not be read.
+
+    FastMCP takes the name from ``name=``, then from a single positional
+    argument, and defaults to the decorated function's. The default is not a
+    guess — it is the framework's documented rule and the spelling 55 of 55
+    ``redis/mcp-redis`` registrations use — but a ``name=`` this reader cannot
+    resolve is never *replaced* by it: ``neo4j-contrib/mcp-neo4j`` registers
+    ``namespace_prefix + "delete_instance"``, and answering ``delete_instance``
+    there would publish a name that server does not serve.
+    """
+
+    if isinstance(decorator, ast.Call):
+        given = _python_keyword(decorator, "name")
+        if given is None and decorator.args:
+            given = decorator.args[0]
+        if given is not None:
+            return _resolve_name(_python_string(given), True)
+    return _resolve_name(node.name, True)
+
+
+def _python_tool_description(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, decorator: ast.expr
+) -> str | None:
+    """The description FastMCP would register: ``description=`` or the docstring."""
+
+    if isinstance(decorator, ast.Call):
+        given = _python_keyword(decorator, "description")
+        if given is not None:
+            return _python_string(given)
+    try:
+        return ast.get_docstring(node, clean=True)
+    except (TypeError, ValueError):  # pragma: no cover - malformed docstring node
+        return None
+
+
+def _python_keyword(call: ast.Call, name: str) -> ast.expr | None:
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _python_string(node: ast.expr) -> str | None:
+    """The value of ``node`` when it is a whole string literal.
+
+    An f-string, a concatenation and a ``.format`` call all resolve to
+    something only at run time, and this returns ``None`` for each — the same
+    answer :func:`_literal_is_whole_value` gives the lexed languages when a
+    literal is only *part* of the value.
+    """
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _python_signature(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[SignatureParameter, ...]:
+    arguments = node.args
+    positional = [*arguments.posonlyargs, *arguments.args]
+    defaults: list[ast.expr | None] = [None] * (
+        len(positional) - len(arguments.defaults)
+    )
+    defaults.extend(arguments.defaults)
+    parameters = [
+        SignatureParameter(
+            name=argument.arg,
+            annotation=_python_annotation(argument.annotation),
+            required=default is None,
+        )
+        for argument, default in zip(positional, defaults, strict=True)
+    ]
+    parameters.extend(
+        SignatureParameter(
+            name=argument.arg,
+            annotation=_python_annotation(argument.annotation),
+            required=default is None,
+        )
+        for argument, default in zip(
+            arguments.kwonlyargs, arguments.kw_defaults, strict=True
+        )
+    )
+    # ``*args`` and ``**kwargs`` are deliberately absent: they are not schema
+    # properties, and a tool that has them takes arguments this reader cannot
+    # enumerate rather than one parameter named ``kwargs``.
+    return tuple(parameters)
+
+
+def _python_annotation(node: ast.expr | None) -> str | None:
+    if node is None:
+        return None
+    try:
+        return ast.unparse(node)
+    except (AttributeError, ValueError, RecursionError):  # pragma: no cover
+        return None
+
+
+class _PythonOffsets:
+    """Character offsets for ``ast`` positions.
+
+    ``col_offset`` is a **UTF-8 byte** offset into the line, while every other
+    offset this module publishes is a character offset into the text. A source
+    line containing a non-ASCII character makes the two differ, so the
+    conversion is done rather than assumed.
+    """
+
+    def __init__(self, text: str) -> None:
+        self._lines = text.splitlines(keepends=True)
+        self._starts: list[int] = []
+        offset = 0
+        for line in self._lines:
+            self._starts.append(offset)
+            offset += len(line)
+        self._length = offset
+
+    def _character_column(self, line: int, byte_column: int) -> int:
+        if not 1 <= line <= len(self._lines):
+            return 0
+        raw = self._lines[line - 1].encode("utf-8")[:byte_column]
+        return len(raw.decode("utf-8", errors="ignore"))
+
+    def offset(self, node: ast.AST) -> int:
+        line = getattr(node, "lineno", 1)
+        if not 1 <= line <= len(self._starts):
+            return self._length
+        return self._starts[line - 1] + self._character_column(
+            line, getattr(node, "col_offset", 0)
+        )
+
+    def end_offset(self, node: ast.AST) -> int:
+        line = getattr(node, "end_lineno", None)
+        if line is None or not 1 <= line <= len(self._starts):
+            return self._length
+        return self._starts[line - 1] + self._character_column(
+            line, getattr(node, "end_col_offset", 0)
+        )
+
+    def column(self, node: ast.AST) -> int:
+        """The 1-based character column, matching :meth:`MaskedSource.line_column`."""
+
+        return self._character_column(
+            getattr(node, "lineno", 1), getattr(node, "col_offset", 0)
+        ) + 1
+
+def scan_source(
+    text: str,
+    language: str,
+    *,
+    module_path: str | None = None,
+    server_index: PythonServerIndex | None = None,
+) -> SourceScanResult:
     """Find every registration site in one file.
 
     An unresolved site is dropped when a resolved one sits inside it. The
@@ -1872,6 +2726,10 @@ def scan_source(text: str, language: str) -> SourceScanResult:
     """
     if PREFILTER_TOKEN not in text.lower():
         return SourceScanResult()
+    if language == "python":
+        return _python_sites(
+            text, module_path=module_path, server_index=server_index
+        )
     source = mask_source(text, language)
     sites: list[RegistrationSite] = []
     if language == "typescript":
@@ -1933,6 +2791,21 @@ _EVIDENCE_NAME_LIMIT = 5
 #: Dependency sections of a ``package.json`` that count. ``devDependencies`` is
 #: included on purpose: the question is "was this repository written against
 #: MCP", not "does it ship the SDK at runtime".
+#: Python project files read for the language gate. ``setup.py`` is absent on
+#: purpose: its dependencies are an argument to a function call, and grepping a
+#: Python module for ``mcp`` is the spelling-shaped proof this gate rejects.
+_PYTHON_PROJECT_FILES: frozenset[str] = frozenset({"pyproject.toml"})
+
+#: Dependency tables of a ``pyproject.toml`` that count: PEP 621's own list,
+#: PEP 735's dependency groups, and Poetry's table.
+_PYPROJECT_DEPENDENCY_PATHS: tuple[tuple[str, ...], ...] = (
+    ("project", "dependencies"),
+    ("project", "optional-dependencies"),
+    ("dependency-groups",),
+    ("tool", "poetry", "dependencies"),
+    ("tool", "poetry", "group"),
+)
+
 _PACKAGE_JSON_DEPENDENCY_KEYS = (
     "dependencies",
     "devDependencies",
@@ -2012,34 +2885,43 @@ def _discover_mcp_server_source(
     # rather than beside it.
     scannable.sort(key=lambda pair: pair[1])
     truncated = len(scannable) > max_source_files
+    read = scannable[:max_source_files]
+    server_index = _mcp_python_server_index(read)
     names: set[str] = set()
     languages: set[str] = set()
     unresolved_by_file: dict[str, int] = {}
     candidate_files: list[str] = []
-    for path, relative in scannable[:max_source_files]:
+    for path, relative in read:
         language = language_for_path(path)
         if language is None:  # pragma: no cover - filtered above
             continue
-        try:
-            if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
-                continue
-        except OSError:
-            continue
-        text = _read_mcp_source_text(path)
+        text = _mcp_source_text(path)
         if text is None:
             continue
-        result = scan_source(text, language)
+        result = scan_source(
+            text, language, module_path=relative, server_index=server_index
+        )
         resolved = [site.name for site in result.sites if site.name is not None]
         opaque = sum(1 for site in result.sites if site.name is None)
         if opaque:
             unresolved_by_file[relative] = opaque
-        if not resolved:
+        # A site that proves a server counts even when its name does not
+        # resolve. Nothing lexical does — those match a spelling. The Python
+        # idiom has already followed the decorator back to a `FastMCP(...)`
+        # construction, and requiring a name on top would withhold the route
+        # from `neo4j-contrib/mcp-neo4j`, whose 40 registrations are every one
+        # of them `name=namespace_prefix + "…"`.
+        if not resolved and not any(site.proves_server for site in result.sites):
             continue
         languages.add(language)
         names.update(resolved)
         candidate_files.append(relative)
+        # The module that constructed the server is part of the route even
+        # though it registers nothing: `redis/mcp-redis` builds its server in
+        # `src/common/server.py` and decorates in `src/tools/*.py`.
+        candidate_files.extend(result.server_modules)
 
-    if not names:
+    if not candidate_files:
         return McpSourceDiscovery(
             unresolved_count=sum(unresolved_by_file.values()), truncated=truncated
         )
@@ -2056,8 +2938,14 @@ def _discover_mcp_server_source(
     evidence = _mcp_evidence_lines(
         framework, languages, names, root, truncated, unresolved
     )
-    covering_export, uncovered = _mcp_covering_export(
-        workspace, exported_source_paths, names
+    covering_export, uncovered = (
+        _mcp_covering_export(workspace, exported_source_paths, names)
+        # An export cannot be shown to *contain* a surface with no names in it:
+        # `names <= covered` is vacuously true for the empty set, so asking
+        # would let any readable export displace a route whose whole content is
+        # "40 registrations nobody can enumerate".
+        if names
+        else (None, set())
     )
     if covering_export is not None:
         return McpSourceDiscovery(
@@ -2106,6 +2994,33 @@ def _discover_mcp_server_source(
     )
 
 
+def _mcp_python_server_index(scannable: list[tuple[Path, str]]) -> PythonServerIndex:
+    """Index every Python module in the walk that constructs a FastMCP server.
+
+    Built ahead of the scan: `redis/mcp-redis` constructs its server in one
+    module and decorates in eleven others, so resolving bindings as the walk
+    went would prove or refuse the same decorator depending on file order.
+    """
+    modules: list[tuple[str, str]] = []
+    for path, relative in scannable:
+        if language_for_path(path) != "python":
+            continue
+        text = _mcp_source_text(path)
+        if text is not None:
+            modules.append((relative, text))
+    return PythonServerIndex.build(modules)
+
+
+def _mcp_source_text(path: Path) -> str | None:
+    """One source file's text, or ``None`` when this walk will not read it."""
+    try:
+        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+            return None
+    except OSError:
+        return None
+    return _read_mcp_source_text(path)
+
+
 def _read_mcp_source_text(path: Path) -> str | None:
     """The adapter's own read, not a lenient copy of it.
 
@@ -2130,6 +3045,9 @@ def _mcp_framework_evidence(workspace: Path, files: list[Path]) -> _FrameworkEvi
     evidence = _FrameworkEvidence()
     for path in files:
         name = path.name
+        if name in _PYTHON_PROJECT_FILES or _is_requirements_file(name):
+            _record_python_mcp_evidence(workspace, path, evidence)
+            continue
         if name not in {"package.json", "go.mod"}:
             continue
         relative = _mcp_relative(path, workspace)
@@ -2163,6 +3081,84 @@ def _mcp_framework_evidence(workspace: Path, files: list[Path]) -> _FrameworkEvi
                 evidence.reasons.append(f"{relative} depends on {dependency}")
                 break
     return evidence
+
+
+def _is_requirements_file(name: str) -> bool:
+    """Whether ``name`` is a pip requirements file."""
+    lowered = name.lower()
+    return lowered.startswith("requirements") and lowered.endswith(".txt")
+
+
+def _record_python_mcp_evidence(
+    workspace: Path, path: Path, evidence: _FrameworkEvidence
+) -> None:
+    """Admit Python when a project file declares ``mcp`` or ``fastmcp``."""
+    relative = _mcp_relative(path, workspace)
+    if relative is None:
+        return
+    if any(part in SKIP_DIRECTORY_NAMES for part in PurePosixPath(relative).parts):
+        return
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    requirements = (
+        _pyproject_requirements(text)
+        if path.name in _PYTHON_PROJECT_FILES
+        else _requirements_txt(text)
+    )
+    dependency = declares_python_mcp_framework(requirements)
+    if dependency is None:
+        return
+    evidence.languages.add("python")
+    evidence.reasons.append(f"{relative} depends on {dependency}")
+
+
+def _pyproject_requirements(text: str) -> list[str]:
+    """Every requirement string a ``pyproject.toml`` declares.
+
+    Parsed with ``tomllib`` rather than scanned line by line, because the
+    line scan this script uses for framework tokens drops
+    ``mcp[cli]>=1.26.0,<2`` — the requirement two of the five surveyed servers
+    declare — for carrying an extras marker.
+    """
+    try:
+        data = tomllib.loads(text)
+    except (tomllib.TOMLDecodeError, ValueError, RecursionError):
+        return []
+    requirements: list[str] = []
+    for path in _PYPROJECT_DEPENDENCY_PATHS:
+        node: Any = data
+        for key in path:
+            node = node.get(key) if isinstance(node, dict) else None
+        requirements.extend(_toml_requirements(node))
+    return requirements
+
+
+def _toml_requirements(node: Any, depth: int = 0) -> list[str]:
+    """Requirement strings inside a dependency list, table, or table of lists."""
+    if depth > 3:  # pragma: no cover - a dependency table is never this deep
+        return []
+    if isinstance(node, str):
+        return [node]
+    if isinstance(node, list):
+        return [item for item in node if isinstance(item, str)]
+    if isinstance(node, dict):
+        found: list[str] = []
+        for key, value in node.items():
+            nested = _toml_requirements(value, depth + 1)
+            found.extend(nested if nested else [str(key)])
+        return found
+    return []
+
+
+def _requirements_txt(text: str) -> list[str]:
+    """Requirement lines from a pip requirements file."""
+    return [
+        line
+        for raw in text.splitlines()
+        if (line := raw.strip()) and not line.startswith(("-", "#"))
+    ]
 
 
 def _mcp_package_dependencies(text: str) -> set[str]:
@@ -2311,11 +3307,19 @@ def _mcp_evidence_lines(
     if len(names) > len(sample):
         shown += ", …"
     lines = [
-        f"MCP tool registrations in {'/'.join(sorted(languages))} source under "
-        f"{root}/: {len(names)} tool name(s) — {shown}",
+        (
+            f"MCP tool registrations in {'/'.join(sorted(languages))} source "
+            f"under {root}/: {len(names)} tool name(s) — {shown}"
+        )
+        if names
+        else (
+            f"MCP tool registrations in {'/'.join(sorted(languages))} source "
+            f"under {root}/: {unresolved} registration(s), none of which this "
+            "reader can name"
+        ),
     ]
     lines.extend(sorted(framework.reasons)[:_EVIDENCE_NAME_LIMIT])
-    if unresolved:
+    if unresolved and names:
         # Named here because this is what a human reads when deciding whether
         # to adopt, and "61 tools" without "and 3 more this reader cannot name"
         # is the over-claim the whole input is built to avoid.

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -1000,7 +1000,14 @@ def is_scannable_path(relative_path: Any) -> bool:
     if any(part.lower() in TEST_DIRECTORY_NAMES for part in parts[:-1]):
         return False
     name = path.name.lower()
-    if name in _TEST_FILE_NAMES or name.startswith(_TEST_FILE_PREFIXES):
+    # Scoped to Python, because the *reason* is: pytest collects `test_*.py`,
+    # so a suffix-only rule reads `test_server.py` as the server. `test_util.go`
+    # and `test_helpers.ts` are ordinary module names, and excluding one costs
+    # a surface with no omission to show for it — an excluded path is never
+    # read, so nothing records that it was skipped.
+    if language_for_path(path) == "python" and (
+        name in _TEST_FILE_NAMES or name.startswith(_TEST_FILE_PREFIXES)
+    ):
         return False
     return not name.endswith(_TEST_FILE_SUFFIXES)
 
@@ -2064,7 +2071,23 @@ class _PythonModule:
             return
         if isinstance(node, ast.ClassDef):
             self._bind(scope, node.name, node)
-            for child in (*node.decorator_list, *node.bases):
+            for child in (
+                *node.decorator_list,
+                *node.bases,
+                # PEP 695 type parameters — the one child list of a scope
+                # node this walk would otherwise skip.
+                #
+                # Inert for any module Python will run, and knowably so: the
+                # only construct that could bind a name here is a walrus, and
+                # `compile` refuses one in a TypeVar bound ("named expression
+                # cannot be used within a TypeVar bound") even though
+                # `ast.parse` accepts it. So a perturbation sweep reports this
+                # line untested and is right to. It is here because the rule is
+                # "visit every child list of a scope node", and a reader who
+                # later adds a construct to `type_params` should not have to
+                # rediscover the gap.
+                *getattr(node, "type_params", ()),
+            ):
                 self._visit(child, scope)
             for keyword in node.keywords:
                 self._visit(keyword.value, scope)
@@ -2087,6 +2110,8 @@ class _PythonModule:
             self._bind(scope, node.name, node)
             for decorator in node.decorator_list:
                 self._visit(decorator, scope)
+            for parameter in getattr(node, "type_params", ()):
+                self._visit(parameter, scope)
             if node.returns is not None:
                 self._visit(node.returns, scope)
         for default in (*arguments.defaults, *arguments.kw_defaults):
@@ -2150,10 +2175,18 @@ class _PythonModule:
     # -- Resolution -----------------------------------------------------
 
     def _scope_chain(self, node: ast.AST) -> list[ast.AST]:
+        """The scopes a name at ``node`` is looked up in, innermost first.
+
+        A class body is searched only when it is the scope the name is written
+        in: Python does not close over class scope, so a function nested inside
+        a method resolves ``mcp`` to the module and never to a class attribute
+        of the same name.
+        """
         chain: list[ast.AST] = []
         scope = self._scopes.get(id(node))
         while scope is not None:
-            chain.append(scope)
+            if not isinstance(scope, ast.ClassDef) or not chain:
+                chain.append(scope)
             if scope is self.tree:
                 break
             scope = self._scopes.get(id(scope))
@@ -2396,10 +2429,19 @@ def _python_module_key_matches(key: tuple[str, ...], parts: tuple[str, ...]) -> 
 def _python_module_paths(
     package: PurePosixPath, parts: tuple[str, ...]
 ) -> tuple[str, ...]:
-    base = package.joinpath(*parts) if parts else package
+    if not parts:
+        # ``from . import x`` names no module path of its own: what it binds is
+        # an attribute of the package's ``__init__``, which is where a name it
+        # re-exports would be bound. That is Python's rule and not an
+        # approximation of it: after ``from . import server``, the name
+        # is the submodule *unless* ``__init__`` binds something else
+        # of that name, and a submodule has no ``.tool`` to register
+        # with — so the only case worth resolving is the re-export.
+        return ((package / "__init__.py").as_posix(),)
+    base = package.joinpath(*parts)
     return (
         (base / "__init__.py").as_posix(),
-        base.with_suffix(".py").as_posix() if parts else "",
+        base.with_suffix(".py").as_posix(),
     )
 
 
@@ -2415,8 +2457,8 @@ def _python_sites(
     if tree is None:
         return SourceScanResult(anomalies=("unparseable_python",))
     module = _PythonModule(tree)
-    offsets = _PythonOffsets(text)
     index = server_index or PythonServerIndex()
+    offsets: _PythonOffsets | None = None
     sites: list[RegistrationSite] = []
     server_modules: set[str] = set()
     for node in ast.walk(tree):
@@ -2431,8 +2473,14 @@ def _python_sites(
             )
             if proving_module is not None:
                 server_modules.add(proving_module)
+            # Built on the first site, not per file: most modules that pass the
+            # `"tool"` prefilter register nothing — a variable of that name, a
+            # word in a docstring — and the line table would be built and
+            # thrown away for every one of them.
+            if offsets is None:
+                offsets = _PythonOffsets(text)
             sites.append(
-                _python_site(node, decorator, receiver, offsets, proven=proven)
+                _python_site(node, decorator, offsets, proven=proven)
             )
     sites.sort(key=lambda site: (site.line, site.column))
     return SourceScanResult(
@@ -2522,7 +2570,6 @@ def _python_server_receiver(
 def _python_site(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     decorator: ast.expr,
-    receiver: ast.expr,
     offsets: _PythonOffsets,
     *,
     proven: bool,
@@ -2544,7 +2591,6 @@ def _python_site(
             span=span,
             unresolved_reason="server_binding_not_proven",
         )
-    del receiver
     name, unresolved = _python_tool_name(node, decorator)
     return RegistrationSite(
         idiom="py_fastmcp_decorator",
@@ -2989,7 +3035,9 @@ def _discover_mcp_server_source(
         unresolved_count=unresolved,
         evidence=evidence,
         framework_evidence=tuple(sorted(framework.reasons)),
-        candidate_files=tuple(sorted(candidate_files)),
+        # De-duplicated: one module can prove the binding for every file
+        # that imports it.
+        candidate_files=tuple(sorted(set(candidate_files))),
         truncated=truncated,
     )
 
@@ -3136,7 +3184,13 @@ def _pyproject_requirements(text: str) -> list[str]:
 
 
 def _toml_requirements(node: Any, depth: int = 0) -> list[str]:
-    """Requirement strings inside a dependency list, table, or table of lists."""
+    """Every string in a dependency table that could name a distribution.
+
+    Both halves of a table, rather than a choice between them: Poetry writes
+    the name as the *key* with a constraint as the value, and emitting only
+    the value made every Poetry table dead. A group name is not a
+    distribution this gate looks for, so admitting keys costs nothing.
+    """
     if depth > 3:  # pragma: no cover - a dependency table is never this deep
         return []
     if isinstance(node, str):
@@ -3146,8 +3200,8 @@ def _toml_requirements(node: Any, depth: int = 0) -> list[str]:
     if isinstance(node, dict):
         found: list[str] = []
         for key, value in node.items():
-            nested = _toml_requirements(value, depth + 1)
-            found.extend(nested if nested else [str(key)])
+            found.append(str(key))
+            found.extend(_toml_requirements(value, depth + 1))
         return found
     return []
 

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -2460,14 +2460,17 @@ class PythonServerIndex:
 
     @classmethod
     def build(cls, modules: Any) -> PythonServerIndex:
-        """Index ``(relative posix path, source text)`` pairs."""
+        """Index ``(relative posix path, source text)`` pairs.
 
-        indexed: dict[str, frozenset[str]] = {}
-        for path, text in modules:
-            exports = python_server_exports(text)
-            if exports:
-                indexed[path] = exports
-        return cls(indexed)
+        Every scanned module, exporting nothing where it constructs nothing:
+        holding only the servers would take a *conflicting* candidate out of
+        the universe before the uniqueness check runs, and an unrelated module
+        would then supply binding evidence the import never named.
+        """
+
+        return cls(
+            {path: python_server_exports(text) for path, text in modules}
+        )
 
     def resolve(self, module_path: str | None, module: str, level: int) -> str | None:
         """The indexed module an import in ``module_path`` refers to."""
@@ -2553,7 +2556,7 @@ def _python_sites(
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
-        for decorator in node.decorator_list:
+        for position, decorator in enumerate(node.decorator_list):
             receiver = _python_tool_receiver(decorator, module)
             if receiver is None:
                 continue
@@ -2562,6 +2565,10 @@ def _python_sites(
             )
             if proving_module is not None:
                 server_modules.add(proving_module)
+            # Everything *below* the registration in the source runs first, so
+            # the object `.tool` receives is that decorator's return value and
+            # not this `def`. See `_python_wrapped_before_registration`.
+            wrapped = bool(node.decorator_list[position + 1 :])
             # Built on the first site, not per file: most modules that pass the
             # `"tool"` prefilter register nothing — a variable of that name, a
             # word in a docstring — and the line table would be built and
@@ -2569,7 +2576,9 @@ def _python_sites(
             if offsets is None:
                 offsets = _PythonOffsets(text)
             sites.append(
-                _python_site(node, decorator, offsets, proven=proven)
+                _python_site(
+                    node, decorator, offsets, proven=proven, wrapped=wrapped
+                )
             )
     sites.sort(key=lambda site: (site.line, site.column))
     return SourceScanResult(
@@ -2656,12 +2665,29 @@ def _python_server_receiver(
     return True, target
 
 
+def _python_wrapped_before_registration() -> None:
+    """Why a decorator below the registration withholds the name.
+
+    Decorators apply bottom-up: ``@mcp.tool()`` over ``@replace`` registers
+    ``replace(harmless)``, so the name is that object's ``__name__`` and the
+    schema is ``inspect.signature`` of it. A ``functools.wraps`` wrapper does
+    preserve both, and every such site measured in ``awslabs/mcp`` is that
+    shape — but that is a fact about the decorator's *body*, in another module
+    for most of them, and this reader does not read bodies across modules.
+
+    So the site keeps its provenance and loses its name, which is the direction
+    #431 settled for the Go octal escape: an action id nobody serves is worse
+    than a recorded omission.
+    """
+
+
 def _python_site(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     decorator: ast.expr,
     offsets: _PythonOffsets,
     *,
     proven: bool,
+    wrapped: bool,
 ) -> RegistrationSite:
     line, column = decorator.lineno, offsets.column(decorator)
     # The span is the decorator expression, not the function it decorates.
@@ -2680,7 +2706,11 @@ def _python_site(
             span=span,
             unresolved_reason="server_binding_not_proven",
         )
-    name, unresolved = _python_tool_name(node, decorator)
+    name, unresolved = (
+        (None, "wrapped_before_registration")
+        if wrapped
+        else _python_tool_name(node, decorator)
+    )
     return RegistrationSite(
         idiom="py_fastmcp_decorator",
         name=name,
@@ -2689,8 +2719,9 @@ def _python_site(
         span=span,
         description=_python_tool_description(node, decorator),
         unresolved_reason=unresolved,
-        parameters=_python_signature(node),
-        returns=_python_annotation(node.returns),
+        # Withheld with the name: the schema comes from the same object.
+        parameters=None if wrapped else _python_signature(node),
+        returns=None if wrapped else _python_annotation(node.returns),
         proves_server=True,
     )
 
@@ -2710,6 +2741,11 @@ def _python_tool_name(
     """
 
     if isinstance(decorator, ast.Call):
+        if any(keyword.arg is None for keyword in decorator.keywords):
+            # ``@mcp.tool(**options)``. A ``**`` unpacking can carry ``name``,
+            # decided at run time, so the framework's default no longer
+            # provably applies and the function's name would be a guess.
+            return None, "name_not_literal"
         given = _python_keyword(decorator, "name")
         if given is None and decorator.args:
             given = decorator.args[0]
@@ -3083,15 +3119,24 @@ def _discover_mcp_server_source(
     evidence = _mcp_evidence_lines(
         framework, languages, names, root, truncated, unresolved
     )
-    covering_export, uncovered = (
-        _mcp_covering_export(workspace, exported_source_paths, names)
-        # An export cannot be shown to *contain* a surface with no names in it:
-        # `names <= covered` is vacuously true for the empty set, so asking
-        # would let any readable export displace a route whose whole content is
-        # "40 registrations nobody can enumerate".
-        if names
-        else (None, set())
+    covering_export, uncovered = _mcp_covering_export(
+        workspace, exported_source_paths, names
     )
+    if covering_export is not None and unresolved:
+        # Containment is the test, and an export cannot be shown to contain a
+        # registration *nobody could name*. Withholding the route here sends
+        # the reader to the export and never to `scan`, so the unreadable
+        # registration reaches no exclusion ledger at all. One rule covers both
+        # readings: no readable name makes the comparison vacuous, and some
+        # readable makes an export naming exactly those look complete.
+        evidence = (
+            *evidence,
+            f"An MCP tool export ({covering_export}) names every registration "
+            f"this reader could read and none of the {unresolved} it could "
+            "not; both routes are suggested, so the unreadable ones still "
+            "reach the exclusion ledger",
+        )
+        covering_export = None
     if covering_export is not None:
         return McpSourceDiscovery(
             unresolved_count=unresolved,


### PR DESCRIPTION
Closes #484.

## What was missing

[#431](https://github.com/ThreeMoonsLab/agents-shipgate/issues/431) shipped a built-in registry of MCP tool-registration idioms covering TypeScript and Go, and [its own 30-server survey](https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/mcp-registration-idioms.md) named what it left out: Python's `@mcp.tool` decorator, the largest single shape by both repositories and call sites. `redis/mcp-redis`, `chroma-core/chroma-mcp` and `neo4j-contrib/mcp-neo4j` were all in the state MongoDB and Grafana were in before #431 — `detect` returned `is_agent_project: false` for a first-party server publishing dozens of tools.

## Measured, on live checkouts

Identical verdicts, routes and evidence from the installed CLI and the zero-install detector:

| repository | route | tools | unenumerated |
|---|---|---:|---:|
| `redis/mcp-redis` | `src` | 53 | 0 |
| `chroma-core/chroma-mcp` | `src/chroma_mcp` | 13 | 0 |
| `neo4j-contrib/mcp-neo4j` | `servers` | 0 | 40 |
| `awslabs/mcp` | `src` | 334 | 107 |

Before this change all four reported `mcp_server_source` nowhere; `mcp-neo4j` and `chroma-mcp` were `is_agent_project: false` outright.

## Why it is a mechanism, not a sixth pattern

Three facts, each measured before it was designed for:

- **The name is usually not written down.** `@mcp.tool()` on `def dbsize()` registers `dbsize` — all 53 of `redis/mcp-redis`'s registrations are the bare form, so a reader looking for a literal beside the call finds none of them.
- **The schema is the signature.** This idiom publishes an input schema where the lexical idioms genuinely have nothing to publish. The request `Context` parameter is dropped, because the server drops it too; so are `*args`/`**kwargs`.
- **Whether it registers anything is a binding fact.** `@app.tool` is a tool registration when `app` is a server and somebody else's decorator otherwise. The reader follows the decorated name back to a server construction — **across modules**, because `redis/mcp-redis` constructs in `src/common/server.py` and decorates in `src/tools/*.py` — and refuses out loud when it cannot.

## Two findings that changed the design after measurement

**The official Python SDK v2 renamed `FastMCP` to `MCPServer`.** `mcp.server.fastmcp` is now a module that exists only to raise `ModuleNotFoundError`, and 41 of `awslabs/mcp`'s servers had already moved. A reader that knew one class name read **105 tools where there are 334**. The reader knows `(module, class)` pairs, and the index prefilter is derived from that table so the two cannot drift.

**A server can register 40 tools and name none of them.** Every `neo4j-contrib/mcp-neo4j` tool is `name=namespace_prefix + "…"`. The lexical idioms' rule — offer no route without a resolved name — would have reported that repository as "not an agent project" *because* its names are dynamic, which is the silent miss this input exists to end. A Python site carries its own provenance (it was only emitted after the decorator was followed back to a server construction, and a client does not construct a server), so the route is offered and the evidence says `40 registration(s), none of which this reader can name`. A committed export cannot displace such a route either: containment is the test, and an export contains an empty set vacuously.

## What it still refuses

The ceiling stays `medium`. A runtime-built name stays an omission the exclusion ledger accounts for. A decorator on an object the reader cannot follow — `@self.mcp.tool` on an injected server, `app = create_server()` on a factory's result, both measured in `awslabs/mcp` — is recorded rather than guessed at or dropped.

## Both detectors move together

`tools/shipgate-detect.py` goes 0.5.0 → 0.6.0 in the same commit. #485 made it a second implementation of this reader, and `tests/mcp_idiom_corpus.py` is what keeps it from becoming a different one: the whole Python probe list and the cross-module trees live there once, and both readers are driven through all of it — every site field, span included, plus `parameters`, `returns` and `proves_server`, which decide the schema and whether a route exists at all.

## Verification

- **32 adversarial probes** covering the list #484 required (alias, runtime name, factory, `functools.wraps`, conditional registration, re-bound symbol, `@app.tool` on a non-server) plus star imports, scope shadowing, the three constructor spellings, PEP 695 generics, and docstring/class/positional shapes.
- **A 30-case perturbation sweep: 27 caught.** The three that are not are inert by construction and say so at the line — the index prefilter is a cost bound; a `type_params` subtree cannot bind a name in any module Python will compile (`ast.parse` accepts a walrus in a TypeVar bound, `compile` refuses it); and reading an empty module through `or` returns the same text.
- All CI checks green. `IDIOM_REGISTRY_VERSION` → `2`; `TRIGGER-MCP-TOOL-REGISTRATION-SOURCE` routes `@mcp.tool`.

## Review rounds

Two self-review passes ran on this branch and their fixes are in it. Four changed behaviour, and the first is the one worth reading:

- **The Poetry half of the Python language gate was dead.** The dependency walker returned a table's *constraint* where the distribution is the key, so `mcp = "^1.6.0"` produced `^1.6.0` and never `mcp` — three of the five tables named in the constant could never match, and a Poetry-managed server got no route at all. Fixed, and the reason it shipped is closed: every fixture in the file wrote PEP 621, so a parametrised test now drives all five tables plus `requirements*.txt`.
- **Class scopes were searched from a nested function**, where Python does not close over them — a real registration was reported unenumerable.
- **The route repeated its proving module** once per importing file. The fixture now has two tool modules, because with one importer the defect is invisible.
- **The test-file *prefix* rule was applied to every language**, silently dropping `test_helpers.ts` and `test_util.go` from the surface. Scoped to Python, where the reason (pytest collects `test_*.py`) lives.

#441's scaffold tests moved to the factory-bound shape, since their original reproduction is a workspace `detect` now reads — that is the fix, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)