### PR TITLE
Report init generation defects without prescribing repository repair (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   `CHANGE_ME` placeholder. The later identity-specific recovery question is
   tracked separately in #543; existing purpose/permission review remains.
 
+- **An init generator failure is a product defect, not a request to refill a template.**
+  (#328) Rendering and generated-manifest validation now use the same structured
+  `internal_error` route, with no edit or `--minimal` fallback. Setup writes no
+  manifest, CI workflow or instruction kit on this failure. Genuine malformed
+  user manifests still name the existing file for repair.
+
 - **The FastMCP signature projection now resolves the injected `Context`, and
   says so when it cannot read a type.** (#539) #535 made Python MCP servers
   discoverable and read their signatures. Two of the facts it published about

--- a/docs/errors.json
+++ b/docs/errors.json
@@ -123,9 +123,10 @@
       "additional_fields": [
         "message",
         "next_action",
-        "next_actions"
+        "next_actions",
+        "details"
       ],
-      "recovery_hint": "File an issue at https://github.com/ThreeMoonsLab/agents-shipgate/issues with the message and a minimal reproduction. Re-run with `--verbose` to capture the traceback."
+      "recovery_hint": "File an issue at https://github.com/ThreeMoonsLab/agents-shipgate/issues with the message and a minimal reproduction. Re-run with `--verbose` to capture the traceback. For init generation failures, details.failure is manifest_generation_failed and details.origin is agents_shipgate. The sole route is to report the product defect; it carries no repository edit or fallback command. No manifest, CI workflow or instruction kit is written. --minimal remains an explicit user choice, not a remedy for generated output that failed validation."
     },
     {
       "id": "environment_error",

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -1516,52 +1516,29 @@ def register(app: typer.Typer) -> None:
                     exit_code=4,
                 )
                 raise typer.Exit(4) from exc
-            rendered = render_auto_manifest(
-                workspace_resolved, detect_result, control_pack=control_pack
-            )
-            template = rendered.text
-            tool_surface_origin = rendered.tool_surface_origin
-            scaffold_summary = rendered.scaffold_summary
-            # Validation gate: refuse to emit a manifest the schema would reject.
+            # Both rendering and validation belong to the product boundary.
+            # A generated document failing our own schema is not malformed
+            # adopter input, and no setup files have been written yet (#328).
             try:
+                rendered = render_auto_manifest(
+                    workspace_resolved, detect_result, control_pack=control_pack
+                )
+                template = rendered.text
+                tool_surface_origin = rendered.tool_surface_origin
+                scaffold_summary = rendered.scaffold_summary
                 _validate_manifest_text(template)
-            except Exception as exc:  # noqa: BLE001 - validation surface
-                message = f"Generated manifest failed validation: {exc}"
+            except Exception as exc:  # noqa: BLE001 - generation boundary
+                message = f"Agents Shipgate defect: manifest generation failed: {exc}"
                 typer.echo(message, err=True)
-                minimal_action = NextAction(
-                    kind="command",
-                    # Through the one recovery builder, like the two early
-                    # validation routes above. A bare `init --minimal` dropped
-                    # the workspace this run was pointed at, the `--write` that
-                    # made it a real run, and the `--json` the caller is
-                    # reading the answer through — so following the fallback
-                    # exactly produced a dry run against the process directory.
-                    # (The console-script spelling was never the problem:
-                    # `NextAction` retargets `command` on construction.)
-                    command=_recovery_command(
-                        workspace=workspace_resolved,
-                        write=write,
-                        local_review=local_review,
-                        json_output=json_output,
-                        setup_flags=_invocation_flags(
-                            minimal=True,
-                            ci=ci,
-                            claude_code=claude_code,
-                            agent_instructions=agent_instructions,
-                            control_pack=control_pack,
-                            allow_unresolved_scope=allow_unresolved_scope,
-                            agent_instructions_kit=agent_instructions_kit,
-                            max_python_files=max_python_files,
-                        ),
-                    ),
+                report_action = NextAction(
+                    kind="review",
                     why=(
-                        "Auto-detected manifest failed schema validation. "
-                        "Fall back to the legacy CHANGE_ME-heavy template."
+                        "Report this Agents Shipgate defect with the failure message "
+                        "and a minimal reproduction at "
+                        "https://github.com/ThreeMoonsLab/agents-shipgate/issues. "
+                        "Do not change the repository to repair generated output."
                     ),
-                    expects=(
-                        "shipgate.yaml renders with placeholder fields "
-                        "you fill in manually."
-                    ),
+                    expects="A product fix that can generate a valid manifest from these inputs.",
                 )
                 _emit_agent_mode_error_routing(
                     "internal_error",
@@ -1570,11 +1547,14 @@ def register(app: typer.Typer) -> None:
                         workspace=workspace_resolved,
                         reason=message,
                         exit_code=4,
-                        action=minimal_action,
-                        action_kind="initialize",
+                        action=report_action,
                     ),
                     message=message,
                     exit_code=4,
+                    details={
+                        "failure": "manifest_generation_failed",
+                        "origin": "agents_shipgate",
+                    },
                 )
                 raise typer.Exit(4) from exc
             placeholders = collect_placeholders(template)

--- a/tests/test_setup_control.py
+++ b/tests/test_setup_control.py
@@ -2210,18 +2210,15 @@ def _error_lines(output: str) -> list[dict]:
     return [json.loads(line) for line in output.splitlines() if line.startswith('{"error"')]
 
 
-def test_a_failed_render_routes_the_fallback_at_the_run_it_is_correcting(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("failure_site", ["render_auto_manifest", "_validate_manifest_text"])
+@pytest.mark.parametrize("extra_flags", [[], ["--ci", "--agent-instructions=default"]])
+def test_a_generated_manifest_failure_reports_a_product_defect_without_repo_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_site: str, extra_flags: list[str]
 ):
-    """The `internal_error` route, which no fixture can reach without a fault.
+    """A product exception must not send an adopter back to a blank template.
 
-    Two things this pins. The error line carries the envelope at all — it is a
-    setup answer, and a run that produced no payload is exactly the run whose
-    caller has nothing else to route on. And the fallback repeats the
-    invocation it is correcting: a bare ``init --minimal`` dropped the
-    workspace, the ``--write`` that made it a real run, and the ``--json`` the
-    caller is reading the answer through, so following it exactly produced a
-    dry run against the process directory.
+    Exercise the real CLI and both generation stages. No setup surface may be
+    written, even when the invocation asked for CI and an instruction kit.
     """
 
     monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
@@ -2232,32 +2229,58 @@ def test_a_failed_render_routes_the_fallback_at_the_run_it_is_correcting(
     )
     import agents_shipgate.cli._register_init as init_module
 
-    def refuse(_text: str) -> None:
+    def refuse(*_args, **_kwargs):
         raise ValueError("synthetic schema failure")
 
-    monkeypatch.setattr(init_module, "_validate_manifest_text", refuse)
-
-    result = runner.invoke(app, ["init", "--workspace", str(tmp_path), "--write", "--json"])
+    monkeypatch.setattr(init_module, failure_site, refuse)
+    before = {p.relative_to(tmp_path): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    result = runner.invoke(
+        app, ["init", "--workspace", str(tmp_path), "--write", "--json", *extra_flags]
+    )
     assert result.exit_code == 4
-    lines = _error_lines(result.output)
+    lines = _error_lines(result.stderr)
     assert len(lines) == 1, result.output
     payload = lines[0]
     control = payload["control"]
 
     assert payload["error"] == "internal_error"
+    assert payload["details"]["failure"] == "manifest_generation_failed"
+    assert payload["details"]["origin"] == "agents_shipgate"
+    assert "Agents Shipgate defect" in payload["message"]
     assert control["operation"] == "init"
     assert control["execution"] == "failed"
     assert control["exit_code"] == 4
     assert control["decision"] == SETUP_INCOMPLETE
     assert control["decision_source"] == "setup"
     assert set(control["permissions"].values()) == {False}
-    # One selected route across both fields on the line.
-    assert control["next_action"]["command"] == payload["next_actions"][0]["command"]
-    fallback = shlex.split(control["next_action"]["command"])
-    assert fallback[fallback.index("--workspace") + 1] == str(tmp_path)
-    assert "--write" in fallback
-    assert "--minimal" in fallback
-    assert "--json" in fallback
+    assert control["control_state"] == "human_review_required"
+    assert control["next_action"]["command"] is None
+    assert control["next_action"]["actor"] == "human"
+    assert len(payload["next_actions"]) == 1
+    action = payload["next_actions"][0]
+    assert action["kind"] == "review"
+    assert action.get("path") is None
+    assert action.get("command") is None
+    assert "--minimal" not in payload["next_action"]
+    assert "Report" in payload["next_action"]
+    assert not list(_PUBLISHED_SCHEMA.iter_errors(control))
+    validate_agent_control_envelope(control)
+    after = {p.relative_to(tmp_path): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    assert after == before
+
+
+def test_a_malformed_user_manifest_still_routes_to_the_file_for_repair(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    manifest = tmp_path / "shipgate.yaml"
+    manifest.write_text("agent: [broken\n", encoding="utf-8")
+    result = runner.invoke(app, ["doctor", "--config", str(manifest), "--json"])
+    assert result.exit_code == 2
+    payload = _error_lines(result.stderr)[0]
+    assert payload["error"] == "config_error"
+    assert payload["control"]["next_action"]["kind"] == "edit"
+    assert payload["control"]["next_action"]["path"] == str(manifest)
+    assert payload["next_actions"][0]["path"] == str(manifest)
+    assert "manifest_generation_failed" not in json.dumps(payload)
 
 
 def test_a_discovery_failure_is_a_human_route_with_no_authority(


### PR DESCRIPTION
## Summary

When auto-init generates a manifest that its own schema rejects, it currently tells the adopter to rerun `--write --minimal` and refill placeholders. That turns a product exception into work on the user's repository. Route rendering and validation exceptions to one human-readable and machine-identifiable product defect instead, without an edit or fallback command.

The error remains `internal_error`, exit 4, with the existing all-false setup control envelope. `details.failure=manifest_generation_failed` and `details.origin=agents_shipgate` identify this bounded case. No manifest, workflow or instruction kit is written, including when the failed invocation requested them. Explicit `--minimal` remains available; malformed user YAML still routes to its existing file for repair.

Implements the first concrete slice of #328. That issue remains open for the cross-command error taxonomy; this PR does not claim that every adapter limitation is now correctly classified.

## Type

- [x] CLI or GitHub Action behavior

## Verification

- Four injected rendering/validation cases failed before this fix, then passed; the malformed-user-YAML counterexample passes.
- Full non-performance pytest suite passed with eight workers.
- Setup-control, init, agent-mode and public-surface suites passed; 22 integration/identity cases passed again after rebasing on #544.
- Ruff, generated-schema consistency and diff checks passed.
- Committed base/head verifier and fresh control report `complete` / `passed`.

## Release-readiness notes

- [x] No user-code import added to default scan paths
- [x] No network access added to default scan paths
- [x] Existing error kind, exit code and frozen control schemas retained

`docs/errors.json` documents the specific diagnostic and recovery boundary. No policy, suppression or declaration is altered.