### PR TITLE
Diff: retain the evidence behind matched finding identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Retain base finding evidence for the existing fingerprint comparison and
+  expose changed predicate support, sources, subjects and release contribution.
+  Reports distinguish identity matches from change attribution and disclose
+  missing support or ambiguous matches. The gate and legacy JSON buckets are
+  unchanged; #515's default diff scope awaits dependency-coverage proof (#557).
+
 - Show the bounded human review question at the start of existing PR comments
   and Check Run summaries, with source links, actor, outcomes, coverage limits
   and exact omitted-question counts. PR publication permission/context refusals

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -143,6 +143,27 @@ load in older package versions.
 `release_decision.baseline_delta`; `--diff-from` drives `tool_surface_diff` and
 `action_surface_diff`.
 
+Finding delta buckets compare **identity**, not whether the PR caused a risk.
+`new_findings` means an identity was absent from the reference;
+`resolved_findings` means it is absent from the head; `unchanged_findings` means
+the identity matched. None proves introduction, remediation or unchanged
+authority. `accepted_debt` keeps its existing reviewed-baseline meaning.
+
+The current implementation retains full base report findings and compares
+their predicate support, source references, capability subjects and release
+contribution with matching head findings. `tool_surface_diff.notes` names
+changed evidence and base/head locations, unavailable support and ambiguous
+identities. The legacy buckets and gate are unchanged. A baseline or older
+reference without full finding evidence cannot establish that comparison;
+regenerate a base report to inspect it. Equal predicate support still does not
+establish complete shared-helper, binding or configuration dependency coverage.
+
+The Markdown summary calls these **finding identities** and discloses omitted
+comparison notes; all notes remain in `report.json`. Inspect both full reports
+before attributing a finding to the change. #515's default diff scope remains
+open on dependency-proof prerequisite #557; this comparison does not exclude
+standing findings from the release decision.
+
 Scope deltas distinguish tool-required scopes from manifest-declared scopes.
 If the same literal scope moves between those kinds, the diff reports one
 removed scope and one added scope so the JSON preserves the source of the

--- a/src/agents_shipgate/cli/scan/surface_redaction.py
+++ b/src/agents_shipgate/cli/scan/surface_redaction.py
@@ -19,6 +19,7 @@ from agents_shipgate.core.lenses.tool_surface import ToolSurfaceDiffReference, _
 from agents_shipgate.core.privacy import RedactionStats, redact_data, sanitize_model
 from agents_shipgate.schemas.codex_plugin import CodexPluginSurface
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.report import Finding
 from agents_shipgate.schemas.surfaces import (
     ActionDeclarationFacts,
     ActionFact,
@@ -236,6 +237,11 @@ def _sanitize_diff_reference(
         action_facts=action_facts,
         declaration_facts=declaration_facts,
         findings=findings,
+        finding_evidence=(
+            tuple(sanitize_model(row, Finding, stats=stats, path="tool_surface_diff.base.finding_evidence[]")
+                  for row in reference.finding_evidence)
+            if reference.finding_evidence is not None else None
+        ),
         notes=tuple(
             redact_data(
                 list(reference.notes),

--- a/src/agents_shipgate/core/lenses/finding_comparison.py
+++ b/src/agents_shipgate/core/lenses/finding_comparison.py
@@ -1,0 +1,78 @@
+"""Evidence diagnostics for the legacy fingerprint diff, never release scope.
+
+The four shipped finding buckets compare identity. Neither those buckets nor
+matching predicate support establish a dependency closure or change causality.
+Keep that limit visible while retaining the base evidence needed to inspect a
+match whose support moved (#515).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from agents_shipgate.schemas.report import Finding
+
+_LIMIT = (
+    "Finding comparison is fingerprint-based, not attribution to this change. "
+    "Shared-helper, binding and configuration dependency coverage is not established; "
+    "matching findings do not prove unchanged authority."
+)
+
+
+def _groups(findings: list[Finding] | tuple[Finding, ...]) -> dict[str, list[Finding]]:
+    groups: dict[str, list[Finding]] = defaultdict(list)
+    for finding in findings:
+        if not finding.suppressed and (key := finding.fingerprint or finding.id):
+            groups[key].append(finding)
+    return groups
+
+
+def _locations(finding: Finding) -> str:
+    paths = sorted({source.path or source.ref for source in (finding.source, finding.policy_evidence_source)
+                    if source is not None and (source.path or source.ref)})
+    return ", ".join(paths) or "source location unavailable"
+
+
+def finding_comparison_notes(
+    findings: list[Finding], base_evidence: tuple[Finding, ...] | None,
+) -> list[str]:
+    notes = [_LIMIT]
+    if base_evidence is None:
+        return [*notes, "Base finding evidence is unavailable; fingerprint matches cannot compare supporting evidence. Regenerate the base report from its source workspace to inspect that evidence."]
+    before, after = _groups(base_evidence), _groups(findings)
+    changed: list[str] = []
+    ambiguous = 0
+    missing_support = 0
+    for key in sorted(before.keys() & after.keys()):
+        if len(before[key]) != 1 or len(after[key]) != 1:
+            ambiguous += 1
+            continue
+        old, new = before[key][0], after[key][0]
+        axes = []
+        if old.support is None or new.support is None:
+            missing_support += 1
+        # Compare the carried content too: a supplied digest alone is not
+        # proof that two serialized support objects express the same thing.
+        if old.support != new.support:
+            axes.append("predicate support")
+        if (old.source, old.policy_evidence_source) != (new.source, new.policy_evidence_source):
+            axes.append("source references")
+        if (old.tool_id, old.agent_id, old.capability_refs) != (new.tool_id, new.agent_id, new.capability_refs):
+            axes.append("capability subjects")
+        if (old.severity, old.confidence, old.blocks_release) != (new.severity, new.confidence, new.blocks_release):
+            axes.append("release contribution")
+        if axes:
+            subject = new.tool_name or old.tool_name or new.title
+            changed.append(
+                f"{subject} ({new.check_id}) — changed evidence: {', '.join(axes)}; "
+                f"base: {_locations(old)}; head: {_locations(new)}. "
+                "Inspect both reports; this comparison does not establish widening or improvement."
+            )
+    if changed or ambiguous or missing_support:
+        notes.append(
+            f"Evidence comparison: {len(changed)} matched finding(s) have changed evidence; "
+            f"{missing_support} match(es) have predicate support unavailable on one or both sides; "
+            f"{ambiguous} ambiguous finding identities were not compared. "
+            "All matched rows remain in the legacy unchanged_findings identity bucket."
+        )
+    return [*notes, *changed]

--- a/src/agents_shipgate/core/lenses/tool_surface.py
+++ b/src/agents_shipgate/core/lenses/tool_surface.py
@@ -16,6 +16,7 @@ from agents_shipgate.core.domain import AgentRemoteBinding, Tool, ToolkitScopeBo
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.findings.identity import _canonicalize_for_fingerprint
 from agents_shipgate.core.heuristics import is_broad_scope
+from agents_shipgate.core.lenses.finding_comparison import finding_comparison_notes
 from agents_shipgate.core.remote_bindings import remote_binding_facts
 from agents_shipgate.core.risk_hints import HIGH_RISK_TAGS, risk_tags
 from agents_shipgate.core.static_inputs import read_static_input_text
@@ -81,6 +82,10 @@ class ToolSurfaceDiffReference:
     # report that predates the block.
     effective_policy: EffectivePolicy | None = None
     binding_facts: AgentBindingGraphAssessment | None = None
+    # In-memory only. Legacy finding delta rows deliberately omit evidence;
+    # retaining the full base rows allows a diagnostic comparison without
+    # changing finding fingerprints or inventing dependency completeness.
+    finding_evidence: tuple[Finding, ...] | None = None
 
 
 def build_tool_surface_facts(
@@ -234,7 +239,7 @@ def compute_tool_surface_diff(
             base=diff_base,
             summary=_summary_from_diff_parts(finding_deltas=finding_deltas),
             finding_deltas=finding_deltas,
-            notes=notes,
+            notes=[*notes, *finding_comparison_notes(findings, reference.finding_evidence)] if reference else notes,
         )
 
     tool_changes = _diff_tools(current.tools, base.tools)
@@ -253,7 +258,8 @@ def compute_tool_surface_diff(
         policy_drift=policy_drift,
         finding_deltas=finding_deltas,
     )
-    notes = ["Tool renames are reported as one removed tool plus one added tool."]
+    notes = finding_comparison_notes(findings, reference.finding_evidence if reference else None)
+    notes.append("Tool renames are reported as one removed tool plus one added tool.")
     if reference:
         notes.extend(reference.notes)
     return ToolSurfaceDiff(
@@ -967,6 +973,7 @@ def _reference_from_report_payload(
             for item in (_finding_item(finding) for finding in report.findings)
             if item is not None
         ],
+        finding_evidence=tuple(report.findings),
         notes=tuple(notes),
         action_notes=tuple(action_notes),
         # Present on v0.22+ base reports; None for older bases (the

--- a/src/agents_shipgate/packet/builder.py
+++ b/src/agents_shipgate/packet/builder.py
@@ -439,7 +439,7 @@ def _build_tool_surface_diff(
         highlights=_tool_surface_diff_highlights(
             diff, _tool_source_index(tools)
         ),
-        notes=list(diff.notes[:3]),
+        notes=list(diff.notes),
     )
 
 

--- a/src/agents_shipgate/packet/html.py
+++ b/src/agents_shipgate/packet/html.py
@@ -464,8 +464,8 @@ def _render_tool_surface_diff(section: ToolSurfaceDiffSection) -> str:
         f"{summary.tools_changed} changed</li>"
     )
     parts.append(
-        f"<li>Evidence gaps: {summary.new_findings} new finding(s), "
-        f"{summary.resolved_findings} resolved, "
+        f"<li>Finding identities: {summary.new_findings} added, "
+        f"{summary.resolved_findings} absent, "
         f"{summary.accepted_debt} accepted debt</li>"
     )
     parts.append(
@@ -479,6 +479,12 @@ def _render_tool_surface_diff(section: ToolSurfaceDiffSection) -> str:
         for item in section.highlights:
             parts.append(f"<li>{escape(item)}</li>")
         parts.append("</ul>")
+    if section.notes:
+        parts.append("<h3>Comparison limits</h3><ul>")
+        parts.extend(f"<li>{escape(note)}</li>" for note in section.notes[:3])
+        parts.append("</ul>")
+        if len(section.notes) > 3:
+            parts.append(f"<p>{len(section.notes) - 3} more notes in packet.json; inspect both reports before attributing a finding to the change.</p>")
     return "".join(parts)
 
 

--- a/src/agents_shipgate/packet/markdown.py
+++ b/src/agents_shipgate/packet/markdown.py
@@ -465,9 +465,9 @@ def _append_tool_surface_diff(lines: list[str], section: ToolSurfaceDiffSection)
         f"{summary.tools_changed} changed"
     )
     lines.append(
-        "- Evidence gaps: "
-        f"{summary.new_findings} new finding(s), "
-        f"{summary.resolved_findings} resolved, "
+        "- Finding identities: "
+        f"{summary.new_findings} added, "
+        f"{summary.resolved_findings} absent, "
         f"{summary.accepted_debt} accepted debt"
     )
     lines.append(
@@ -482,6 +482,11 @@ def _append_tool_surface_diff(lines: list[str], section: ToolSurfaceDiffSection)
         lines.append("")
         for item in section.highlights:
             lines.append(f"- {_escape(item)}")
+    if section.notes:
+        lines.extend(["", "### Comparison limits", ""])
+        lines.extend(f"- {_escape(note)}" for note in section.notes[:3])
+        if len(section.notes) > 3:
+            lines.append(f"{len(section.notes) - 3} more notes in packet.json; inspect both reports before attributing a finding to the change.")
     lines.append("")
 
 

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -816,9 +816,9 @@ def _append_tool_surface_diff(lines: list[str], report: ReadinessReport) -> None
             or diff.summary.accepted_debt
         ):
             lines.append(
-                "- Finding deltas: "
-                f"{diff.summary.new_findings} new, "
-                f"{diff.summary.resolved_findings} resolved, "
+                "- Finding identities: "
+                f"{diff.summary.new_findings} added, "
+                f"{diff.summary.resolved_findings} absent, "
                 f"{diff.summary.accepted_debt} accepted debt"
             )
         lines.append("")
@@ -845,10 +845,10 @@ def _append_tool_surface_diff(lines: list[str], report: ReadinessReport) -> None
                 f"{summary.policy_drift_items} policy drift item(s)"
             ),
             (
-                "- Findings: "
-                f"{summary.new_findings} new, "
-                f"{summary.resolved_findings} resolved, "
-                f"{summary.unchanged_findings} unchanged, "
+                "- Finding identities: "
+                f"{summary.new_findings} added, "
+                f"{summary.resolved_findings} absent, "
+                f"{summary.unchanged_findings} matched, "
                 f"{summary.accepted_debt} accepted debt"
             ),
             "",
@@ -889,6 +889,8 @@ def _append_tool_surface_diff(lines: list[str], report: ReadinessReport) -> None
     )
     if diff.notes:
         _append_diff_values(lines, "Notes", diff.notes[:3])
+        if len(diff.notes) > 3:
+            lines.append(f"{len(diff.notes) - 3} more comparison notes in report.json; inspect both reports before attributing a finding to the change.")
 
 
 def _append_action_surface_diff(lines: list[str], report: ReadinessReport) -> None:

--- a/src/agents_shipgate/report/pr_comment.py
+++ b/src/agents_shipgate/report/pr_comment.py
@@ -928,8 +928,9 @@ def _diff_lines(report: ReadinessReport) -> list[str]:
             f"-{summary.tools_removed}, {summary.tools_changed} changed"
         )
         lines.append(
-            f"Findings: {summary.new_findings} new, "
-            f"{summary.resolved_findings} resolved, {summary.accepted_debt} accepted debt"
+            f"Finding identities: {summary.new_findings} added, "
+            f"{summary.resolved_findings} absent, {summary.accepted_debt} accepted debt. "
+            "Identity differences do not attribute a finding to this change; inspect the evidence comparison notes in report.json."
         )
     elif tool_diff.notes:
         lines.append(f"Tool-surface diff: {_escape(tool_diff.notes[0])}")

--- a/tests/test_finding_comparison_evidence.py
+++ b/tests/test_finding_comparison_evidence.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.cli.scan.surface_redaction import _sanitize_diff_reference
+from agents_shipgate.core.findings.identity import assign_finding_ids
+from agents_shipgate.core.lenses.tool_surface import (
+    ToolSurfaceDiffReference,
+    _finding_item,
+    compute_tool_surface_diff,
+    load_tool_surface_diff_reference,
+)
+from agents_shipgate.core.policy_evidence import finding_support, predicate_evidence
+from agents_shipgate.core.privacy import RedactionStats
+from agents_shipgate.schemas.common import SourceReference
+from agents_shipgate.schemas.report import Finding, ReadinessReport
+from agents_shipgate.schemas.surfaces import ToolSurfaceFacts
+from tests.test_policy_packs import _manifest_without_policy_pack, _write_openapi, run_scan
+
+
+def _finding(*, scope="refunds:read", path="shared/guard.py", eligible=True):
+    finding = Finding(
+        check_id="ORG-REFUND-GUARD", title="Review refund guard", severity="high",
+        category="policy", tool_id="tool_refund", tool_name="refund",
+        evidence={"requires_review": True}, recommendation="Review shared/guard.py.",
+        source=SourceReference(type="python", path="tools/refund.py", start_line=4),
+        policy_evidence_source=SourceReference(type="file", path=path, start_line=2),
+        support=finding_support([predicate_evidence(
+            "required_scope", "matched", observed=scope, confidence="high",
+            evidence_bases=["typed_provider_fact"], policy_eligible=eligible,
+        )]),
+    )
+    return assign_finding_ids([finding])[0]
+
+
+def _compare(base, head):
+    return compute_tool_surface_diff(
+        ToolSurfaceFacts(), ToolSurfaceFacts(), head,
+        reference=ToolSurfaceDiffReference(
+            kind="report", facts=ToolSurfaceFacts(),
+            findings=[_finding_item(row) for row in base], finding_evidence=tuple(base),
+        ),
+    )
+
+
+@pytest.mark.parametrize("before,after", [
+    ({"scope": "refunds:read"}, {"scope": "refunds:*"}),
+    ({"scope": "refunds:*"}, {"scope": "refunds:read"}),
+    ({"eligible": False}, {"eligible": True}),
+    ({"path": "shared/guard.py"}, {"path": "config/guard.yaml"}),
+])
+def test_same_fingerprint_does_not_hide_changed_support_or_source(before, after):
+    base, head = _finding(**before), _finding(**after)
+    assert base.fingerprint == head.fingerprint
+    originals = base.model_dump_json(), head.model_dump_json()
+    diff = _compare([base], [head])
+    # The legacy bucket remains an identity comparison, not a safety claim.
+    assert diff.summary.unchanged_findings == 1
+    assert any("1 matched finding" in note and "changed evidence" in note for note in diff.notes)
+    assert any("refund" in note and "tools/refund.py" in note for note in diff.notes)
+    assert any("not attribution" in note for note in diff.notes)
+    assert originals == (base.model_dump_json(), head.model_dump_json())
+
+
+def test_standing_weakness_is_not_automatically_safe_or_attributed():
+    base, head = _finding(), _finding()
+    diff = _compare([base], [head])
+    assert diff.summary.unchanged_findings == 1
+    assert not any("changed evidence:" in note for note in diff.notes)
+    assert any("dependency coverage is not established" in note for note in diff.notes)
+
+
+def test_a_new_fingerprint_is_not_presented_as_proven_new_authority():
+    head = _finding()
+    diff = _compare([], [head])
+    assert diff.summary.new_findings == 1
+    assert any("not attribution" in note for note in diff.notes)
+
+
+def test_missing_base_evidence_is_explicit_even_when_surface_facts_exist():
+    head = _finding()
+    reference = ToolSurfaceDiffReference(
+        kind="baseline", facts=ToolSurfaceFacts(), findings=[_finding_item(head)],
+    )
+    diff = compute_tool_surface_diff(ToolSurfaceFacts(), ToolSurfaceFacts(), [head], reference=reference)
+    assert any("Base finding evidence is unavailable" in note for note in diff.notes)
+
+
+def test_missing_support_and_colliding_subjects_cannot_earn_a_complete_comparison():
+    missing = _finding().model_copy(update={"support": None})
+    diff = _compare([missing], [_finding()])
+    assert any("support unavailable" in note for note in diff.notes)
+    duplicate = _finding().model_copy(update={"agent_id": "second-agent"})
+    diff = _compare([_finding(), duplicate], [_finding(), duplicate])
+    assert any("ambiguous finding identities" in note for note in diff.notes)
+
+
+def test_report_loader_retains_evidence_which_the_legacy_delta_row_drops(tmp_path):
+    payload = json.loads(Path("samples/support_refund_agent/expected/report.json").read_text())
+    report = ReadinessReport.model_validate(payload)
+    finding = _finding()
+    report.findings = [finding]
+    path = tmp_path / "base.json"
+    path.write_text(report.model_dump_json())
+    reference = load_tool_surface_diff_reference(path)
+    assert reference.finding_evidence == (finding,)
+    assert reference.finding_evidence[0].support == finding.support
+
+
+def test_public_reference_sanitizes_the_retained_evidence_before_rendering():
+    secret = "sk-" + "A" * 48
+    finding = _finding(path=f"config/{secret}/guard.yaml")
+    reference = ToolSurfaceDiffReference(kind="report", facts=ToolSurfaceFacts(), finding_evidence=(finding,))
+    public = _sanitize_diff_reference(reference, stats=RedactionStats())
+    assert public is not None and public.finding_evidence is not None
+    assert secret not in public.finding_evidence[0].model_dump_json()
+    assert secret in finding.model_dump_json()
+
+
+def test_real_policy_scan_keeps_identity_but_exposes_changed_support(tmp_path):
+    _write_openapi(tmp_path)
+    (tmp_path / "shipgate.yaml").write_text(_manifest_without_policy_pack() + """
+checks:
+  policy_packs:
+    - path: org-pack.yaml
+""")
+    pack = tmp_path / "org-pack.yaml"
+    policy = """
+name: Refund review
+rules:
+  - id: ORG-REVIEW-REFUND
+    title: Review refund capability
+    severity: high
+    confidence: high
+    recommendation: Review create_refund in openapi.yaml.
+    match:
+      source_types: [openapi]
+"""
+    pack.write_text(policy)
+    base, _ = run_scan(config_path=tmp_path / "shipgate.yaml", output_dir=tmp_path / "base",
+                       formats=["json", "markdown"], ci_mode="advisory")
+    pack.write_text(policy.replace("confidence: high", "confidence: medium"))
+    head, _ = run_scan(config_path=tmp_path / "shipgate.yaml", output_dir=tmp_path / "head",
+                       formats=["json", "markdown"], ci_mode="advisory",
+                       diff_from_path=tmp_path / "base" / "report.json")
+    old = next(row for row in base.findings if row.check_id == "ORG-REVIEW-REFUND")
+    new = next(row for row in head.findings if row.check_id == old.check_id)
+    assert old.fingerprint == new.fingerprint
+    assert old.support != new.support
+    notes = head.tool_surface_diff.notes
+    assert any("changed evidence" in note and "create_refund" in note and "org-pack.yaml" in note for note in notes)
+    assert "Finding identities:" in (tmp_path / "head" / "report.md").read_text()
+    assert any(row.fingerprint == new.fingerprint for row in head.tool_surface_diff.finding_deltas.unchanged_findings)
+    for name in ("packet.md", "packet.html"):
+        text = (tmp_path / "head" / name).read_text()
+        assert "Finding identities:" in text and "not attribution" in text
+        assert "changed evidence" in text


### PR DESCRIPTION
Refs #515; dependency proof is deferred in #557. #515 remains open.

A matching finding fingerprint currently hides changes to its supporting predicates, source references or release contribution. The base report reader now retains those full findings through the privacy projection and compares them alongside the existing identity buckets. `tool_surface_diff.notes` names moved evidence with base/head locations and explicitly identifies missing support and ambiguous matches. A real policy confidence change reproduces the same-fingerprint/different-support case.

Human report, PR and packet copy calls the buckets finding identities, rather than asserting that an absent fingerprint is a repaired risk or a matched fingerprint is unchanged authority. Packet JSON retains all comparison notes; bounded Markdown/HTML disclose omitted notes. No fingerprint, legacy bucket, schema, baseline acceptance or release gate changes.

### Boundary and next implementation

This is the evidence-comparison prerequisite, not default diff scope. The current readers do not prove a complete imported/shared-helper, binding and configuration dependency closure. Equal predicate support cannot establish that an unmodeled dependency had no effect. #557 records the required paired-reader proof before #515 may exclude standing findings and bind an explicit scope into report/receipt identity. New fingerprints are not proof of introduced authority either.

The change uses the existing diff and notes surface. The metric is fewer misleading unchanged/new finding interpretations at PR review, without compromising the existing safety bars. No new command, report block, schema version or second verdict.

### Validation

- Eleven new tests cover matched support/source/eligibility changes, standing weakness and improvement pairs, new identity, missing base/support, ambiguous identity, full report loading, privacy redaction and a real policy scan through report/packet output.
- Existing diff/report/packet, cold-reader and distribution tests; full functional suite; Ruff and generated-schema checks.
- Local capability check has no boundary issues; committed verification and fresh control are required before publication/merge.

Known limitation: this pass does not claim causality or repair cal-1's scope decision. #515/#557 retain that obligation for the reader evidence work and subsequent fixed-history measurement.