### PR TITLE
Review UX: show the current question in PRs and retain permission-denied evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Show the bounded human review question at the start of existing PR comments
+  and Check Run summaries, with source links, actor, outcomes, coverage limits
+  and exact omitted-question counts. PR publication permission/context refusals
+  retain the review in the workflow summary without changing the gate. This is
+  #337's presentation slice; authenticated decision recording remains open under
+  the independent signer pilot #555.
+
 - Evaluate externally signed decisions on the bounded human review request
   without rewriting static evidence or granting authority. Full current scope,
   external host key trust, reviewer eligibility and expiry are checked;

--- a/action.yml
+++ b/action.yml
@@ -562,27 +562,40 @@ runs:
           // Upsert via sticky marker so re-runs update the existing comment instead of spamming the PR.
           // Paginate the lookup — single-page (per_page=100) misses the marker on PRs with >100
           // earlier comments before Shipgate's first run, which would silently regress to append-only.
-          const allComments = await github.paginate(github.rest.issues.listComments, {
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-            per_page: 100,
-          });
-          const prior = allComments.find((c) => c.body && c.body.startsWith(STICKY));
-          if (prior) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: prior.id,
-              body,
-            });
-          } else {
-            await github.rest.issues.createComment({
+          try {
+            const allComments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body,
+              per_page: 100,
             });
+            const prior = allComments.find((c) => c.body && c.body.startsWith(STICKY));
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+          } catch (error) {
+            const headers = error.response?.headers || {};
+            const rateLimited = headers['x-ratelimit-remaining'] === '0' ||
+              headers['retry-after'] !== undefined || /rate limit/i.test(error.message || '');
+            if (![403, 404].includes(error.status) || rateLimited) throw error;
+            const limitation = 'PR comment publication is unavailable with this token or PR context. ' +
+              'Read the review below in the workflow summary. No authenticated decision is recorded; ' +
+              'the verifier gate and current control still apply.';
+            core.warning(limitation);
+            await core.summary.addHeading('Agents Shipgate: PR publication unavailable', 2)
+              .addRaw(limitation, true).addRaw(body, true).write();
           }
 
     - name: Build Agents Shipgate check-run payload

--- a/docs/human-review-request.md
+++ b/docs/human-review-request.md
@@ -58,6 +58,36 @@ CLI. Continue by presenting the request to a human and following current
 `control.next_action`; prose acknowledgement never clears it. GitHub authentication and acquisition belong
 to [#337](https://github.com/ThreeMoonsLab/agents-shipgate/issues/337).
 
+## PR and check presentation
+
+On current `main`, a verifier that produces this request also puts the question
+near the start of both PR comment styles. The existing GitHub Check Run summary
+uses the same comment. A reviewer sees the concern, medium severity, actor,
+accept/reject/dispute meanings and coverage boundary without opening a job log.
+GitHub.com source files link to the exact reviewed commit; local and other
+repository locators retain file paths instead of guessed web URLs.
+
+The display is bounded and states how many questions are omitted. Read the full
+request before deciding a partial or abbreviated list. The file remains in the
+report directory and, when artifact upload is enabled, in the uploaded report.
+If `upload_artifact: false` leaves the full request unavailable, reproduce the
+verification locally to read it; the displayed prefix is not the complete scope.
+Older builds that do not emit a review request retain their existing comment.
+
+The supported review location today is the PR's Conversation for discussion.
+The Action explicitly says **no authenticated decision is recorded**. Ordinary
+comments/approvals do not clear control, and an acceptance sentence is not a
+signature. The independent GitHub signer/identity boundary remains
+[#555](https://github.com/ThreeMoonsLab/agents-shipgate/issues/555); the broader
+authenticated workflow in #337 remains open.
+
+When PR publication receives a permission/context refusal (403/404), the Action
+places the same review in the workflow summary with a visible limitation. Forks
+and minimal tokens can therefore read the question without pretending that a PR
+comment was published. Authentication errors, rate limits and server failures
+still fail visibly. The merge-verdict policy and original verifier exit-code
+steps continue to run; publication fallback grants no authority.
+
 ## Identity and verification
 
 The request reuses the existing verification graph:

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -4484,6 +4484,7 @@ def _write_artifacts(
             style=pr_comment_style,
             capability_lock_diff=capability_lock_diff,
             human_context=human_context,
+            human_review_request=review_request,
         ),
         encoding="utf-8",
     )

--- a/src/agents_shipgate/report/human_review.py
+++ b/src/agents_shipgate/report/human_review.py
@@ -1,0 +1,73 @@
+"""Bounded PR presentation of an existing review request; no decision ingestion."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import quote
+
+from agents_shipgate.report.markdown import _safe_markdown_text
+from agents_shipgate.schemas.human_review_request import HumanReviewRequestV1
+
+_MAX_REVIEW_ROWS = 3
+_MAX_DETAIL_CHARS = 1100
+_GITHUB_REPOSITORY = re.compile(r"github\.com/[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+
+def _text(value: str, limit: int) -> str:
+    single_line = re.sub(r"[\x00-\x1f\x7f]", " ", value)
+    if len(single_line) > limit:
+        single_line = single_line[:limit - 1] + "…"
+    return _safe_markdown_text(single_line)
+
+
+def _source(request: HumanReviewRequestV1, path: str) -> str:
+    label = _text(path, 120)
+    # Only GitHub.com repository locators have this known blob URL shape.
+    # Local/custom hosts retain the exact file path rather than a guessed URL.
+    if _GITHUB_REPOSITORY.fullmatch(request.repository_id):
+        target = f"https://{request.repository_id}/blob/{request.source_head_commit_sha}/{quote(path, safe='/')}"
+        return f"[{label}]({target})"
+    return label
+
+
+def human_review_lines(request: HumanReviewRequestV1) -> list[str]:
+    """Show the question before long findings, with exact omitted-row counts.
+
+    #555 still owns the independent signer boundary. The current Action may
+    publish a question, not claim that an authenticated decision was recorded.
+    The fixed actor/consequence/fallback lines precede bounded source prose so
+    truncation cannot turn a partial question into an approval instruction.
+    """
+
+    rows: list[str] = []
+    abbreviated = False
+    for item, question in zip(request.review_items, request.questions, strict=True):
+        if len(rows) >= _MAX_REVIEW_ROWS:
+            break
+        sources = ", ".join(_source(request, path) for path in item.paths[:2])
+        if len(item.paths) > 2:
+            sources += f"; {len(item.paths) - 2} more source paths in the full request"
+        if not sources:
+            sources = "source location unavailable; open the full request"
+        row = f"- **Medium documentation concern:** {_text(question.question, 350)} Evidence: {sources}."
+        if sum(len(value) + 1 for value in [*rows, row]) > _MAX_DETAIL_CHARS:
+            break
+        rows.append(row)
+        abbreviated |= len(question.question) > 350 or any(len(path) > 120 for path in item.paths[:2])
+    total = len(request.review_items)
+    hidden = total - len(rows)
+    scope = f"Showing {len(rows)} of {total} review questions for commit `{request.source_head_commit_sha[:12]}`."
+    if hidden:
+        scope += f" {hidden} omitted; do not decide a partial list."
+    if abbreviated:
+        scope += " Some text is abbreviated; read the full request before deciding."
+    return [
+        "", "### Review question",
+        "An eligible authenticated human must decide; the author and bots cannot supply this decision.",
+        "**Accept** records agreement with the concern; **Reject** requests a fix; **Dispute** records disagreement for triage. None grants merge/completion or suppresses a finding.",
+        "**No authenticated decision is recorded by this Action.** Discuss the question in this PR's Conversation; a comment or ordinary approval does not clear current control.",
+        "Coverage: complete static evidence for this documentation-quality class; runtime behavior is not proven.",
+        scope,
+        *rows,
+        "Full scope and identity: `human-review-request.json` in the report directory or uploaded report artifact.",
+    ]

--- a/src/agents_shipgate/report/pr_comment.py
+++ b/src/agents_shipgate/report/pr_comment.py
@@ -21,7 +21,9 @@ from agents_shipgate.report.human_order import (
     should_render_surface_first,
     surface_lead,
 )
+from agents_shipgate.report.human_review import human_review_lines
 from agents_shipgate.schemas.capabilities import CapabilityLockDiffV1
+from agents_shipgate.schemas.human_review_request import HumanReviewRequestV1
 from agents_shipgate.schemas.report import ReadinessReport
 from agents_shipgate.schemas.verifier import (
     VerifierArtifact,
@@ -72,18 +74,32 @@ def render_pr_comment(
     style: str = "capability-review",
     capability_lock_diff: CapabilityLockDiffV1 | None = None,
     human_context: HumanArtifactContext | None = None,
+    human_review_request: HumanReviewRequestV1 | None = None,
 ) -> str:
+    # The producer decides eligibility; this projection only accepts the same
+    # current request identity, never a request retained from an earlier run.
+    request = human_review_request
+    if request is not None and (
+        request.verification_request_id != verifier.request_id
+        or request.decision_id != verifier.decision_id
+        or request.input_set_id != verifier.input_set_id
+        or request.head_tree_sha != verifier.head_tree_sha
+        or verifier.decision != "review_required"
+    ):
+        request = None
     if style == "findings":
         return _render_findings_comment(
             verifier,
             report=report,
             human_context=human_context,
+            human_review_request=request,
         )
     return _render_capability_review_comment(
         verifier,
         report=report,
         capability_lock_diff=capability_lock_diff,
         human_context=human_context,
+        human_review_request=request,
     )
 
 
@@ -93,10 +109,12 @@ def _render_capability_review_comment(
     report: ReadinessReport | None,
     capability_lock_diff: CapabilityLockDiffV1 | None,
     human_context: HumanArtifactContext | None,
+    human_review_request: HumanReviewRequestV1 | None,
 ) -> str:
     prose_lines = [
         STICKY_MARKER,
         "## Agents Shipgate",
+        *(human_review_lines(human_review_request) if human_review_request else []),
         *_human_summary_lines(
             verifier,
             report=report,
@@ -573,6 +591,7 @@ def _render_findings_comment(
     *,
     report: ReadinessReport | None,
     human_context: HumanArtifactContext | None,
+    human_review_request: HumanReviewRequestV1 | None,
 ) -> str:
     surface_first = bool(
         report is not None and should_render_surface_first(report, context=human_context)
@@ -594,6 +613,8 @@ def _render_findings_comment(
         else f"## Agents Shipgate result: {verifier.merge_verdict}"
     )
     lines = [STICKY_MARKER, title]
+    if human_review_request is not None:
+        lines.extend(human_review_lines(human_review_request))
     if surface_first and report is not None:
         lines.extend(
             [

--- a/tests/test_human_review_presentation.py
+++ b/tests/test_human_review_presentation.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agents_shipgate.report.human_review import human_review_lines
+from agents_shipgate.report.pr_comment import render_pr_comment
+from agents_shipgate.schemas.human_authorization import (
+    HumanAuthorizationReviewItemV1,
+    review_set_id,
+)
+from agents_shipgate.schemas.human_review_request import (
+    HumanReviewQuestionV1,
+    HumanReviewRequestV1,
+    build_human_review_request,
+)
+from scripts.github_check_run import build_check_run_payload
+from tests.test_authorization_verify_integration import _committed_review_repo, _git, _verify
+
+
+@pytest.fixture(scope="module")
+def presentation_case(tmp_path_factory):
+    repo = _committed_review_repo(tmp_path_factory.mktemp("review-presentation"))
+    _git(repo, "remote", "set-url", "origin", "https://github.com/acme/review-agent.git")
+    verifier, report, _ = _verify(repo)
+    out = repo / "agents-shipgate-reports"
+    request = HumanReviewRequestV1.model_validate_json((out / "human-review-request.json").read_text())
+    return repo, out, verifier, report, request
+
+
+def test_real_verify_publishes_the_question_in_the_existing_pr_comment(presentation_case):
+    _, out, verifier, report, request = presentation_case
+    text = (out / "pr-comment.md").read_text()
+    assert "### Review question" in text
+    assert "docs.lookup" in text
+    assert f"https://github.com/acme/review-agent/blob/{request.source_head_commit_sha}/tools.json" in text
+    assert "Accept" in text and "Reject" in text and "Dispute" in text
+    assert "No authenticated decision is recorded" in text
+    assert "author and bots cannot supply" in text
+    assert "runtime behavior" in text
+    assert report.release_decision.decision == "review_required"
+    assert not verifier.control.permissions.merge
+
+
+@pytest.mark.parametrize("style", ["capability-review", "findings"])
+def test_both_comment_styles_and_the_check_summary_carry_the_same_question(presentation_case, style):
+    _, _, verifier, report, request = presentation_case
+    before = report.model_dump_json(), verifier.model_dump_json(), request.model_dump_json()
+    text = render_pr_comment(verifier, report=report, style=style, human_review_request=request)
+    assert text.index("### Review question") < text.index("Release gate:")
+    assert len(text) <= 6000
+    assert before == (report.model_dump_json(), verifier.model_dump_json(), request.model_dump_json())
+    payload = build_check_run_payload(
+        verifier=verifier.model_dump(mode="json"), report=report.model_dump(mode="json"),
+        summary_markdown=text, check_run_policy="require-mergeable",
+    )
+    assert payload["conclusion"] == "failure"
+    assert "### Review question" in payload["output"]["summary"]
+    assert "No authenticated decision is recorded" in payload["output"]["summary"]
+
+
+def test_no_request_and_mismatched_request_do_not_create_an_approval_route(presentation_case):
+    _, _, verifier, report, request = presentation_case
+    assert "### Review question" not in render_pr_comment(verifier, report=report)
+    stale = request.model_copy(update={"verification_request_id": "sha256:" + "f" * 64})
+    text = render_pr_comment(verifier, report=report, human_review_request=stale)
+    assert "### Review question" not in text
+    assert "human_review_required" in text
+
+
+def _request_with_rows(request, *, count=1, path="tools.json", question=None):
+    fields = {name: getattr(request, name) for name in type(request).model_fields
+              if name not in {"schema_version", "review_request_id"}}
+    rows = [HumanAuthorizationReviewItemV1(
+        review_item_id=f"review-{index:02}", check_id="SHIP-DOC-MISSING-DESCRIPTION", paths=[path]
+    ) for index in range(count)]
+    fields.update(review_items=rows, review_set_id=review_set_id(rows), questions=[
+        HumanReviewQuestionV1(review_item_id=row.review_item_id,
+                             question=question or f"Does docs.lookup need its description repaired? {index}")
+        for index, row in enumerate(rows)
+    ])
+    return build_human_review_request(**fields)
+
+
+@pytest.mark.parametrize("style", ["capability-review", "findings"])
+def test_large_scope_keeps_actor_consequences_and_an_exact_omission_count(presentation_case, style):
+    _, _, verifier, report, request = presentation_case
+    large = _request_with_rows(request, count=40)
+    text = render_pr_comment(verifier, report=report, style=style, human_review_request=large)
+    assert len(text) <= 6000
+    assert "Showing 3 of 40" in text and "37 omitted; do not decide a partial list" in text
+    assert "No authenticated decision is recorded" in text
+    assert "None grants merge/completion" in text
+    if style == "capability-review":
+        block = text.split("### Agent instruction block\n```json\n", 1)[1].split("```", 1)[0]
+        assert isinstance(json.loads(block), dict)
+
+
+def test_source_links_quote_the_actual_path_and_escape_repository_text(presentation_case):
+    request = _request_with_rows(
+        presentation_case[4], path="tools/a [draft] #1?.json",
+        question="Accept <script>alert(1)</script> [fake](javascript:evil) for docs.lookup?",
+    )
+    text = "\n".join(human_review_lines(request))
+    assert "/tools/a%20%5Bdraft%5D%20%231%3F.json)" in text
+    assert "<script>" not in text and "[fake](javascript:evil)" not in text
+    local = request.model_copy(update={"repository_id": "local:workspace"})
+    local_text = "\n".join(human_review_lines(local))
+    assert "https://local" not in local_text
+    assert "tools/a" in local_text
+
+
+@pytest.mark.parametrize("field", ["decision_id", "input_set_id", "head_tree_sha"])
+def test_mismatched_current_evidence_omits_the_question(presentation_case, field):
+    _, _, verifier, report, request = presentation_case
+    wrong = request.model_copy(update={field: "f" * 40 if field.endswith("sha") else "sha256:" + "f" * 64})
+    assert "### Review question" not in render_pr_comment(verifier, report=report, human_review_request=wrong)
+
+
+@pytest.mark.parametrize("decision", ["blocked", "insufficient_evidence", "passed"])
+def test_excluded_current_decisions_keep_their_existing_route(presentation_case, decision):
+    _, _, verifier, report, request = presentation_case
+    current = verifier.model_copy(update={"decision": decision})
+    text = render_pr_comment(current, report=report, human_review_request=request)
+    assert "### Review question" not in text
+    assert current.control == verifier.control
+
+
+def test_abbreviated_questions_and_oversized_source_paths_are_explicit(presentation_case):
+    request = _request_with_rows(presentation_case[4], question="docs.lookup " + "x" * 600)
+    text = "\n".join(human_review_lines(request))
+    assert "Some text is abbreviated; read the full request before deciding" in text
+    huge = _request_with_rows(presentation_case[4], path="a/" * 600 + "tools.json")
+    text = "\n".join(human_review_lines(huge))
+    assert "Showing 0 of 1" in text and "1 omitted; do not decide a partial list" in text
+    assert len(text) < 2200
+
+
+_NODE_HARNESS = r"""
+const fs = require('fs');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const events = [];
+function fail(stage) {
+  if (input.at === stage) {
+    const error = new Error(input.message || 'Resource not accessible');
+    error.status = input.status;
+    error.response = {headers: input.headers || {}};
+    throw error;
+  }
+}
+const github = {
+  rest: {issues: {
+    listComments: async () => {},
+    updateComment: async (args) => { fail('update'); events.push(['update', args]); },
+    createComment: async (args) => { fail('create'); events.push(['create', args]); },
+  }},
+  paginate: async () => {
+    fail('list');
+    return input.prior ? [{id: 123, body: '<!-- agents-shipgate-pr-comment -->old'}] : [];
+  },
+};
+const summary = {
+  addHeading(value) { events.push(['heading', value]); return this; },
+  addRaw(value) { events.push(['summary', value]); return this; },
+  async write() { events.push(['written']); },
+};
+const core = {warning(value) { events.push(['warning', value]); }, summary};
+const context = {repo: {owner: 'acme', repo: 'review-agent'}, issue: {number: 7}};
+const moduleFor = (name) => name === 'fs' ? {
+  existsSync() {return true;}, readFileSync() {return input.body;},
+} : require(name);
+const env = {GITHUB_SERVER_URL: 'https://github.com', GITHUB_RUN_ID: '123'};
+const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+(async () => {
+  let thrown = null;
+  try { await new AsyncFunction('github', 'core', 'context', 'require', 'process', input.script)
+    (github, core, context, moduleFor, {env}); }
+  catch(error) { thrown = error.status || String(error); }
+  process.stdout.write(JSON.stringify({events, thrown}));
+})();
+"""
+
+
+def _run_action_publication(**case):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required to execute the GitHub Action script; present on CI runners")
+    action = yaml.safe_load(Path("action.yml").read_text())
+    script = next(step["with"]["script"] for step in action["runs"]["steps"]
+                  if step["name"] == "Comment on pull request")
+    result = subprocess.run([node, "-e", _NODE_HARNESS], input=json.dumps({
+        "script": script, "body": "<!-- agents-shipgate-pr-comment -->\n### Review question\nEvidence: tools.json",
+        **case,
+    }), text=True, capture_output=True, check=True, timeout=10)
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize("at,status,prior", [("list", 403, False), ("create", 403, False), ("update", 404, True)])
+def test_action_publication_denial_keeps_review_visible_without_claiming_an_approval(at, status, prior):
+    result = _run_action_publication(at=at, status=status, prior=prior)
+    assert result["thrown"] is None
+    assert not any(kind in {"create", "update"} for kind, *_ in result["events"])
+    summaries = "\n".join(row[1] for row in result["events"] if row[0] == "summary")
+    assert "### Review question" in summaries and "Evidence: tools.json" in summaries
+    assert "No authenticated decision is recorded" in summaries
+    assert "verifier gate and current control still apply" in summaries
+    assert ["written"] in result["events"]
+
+
+@pytest.mark.parametrize("status,headers,message", [
+    (401, {}, "Bad credentials"), (429, {}, "Too many requests"), (503, {}, "Unavailable"),
+    (403, {"x-ratelimit-remaining": "0"}, "Forbidden"),
+    (403, {"retry-after": "60"}, "Forbidden"), (403, {}, "Secondary rate limit"),
+])
+def test_action_does_not_hide_authentication_rate_limit_or_server_failures(status, headers, message):
+    result = _run_action_publication(at="list", status=status, headers=headers, message=message)
+    assert result["thrown"] == status
+    assert not result["events"]
+
+
+@pytest.mark.parametrize("prior,operation", [(False, "create"), (True, "update")])
+def test_normal_publication_still_upserts_one_current_comment(prior, operation):
+    result = _run_action_publication(prior=prior)
+    assert result["thrown"] is None
+    assert len(result["events"]) == 1
+    kind, args = result["events"][0]
+    assert kind == operation and "### Review question" in args["body"]
+    assert "Workflow artifacts:" in args["body"]


### PR DESCRIPTION
Refs #337 (presentation and publication-fallback slice); parent #504. The authenticated continuation and independent human pilot remain open under #555.

An eligible verifier run already writes a precise human review request, but a PR reader sees no corresponding question. Both existing comment styles now lead with that request: the documentation concern, medium severity, eligible actor, accepted/rejected/disputed meanings, static coverage boundary and source links pinned to the reviewed commit. Check Run summaries use the same comment.

The presentation keeps the complete request separate from the bounded display. Large requests state exact omitted-question counts; abbreviated text and oversized paths cannot look like a complete review. Existing agent instructions stay intact within the 6,000-character comment budget. Local/custom-host sources retain file paths instead of guessed URLs.

PR comment publication refusals (403/404 without rate-limit signals) now preserve the same review in the workflow summary with an explicit limitation. Authentication failures, rate limits and server errors still fail visibly. Sticky upsert, Check Run conclusions, merge-verdict policy and the original verifier exit-code step remain unchanged.

### Authority and scope

This Action explicitly records **no authenticated decision**. PR Conversation is a discussion fallback; a normal comment or approval does not clear control. #555 owns the independently authenticated signer/deployment experiment. #337 remains open; this PR is not a completed human-review pilot.

The change reuses the existing request, PR renderer, Check Run summary and Action. No new command, persisted schema or runtime-contract version. Headline metric: a reviewer can identify the question, evidence, actor and remaining obligation without opening a job log, including when publication permission is absent. It does not add another release verdict or scanner network access.

### Validation

- Four initial regressions failed on main: the real verifier comment omitted the question and neither comment style accepted the current request.
- 25 new presentation/publication cases cover both styles, current-identity mismatch and excluded decisions, 40-question omission counts, valid retained agent JSON, special/oversized paths, escaped repository text, abbreviation disclosure and unchanged strict Check Run outcome.
- Node tests execute the actual inline Action script with simulated GitHub responses: create/update, list/create/update permission denial, authentication failure, both rate-limit signals, and server failure.
- Focused request/evaluator/distribution tests, full non-performance suite, Ruff, generated-schema and generated-document checks pass.

The implementation is on current main; a released CLI without the optional request keeps its existing comment. If report upload is disabled, the docs require reproducing verification locally to read a missing full request, rather than treating a displayed prefix as complete evidence.