### PR TITLE
Reporting: distinguish provisional action effects from static evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Label conservative action-effect projections separately from their static
+  evidence in CLI, report, PR and packet summaries. Inferred/default/unknown
+  effects remain visible as provisional risks, with current pass eligibility;
+  declared and structural evidence are distinct. No gate or evidence is
+  upgraded by the presentation (#357).
+
 - Retain base finding evidence for the existing fingerprint comparison and
   expose changed predicate support, sources, subjects and release contribution.
   Reports distinguish identity matches from change attribution and disclose

--- a/docs/effect-evidence.md
+++ b/docs/effect-evidence.md
@@ -1,0 +1,55 @@
+# Effect projections and evidence
+
+This describes the current source-tree presentation. Older builds may use the
+shorter `Effects` heading; their existing JSON evidence fields still distinguish
+the projection from its support.
+
+An action can have a conservative `write` projection while its effect evidence
+is `unknown`. The first is the risk envelope Agents Shipgate retains when it
+cannot establish a narrower effect; the second says what the static reader
+actually established. Neither a name such as `lookup_account` nor the severity
+of a policy finding supplies the missing evidence.
+
+Human summaries use **Conservative effect projections** for the risk counts
+and **Effect evidence** for their basis. Write/destructive entries carry the
+same basis beside the action name; `not pass-eligible` is the existing semantic
+assessment's answer, including its identity, binding and authority obligations.
+These labels are shared by the CLI, GitHub step summary, report, PR and cold
+packet lead. They do not compute a second decision.
+
+| Existing effect status | Human wording | Meaning |
+| --- | --- | --- |
+| `declared` | reviewed declaration | A reviewed static declaration supports the effect. |
+| `structural` | structural evidence | The reader has supporting protocol/provider/scope evidence. |
+| `inferred` | provisional: inference | A heuristic suggests the risk; it does not satisfy effect evidence. |
+| `protocol_default` | provisional: protocol default | The protocol's conservative default retains risk without proving behavior. |
+| `unknown` | provisional: unknown effect | The effect could not be established; the conservative risk remains. |
+| `conflicting` | conflicting effect evidence | Claims disagree; the review obligation remains. |
+| assessment absent in an older artifact | provisional: evidence unavailable | The old output carries no assessment; absence is not proof. |
+
+**Provisional signals still require attention.** Follow the named evidence
+request in the report. Static support for the effect alone does not establish
+the agent's identity, deployed wiring or authority. A patch or inventory
+suggestion alone does not prove runtime behavior or complete a human review.
+
+## Reading the existing JSON
+
+No new report field or enum is introduced. For each
+`action_surface_facts.actions[]` row:
+
+- `effect` is the conservative projection, also carried as
+  `semantic_assessment.conservative_effect`.
+- `semantic_assessment.effect.status`, `claims[].basis`,
+  `claims[].policy_eligible` and `issues[]` describe the supporting evidence.
+- `semantic_assessment.pass_eligible` answers the combined semantic question;
+  a structural effect can still have an unresolved binding or authority.
+
+Policy severity cannot turn a heuristic claim into typed evidence. Renderers
+leave claims, risk tags, severity, pass eligibility and the release decision
+unchanged. Runtime behavior is never proven by this static presentation.
+
+The `google_adk_cold_start_agent` sample demonstrates the distinction:
+`assemble_case_timeline` retains a `write` projection with `unknown` effect
+evidence; `ops.queue_backfill` uses a protocol default; `record_case_outcome`
+has a reviewed declaration. Their different labels come directly from the
+existing semantic assessments.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -209,6 +209,11 @@ description, or see [`checks.md`](checks.md) for the catalog.
 
 ### 5. What the run did not establish
 
+On current `main`, capability summaries distinguish conservative effect
+projections from their static evidence. A provisional `write` and unknown
+effect evidence are compatible answers; see [effect projections and
+evidence](effect-evidence.md) for the existing JSON fields and review meaning.
+
 `report.md` carries its own coverage limit, and that limit is part of the
 answer:
 

--- a/samples/google_adk_cold_start_agent/expected/cold-report.md
+++ b/samples/google_adk_cold_start_agent/expected/cold-report.md
@@ -9,8 +9,11 @@ See `packet.md` for the reviewer-shaped Release Evidence Packet.
 ## Capability Surface
 
 Surface: 9 tools from 3 sources.
-Effects: 1 read, 7 write, 1 financial write.
-Write/destructive actions: issue\_goodwill\_refund \(financial write\), assemble\_case\_timeline \(write\), list\_case\_attachments \(write\), ops.append\_case\_note \(write\), ops.export\_case\_bundle \(write\), ops.queue\_backfill \(write\), record\_case\_outcome \(write\), update\_case\_index \(write\).
+Conservative effect projections: 1 read, 7 write, 1 financial write.
+Effect evidence: 1 reviewed declaration, 1 provisional: inference, 2 provisional: protocol default, 2 structural evidence, 3 provisional: unknown effect.
+Provisional signals still require attention; they do not satisfy effect evidence. Static evidence does not prove runtime behavior.
+Write/destructive actions: issue\_goodwill\_refund \(financial write\) \[provisional: inference; not pass-eligible\], assemble\_case\_timeline \(write\) \[provisional: unknown effect; not pass-eligible\], list\_case\_attachments \(write\) \[provisional: unknown effect; not pass-eligible\], ops.append\_case\_note \(write\) \[structural evidence\], ops.export\_case\_bundle \(write\) \[provisional: protocol default; not pass-eligible\], ops.queue\_backfill \(write\) \[provisional: protocol default; not pass-eligible\], record\_case\_outcome \(write\) \[reviewed declaration\], update\_case\_index \(write\) \[provisional: unknown effect; not pass-eligible\].
+Effect evidence alone does not clear identity, binding or authority gaps. Follow the named evidence requests; a patch or inventory suggestion alone does not prove behavior or finish a human review.
 
 ## Top Findings
 

--- a/src/agents_shipgate/report/human_order.py
+++ b/src/agents_shipgate/report/human_order.py
@@ -43,6 +43,15 @@ class HumanArtifactContext:
 
 
 _SURFACE_WRITE_ACTION_LIMIT = 8
+_EFFECT_EVIDENCE_LABELS = {
+    "declared": "reviewed declaration",
+    "structural": "structural evidence",
+    "inferred": "provisional: inference",
+    "protocol_default": "provisional: protocol default",
+    "unknown": "provisional: unknown effect",
+    "conflicting": "conflicting effect evidence",
+    "unavailable": "provisional: evidence unavailable",
+}
 
 
 @dataclass(frozen=True)
@@ -50,7 +59,8 @@ class SurfaceLead:
     tool_count: int
     source_count: int
     effect_counts: tuple[tuple[str, int], ...]
-    write_actions: tuple[tuple[str, str], ...]
+    write_actions: tuple[tuple[str, str, str, bool], ...]
+    effect_evidence_counts: tuple[tuple[str, int], ...]
     source_unit: Literal["source", "source type"] = "source"
 
     def text_lines(self) -> list[str]:
@@ -60,13 +70,25 @@ class SurfaceLead:
             effects = ", ".join(
                 f"{count} {effect_phrase(effect)}" for effect, count in self.effect_counts
             )
-            lines.append(f"Effects: {effects}.")
+            lines.append(f"Conservative effect projections: {effects}.")
         else:
-            lines.append("Effects: no root-reachable action effects were classified.")
+            lines.append("Conservative effect projections: no root-reachable action effects were classified.")
+        if self.effect_evidence_counts:
+            evidence = ", ".join(
+                f"{count} {_EFFECT_EVIDENCE_LABELS.get(status, _EFFECT_EVIDENCE_LABELS['unavailable'])}"
+                for status, count in self.effect_evidence_counts
+            )
+            lines.append(f"Effect evidence: {evidence}.")
+            lines.append(
+                "Provisional signals still require attention; they do not satisfy effect evidence. "
+                "Static evidence does not prove runtime behavior."
+            )
         if self.write_actions:
             actions = ", ".join(
-                f"{display_literal(name)} ({effect_phrase(effect)})"
-                for name, effect in self.write_actions[:_SURFACE_WRITE_ACTION_LIMIT]
+                f"{display_literal(name)} ({effect_phrase(effect)}) "
+                f"[{_EFFECT_EVIDENCE_LABELS.get(status, _EFFECT_EVIDENCE_LABELS['unavailable'])}"
+                f"{'; not pass-eligible' if not eligible else ''}]"
+                for name, effect, status, eligible in self.write_actions[:_SURFACE_WRITE_ACTION_LIMIT]
             )
             hidden = len(self.write_actions) - _SURFACE_WRITE_ACTION_LIMIT
             if hidden > 0:
@@ -74,6 +96,11 @@ class SurfaceLead:
             lines.append(f"Write/destructive actions: {actions}.")
         else:
             lines.append("Write/destructive actions: none.")
+        if self.effect_evidence_counts:
+            lines.append(
+                "Effect evidence alone does not clear identity, binding or authority gaps. "
+                "Follow the named evidence requests; a patch or inventory suggestion alone does not prove behavior or finish a human review."
+            )
         return lines
 
 
@@ -287,6 +314,10 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
         source_unit = "source type"
 
     counts = Counter(action.effect for action in report.action_surface_facts.actions)
+    evidence_counts = Counter(
+        action.semantic_assessment.effect.status if action.semantic_assessment else "unavailable"
+        for action in report.action_surface_facts.actions
+    )
     effect_counts = tuple(
         sorted(
             counts.items(),
@@ -299,7 +330,9 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
     write_actions = tuple(
         sorted(
             {
-                (action.tool_name, action.effect)
+                (action.tool_name, action.effect,
+                 action.semantic_assessment.effect.status if action.semantic_assessment else "unavailable",
+                 action.semantic_assessment.pass_eligible if action.semantic_assessment else False)
                 for action in report.action_surface_facts.actions
                 if action.effect in {"write", "financial_write", "destructive"}
             },
@@ -307,6 +340,8 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
                 -ACTION_EFFECT_RANK.get(item[1], 99),
                 item[0],
                 item[1],
+                item[2],
+                item[3],
             ),
         )
     )
@@ -316,6 +351,7 @@ def surface_lead(report: ReadinessReport) -> SurfaceLead:
         source_unit=source_unit,
         effect_counts=effect_counts,
         write_actions=write_actions,
+        effect_evidence_counts=tuple(sorted(evidence_counts.items())),
     )
 
 

--- a/tests/test_cold_reader_order.py
+++ b/tests/test_cold_reader_order.py
@@ -389,6 +389,17 @@ def test_archived_adopted_verify_remains_verdict_first(tmp_path):
     )
     assert adopted_findings_comment.count("Release gate:") == 2
 
+    for style in ("capability-review", "findings"):
+        evidence_comment = render_pr_comment(
+            verifier, report=report, style=style,
+            human_context=HumanArtifactContext(manifest_introduced=True),
+        )
+        assert "Conservative effect projections:" in evidence_comment
+        assert "Effect evidence:" in evidence_comment
+        assert "provisional: unknown effect" in evidence_comment
+        assert "Provisional signals still require attention" in evidence_comment
+        assert len(evidence_comment) <= 6_000
+
     large = report.model_copy(deep=True)
     seed = large.action_surface_facts.actions[0]
     large.action_surface_facts.actions = [

--- a/tests/test_effect_provenance_presentation.py
+++ b/tests/test_effect_provenance_presentation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agents_shipgate.cli._helpers import _print_cli_summary
+from agents_shipgate.packet.html import render_packet_html
+from agents_shipgate.packet.json_packet import load_packet_json
+from agents_shipgate.packet.markdown import render_packet_markdown
+from agents_shipgate.report.human_order import cold_reader_lead, surface_lead
+from agents_shipgate.report.markdown import render_markdown_report
+from tests.test_cold_reader_order import _cold_scan
+
+
+def test_real_mixed_surface_distinguishes_provisional_effects_from_static_evidence(tmp_path, monkeypatch):
+    _, report, _, _ = _cold_scan(tmp_path, monkeypatch)
+    before = report.model_dump_json()
+    text = "\n".join(surface_lead(report).text_lines())
+    assert "Conservative effect projections:" in text
+    assert "Effect evidence:" in text
+    assert "assemble_case_timeline (write) [provisional: unknown effect" in text
+    assert "ops.queue_backfill (write) [provisional: protocol default" in text
+    assert "issue_goodwill_refund (financial write) [provisional: inference" in text
+    assert "record_case_outcome (write) [reviewed declaration" in text
+    assert "not pass-eligible" in text
+    assert "Provisional signals still require attention" in text
+    assert "runtime behavior" in text
+    assert report.model_dump_json() == before
+
+
+def test_existing_human_projections_and_json_keep_the_same_evidence(tmp_path, monkeypatch, capsys):
+    repo, report, context, github = _cold_scan(tmp_path, monkeypatch)
+    _print_cli_summary(report, "advisory", 0, human_context=context)
+    packet = load_packet_json((repo / "reports" / "packet.json").read_text())
+    outputs = [capsys.readouterr().out, github,
+               render_markdown_report(report, human_context=context),
+               render_packet_markdown(packet, human_context=context, cold_lead=cold_reader_lead(report)),
+               render_packet_html(packet, human_context=context, cold_lead=cold_reader_lead(report))]
+    for text in outputs:
+        assert "Conservative effect projections:" in text
+        assert "Effect evidence:" in text
+        assert "provisional: unknown effect" in text
+        assert "Provisional signals still require attention" in text
+    wire = json.loads((repo / "reports" / "report.json").read_text())
+    action = next(row for row in wire["action_surface_facts"]["actions"]
+                  if row["tool_name"] == "assemble_case_timeline")
+    assert action["effect"] == "write"
+    assert action["semantic_assessment"]["effect"]["status"] == "unknown"
+    assert action["semantic_assessment"]["pass_eligible"] is False
+    assert wire["release_decision"]["decision"] == "insufficient_evidence"
+
+
+@pytest.mark.parametrize("state,label", [
+    ("declared", "reviewed declaration"), ("structural", "structural evidence"),
+    ("inferred", "provisional: inference"), ("protocol_default", "provisional: protocol default"),
+    ("unknown", "provisional: unknown effect"), ("conflicting", "conflicting effect evidence"),
+    (None, "provisional: evidence unavailable"),
+])
+def test_every_existing_effect_state_has_explicit_copy(tmp_path, monkeypatch, state, label):
+    _, report, _, _ = _cold_scan(tmp_path, monkeypatch)
+    action = next(row for row in report.action_surface_facts.actions if row.tool_name == "assemble_case_timeline")
+    if state is None:
+        action.semantic_assessment = None
+    else:
+        assessment = action.semantic_assessment
+        action.semantic_assessment = assessment.model_copy(update={
+            "effect": assessment.effect.model_copy(update={"status": state}),
+        })
+    text = "\n".join(surface_lead(report).text_lines())
+    assert f"assemble_case_timeline (write) [{label}; not pass-eligible]" in text
+
+
+def test_severity_and_rendering_do_not_upgrade_evidence(tmp_path, monkeypatch):
+    _, report, context, _ = _cold_scan(tmp_path, monkeypatch)
+    for finding in report.findings:
+        finding.severity = "critical"
+    before = report.model_dump_json()
+    render_markdown_report(report, human_context=context)
+    surface_lead(report).text_lines()
+    assert report.model_dump_json() == before
+    action = next(row for row in report.action_surface_facts.actions if row.tool_name == "assemble_case_timeline")
+    assert action.semantic_assessment.effect.status == "unknown"
+    assert not action.semantic_assessment.pass_eligible


### PR DESCRIPTION
Closes #357.

The cold ADK sample reports seven writes and one financial write even though six action effects are supported only by inference, protocol defaults or unknown evidence. The existing surface lead now labels those numbers as conservative projections and shows each effect's evidence status beside the risk. Provisional signals remain visible and explicitly require attention; they cannot satisfy missing effect evidence.

The same ephemeral projection feeds CLI output, GitHub step summaries, reports, both PR styles and cold packet Markdown/HTML. Declared/structural support remains distinct from inference/default/unknown/conflicting or absent legacy evidence. A row's not-pass-eligible marker comes from the existing semantic assessment, so supported effects do not conceal unresolved identity, binding or authority obligations.

No engine, JSON grammar, conservative effect, risk tag, severity, pass eligibility or gate changes. The new reference page documents the existing JSON paths, and the quickstart links to it with the source/release distinction explicit. The updated cold-report golden changes only its capability lead.

### Validation

- Nine new regression cases failed before the presentation change; the existing no-mutation control passed. Ten new cases now cover the real mixed surface, all six effect states, absent legacy evidence, console/report/packet and existing JSON consistency, and unchanged evidence under severity changes.
- The real verifier test checks both PR styles, including the preserved 6,000-character limit, long/hostile names and omitted-action counts.
- 536 focused reporting, packet, semantic, policy-evidence and distribution checks; full functional suite; Ruff and generated-schema/document checks pass.
- Local boundary check has no violations/issues; exact committed verification and fresh control gate publication and merge.

This reuses existing human output and provenance. No new command, persisted summary or schema is added. The intended first-value improvement is that a reviewer can understand why an action is conservatively write-capable yet not semantically pass-eligible, without treating a provisional signal as safe or a patch/inventory suggestion as runtime proof.