### PR TITLE
fix(control): reject live input drift during the final authority check

### DIFF
--- a/src/agents_shipgate/core/current_control.py
+++ b/src/agents_shipgate/core/current_control.py
@@ -284,6 +284,7 @@ def _receipt_binding_refusal(
     *,
     request_id: str | None,
     decision_id: str | None,
+    receipt_bytes: bytes | None = None,
 ) -> str | None:
     """Return why completion must be refused, or ``None`` when it may stand."""
 
@@ -294,7 +295,11 @@ def _receipt_binding_refusal(
             "so completion authority cannot be established."
         )
     try:
-        receipt = _load_receipt(out_dir, ref)
+        receipt = (
+            _load_receipt(out_dir, ref)
+            if receipt_bytes is None
+            else VerificationReceipt.model_validate_json(receipt_bytes)
+        )
     except ValueError as exc:
         return f"The bound terminal receipt could not be read: {exc}"
     if receipt.request_id != request_id or receipt.decision_id != decision_id:
@@ -542,7 +547,14 @@ def read_current_control(
     for _ in range(max(1, attempts)):
         pointer = _load_pointer(out_dir, path)
         try:
-            captured = _validate_bound_artifacts(out_dir, pointer, capture=capture)
+            # Currency checks must parse the same plan and receipt bytes that
+            # this pass validated, including on the final observation. Reopening
+            # them could compare live inputs against another generation's plan.
+            validated = _validate_bound_artifacts(
+                out_dir,
+                pointer,
+                capture=set(capture) | {"verification_plan", RECEIPT_ARTIFACT_KEY},
+            )
         except CurrentControlUnavailable as mismatch:
             # A run that republished mid-read moves the pointer too. Retry that
             # case; a mismatch under a pointer that did not move is a real
@@ -551,9 +563,10 @@ def read_current_control(
                 raise
             last = mismatch
             continue
+        captured = {key: data for key, data in validated.items() if key in capture}
         observed = observe()
         try:
-            _validate_control_currency(out_dir, pointer, observed)
+            _validate_control_currency(out_dir, pointer, observed, artifacts=validated)
         except CurrentControlUnavailable as stale:
             # The set validated; only its currency did not. Hand the captured
             # bytes on so the caller can recover the producing run's own exact
@@ -565,12 +578,23 @@ def read_current_control(
         if confirmation.current_control_id != pointer.current_control_id:
             last = moved
             continue
-        # The workspace is re-observed after the pointer is confirmed, and both
-        # observations must agree. Checking the pointer alone left a window in
-        # which HEAD advanced between the comparison and the return.
-        if _workspace_fingerprint(observe()) != _workspace_fingerprint(observed):
+        # HEAD and path names alone miss edits to an already-dirty file and
+        # movement of the comparison base. Apply exactly the same complete
+        # currency checks again, against the same validated evidence bytes.
+        confirmed = observe()
+        try:
+            _validate_control_currency(out_dir, pointer, confirmed, artifacts=validated)
+        except CurrentControlUnavailable as stale:
+            stale.artifacts = dict(captured)
+            raise
+        if _workspace_fingerprint(confirmed) != _workspace_fingerprint(observed):
             workspace_moved.artifacts = dict(captured)
             last = workspace_moved
+            continue
+        # Currency checks perform live reads too. A publication during that
+        # final observation must not return the superseded pointer.
+        if _load_pointer(out_dir, path).current_control_id != pointer.current_control_id:
+            last = moved
             continue
         # `captured` was read in the same pass that hashed it, and neither the
         # pointer nor the workspace moved since. Returning the bytes is what
@@ -585,15 +609,17 @@ def read_current_control(
 
 
 def _workspace_fingerprint(live: LiveWorkspace | None) -> tuple[object, ...]:
-    """What must not change between the currency check and the return.
+    """Additional context that must agree across complete currency checks.
 
     ``None`` fingerprints distinctly from any resolved workspace, so a
     workspace that becomes unresolvable mid-read is drift rather than a match.
+    This is not a substitute for validating base and overlay currency.
     """
 
     if live is None:
         return (None,)
     return (
+        live.root,
         live.repository,
         live.head_commit_sha,
         live.head_tree_sha,
@@ -674,6 +700,8 @@ def _validate_control_currency(
     out_dir: Path,
     pointer: CurrentControlPointer,
     live: LiveWorkspace | None,
+    *,
+    artifacts: Mapping[str, bytes],
 ) -> None:
     """Refuse a pointer whose evidence no longer describes this workspace."""
 
@@ -684,6 +712,7 @@ def _validate_control_currency(
             pointer.artifacts,
             request_id=pointer.request_id,
             decision_id=pointer.decision_id,
+            receipt_bytes=artifacts.get(RECEIPT_ARTIFACT_KEY),
         )
         if refusal is not None:
             raise CurrentControlUnavailable("receipt_mismatch", refusal, path=out_dir)
@@ -731,7 +760,9 @@ def _validate_control_currency(
         )
     _validate_base_currency(out_dir, identity, live, required=grants_authority)
     if identity.snapshot_kind == "worktree_overlay":
-        _validate_worktree_currency(out_dir, pointer, live, required=grants_authority)
+        _validate_worktree_currency(
+            out_dir, pointer, live, required=grants_authority, artifacts=artifacts
+        )
     elif identity.snapshot_kind == "committed_tree":
         _require_clean_worktree(out_dir, live, required=grants_authority)
 
@@ -742,6 +773,7 @@ def _validate_worktree_currency(
     live: LiveWorkspace,
     *,
     required: bool,
+    artifacts: Mapping[str, bytes],
 ) -> None:
     """Confirm the working tree is still the one a worktree decision saw.
 
@@ -784,13 +816,7 @@ def _validate_worktree_currency(
         _validate_live_overlay(out_dir, pointer, live)
         return
     try:
-        data = read_regular_file_beneath(
-            out_dir,
-            ref.path,
-            max_size=MAX_BOUND_ARTIFACT_BYTES,
-            label="current control plan",
-        )
-        plan = VerificationPlan.model_validate_json(data)
+        plan = VerificationPlan.model_validate_json(artifacts["verification_plan"])
         # Not `inputs.changed_paths`: since #336 that is the merge-base-
         # relative evaluated set, while the overlay this pointer was
         # published against is HEAD-relative and recorded separately.

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -1054,9 +1054,38 @@ def _absent_overlay_entry() -> dict[str, Any]:
 
 
 def _overlay_entry(lexical: Path, candidate: Path, snapshot: Any) -> dict[str, Any]:
+    """Keep entry metadata and its digest in one unchanged live observation."""
+
+    before = _overlay_entry_stat(lexical)
+    entry = _overlay_entry_data(lexical, candidate, snapshot, before)
+    after = _overlay_entry_stat(lexical)
+    if _overlay_stat_identity(before) != _overlay_stat_identity(after):
+        raise ValueError(f"worktree entry changed while its identity was read: {lexical}")
+    return entry
+
+
+def _overlay_entry_stat(path: Path) -> os.stat_result | None:
     try:
-        info = os.lstat(lexical)
+        return os.lstat(path)
     except OSError:
+        return None
+
+
+def _overlay_stat_identity(info: os.stat_result | None) -> tuple[int, ...] | None:
+    if info is None:
+        return None
+    # These fields detect drift during the read; they are not persisted in the
+    # normalized overlay, whose identity still excludes timestamps and umask.
+    return (
+        info.st_dev, info.st_ino, info.st_mode, info.st_size,
+        info.st_mtime_ns, info.st_ctime_ns,
+    )
+
+
+def _overlay_entry_data(
+    lexical: Path, candidate: Path, snapshot: Any, info: os.stat_result | None
+) -> dict[str, Any]:
+    if info is None:
         return _absent_overlay_entry()
     if stat.S_ISLNK(info.st_mode):
         # Hash the link target, never what it points at. Following it here is

--- a/tests/test_agent_control_envelope.py
+++ b/tests/test_agent_control_envelope.py
@@ -1437,6 +1437,51 @@ def test_the_workspace_is_re_observed_before_authority_is_returned(repo: Path):
     assert raised.value.reason == "workspace_changed"
 
 
+@pytest.mark.parametrize("entrypoint", ["refresh", "verify"])
+def test_control_cli_refuses_a_same_path_edit_during_final_observation(
+    repo: Path, monkeypatch, entrypoint: str
+):
+    from agents_shipgate.cli import agent_interface
+    from agents_shipgate.cli.verify import command as verify_command
+
+    tools = repo / "tools.json"
+    tools.write_text(tools.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    _completed_verifier(repo)
+    observations = []
+
+    def observe(workspace, reports_dir):
+        live = live_workspace(workspace, reports_dir)
+        observations.append(live)
+        if len(observations) == 2:
+            tools.write_text(tools.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        return live
+
+    module = agent_interface if entrypoint == "refresh" else verify_command
+    monkeypatch.setattr(module, "live_workspace", observe)
+    if entrypoint == "refresh":
+        result = runner.invoke(
+            app,
+            [
+                "agent", "control", "--workspace", str(repo),
+                "--reports-dir", str(repo / "agents-shipgate-reports"),
+            ],
+        )
+        assert result.exit_code != 0, result.output
+        assert '"control_state": "complete"' not in result.output
+        assert "Re-run verification" in result.output
+    else:
+        result = runner.invoke(
+            app,
+            ["verify", "--workspace", str(repo), "--config", "shipgate.yaml", "--format", "control"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["permissions"]["merge"] is False
+        assert payload["permissions"]["report_complete"] is False
+        assert "Re-run verification" in payload["reason"]
+    assert len(observations) == 2
+
+
 @pytest.mark.parametrize(
     ("mutation", "why"),
     [

--- a/tests/test_current_control.py
+++ b/tests/test_current_control.py
@@ -327,6 +327,172 @@ def test_advancing_the_base_invalidates_a_decision_about_the_range(repo: Path) -
     assert "base this decision was made against moved" in str(raised.value)
 
 
+@pytest.mark.parametrize("observation", [1, 2])
+@pytest.mark.parametrize("mutation", ["content", "chmod", "symlink"])
+def test_live_read_rechecks_same_path_overlay_changes(
+    repo: Path, observation: int, mutation: str
+) -> None:
+    """A stable path list cannot establish that its content or mode is current."""
+
+    readme = repo / "README.md"
+    readme.write_text("before\n", encoding="utf-8")
+    (repo / "twin.md").write_text("reviewed\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "document fixture")
+    readme.write_text("reviewed\n", encoding="utf-8")
+    completed, _, _ = _verify(repo, archive_head=False)
+    assert completed.control.state == "complete"
+    reports = repo / "agents-shipgate-reports"
+    original = (reports / "verifier.json").read_bytes()
+    unchanged = read_current_control(reports, live=lambda: _live(repo))
+    assert unchanged.pointer.control.permissions.merge is True
+    observations = []
+
+    def observe():
+        live = _live(repo)
+        observations.append(live)
+        if len(observations) == observation:
+            if mutation == "content":
+                readme.write_text("changed after verification\n", encoding="utf-8")
+            elif mutation == "chmod":
+                readme.chmod(0o755)
+            else:
+                readme.unlink()
+                readme.symlink_to("twin.md")
+        return live
+
+    with pytest.raises(CurrentControlUnavailable) as raised:
+        read_current_control(reports, live=observe, capture=("verifier",), attempts=1)
+    assert raised.value.reason == "workspace_changed"
+    assert raised.value.artifacts == {"verifier": original}
+    assert len(observations) == observation
+    assert _live(repo).changed_paths == observations[0].changed_paths
+    assert _live(repo).head_commit_sha == observations[0].head_commit_sha
+
+
+@pytest.mark.parametrize("observation", [1, 2])
+@pytest.mark.parametrize("movement", ["base", "merge_base"])
+def test_live_read_rechecks_the_resolved_base(
+    repo: Path, observation: int, movement: str
+) -> None:
+    """Moving only the comparison base invalidates the first interleaved read."""
+
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "README.md").write_text("feature\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "feature work")
+    completed, _, _ = _verify(repo, base="main")
+    assert completed.control.state == "complete"
+    reports = repo / "agents-shipgate-reports"
+    original = (reports / "verifier.json").read_bytes()
+    assert read_current_control(reports, live=lambda: _live(repo)).pointer.control.permissions.merge
+    observations = []
+
+    def observe():
+        live = _live(repo)
+        observations.append(live)
+        if len(observations) == observation:
+            if movement == "base":
+                _git(repo, "branch", "-f", "main", "HEAD")
+            else:
+                # A shallower local history can hide ancestry without moving
+                # either endpoint or changing the HEAD tree.
+                (repo / ".git" / "shallow").write_text(
+                    commit_sha(repo, "HEAD") + "\n", encoding="utf-8"
+                )
+        return live
+
+    with pytest.raises(CurrentControlUnavailable) as raised:
+        read_current_control(reports, live=observe, capture=("verifier",), attempts=1)
+    assert raised.value.reason == "workspace_changed"
+    assert "base this decision was made against moved" in str(raised.value)
+    assert raised.value.artifacts == {"verifier": original}
+    assert len(observations) == observation
+    assert _live(repo).changed_paths == observations[0].changed_paths
+    assert _live(repo).head_commit_sha == observations[0].head_commit_sha
+
+
+def test_currency_parses_only_the_plan_and_receipt_bytes_validated_this_pass(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tools = repo / "tools.json"
+    tools.write_text(tools.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    completed, _, _ = _verify(repo, archive_head=False)
+    assert completed.control.state == "complete"
+    reports = repo / "agents-shipgate-reports"
+    original = (reports / "verifier.json").read_bytes()
+    real_read = current_control_module.read_regular_file_beneath
+    reads: dict[str, int] = {}
+
+    def read_once(root, path, **kwargs):
+        if path in {"verification-plan.json", "verification-receipt.json"}:
+            reads[path] = reads.get(path, 0) + 1
+            assert reads[path] == 1, "currency reopened already-validated evidence"
+        return real_read(root, path, **kwargs)
+
+    monkeypatch.setattr(current_control_module, "read_regular_file_beneath", read_once)
+    result = read_current_control(reports, live=lambda: _live(repo), capture=("verifier",))
+    assert result.pointer.control.permissions.merge is True
+    assert result.artifacts == {"verifier": original}
+    assert reads == {"verification-plan.json": 1, "verification-receipt.json": 1}
+
+
+def test_final_overlay_observation_refuses_a_mode_change_while_hashing(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agents_shipgate.core import verification_identity
+
+    tools = repo / "tools.json"
+    tools.write_text(tools.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    completed, _, _ = _verify(repo, archive_head=False)
+    assert completed.control.state == "complete"
+    reports = repo / "agents-shipgate-reports"
+    original = (reports / "verifier.json").read_bytes()
+    real_hash = verification_identity.sha256_file
+    hashes = []
+
+    def hash_then_change_mode(path):
+        digest = real_hash(path)
+        if path == tools:
+            hashes.append(digest)
+            if len(hashes) == 2:
+                tools.chmod(0o755)
+        return digest
+
+    monkeypatch.setattr(verification_identity, "sha256_file", hash_then_change_mode)
+    with pytest.raises(CurrentControlUnavailable) as raised:
+        read_current_control(reports, live=lambda: _live(repo), capture=("verifier",), attempts=1)
+    assert raised.value.reason == "workspace_unverifiable"
+    assert raised.value.artifacts == {"verifier": original}
+    assert len(hashes) == 2
+
+
+@pytest.mark.parametrize("attempts", [1, 3])
+def test_final_live_observation_cannot_return_a_superseded_pointer(
+    repo: Path, attempts: int
+) -> None:
+    _verify(repo)
+    reports = repo / "agents-shipgate-reports"
+    observations = []
+
+    def observe():
+        live = _live(repo)
+        observations.append(live)
+        if len(observations) % 2 == 0:
+            begin_current_control(reports, operation="verify", reason="A new run started.")
+        return live
+
+    if attempts == 1:
+        with pytest.raises(CurrentControlUnavailable) as raised:
+            read_current_control(reports, live=observe, attempts=attempts)
+        assert raised.value.reason == "generation_changed"
+    else:
+        result = read_current_control(reports, live=observe, attempts=attempts)
+        assert result.pointer.lifecycle_state == "in_progress"
+        assert result.pointer.control.permissions.merge is False
+    assert len(observations) <= attempts * 2
+
+
 def test_completion_is_refused_when_the_workspace_cannot_be_checked(repo: Path) -> None:
     """`live=None` means "not compared", which is never a pass for completion."""
 


### PR DESCRIPTION
A current-control read could return merge authority after an already-dirty file or the comparison base changed during its final observation. The last comparison checked HEAD and path names but omitted the content, metadata and base checks performed earlier.

Run the same complete currency validation on both live observations, using plan and receipt bytes captured during this pass's hash validation. Reconfirm the pointer after the final live reads. The shared overlay reader also rejects entry metadata changing while its content digest is read, without changing persisted overlay identities or public schemas. Refusals retain the original captured verifier for exact recovery.

Validation:
- Reproduced the four original second-observation failures before the repair (content, executable bit, symlink, base); separately reproduced a mode change while hashing.
- 132 current-control and compact-control tests passed, including real Git base/shallow-history changes, bounded pointer retries, both CLI consumers and captured-evidence checks.
- Full pytest suite and whole-repository Ruff passed.
- Working-tree and committed-ref verification passed; fresh control is complete.
- Independent coding-agent review/address round 1 is recorded on this PR at `97f42cc9`; no actionable findings and no follow-up code changes.
- All nine applicable GitHub CI checks passed, including the three full-suite shards and combined coverage; release-tag-consistency is intentionally skipped for this non-release PR.

Fixes #567. New unrelated default-report-path behavior is deferred in #575. This repair is a prerequisite to final candidate evidence; it does not qualify or publish v1.0.