### PR TITLE
Keep fixture-only names out of the reviewed product identity (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Test- and template-only agent names require review.** (#533) Discovery
+  keeps these names visible with their source and rationale, but `init` no
+  longer asserts them as the product's reviewed identity. A name also declared
+  in product code remains eligible under the existing quality and scope rules.
+  Installed and standalone detectors apply the same declaration-site floor;
+  tool discovery remains available and unresolved names use the existing
+  `CHANGE_ME` placeholder. The later identity-specific recovery question is
+  tracked separately in #543; existing purpose/permission review remains.
+
 - **The FastMCP signature projection now resolves the injected `Context`, and
   says so when it cannot read a type.** (#539) #535 made Python MCP servers
   discoverable and read their signatures. Two of the facts it published about

--- a/src/agents_shipgate/cli/discovery/signals.py
+++ b/src/agents_shipgate/cli/discovery/signals.py
@@ -2181,7 +2181,8 @@ def _rank_agent_name_candidates(
     - **Origin.** Product code outranks test code.
     - **Corroboration.** A name the project name independently agrees with
       is two sources, not one.
-    - **Quality floor.** A value too short or too generic to be an identity
+    - **Quality floor.** A value too short, too generic, or declared only in
+      non-product code cannot establish the reviewed product's identity. It
       is ranked last and made unselectable, so ``init`` writes CHANGE_ME and
       asks for review rather than asserting something unreliable.
 
@@ -2247,6 +2248,7 @@ def _rank_agent_name_candidates(
     # candidate points at.
     declared_in: dict[str, list[Path]] = {}
     best_project: dict[str, Path] = {}
+    product_declared: set[str] = set()
     order = 0
     for fact in facts:
         if not fact.agent_names:
@@ -2263,6 +2265,8 @@ def _rank_agent_name_candidates(
             if resolved is None:
                 continue
             value, provenance, detail = resolved
+            if _non_product_origin(evidence.rel_path) is None:
+                product_declared.add(value)
             ranked = _score_agent_name(
                 value=value,
                 role=evidence.role,
@@ -2283,6 +2287,14 @@ def _rank_agent_name_candidates(
                 best_project[value] = project
 
     for value, ranked in best.items():
+        # Selection is a claim about the product, not the highest score left
+        # in the list. Inspect every declaration site before applying this
+        # floor so a product/test shared name remains eligible (#533).
+        if value not in product_declared:
+            ranked.selectable = False
+            ranked.rationale.append(
+                "rejected: declared only in non-product code, not a reviewed product identity"
+            )
         # The candidate's own project first when it is blocked, so the
         # sentence names the project every other field already points at;
         # declaration order decides the rest.

--- a/tests/test_agent_identity_origin.py
+++ b/tests/test_agent_identity_origin.py
@@ -1,0 +1,69 @@
+"""A fixture identity must not become a reviewed product declaration (#533)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.discovery.signals import detect_workspace, select_agent_name
+from agents_shipgate.cli.main import app
+
+
+def _agent(path: Path, name: str = "AlphaFixture") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "from google.adk.agents import LlmAgent\n"
+        f"worker = LlmAgent(name={name!r})\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["tests/test_agent.py", "skills/recipe/resources/templates/app/agent.py"],
+)
+def test_non_product_identity_stays_visible_and_unasserted(tmp_path, relative):
+    _agent(tmp_path / relative)
+    detected = detect_workspace(tmp_path)
+    candidate = next(c for c in detected.agent_name_candidates if c.value == "AlphaFixture")
+    assert candidate.selectable is False
+    assert any("only in non-product code" in reason for reason in candidate.rationale)
+    assert select_agent_name(detected.agent_name_candidates) is None
+    assert detected.is_agent_project is True
+
+    result = CliRunner().invoke(
+        app, ["init", "--workspace", str(tmp_path), "--write", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert yaml.safe_load((tmp_path / "shipgate.yaml").read_text())["agent"]["name"] == "CHANGE_ME"
+    assert payload["auto_detected"]["agent_name"] is None
+    assert any(p["path"] == "agent.name" for p in payload["placeholders"])
+    # Existing purpose/permission review still applies. Identity-specific
+    # recovery after those are supplied is a separate follow-up (#543).
+    assert payload["control"]["control_state"] == "human_review_required"
+    assert payload["control"]["next_action"]["actor"] == "human"
+
+
+@pytest.mark.parametrize("product_path", ["a_agent.py", "z_agent.py"])
+def test_product_declaration_keeps_a_shared_name_selectable_in_either_order(tmp_path, product_path):
+    _agent(tmp_path / "tests/test_agent.py", "ProductAgent")
+    _agent(tmp_path / product_path, "ProductAgent")
+    detected = detect_workspace(tmp_path)
+    selected = select_agent_name(detected.agent_name_candidates)
+    assert selected is not None and selected.value == "ProductAgent"
+    assert selected.path == product_path
+    assert not any("only in non-product code" in reason for reason in selected.rationale)
+
+
+def test_project_name_corroboration_cannot_make_a_test_identity_selectable(tmp_path):
+    project = tmp_path / "AlphaFixture"
+    _agent(project / "tests/test_agent.py")
+    detected = detect_workspace(project)
+    candidate = next(c for c in detected.agent_name_candidates if c.value == "AlphaFixture")
+    assert any("corroborated" in reason for reason in candidate.rationale)
+    assert candidate.selectable is False

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1229,8 +1229,8 @@ def test_conflicting_import_roots_leave_the_name_unresolved(tmp_path: Path) -> N
 def test_one_character_literal_never_becomes_the_agent_name(tmp_path: Path) -> None:
     """#320, in the shape usestrix/strix reported it: every ``Agent(name=…)``
     literal in the repository lives in a test, and the one the walk reaches
-    first is a single character. ``t`` must be unselectable, and the name the
-    project name independently corroborates must win."""
+    first is a single character. Neither name declares the product: project
+    name corroboration cannot make a test-only identity selectable (#533)."""
     project = tmp_path / "strix"
     tests_dir = project / "tests"
     tests_dir.mkdir(parents=True)
@@ -1252,8 +1252,9 @@ def test_one_character_literal_never_becomes_the_agent_name(tmp_path: Path) -> N
     assert any("context-poor" in reason for reason in by_value["t"].rationale)
 
     selected = select_agent_name(result.agent_name_candidates)
-    assert selected is not None and selected.value == "Strix"
-    assert any("corroborated" in reason for reason in selected.rationale)
+    assert selected is None
+    assert by_value["Strix"].selectable is False
+    assert any("corroborated" in reason for reason in by_value["Strix"].rationale)
 
 
 def test_generic_placeholder_name_fails_closed_to_change_me(tmp_path: Path) -> None:
@@ -1276,7 +1277,7 @@ def test_generic_placeholder_name_fails_closed_to_change_me(tmp_path: Path) -> N
 
 def test_test_declared_name_ranks_below_product_declared_name(tmp_path: Path) -> None:
     """A name that only a test declares is a fixture name. It stays a
-    candidate — often it is the real one — but product code outranks it."""
+    visible candidate, but without a product declaration it is not selectable."""
     project = tmp_path / "svc"
     (project / "tests").mkdir(parents=True)
     (project / "service.py").write_text(

--- a/tests/test_zero_install_detector.py
+++ b/tests/test_zero_install_detector.py
@@ -994,6 +994,25 @@ def _write_ranking_probe(root: Path) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "non_product", ["tests/test_agent.py", "skills/recipe/resources/templates/app/agent.py"]
+)
+@pytest.mark.parametrize("product", [None, "a_agent.py", "z_agent.py"])
+def test_non_product_identity_floor_matches_cli(script_module, tmp_path, non_product, product):
+    source = "from google.adk.agents import LlmAgent\nworker = LlmAgent(name='SharedAgent')\n"
+    target = tmp_path / non_product
+    target.parent.mkdir(parents=True)
+    target.write_text(source, encoding="utf-8")
+    if product:
+        (tmp_path / product).write_text(source, encoding="utf-8")
+    script = script_module.detect(tmp_path)
+    installed = detect_workspace(tmp_path.resolve()).model_dump(mode="json")
+    assert script["agent_name_candidates"] == installed["agent_name_candidates"]
+    candidate = next(c for c in script["agent_name_candidates"] if c["value"] == "SharedAgent")
+    assert candidate["selectable"] is (product is not None)
+    assert script["is_agent_project"] is True
+
+
 def test_script_agent_name_ranking_matches_cli(script_module, tmp_path):
     """Samples all carry a single unambiguous name literal, so they cannot
     catch a ranking divergence. This workspace can: it has a hierarchy, a
@@ -1161,11 +1180,11 @@ def test_script_scopes_an_unreadable_root_like_the_cli(script_module, tmp_path, 
         "monorepo": {"CleanRoot"},
         "weak_markers": {"OneRoot"},
         "shared_name": set(),
-        "eval_test_file": {"RagRoot", "inner"},
-        "scaffolding_template": {"RealRoot", "inner"},
-        "readable_template": {"ProductHelper", "TemplateRoot"},
+        "eval_test_file": {"RagRoot"},
+        "scaffolding_template": {"RealRoot"},
+        "readable_template": {"ProductHelper"},
         "bare_templates": set(),
-        "case_folded_template": {"RealRoot", "inner"},
+        "case_folded_template": {"RealRoot"},
         "two_unreadable_roots": set(),
         "non_agent_strong_marker": set(),
         "non_agent_weak_marker": set(),

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -4975,6 +4975,7 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
     # other published field of the candidate points at.
     declared_in: dict[str, list[str]] = {}
     best_project: dict[str, str] = {}
+    product_declared: set[str] = set()
     order = 0
     for path, facts in py_facts:
         if not facts["names"]:
@@ -5009,6 +5010,8 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
                     evidence["why"] or "declared as a child of another agent, not the root"
                 )
             origin = _non_product_origin(rel)
+            if origin is None:
+                product_declared.add(value)
             if origin is not None:
                 # Larger than every other signal combined: a fixture or a
                 # scaffolding template that happens to build an App root is
@@ -5067,6 +5070,11 @@ def _rank_agent_names(py_facts: list[tuple[Path, dict[str, Any]]], workspace: Pa
                     "static value",
                 )
     for value, ranked in best.items():
+        if value not in product_declared:
+            ranked["selectable"] = False
+            ranked["rationale"].append(
+                "rejected: declared only in non-product code, not a reviewed product identity"
+            )
         # The candidate's own project first when it is blocked, so the
         # sentence names the project every other field already points at.
         blocking = sorted(


### PR DESCRIPTION
## Summary

When every declaration of a name lives in tests or scaffolding templates, `init` currently selects it even though discovery already identifies those sites as non-product. Reject that candidate for selection while retaining its evidence and rationale. A matching declaration in product code stays eligible regardless of file order; recognized tool surfaces remain adoptable.

The installed and standalone rankers apply the same quality floor. `init` writes an unresolved `agent.name` placeholder instead of asserting a fixture's identity. The later identity-specific recovery question is reproduced separately in #543 and deferred: the existing human route for purpose/permissions does not prove that the name itself has been confirmed.

Closes #533.

## Type

- [x] CLI or GitHub Action behavior

## Verification

- Eleven new origin, order, and installed/standalone parity cases pass; three intended regressions failed before the fix.
- Full non-performance pytest suite passed with eight workers; focused discovery/init/standalone suites passed.
- Ruff and generated-schema consistency check passed.
- Committed base/head verification reports `complete` / `passed`, with no new authority declarations.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] No check IDs or persisted schema grammars changed

This intentionally changes a previously selectable test/template-only name into a visible rejected candidate; it does not discard discovery or fabricate another name.