### PR TITLE
Qualification: report actual coverage misses without changing safety thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Count actual `insufficient_evidence` qualification outcomes per profile with
+  denominators, case IDs, named evidence gaps and explicit unscored cases.
+  Mark the legacy expected-IE metric not applicable on the three-label corpus;
+  all existing scores and thresholds remain unchanged. Qualification v6 adds
+  these diagnostics while preserving old artifacts without inventing coverage
+  they never recorded (#520).
+
 - Label conservative action-effect projections separately from their static
   evidence in CLI, report, PR and packet summaries. Inferred/default/unknown
   effects remain visible as provisional risks, with current pass eligibility;

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -13,6 +13,25 @@ for reproducible CI.
 
 ---
 
+## Qualification coverage diagnostics (v6, #520)
+
+`shipgate.safety_qualification` advances v5 → v6 to add `coverage_misses[]`
+and `intervals[].applicability` to the existing result. Both are required on
+v6; the reader checks their counts, cases and applicability against recorded
+outcomes and policy. All six legacy metric values and `passed` booleans retain
+their meaning. Expected-IE is explicitly `not_applicable` only when its
+denominator and policy floor are both zero; it is not a coverage success.
+Actual IE still loses the applicable exact-outcome score.
+
+V5 remains readable and retains its envelope on round-trip. Existing v1/v2/v4
+beta/test artifacts normalize to v5 as before; they cannot name `pre_1_0`.
+Old artifacts omit the new fields, which means unrecorded rather than zero.
+The typed reader rejects new fields mislabeled as an older closed grammar.
+V3 remains unsupported. Corpus/receipt-index v4, report v0.43, policy labels,
+thresholds and release permissions are unchanged. See
+[qualification coverage](docs/qualification-coverage.md) for denominators,
+unscored cases and the limits of named gap evidence.
+
 <a id="migration-note-unreleased-human-review-decision"></a>
 
 ## Migration Note: 0.16.0 — external review decisions stay separate from the gate

--- a/docs/qualification-coverage.md
+++ b/docs/qualification-coverage.md
@@ -1,0 +1,47 @@
+# Reading qualification coverage misses
+
+The qualification runner scores the frozen human labels against terminal
+verifier receipts. An actual `insufficient_evidence` on the approved three-label
+corpus is a coverage miss and still loses the applicable exact-outcome score.
+It is never relabeled to match an expected outcome.
+
+In `shipgate.safety_qualification/v6`, read `coverage_misses[]` by profile:
+
+- `count` counts recorded actual-IE outcomes; `denominator` includes **every
+  corpus case** in that profile, including ones without a valid receipt.
+- `rate` is `count / denominator`, rounded to six decimal places. It is a
+  **lower bound** while `unscored_case_ids` is nonempty. A zero with unscored
+  cases does not establish complete coverage. Those cases retain their existing
+  receipt failures and prevent qualification.
+- `cases[]` names every actual-IE case and copies the existing typed
+  `evidence_gaps` from the validated report object used for scoring. Subject,
+  source reference, reason and next action retain their report meaning. No
+  report is reread to produce these diagnostics.
+- `gap_status: unclassified` means that report recorded no named gap rows.
+  It remains a counted miss. `named_gaps` says that rows exist; it does not
+  prove their exhaustiveness or identify whether a missing input or a product
+  reader fix resolves the case. That distinction remains [#561](https://github.com/ThreeMoonsLab/agents-shipgate/issues/561).
+
+The six existing `intervals[]` metrics keep their numbers, Wilson intervals,
+requirements and `passed` booleans. Read `applicability` before presenting a
+metric as coverage achieved:
+
+| Value | Meaning |
+|---|---|
+| `applicable` | The existing outcome-specific policy test applies. |
+| `not_applicable` | Expected-IE has no corpus cases and its policy floor is zero. Legacy `0/0`, rate `0`, `passed: true` is **not** a coverage success. |
+| `diagnostic` | Overall exactness is descriptive; the existing outcome-specific tests govern qualification. |
+
+A positive expected-IE floor remains applicable and fails when unmet, even
+with a zero denominator. No threshold, label, decision value or release
+permission changes. Coverage-miss rates add no qualification threshold.
+
+Older v1/v2/v4 artifacts retain their existing beta/test restriction and
+normalize to v5; v5 remains readable for all of its original tiers. They have
+no coverage diagnostics or applicability field. Absence means **not recorded**,
+never zero. A v6 artifact must carry both fields; relabeling those fields as an
+older closed grammar is rejected. Corpus and receipt-index versions stay v4.
+
+This diagnostic slice does not issue signed qualification. The artifact
+read-consistency defect [#559](https://github.com/ThreeMoonsLab/agents-shipgate/issues/559)
+must be resolved before the final candidate scoring in #509.

--- a/scripts/_release_support.py
+++ b/scripts/_release_support.py
@@ -207,7 +207,7 @@ QUALIFICATION_POLICIES: dict[str, QualificationPolicy] = {
 
 # Restated from ``agents_shipgate.schemas.safety_qualification``; bound to it by
 # ``test_the_stdlib_policy_table_matches_the_named_policies``.
-CURRENT_QUALIFICATION_ENVELOPE = "shipgate.safety_qualification/v5"
+CURRENT_QUALIFICATION_ENVELOPE = "shipgate.safety_qualification/v6"
 LEGACY_QUALIFICATION_ENVELOPES = frozenset(
     {
         "shipgate.safety_qualification/v1",
@@ -226,7 +226,7 @@ def qualification_envelope_admits_tier(schema_version: object, tier: object) -> 
     this on raw JSON because it never parses the envelope otherwise.
     """
 
-    if schema_version == CURRENT_QUALIFICATION_ENVELOPE:
+    if schema_version in {CURRENT_QUALIFICATION_ENVELOPE, "shipgate.safety_qualification/v5"}:
         return True
     if schema_version in LEGACY_QUALIFICATION_ENVELOPES:
         return tier in LEGACY_QUALIFICATION_TIERS

--- a/scripts/run_safety_qualification.py
+++ b/scripts/run_safety_qualification.py
@@ -26,7 +26,7 @@ from email.parser import BytesParser
 from email.policy import default as email_policy
 from fractions import Fraction
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import ValidationError
@@ -34,9 +34,11 @@ from pydantic import ValidationError
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.schemas.common import ReleaseDecisionStatus
 from agents_shipgate.schemas.disclaimers import STATIC_VERDICT_DISCLAIMER
-from agents_shipgate.schemas.report import ReadinessReport
+from agents_shipgate.schemas.report import EvidenceGap, ReadinessReport
 from agents_shipgate.schemas.safety_qualification import (
     FrozenSafetyCorpusV1,
+    QualificationCoverageMissCaseV1,
+    QualificationCoverageMissV1,
     QualificationInputDigestV1,
     SafetyConfusionMatrixV1,
     SafetyConfusionRowV1,
@@ -234,7 +236,7 @@ def _evaluate_receipt(
     entry: SafetyReceiptEntryV1,
     wheel_version: str,
     report_schema_version: str,
-) -> tuple[ReleaseDecisionStatus | None, str | None, list[str]]:
+) -> tuple[ReleaseDecisionStatus | None, str | None, list[str], list[EvidenceGap]]:
     errors: list[str] = []
     try:
         receipt_path = _confined_path(index_root, entry.receipt_path)
@@ -390,10 +392,12 @@ def _evaluate_receipt(
             or binding_coverage["pass_eligible"] is not True
         ):
             raise ValueError("passed receipt violates binding-backed pass invariants")
-        return receipt_decision, receipt_hash, []
+        # Keep the same parsed report used for scoring; diagnostics perform no
+        # second artifact read and cannot turn an invalid receipt into evidence.
+        return receipt_decision, receipt_hash, [], report_model.release_decision.evidence_coverage.evidence_gaps
     except (OSError, UnicodeError, json.JSONDecodeError, ValidationError, ValueError) as exc:
         errors.append(str(exc))
-    return None, None, errors
+    return None, None, errors, []
 
 
 def cohen_kappa(cases: Iterable[SafetyCorpusCaseV1]) -> tuple[float, int]:
@@ -439,6 +443,34 @@ def wilson_interval(numerator: int, denominator: int) -> WilsonIntervalV1:
     )
 
 
+def _coverage_misses(
+    case_results: list[SafetyQualificationCaseResultV1],
+    gaps_by_case: dict[str, list[EvidenceGap]],
+) -> list[QualificationCoverageMissV1]:
+    rows = []
+    for profile in sorted({case.profile for case in case_results}):
+        cases = [case for case in case_results if case.profile == profile]
+        misses = [case for case in cases if case.actual_decision == "insufficient_evidence"]
+        rows.append(
+            QualificationCoverageMissV1(
+                profile=profile,
+                count=len(misses),
+                denominator=len(cases),
+                rate=round(len(misses) / len(cases), 6),
+                unscored_case_ids=[case.id for case in cases if case.actual_decision is None],
+                cases=[
+                    QualificationCoverageMissCaseV1(
+                        case_id=case.id,
+                        gap_status="named_gaps" if gaps_by_case.get(case.id) else "unclassified",
+                        evidence_gaps=gaps_by_case.get(case.id, []),
+                    )
+                    for case in misses
+                ],
+            )
+        )
+    return rows
+
+
 def _metric(
     *,
     name: str,
@@ -446,6 +478,7 @@ def _metric(
     denominator: int,
     requirement: str,
     passed: bool,
+    applicability: Literal["applicable", "not_applicable", "diagnostic"] = "applicable",
 ) -> SafetyQualificationMetricV1:
     return SafetyQualificationMetricV1(
         name=name,
@@ -455,6 +488,7 @@ def _metric(
         interval=wilson_interval(numerator, denominator),
         requirement=requirement,
         passed=passed,
+        applicability=applicability,
     )
 
 
@@ -616,6 +650,7 @@ def run_safety_qualification(
         )
 
     case_results: list[SafetyQualificationCaseResultV1] = []
+    gaps_by_case: dict[str, list[EvidenceGap]] = {}
     for case in corpus.cases:
         entry = receipts_by_case.get(case.id)
         if entry is None:
@@ -635,12 +670,13 @@ def run_safety_qualification(
                 )
             )
             continue
-        actual, receipt_sha256, receipt_errors = _evaluate_receipt(
+        actual, receipt_sha256, receipt_errors, evidence_gaps = _evaluate_receipt(
             index_root=receipt_index_path.parent,
             entry=entry,
             wheel_version=wheel_version,
             report_schema_version=active_requirements.required_report_schema_version,
         )
+        gaps_by_case[case.id] = evidence_gaps
         if receipt_errors:
             for error in receipt_errors:
                 _failure(
@@ -811,6 +847,12 @@ def run_safety_qualification(
             denominator=ie_denominator,
             requirement=(f">= {active_requirements.minimum_insufficient_evidence_exact} cases"),
             passed=ie_exact >= active_requirements.minimum_insufficient_evidence_exact,
+            applicability=(
+                "not_applicable"
+                if ie_denominator == 0
+                and active_requirements.minimum_insufficient_evidence_exact == 0
+                else "applicable"
+            ),
         ),
         _metric(
             name="overall_exact_rate",
@@ -818,6 +860,7 @@ def run_safety_qualification(
             denominator=len(case_results),
             requirement="reported for audit; outcome-specific thresholds govern",
             passed=True,
+            applicability="diagnostic",
         ),
     ]
     for metric in metrics:
@@ -905,6 +948,7 @@ def run_safety_qualification(
         intervals=metrics,
         cases=case_results,
         failures=failures,
+        coverage_misses=_coverage_misses(case_results, gaps_by_case),
     )
 
 

--- a/src/agents_shipgate/schemas/safety_qualification.py
+++ b/src/agents_shipgate/schemas/safety_qualification.py
@@ -763,11 +763,15 @@ class SafetyQualificationResultV1(BaseModel):
             declared in LEGACY_QUALIFICATION_ENVELOPES
             or declared == "shipgate.safety_qualification/v5"
         ):
+            intervals = data.get("intervals")
+            # Leave malformed containers to typed validation. A before-hook
+            # must not turn invalid input into an uncaught TypeError.
+            intervals = intervals if isinstance(intervals, (list, tuple)) else ()
             if "coverage_misses" in data or any(
                 "applicability" in item
                 if isinstance(item, dict)
                 else getattr(item, "applicability", None) is not None
-                for item in data.get("intervals", [])
+                for item in intervals
             ):
                 raise ValueError("coverage diagnostics and applicability require the v6 envelope")
         if declared not in LEGACY_QUALIFICATION_ENVELOPES:

--- a/src/agents_shipgate/schemas/safety_qualification.py
+++ b/src/agents_shipgate/schemas/safety_qualification.py
@@ -8,13 +8,13 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from agents_shipgate.schemas.common import ReleaseDecisionStatus
 from agents_shipgate.schemas.disclaimers import STATIC_VERDICT_DISCLAIMER
+from agents_shipgate.schemas.report import EvidenceGap
 
 SAFETY_CORPUS_SCHEMA_VERSION = "shipgate.safety_corpus/v4"
 SAFETY_RECEIPT_INDEX_SCHEMA_VERSION = "shipgate.safety_receipt_index/v4"
-# v5 carries the ``pre_1_0`` tier and the production_qualified/tier invariant
-# added for issue #341. The corpus and receipt-index envelopes stay at v4: their
-# grammar did not move, and versions here track grammar, not release batches.
-SAFETY_QUALIFICATION_SCHEMA_VERSION = "shipgate.safety_qualification/v5"
+# v6 adds diagnostic coverage misses and explicit metric applicability. v5
+# remains readable without inventing diagnostics its producer never recorded.
+SAFETY_QUALIFICATION_SCHEMA_VERSION = "shipgate.safety_qualification/v6"
 
 SafetyProfile = Literal[
     "mcp",
@@ -648,6 +648,9 @@ class SafetyQualificationMetricV1(BaseModel):
     interval: WilsonIntervalV1
     requirement: str
     passed: bool
+    applicability: Literal["applicable", "not_applicable", "diagnostic"] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
 
 class SafetyQualificationCaseResultV1(BaseModel):
@@ -677,14 +680,46 @@ class SafetyQualificationSummaryV1(BaseModel):
     outcome_counts: dict[ReleaseDecisionStatus, int]
 
 
+class QualificationCoverageMissCaseV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    gap_status: Literal["named_gaps", "unclassified"]
+    evidence_gaps: list[EvidenceGap]
+
+    @model_validator(mode="after")
+    def _gap_status_matches_evidence(self) -> QualificationCoverageMissCaseV1:
+        expected = "named_gaps" if self.evidence_gaps else "unclassified"
+        if self.gap_status != expected:
+            raise ValueError("coverage gap status must describe the recorded evidence")
+        return self
+
+
+class QualificationCoverageMissV1(BaseModel):
+    """Recorded actual-IE outcomes, over all attempted cases in this profile.
+
+    Unscored cases are not zero misses: the rate is a lower bound while any
+    exist. Named gaps explain evidence, not ownership of the missing remedy.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile: SafetyProfile
+    count: int = Field(ge=0)
+    denominator: int = Field(gt=0)
+    rate: float = Field(ge=0, le=1)
+    unscored_case_ids: list[str]
+    cases: list[QualificationCoverageMissCaseV1]
+
+
 class SafetyQualificationResultV1(BaseModel):
     """Deterministic, wheel-bound qualification result for a named policy."""
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["shipgate.safety_qualification/v5"] = (
-        SAFETY_QUALIFICATION_SCHEMA_VERSION
-    )
+    schema_version: Literal[
+        "shipgate.safety_qualification/v5", "shipgate.safety_qualification/v6"
+    ] = SAFETY_QUALIFICATION_SCHEMA_VERSION
     qualification_tier: QualificationTier
     qualified: bool
     production_qualified: bool
@@ -699,6 +734,9 @@ class SafetyQualificationResultV1(BaseModel):
     intervals: list[SafetyQualificationMetricV1]
     cases: list[SafetyQualificationCaseResultV1]
     failures: list[SafetyQualificationFailureV1]
+    coverage_misses: list[QualificationCoverageMissV1] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -720,6 +758,18 @@ class SafetyQualificationResultV1(BaseModel):
         if not isinstance(data, dict):
             return data
         declared = data.get("schema_version")
+        # An older closed grammar must not be widened by changing its label.
+        if (
+            declared in LEGACY_QUALIFICATION_ENVELOPES
+            or declared == "shipgate.safety_qualification/v5"
+        ):
+            if "coverage_misses" in data or any(
+                "applicability" in item
+                if isinstance(item, dict)
+                else getattr(item, "applicability", None) is not None
+                for item in data.get("intervals", [])
+            ):
+                raise ValueError("coverage diagnostics and applicability require the v6 envelope")
         if declared not in LEGACY_QUALIFICATION_ENVELOPES:
             return data
         if data.get("qualification_tier") not in LEGACY_QUALIFICATION_TIERS:
@@ -728,7 +778,51 @@ class SafetyQualificationResultV1(BaseModel):
                 f"{sorted(LEGACY_QUALIFICATION_TIERS)}; this payload requires "
                 f"{SAFETY_QUALIFICATION_SCHEMA_VERSION}"
             )
-        return {**data, "schema_version": SAFETY_QUALIFICATION_SCHEMA_VERSION}
+        return {**data, "schema_version": "shipgate.safety_qualification/v5"}
+
+    @model_validator(mode="after")
+    def _coverage_accounting_matches_cases(self) -> SafetyQualificationResultV1:
+        if self.schema_version != SAFETY_QUALIFICATION_SCHEMA_VERSION:
+            return self
+        if self.coverage_misses is None:
+            raise ValueError("v6 requires coverage diagnostics")
+        profiles = {case.profile for case in self.cases}
+        if {row.profile for row in self.coverage_misses} != profiles or len(
+            self.coverage_misses
+        ) != len(profiles):
+            raise ValueError("coverage profiles must cover every case exactly once")
+        for row in self.coverage_misses:
+            cases = [case for case in self.cases if case.profile == row.profile]
+            miss_ids = sorted(
+                case.id for case in cases if case.actual_decision == "insufficient_evidence"
+            )
+            unscored = sorted(case.id for case in cases if case.actual_decision is None)
+            if (
+                row.count != len(miss_ids)
+                or row.denominator != len(cases)
+                or row.rate != round(len(miss_ids) / len(cases), 6)
+                or sorted(item.case_id for item in row.cases) != miss_ids
+                or sorted(row.unscored_case_ids) != unscored
+            ):
+                raise ValueError("coverage accounting must match recorded case outcomes")
+            row.cases.sort(key=lambda item: item.case_id)
+            row.unscored_case_ids.sort()
+        self.coverage_misses.sort(key=lambda item: item.profile)
+        for metric in self.intervals:
+            expected = "applicable"
+            if metric.name == "overall_exact_rate":
+                expected = "diagnostic"
+            elif (
+                metric.name == "insufficient_evidence_exact_rate"
+                and metric.denominator == 0
+                and self.requirements.minimum_insufficient_evidence_exact == 0
+            ):
+                expected = "not_applicable"
+            if metric.applicability != expected:
+                raise ValueError(
+                    "metric applicability must match its actual denominator and policy"
+                )
+        return self
 
     @model_validator(mode="after")
     def _production_claim_matches_the_tier(self) -> SafetyQualificationResultV1:

--- a/tests/test_qualification_coverage_misses.py
+++ b/tests/test_qualification_coverage_misses.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+from test_safety_qualification import _case, _conforming_cases, _fixture, _run
+
+from agents_shipgate.schemas.safety_qualification import (
+    SafetyQualificationResultV1,
+    pre_release_safety_requirements,
+)
+from scripts.run_safety_qualification import run_safety_qualification
+
+
+def test_actual_ie_keeps_named_gaps_and_unclassified_cases(tmp_path):
+    gap = {
+        "kind": "source_warning",
+        "subject": "remote MCP",
+        "source_type": "google_adk",
+        "source_ref": "agent.py:12",
+        "why": "The remote tool inventory was not supplied.",
+        "next_action": {
+            "kind": "provide_source",
+            "path": "tools.json",
+            "why": "Supply the existing tool export.",
+            "expects": "A reviewed static tool inventory.",
+        },
+    }
+    paths = _fixture(
+        tmp_path,
+        actual_overrides={"case-review_required": "insufficient_evidence"},
+        evidence_gaps={"case-review_required": [gap]},
+    )
+    result = _run(paths)
+    coverage = result.coverage_misses[0]
+    assert coverage.denominator == 4
+    assert coverage.count == 2
+    assert coverage.rate == 0.5
+    assert coverage.unscored_case_ids == []
+    misses = {case.case_id: case for case in coverage.cases}
+    assert misses["case-review_required"].evidence_gaps[0].source_ref == "agent.py:12"
+    assert misses["case-review_required"].evidence_gaps[0].next_action.path == "tools.json"
+    assert misses["case-insufficient_evidence"].gap_status == "unclassified"
+    assert result.qualified is False
+    metric = next(x for x in result.intervals if x.name == "review_exact_rate")
+    assert (metric.numerator, metric.denominator, metric.passed) == (0, 1, False)
+
+
+def test_missing_receipt_is_unscored_not_a_zero_miss(tmp_path):
+    paths = _fixture(tmp_path)
+    index = json.loads(paths[2].read_text())
+    index["receipts"] = [
+        x for x in index["receipts"] if x["case_id"] != "case-insufficient_evidence"
+    ]
+    paths[2].write_text(json.dumps(index))
+    result = _run(paths)
+    coverage = result.coverage_misses[0]
+    assert (coverage.count, coverage.denominator, coverage.rate) == (0, 4, 0.0)
+    assert coverage.unscored_case_ids == ["case-insufficient_evidence"]
+    assert result.qualified is False
+
+
+def test_three_label_policy_marks_expected_ie_not_applicable(tmp_path):
+    requirements = pre_release_safety_requirements()
+    cases = _conforming_cases(requirements)
+    paths = _fixture(tmp_path, cases=cases)
+    wheel, corpus, receipts, policy = paths
+    result = run_safety_qualification(
+        wheel_path=wheel,
+        corpus_path=corpus,
+        receipt_index_path=receipts,
+        policy_paths=[policy],
+        requirements=requirements,
+    )
+    metric = next(x for x in result.intervals if x.name == "insufficient_evidence_exact_rate")
+    assert (metric.numerator, metric.denominator, metric.passed) == (0, 0, True)
+    assert metric.applicability == "not_applicable"
+    assert len(result.coverage_misses) == 7
+    assert sum(x.denominator for x in result.coverage_misses) == 38
+    assert result.qualified is True
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("count", 0),
+        ("denominator", 99),
+        ("rate", 0.0),
+        ("cases", []),
+        ("unscored_case_ids", ["case-passed"]),
+    ],
+)
+def test_miss_accounting_cannot_disagree_with_case_outcomes(tmp_path, field, value):
+    payload = _run(_fixture(tmp_path)).model_dump(mode="json")
+    payload["coverage_misses"][0][field] = value
+    with pytest.raises(ValidationError, match="coverage"):
+        SafetyQualificationResultV1.model_validate(payload)
+
+
+def test_expected_ie_with_a_real_floor_remains_applicable(tmp_path):
+    result = _run(_fixture(tmp_path))
+    metric = next(x for x in result.intervals if x.name == "insufficient_evidence_exact_rate")
+    assert metric.applicability == "applicable"
+    payload = result.model_dump(mode="json")
+    next(x for x in payload["intervals"] if x["name"] == metric.name)["applicability"] = (
+        "not_applicable"
+    )
+    with pytest.raises(ValidationError, match="applicability"):
+        SafetyQualificationResultV1.model_validate(payload)
+
+
+@pytest.mark.parametrize("version", ["v1", "v2", "v4", "v5"])
+def test_older_grammar_preserves_unrecorded_diagnostics(tmp_path, version):
+    payload = _run(_fixture(tmp_path)).model_dump(mode="json")
+    payload["schema_version"] = f"shipgate.safety_qualification/{version}"
+    with pytest.raises(ValidationError, match="require the v6 envelope"):
+        SafetyQualificationResultV1.model_validate(payload)
+    payload.pop("coverage_misses")
+    for metric in payload["intervals"]:
+        metric.pop("applicability")
+    result = SafetyQualificationResultV1.model_validate(payload)
+    assert result.schema_version == "shipgate.safety_qualification/v5"
+    assert result.coverage_misses is None
+    assert all(metric.applicability is None for metric in result.intervals)
+    encoded = result.model_dump(mode="json")
+    assert "coverage_misses" not in encoded
+    assert all("applicability" not in item for item in encoded["intervals"])
+    assert SafetyQualificationResultV1.model_validate(encoded) == result
+
+
+@pytest.mark.parametrize("missing", ["coverage_misses", "applicability"])
+def test_v6_diagnostics_cannot_be_absent(tmp_path, missing):
+    payload = _run(_fixture(tmp_path)).model_dump(mode="json")
+    if missing == "coverage_misses":
+        payload.pop(missing)
+    else:
+        payload["intervals"][0].pop(missing)
+    with pytest.raises(ValidationError):
+        SafetyQualificationResultV1.model_validate(payload)
+
+
+def test_zero_denominator_does_not_disable_a_positive_floor(tmp_path):
+    paths = _fixture(
+        tmp_path,
+        cases=[
+            _case(f"case-{decision}", decision)
+            for decision in ("passed", "blocked", "review_required")
+        ],
+    )
+    result = _run(paths)
+    metric = next(x for x in result.intervals if x.name == "insufficient_evidence_exact_rate")
+    assert (metric.denominator, metric.applicability, metric.passed) == (0, "applicable", False)
+    assert result.qualified is False
+
+
+@pytest.mark.parametrize("misses,qualified", [(1, True), (2, False)])
+def test_actual_ie_keeps_the_approved_safe_pass_tolerance(tmp_path, misses, qualified):
+    requirements = pre_release_safety_requirements()
+    cases = _conforming_cases(requirements)
+    safe_ids = [case.id for case in cases if case.expected_decision == "passed"][:misses]
+    wheel, corpus, receipts, policy = _fixture(
+        tmp_path,
+        cases=cases,
+        actual_overrides={case_id: "insufficient_evidence" for case_id in safe_ids},
+    )
+    result = run_safety_qualification(
+        wheel_path=wheel,
+        corpus_path=corpus,
+        receipt_index_path=receipts,
+        policy_paths=[policy],
+        requirements=requirements,
+    )
+    metric = next(x for x in result.intervals if x.name == "safe_pass_rate")
+    assert (metric.numerator, metric.denominator) == (14 - misses, 14)
+    assert result.qualified is qualified
+    assert sum(row.count for row in result.coverage_misses) == misses

--- a/tests/test_qualification_coverage_misses.py
+++ b/tests/test_qualification_coverage_misses.py
@@ -140,6 +140,14 @@ def test_v6_diagnostics_cannot_be_absent(tmp_path, missing):
         SafetyQualificationResultV1.model_validate(payload)
 
 
+@pytest.mark.parametrize("intervals", [None, 3, {"metric": "wrong shape"}])
+def test_old_envelope_malformed_metrics_raise_validation_error(intervals):
+    with pytest.raises(ValidationError):
+        SafetyQualificationResultV1.model_validate({
+            "schema_version": "shipgate.safety_qualification/v5", "intervals": intervals,
+        })
+
+
 def test_zero_denominator_does_not_disable_a_positive_floor(tmp_path):
     paths = _fixture(
         tmp_path,

--- a/tests/test_safety_qualification.py
+++ b/tests/test_safety_qualification.py
@@ -311,6 +311,7 @@ def _fixture(
     actual_overrides: dict[str, str] | None = None,
     disagreement_case: str | None = None,
     cases: list[SafetyCorpusCaseV1] | None = None,
+    evidence_gaps: dict[str, list[dict]] | None = None,
 ) -> tuple[Path, Path, Path, Path]:
     wheel = tmp_path / "agents_shipgate-0.16.0b7-py3-none-any.whl"
     _write_wheel(wheel)
@@ -372,6 +373,7 @@ def _fixture(
                 "runtime_behavior_verified": False,
                 "static_verdict_disclaimer": STATIC_VERDICT_DISCLAIMER,
                 "evidence_coverage": {
+                    "evidence_gaps": (evidence_gaps or {}).get(case.id, []),
                     "level": "complete",
                     "human_review_recommended": actual != "passed",
                     "source_warning_count": 0,
@@ -925,7 +927,10 @@ def test_the_qualification_envelope_advanced_for_the_new_grammar(tmp_path: Path)
     """
 
     payload = _run(_fixture(tmp_path)).model_dump(mode="json")
-    assert payload["schema_version"] == "shipgate.safety_qualification/v5"
+    assert payload["schema_version"] == "shipgate.safety_qualification/v6"
+    payload.pop("coverage_misses")
+    for metric in payload["intervals"]:
+        metric.pop("applicability")
 
     legacy = (
         "shipgate.safety_qualification/v1",
@@ -955,7 +960,7 @@ def test_the_qualification_envelope_advanced_for_the_new_grammar(tmp_path: Path)
 
     for rejected in (
         "shipgate.safety_qualification/v3",
-        "shipgate.safety_qualification/v6",
+        "shipgate.safety_qualification/v7",
         "shipgate.safety_qualification",
     ):
         with pytest.raises(ValidationError):

--- a/tests/test_safety_qualification_release.py
+++ b/tests/test_safety_qualification_release.py
@@ -23,7 +23,12 @@ from agents_shipgate.schemas.safety_qualification import (
     production_safety_requirements,
     tier_for_requirements,
 )
-from scripts.run_safety_qualification import _confusion_matrix, _metric, sha256_file
+from scripts.run_safety_qualification import (
+    _confusion_matrix,
+    _coverage_misses,
+    _metric,
+    sha256_file,
+)
 from scripts.verify_safety_qualification_release import (
     main,
     verify_release_qualification,
@@ -129,6 +134,7 @@ def _result(
             denominator=outcome_counts["insufficient_evidence"],
             requirement=f">= {requirements.minimum_insufficient_evidence_exact} cases",
             passed=True,
+            applicability="not_applicable",
         ),
         _metric(
             name="overall_exact_rate",
@@ -136,6 +142,7 @@ def _result(
             denominator=total,
             requirement="reported for audit; outcome-specific thresholds govern",
             passed=True,
+            applicability="diagnostic",
         ),
     ]
     matrices = [_confusion_matrix(cases, profile="all")]
@@ -177,6 +184,7 @@ def _result(
         intervals=metrics,
         cases=cases,
         failures=[],
+        coverage_misses=_coverage_misses(cases, {}),
     )
 
 
@@ -373,9 +381,7 @@ def test_a_pre_1_0_artifact_may_not_claim_a_legacy_envelope(tmp_path: Path) -> N
     wheel, qualification = _fixture(tmp_path, requirements=pre_release_safety_requirements())
     _mutate(
         qualification,
-        lambda payload: payload.__setitem__(
-            "schema_version", "shipgate.safety_qualification/v4"
-        ),
+        lambda payload: _as_v4(payload),
     )
 
     with pytest.raises(ConfigError, match="admits only qualification_tier"):
@@ -388,9 +394,7 @@ def test_a_pre_1_0_artifact_may_not_claim_a_legacy_envelope(tmp_path: Path) -> N
     )
     _mutate(
         qualification,
-        lambda payload: payload.__setitem__(
-            "schema_version", "shipgate.safety_qualification/v4"
-        ),
+        lambda payload: _as_v4(payload),
     )
     assert (
         verify_release_qualification(
@@ -398,6 +402,13 @@ def test_a_pre_1_0_artifact_may_not_claim_a_legacy_envelope(tmp_path: Path) -> N
         ).schema_version
         == "shipgate.safety_qualification/v5"
     )
+
+
+def _as_v4(payload):
+    payload["schema_version"] = "shipgate.safety_qualification/v4"
+    payload.pop("coverage_misses")
+    for metric in payload["intervals"]:
+        metric.pop("applicability")
 
 
 def test_a_production_artifact_still_publishes_a_0_x_tag(tmp_path: Path) -> None:


### PR DESCRIPTION
The approved three-label corpus has no expected-IE cases, but the legacy expected-IE metric printed `0/0` with `passed=true` without saying it was inapplicable. Actual coverage misses also lacked per-profile case evidence. This adds diagnostic accounting to the existing qualification result while preserving the six metrics, approved thresholds, labels and release decisions.

## What changes

- Qualification v6 records actual-IE count/rate over all corpus cases per profile, every missed case, its existing typed gap rows, and explicit unscored IDs. A rate with unscored cases is a lower bound; missing gap rows remain `unclassified`.
- Metrics gain explicit applicability. Expected-IE is not applicable only with zero denominator and zero policy floor. Actual IE continues to lose the applicable exact-outcome score, including the approved safe-pass tolerance.
- Diagnostics reuse the report object already validated for scoring. V5 remains readable without fabricated diagnostics; v1/v2/v4 keep their original beta/test restriction and normalization to v5. New diagnostic fields mislabeled as an older closed grammar are rejected. The stdlib gate recognizes v6 without changing its tier policy.

## Validation

21 new diagnostic/compatibility cases; 64 focused qualification/release tests. The first review found a malformed-old-metric container raising TypeError; the final head fixes it with three negative controls, and the second review found no remaining blockers. Full non-performance suite completed with only ten packaging setup errors from the restricted build dependency download; those ten passed unchanged when rerun with network access. Ruff and generated-schema checks pass. CI must also pass, including combined coverage, before merge.

## Surface discipline and limits

This makes the coverage component of noise/usable-outcome measurement interpretable; it does not claim a measured adoption gain. The existing qualification JSON carries the diagnostics. Its closed grammar requires v6; report, verifier, receipt and control grammars do not change. There is no new verdict, runtime execution or threshold.

The rest of #520 remains open: truthful reader-repair versus missing-input ownership is deferred to #561, and corpus/signing obligations remain #509/#456. The separately discovered artifact read race #559 is not repaired here; the final signed candidate must wait for that repair. Refs #520, #328, #357, #538, #519.