### PR TITLE
Deprecate path-only instruction-weakening findings while retaining structural checks (#516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Deprecated the path-only instruction-weakening check.** (#516)
+  `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED` remains registered for compatibility
+  but emits no new findings. Structured permission, MCP and hook
+  readers and the skill-command mention heuristic remain active. Generic trust-root and local instruction routes are
+  unchanged; #545 tracks their remaining prose-only review boundary.
+
 - **Test- and template-only agent names require review.** (#533) Discovery
   keeps these names visible with their source and rationale, but `init` no
   longer asserts them as the product's reviewed identity. A name also declared

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -2765,9 +2765,14 @@ config error, exit 2). They are ordinary `Finding`s routed through
 - `SHIP-VERIFY-CI-GATE-REMOVED` (critical, floor high) — a Shipgate CI
   workflow path is in the changed files and no longer exists on disk (the PR
   deleted the gate).
-- `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED` (medium, floor medium) — an
-  agent-instruction trust root changed; Shipgate cannot statically prove the
-  instructions were not weakened, so it routes to human review.
+- `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED` (medium, floor medium) —
+  **deprecated in the unreleased minor cycle (#516)**. New scans emit no
+  findings for this ID. It remains registered with the same metadata for
+  historical reports, configured overrides and suppressions, for at least one
+  minor-version cycle after the deprecation ships. It is not repurposed as a
+  structural check. Existing structured host readers, the skill-command mention heuristic and
+  generic trust-root protection remain active; #545 owns the remaining prose-only
+  routing boundary. No release decision enum or severity changes.
 - `SHIP-VERIFY-TRIGGER-CATALOG-DRIFT` (medium, floor medium) — the trigger
   catalog that decides when Shipgate runs changed; routed to human review to
   rule out gate evasion.

--- a/docs/checks.json
+++ b/docs/checks.json
@@ -2928,19 +2928,19 @@
       "autofix_safe": false,
       "category": "verify",
       "default_severity": "medium",
-      "description": "The PR edits agent-instruction trust roots (AGENTS.md, CLAUDE.md, .cursor/rules, skills, etc.) and Shipgate cannot statically prove the instructions were not weakened.",
+      "description": "Deprecated in the unreleased minor cycle; retained for historical reports and configuration. New runs emit no findings for this ID.",
       "docs_url": "https://github.com/ThreeMoonsLab/agents-shipgate/blob/main/docs/checks.md#ship-verify-agent-instructions-weakened",
       "dynamic_default": false,
       "evidence_fields": [
         "kind",
         "changed_instruction_files"
       ],
-      "fires_when": "A VerificationContext is present and a changed file matches an agent-instruction trust-root glob.",
+      "fires_when": "Never on current scans. Historical findings retain their original meaning and metadata; the published ID is not removed or repurposed.",
       "floor_severity": "medium",
       "id": "SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED",
       "mvp_tier": "lifecycle",
-      "rationale": "Prompts are not controls (Principle 3); a static tool cannot judge whether instruction text was weakened, so any change is routed to human review rather than silently trusted.",
-      "recommendation": "A human must review the agent-instruction change and confirm no gate-protecting instruction was removed or softened.",
+      "rationale": "Changed-file membership cannot establish that natural-language instructions weakened a control. Structured permission and execution readers remain active; the generic trust-root route is unchanged (follow-up 545).",
+      "recommendation": "This is a historical instruction-text finding. Re-run the current verifier for structural findings and remaining review obligations; deprecation of this ID does not itself authorize merge or completion.",
       "requires_human_review": true,
       "requires_human_review_regardless_of_patch": false,
       "suggested_patch_kind": "manual"

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -163,7 +163,7 @@ baseline summary and do not fail CI.
 | `SHIP-VERIFY-POLICY-BASE-ABSENT` | medium | A policy or manifest trust root changed and no base policy could be compared — no base report, a first adoption, or a control pack this build cannot resolve; routed to human review without a weakening claim. |
 | `SHIP-VERIFY-BASELINE-OR-WAIVER-EXPANDED` | high | The PR broadens what the gate forgives — a new suppression, a widened waiver scope, or a larger accepted-debt baseline — versus the base. |
 | `SHIP-VERIFY-CI-GATE-REMOVED` | critical | The PR deletes the Shipgate CI workflow from an opted-in repo, which would stop the release gate from running. |
-| `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED` | medium | The PR edits agent-instruction trust roots and weakening cannot be statically disproven; routed to human review. |
+| `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED` | medium | Deprecated; retained for compatibility, with no findings emitted by current scans. |
 | `SHIP-VERIFY-TRIGGER-CATALOG-DRIFT` | medium | The PR changes the trigger catalog that decides when Shipgate runs; routed to human review to rule out gate evasion. |
 | `SHIP-VERIFY-CAPABILITY-SCOPE-BROADENED` | critical | The PR removes or broadens a dynamically-loaded toolkit's least-privilege configuration bound (e.g. a `stripe_agent_toolkit` allowlist), silently expanding the toolkit surface; blocks rather than degrading to insufficient_evidence. |
 | `SHIP-CAP-CONFIG-BINDING-REMOVED` | high | The PR removes the config binding from a dynamic toolkit factory present on both sides of the diff, so the toolkit may fall back to its everything-enabled defaults; routed to human review instead of silent insufficient_evidence parity. |
@@ -1054,13 +1054,16 @@ weakening signal in the family.
 
 ### SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED
 
-Tier B: agent-instruction files (`AGENTS.md`, `CLAUDE.md`, `.claude/`,
-`.cursor/rules/`, `.agents/skills/`, `.codex/`, `SKILL.md`) tell coding
-agents how to behave around the gate. Shipgate is static and makes no NLP
-judgement, so it cannot prove semantic weakening from text — per Principle
-3 ("prompts are not controls"), any verify-mode change to these trust
-roots is routed to human review at `medium`. Deterministic on changed-file
-membership; the human confirms no gate-protecting instruction was removed.
+Deprecated in the unreleased minor cycle (#516). The registered ID, severity
+metadata and historical report compatibility remain for at least one minor
+version cycle. Current scans emit no findings for this ID: a path change does
+not establish that natural-language instructions weakened a control.
+
+Existing structured permission, MCP and hook readers, plus the skill-command
+mention heuristic, remain active, including mixed prose/executable surfaces. No replacement semantic
+check is added. `SHIP-VERIFY-TRUST-ROOT-TOUCHED` and the existing local instruction
+requirement route are unchanged; #545 tracks their remaining prose-only review
+boundary. Disappearance of this one finding is not a passing verifier result.
 
 ### SHIP-VERIFY-TRIGGER-CATALOG-DRIFT
 

--- a/docs/checks/verify.yaml
+++ b/docs/checks/verify.yaml
@@ -145,19 +145,19 @@ checks:
   floor_severity: medium
   mvp_tier: lifecycle
   requires_human_review: true
-  description: The PR edits agent-instruction trust roots (AGENTS.md, CLAUDE.md,
-    .cursor/rules, skills, etc.) and Shipgate cannot statically prove the
-    instructions were not weakened.
-  rationale: Prompts are not controls (Principle 3); a static tool cannot judge
-    whether instruction text was weakened, so any change is routed to human review
-    rather than silently trusted.
-  fires_when: A VerificationContext is present and a changed file matches an
-    agent-instruction trust-root glob.
+  description: Deprecated in the unreleased minor cycle; retained for historical
+    reports and configuration. New runs emit no findings for this ID.
+  rationale: Changed-file membership cannot establish that natural-language
+    instructions weakened a control. Structured permission and execution readers
+    remain active; the generic trust-root route is unchanged (follow-up 545).
+  fires_when: Never on current scans. Historical findings retain their original
+    meaning and metadata; the published ID is not removed or repurposed.
   evidence_fields:
   - kind
   - changed_instruction_files
-  recommendation: A human must review the agent-instruction change and confirm no
-    gate-protecting instruction was removed or softened.
+  recommendation: This is a historical instruction-text finding. Re-run the
+    current verifier for structural findings and remaining review obligations;
+    deprecation of this ID does not itself authorize merge or completion.
 - id: SHIP-VERIFY-TRIGGER-CATALOG-DRIFT
   default_severity: medium
   floor_severity: medium

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3027,7 +3027,7 @@ baseline summary and do not fail CI.
 | `SHIP-VERIFY-POLICY-BASE-ABSENT` | medium | A policy or manifest trust root changed and no base policy could be compared — no base report, a first adoption, or a control pack this build cannot resolve; routed to human review without a weakening claim. |
 | `SHIP-VERIFY-BASELINE-OR-WAIVER-EXPANDED` | high | The PR broadens what the gate forgives — a new suppression, a widened waiver scope, or a larger accepted-debt baseline — versus the base. |
 | `SHIP-VERIFY-CI-GATE-REMOVED` | critical | The PR deletes the Shipgate CI workflow from an opted-in repo, which would stop the release gate from running. |
-| `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED` | medium | The PR edits agent-instruction trust roots and weakening cannot be statically disproven; routed to human review. |
+| `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED` | medium | Deprecated; retained for compatibility, with no findings emitted by current scans. |
 | `SHIP-VERIFY-TRIGGER-CATALOG-DRIFT` | medium | The PR changes the trigger catalog that decides when Shipgate runs; routed to human review to rule out gate evasion. |
 | `SHIP-VERIFY-CAPABILITY-SCOPE-BROADENED` | critical | The PR removes or broadens a dynamically-loaded toolkit's least-privilege configuration bound (e.g. a `stripe_agent_toolkit` allowlist), silently expanding the toolkit surface; blocks rather than degrading to insufficient_evidence. |
 | `SHIP-CAP-CONFIG-BINDING-REMOVED` | high | The PR removes the config binding from a dynamic toolkit factory present on both sides of the diff, so the toolkit may fall back to its everything-enabled defaults; routed to human review instead of silent insufficient_evidence parity. |
@@ -3918,13 +3918,16 @@ weakening signal in the family.
 
 ### SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED
 
-Tier B: agent-instruction files (`AGENTS.md`, `CLAUDE.md`, `.claude/`,
-`.cursor/rules/`, `.agents/skills/`, `.codex/`, `SKILL.md`) tell coding
-agents how to behave around the gate. Shipgate is static and makes no NLP
-judgement, so it cannot prove semantic weakening from text — per Principle
-3 ("prompts are not controls"), any verify-mode change to these trust
-roots is routed to human review at `medium`. Deterministic on changed-file
-membership; the human confirms no gate-protecting instruction was removed.
+Deprecated in the unreleased minor cycle (#516). The registered ID, severity
+metadata and historical report compatibility remain for at least one minor
+version cycle. Current scans emit no findings for this ID: a path change does
+not establish that natural-language instructions weakened a control.
+
+Existing structured permission, MCP and hook readers, plus the skill-command
+mention heuristic, remain active, including mixed prose/executable surfaces. No replacement semantic
+check is added. `SHIP-VERIFY-TRUST-ROOT-TOUCHED` and the existing local instruction
+requirement route are unchanged; #545 tracks their remaining prose-only review
+boundary. Disappearance of this one finding is not a passing verifier result.
 
 ### SHIP-VERIFY-TRIGGER-CATALOG-DRIFT
 

--- a/src/agents_shipgate/checks/verify_agent_instructions.py
+++ b/src/agents_shipgate/checks/verify_agent_instructions.py
@@ -1,66 +1,20 @@
-"""SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED (§5.1 Tier B / Principle 3/4).
+"""Deprecated instruction-semantics check; retained for compatibility (#516).
 
-Agent-instruction files (AGENTS.md, CLAUDE.md, .cursor/rules/**, skills,
-etc.) tell coding agents how to behave around the gate. A PR that edits
-them could be removing a "do not weaken the gate" instruction — but
-Shipgate is static and makes no LLM/NLP judgement, so it CANNOT prove
-semantic weakening from text alone.
-
-Per Principle 3 ("prompts are not controls — back every instruction with a
-deterministic check") and §5.3 ("fail safe to review_required when the
-semantic direction cannot be proven"), this check routes any verify-mode
-modification of an agent-instruction trust root to **human review**: the
-human must confirm the instructions were not weakened. It is deterministic
-(fires on changed-file membership), never blocks on its own (medium), and
-names the human-authority concern that the broader TRUST-ROOT-TOUCHED
-finding does not.
+Path membership cannot establish that prose weakened an instruction. The
+published ID remains registered for at least one minor-version cycle, so old
+configuration and reports still resolve it, but new runs emit no findings.
+Structured permission, hook, MCP and skill-command readers remain separate.
+The generic trust-root route is unchanged; its prose-only boundary is #545.
 """
 
 from __future__ import annotations
 
-from agents_shipgate.checks._verify_common import (
-    changed_files,
-    touched,
-    verification_active,
-    verify_finding,
-)
 from agents_shipgate.core.context import ScanContext
 from agents_shipgate.schemas.report import Finding
 
 CHECK_ID = "SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED"
 
-_AGENT_INSTRUCTION_SURFACES = (
-    "**/AGENTS.md",
-    "**/CLAUDE.md",
-    "**/.claude/**",
-    "**/.cursor/rules/**",
-    "**/.agents/skills/**",
-    "**/.codex/**",
-    "**/SKILL.md",
-)
-
 
 def run(context: ScanContext) -> list[Finding]:
-    if not verification_active(context):
-        return []
-    hit = touched(_AGENT_INSTRUCTION_SURFACES, changed_files(context))
-    if not hit:
-        return []
-    return [
-        verify_finding(
-            context,
-            check_id=CHECK_ID,
-            title="Agent instructions changed; weakening cannot be ruled out",
-            severity="medium",
-            evidence={
-                "kind": "agent_instructions_changed",
-                "changed_instruction_files": hit,
-            },
-            recommendation=(
-                "This PR edits agent-instruction files. Shipgate cannot "
-                "statically prove the instructions were not weakened, so a "
-                "human must review the change and confirm no gate-protecting "
-                "instruction was removed or softened."
-            ),
-        )
-    ]
+    """Keep the shipped check callable without asserting prose semantics."""
+    return []

--- a/tests/test_host_boundary_check.py
+++ b/tests/test_host_boundary_check.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from agents_shipgate.checks.host_boundary import run as host_boundary_run
 from agents_shipgate.config.loader import load_manifest
 from agents_shipgate.core.context import ScanContext
@@ -639,3 +641,41 @@ def test_nested_mcp_and_claude_settings_are_not_host_grants(tmp_path: Path) -> N
         workspace=tmp_path, diff_text=diff
     )
     assert violations == []
+
+
+@pytest.mark.parametrize(("path", "text", "expected"), [
+    (".claude/settings.json", '{"permissions":{"allow":["Bash(*)"]}}',
+     "SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW"),
+    (".claude/settings.json", '{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"echo audit"}]}]}}',
+     "SHIP-HOST-BOUNDARY-HOOK-CHANGED"),
+    (".mcp.json", '{"mcpServers":{"search":{"command":"npx search-server"}}}',
+     "SHIP-HOST-BOUNDARY-MCP-SERVER-ADDED"),
+    (".claude/settings.json", '{broken',
+     "SHIP-HOST-BOUNDARY-CONFIG-PARSE-FAILED"),
+])
+def test_prose_deprecation_keeps_structured_and_malformed_host_inputs(
+    tmp_path: Path, path: str, text: str, expected: str
+):
+    from agents_shipgate.checks import verify_agent_instructions
+
+    # Prose and structured declarations share a protected directory; excluding
+    # that whole directory would make this regression fail (#516).
+    prose = ".claude/README.md"
+    diff = _new_file_diff(prose, "Use concise review summaries.\n") + _new_file_diff(path, text)
+    context = _context(tmp_path, diff)
+    context.verification.changed_files = [prose, path]
+    assert verify_agent_instructions.run(context) == []
+    assert expected in {finding.check_id for finding in host_boundary_run(context)}
+
+
+def test_prose_deprecation_preserves_existing_skill_command_reader(tmp_path: Path):
+    from agents_shipgate.checks import codex_boundary, verify_agent_instructions
+
+    path = ".agents/skills/probe/SKILL.md"
+    diff = _new_file_diff(path, "# Probe\n\nRun `bash scripts/probe.sh`.\n")
+    context = _context(tmp_path, diff)
+    context.verification.changed_files = [path]
+    assert verify_agent_instructions.run(context) == []
+    assert "SHIP-CODEX-BOUNDARY-SKILL-COMMAND-CHANGED" in {
+        finding.check_id for finding in codex_boundary.run(context)
+    }

--- a/tests/test_verify_weakening.py
+++ b/tests/test_verify_weakening.py
@@ -567,11 +567,12 @@ def test_ci_gate_no_verification_emits_nothing():
 # --- SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED -------------------------------
 
 
-def test_agent_instructions_weakened_on_change():
-    findings = verify_agent_instructions.run(_context(changed_files=["AGENTS.md"]))
-    assert len(findings) == 1
-    assert findings[0].check_id == "SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED"
-    assert findings[0].severity == "medium"
+@pytest.mark.parametrize("path", [
+    "AGENTS.md", "agents.md", "CLAUDE.md", ".claude/README.md",
+    ".codex/README.md", ".cursor/rules/style.mdc", ".agents/skills/probe/SKILL.md",
+])
+def test_deprecated_instruction_check_never_asserts_prose_weakening(path):
+    assert verify_agent_instructions.run(_context(changed_files=[path])) == []
 
 
 def test_agent_instructions_unrelated_file_emits_nothing():
@@ -661,10 +662,10 @@ def test_trigger_catalog_drift_sees_case_variant_catalog_paths(path):
     assert findings[0].check_id == "SHIP-VERIFY-TRIGGER-CATALOG-DRIFT"
 
 
-def test_agent_instructions_weakened_sees_case_variant_paths():
-    findings = verify_agent_instructions.run(_context(changed_files=["agents.md"]))
-    assert len(findings) == 1, (
-        "`agents.md` resolves to AGENTS.md on a case-insensitive filesystem "
-        f"and is a Tier A trust root; got {findings!r}."
-    )
-    assert findings[0].check_id == "SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED"
+def test_deprecated_instruction_id_stays_in_the_published_catalog():
+    from agents_shipgate.checks.registry import CHECK_METADATA
+
+    metadata = next(item for item in CHECK_METADATA if item.id == verify_agent_instructions.CHECK_ID)
+    assert "Deprecated" in metadata.description
+    assert metadata.default_severity == "medium"
+    assert metadata.floor_severity == "medium"


### PR DESCRIPTION
## Summary

Deprecate `SHIP-VERIFY-AGENT-INSTRUCTIONS-WEAKENED`: changed-file membership cannot prove that natural-language instructions weakened a control. Keep the shipped ID registered, with its existing severity metadata and historical/configuration compatibility for at least one minor cycle; current scans emit no findings for that ID.

Permission, MCP and hook readers remain active. The existing skill-command mention heuristic is preserved, with a paired regression, rather than silently treating it as proof of structured execution or deleting it along with a directory.

This is the bounded deprecation in #516. The issue remains open for its broader no-escalation outcome: the generic trust-root check and Codex instruction keyword route independently require review on prose. #545 records that scope conflict and their remaining boundary; this PR does not remove a second gate or claim a clean verifier result merely because one finding disappeared.

## Type

- [x] Check or risk-model change
- [x] Documentation and generated catalog update

## Verification

- Prose-path and catalog-retention regressions; mixed prose/permission, hook, MCP, malformed settings and command-bearing skill controls.
- Full non-performance pytest suite passed on the final tree; targeted weakening, host/Codex boundary and public-surface checks passed.
- Ruff, generated catalog/schema consistency, generated long-form documentation and diff checks passed.
- Earlier full-run failure in the missing-trust authorization case passed in isolation; its uncertain cause is deferred in #548. No assertion was relaxed.
- Earlier transient host-inventory reads denied authority; a subsequent original check and fresh verifier supplied a valid current result. Diagnostic fidelity is deferred in #547.

## Release-readiness notes

- [x] No user-code import or network access added
- [x] Published check ID retained; no replacement check or severity change
- [x] `STABILITY.md` describes the minor-cycle deprecation
- [x] Structured readers and malformed-input coverage retained

The generic trust-root table, host authorization policy, CI gate and control permissions are unchanged.