### PR TITLE
docs(release): align qualification instructions with approved policy

### DIFF
--- a/benchmark/safety-qualification/README.md
+++ b/benchmark/safety-qualification/README.md
@@ -1,6 +1,7 @@
 # Evidence-Backed Pass Safety Qualification
 
-This directory is the runbook for the `0.16.0` safety qualification.
+This directory is the runbook for release safety qualification: the optional
+`0.x` track and the separate human-labeled `1.0` beta track.
 The repository does **not** ship fabricated human labels or a passing result.
 Until a real frozen corpus and its verifier receipts exist,
 `safety-qualification.json` must not be published as qualified.
@@ -55,12 +56,27 @@ change either qualification policy.
 
 ## What to build first
 
-[`strata-inventory.csv`](strata-inventory.csv) maps the known candidate pool onto
-the 28 profile × decision cells, so mining aims at the empty ones; how to read
+[`strata-inventory.csv`](strata-inventory.csv) records the pre-1.0 sourcing pool;
+the current policy has 21 profile × decision cells. How to read
 and maintain it is in [`strata-inventory.md`](strata-inventory.md). It is a
 sourcing plan, not evidence: it carries no label, no verdict and no receipt, and
 it is **not** an admissible rater input — it names a target decision for every
 slot, so a rater session that has read it produces no admissible label.
+
+The dated Cut A/B/C records describe historical work, not a frozen-data
+handoff. Verify the actual corpus, admissibility and hashes before using any
+private data; neither a closed issue nor ignored local files prove completion.
+For `1.0`, [#512](https://github.com/ThreeMoonsLab/agents-shipgate/issues/512)
+starts separate beta sourcing and human labeling in parallel with engineering.
+No `0.x` publication is required first. Freeze the final source, workflow,
+policy and exact wheel after selected repairs and
+[#569](https://github.com/ThreeMoonsLab/agents-shipgate/issues/569)'s report
+compatibility work. Beta receipts and the unsigned qualifying result feed
+[#509](https://github.com/ThreeMoonsLab/agents-shipgate/issues/509)'s independent
+signing, then [#510](https://github.com/ThreeMoonsLab/agents-shipgate/issues/510)'s
+same-candidate positive rehearsal. A candidate change requires new bound
+evidence. Coordinate active pre-1.0 retirement before that final wheel freeze;
+the historical format's readability never makes it eligible for a `1.x` tag.
 
 ## Which policy to build for
 
@@ -83,6 +99,37 @@ product/security owner in
 § Amendment 3 there for why no case targets `insufficient_evidence` and why
 four `blocked` cells hold one case.
 
+### Current policy contract
+
+This table is checked against both policy implementations. Report `0.43`
+remains current until the deliberate report `1.0` freeze; no schema reference
+is advanced merely to prepare a release.
+
+| Requirement | `pre_1_0` | `beta` |
+|---|---|---|
+| Cases | 38 | 80 |
+| Strata | 21 | 21 |
+| Expected passed / review_required / blocked | 14 / 14 / 10 | 30 / 20 / 30 |
+| Qualifying origins, minimum | 16 | 32 |
+| Safe passes, minimum | 13 / 14 | 27 / 30 |
+| Review exact, minimum | 14 / 14 | 19 / 20 |
+| Blocked exact, minimum | 10 / 10 | 30 / 30 |
+| Unsafe auto-passes, maximum | 0 / 24 | 0 / 50 |
+| Cohen's kappa, minimum | 0.80 | 0.80 |
+| Holdout per stratum, minimum fraction | 0.20 | 0.20 |
+| Report schema | `0.43` | `0.43` |
+
+The holdout count is `ceil(stratum_count × 0.20)` independently in every
+stratum. Zero unsafe auto-passes also holds per profile. Neither policy asks
+for expected `insufficient_evidence` labels: an actual IE is a miss against
+the case's expected outcome. Missing or invalid receipts remain failures.
+Beta requires two blind human primary labels from the two independent
+disciplines and independent adjudication of disagreements. The separate
+pre-1.0 labeling protocol is limited to Amendment 1's conditions.
+
+Current envelopes: corpus `shipgate.safety_corpus/v4`, receipt index
+`shipgate.safety_receipt_index/v4`, result `shipgate.safety_qualification/v6`.
+
 ### Production acceptance policy (`beta`, 80 cases)
 
 - 80 cases with exact declared MCP/OpenAPI, OpenAI Agents SDK,
@@ -103,8 +150,7 @@ four `blocked` cells hold one case.
 ### Pre-1.0 acceptance policy (`pre_1_0`, 38 cases)
 
 Less coverage, identical strictness. Same seven profiles, same three target
-outcomes, **two cases in each of the 21 strata** — not the production weighting
-scaled down, which would empty the smallest cells.
+outcomes: **two cases in 17 strata and one in four approved blocked strata**.
 
 - 38 cases: 14 `passed`, 14 `review_required`, 10 `blocked`.
 - Four `blocked` cells hold **one** case, not two: `openai_agents_sdk`,
@@ -152,9 +198,11 @@ own cases — the standard-library sealing gate included. A corpus with the righ
 floor, fails at both. Every case needs a unique, non-blank id and a terminal
 verifier decision: an absent decision is a missing case, not a low score.
 
-The result envelope is `shipgate.safety_qualification/v5`, and a `pre_1_0`
-artifact may not claim an earlier one — those readers admit `beta` and `test`
-only. Both gates also check the artifact's declared `requirements` block
+The current result envelope is `shipgate.safety_qualification/v6`. Historical
+v5 results also admit `pre_1_0`; the supported legacy v1/v2/v4 envelopes admit
+`beta` and `test` only,
+so a pre-1.0 artifact cannot claim those older envelopes. Both gates also
+check the artifact's declared `requirements` block
 field-for-field against the approved policy, including
 `required_report_schema_version`, which nothing in `cases` can attest.
 
@@ -191,7 +239,9 @@ sigstore sign --bundle safety-qualification.sigstore.json safety-qualification.j
 ```
 
 Release promotion consumes the signed result and the same wheel through
-protected `pypi` environment variables. See
+repository-scope location variables. Signer identity and OIDC issuer live in
+reviewed `.github/release-trust-roots.json`; the protected `pypi` environment
+controls publication. See
 [`docs/distribution.md`](../../docs/distribution.md#protected-qualification-inputs)
 for the exact variable contract. The tag workflow verifies the signer, a
 qualification tier the version admits, tag/version, and wheel digest before it
@@ -202,13 +252,17 @@ qualification result as trust inputs. It does not cryptographically prove that
 the signer is organizationally independent of the tag pusher, re-run the
 underlying receipts during promotion, or prove that labelers were blind; those
 properties depend on protected-environment governance and benchmark-owner
-process. Repository administrators must lock signer-variable changes behind
-reviewers who are independent of the release initiator.
+process. Repository administrators must protect trust-root changes and the
+publication environment with reviewers independent of the release initiator;
+the existence of workflow YAML alone does not establish that boundary.
 
-The origin minimum — `minimum_qualified_origins = 40` under the production
-policy, `23` under the pre-1.0 one — accepts a combined
+The origin minimum — `minimum_qualified_origins = 32` under the production
+policy, `16` under the pre-1.0 one — accepts a combined
 count of real-history, rejected/reverted, and design-partner cases. It does not
 enforce a four-week observation window or three distinct design partners.
 Those remain external beta rollout stop conditions and must be reviewed from
 the rollout record before promoting affected profiles; do not describe them as
 properties enforced by `safety-qualification.json`.
+The [pilot product ladder](../../docs/design-partner-pilot-results.md) is a
+third decision about first and repeated user value; it substitutes for neither
+the machine qualification nor the four-week/three-partner rollout condition.

--- a/benchmark/safety-qualification/calibration.md
+++ b/benchmark/safety-qualification/calibration.md
@@ -4,7 +4,7 @@
 condition 5 runs the labeling protocol on **five non-corpus cases before any
 corpus label exists**, so that ambiguities in
 [`benchmark/miner/LABELING.md`](../miner/LABELING.md) are found and fixed
-while fixing them costs five relabels rather than fifty-six. This file names
+while fixing them costs a calibration round rather than a full corpus. This file names
 the five cases and why each is here. It records **no label and no verdict**
 for any of them, and it must never: a calibration case's labels are working
 material for sharpening the guide, and the adjudication notes that come out of

--- a/benchmark/safety-qualification/participant-validation.md
+++ b/benchmark/safety-qualification/participant-validation.md
@@ -66,7 +66,7 @@ Hi <name>,
 I maintain agents-shipgate, an open-source, deterministic gate that reviews
 what an AI agent is able to do after a code change. We are qualifying a
 release against a benchmark of real capability-change PRs, and <repo>#<PR> —
-which you <reviewed|wrote> — is one of the 56 cases, at pinned commits
+which you <reviewed|wrote> — is one of the frozen corpus cases, at pinned commits
 <base>..<head>.
 
 You were there and we were not, so your judgment outranks our labels. One

--- a/benchmark/safety-qualification/strata-inventory.md
+++ b/benchmark/safety-qualification/strata-inventory.md
@@ -1,11 +1,17 @@
 # Cut A — the pre-1.0 strata inventory
 
-[`strata-inventory.csv`](strata-inventory.csv) maps the known candidate pool onto
-the 28 profile × decision cells the `pre_1_0` policy requires, so Cut B could mine
-the empty cells instead of re-finding the full ones. It is the first of the four
-cuts in [#456](https://github.com/ThreeMoonsLab/agents-shipgate/issues/456).
-**Sourcing is complete as of the [close-out](#cut-b--the-close-out-2026-09-02):
-every slot is `pinned`, and the next step is the Cut C calibration round.**
+[`strata-inventory.csv`](strata-inventory.csv) records the pre-1.0 candidate
+pool and its sourcing history. The current policy requires 38 cases across
+21 profile × decision cells, with at least 16 qualifying origins; the
+[current policy contract](README.md#current-policy-contract) is authoritative
+for today's allocation. It is part of
+[#456](https://github.com/ThreeMoonsLab/agents-shipgate/issues/456).
+
+The [2026-09-02 close-out](#cut-b--the-close-out-2026-09-02) below records the
+then-current 28-cell sourcing plan. Later policy and inventory changes leave
+that record historical; it does not establish a frozen corpus or receipts.
+The separate 80-case human-labeled beta track is
+[#512](https://github.com/ThreeMoonsLab/agents-shipgate/issues/512).
 
 **It is a sourcing plan, not evidence.** It contains no label, no verifier
 verdict, and no receipt. Nothing in it can qualify a release, and nothing in it
@@ -63,11 +69,11 @@ column so the bias is visible per row rather than argued in prose, and
 worksheet ever stops exposing verdicts — at which point this disclosure should
 be revisited rather than left standing.
 
-The miner's three-way vocabulary also does not distinguish `review_required`
-from `insufficient_evidence` — `needs_human` covers both — so a `needs_human`
-candidate may be targeted at either cell. **Drawing that line is work for the
-Cut C calibration round**, not for this file; the labeling guide has to answer
-it before 56 labels are produced against it.
+The miner's historical `needs_human` vocabulary covered both `review_required`
+and `insufficient_evidence`. Since Amendment 3, neither qualification policy
+has an expected-IE cell. Follow the current labeling guide and independent
+adjudication; never translate an engine abstention into a ground-truth label
+or automatically relabel the historical inventory to fill today's cells.
 
 ## Exposure, and why it decides the split
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -34,7 +34,8 @@ to install a published PyPI version.
 - Pin the build backend in `constraints/release-build.txt` so release wheels are
   byte-reproducible.
 - Use Dependabot for Python and GitHub Actions updates.
-- Add a lockfile for release and dev dependency builds once packaging workflow is finalized.
+- Use the existing hash-locked development, build, sealing and publication
+  closures listed in the [release runbook](release-runbook.md#the-environment-is-locked-and-it-is-cis).
 
 PyPI Trusted Publishing is configured for this repository's tag-triggered
 release workflow and protected `pypi` environment.
@@ -90,9 +91,11 @@ This is a configured trust root, not proof of organizational independence.
 The promotion job trusts the signed qualification summary and does not replay
 its underlying verifier receipts. The four-week, three-design-partner rollout
 is likewise an external beta stop condition; the machine gate enforces only
-the qualification artifact's combined origin minimum — 40 real-history,
-rejected/reverted, or design-partner cases under the production policy and 23
+the qualification artifact's combined origin minimum — 32 real-history,
+rejected/reverted, or design-partner cases under the production policy and 16
 under the pre-1.0 one, the same 40% share of each corpus.
+The [current policy table](../benchmark/safety-qualification/README.md#current-policy-contract)
+keeps these machine floors separate from external rollout and pilot evidence.
 
 ## Marketplace And Site
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -109,9 +109,14 @@ applies** — nothing in the artifact does:
 
 | Version | Accepted qualification | Cases |
 |---|---|---|
-| `0.x` (epoch 0, major 0) | `pre_1_0`, or the stronger `beta` | 56, or 100 |
-| `1.0` and later | `beta` only | 100 |
-| unparsable | `beta` only | 100 |
+| `0.x` (epoch 0, major 0) | `pre_1_0`, or the stronger `beta` | 38, or 80 |
+| `1.0` and later | `beta` only | 80 |
+| unparsable | `beta` only | 80 |
+
+Both policies have 21 strata and no expected `insufficient_evidence` class.
+The [current policy table](../benchmark/safety-qualification/README.md#current-policy-contract)
+records exact outcomes, 16/32 qualifying-origin floors, holdout and human-label
+requirements. It is checked against the typed policy and the stdlib gate.
 
 The `pre_1_0` policy was approved for issue #341 and is recorded, with its
 thresholds and rationale, in
@@ -126,7 +131,7 @@ Both gates apply the rule independently — the exhaustive
 standard-library `scripts/verify_qualification_binding.py` in the sealing job.
 The sealing gate cannot import the project, so it *restates* each tier's
 strata, exact-match floors, per-stratum holdout, and origin and κ floors, and
-re-derives them from the raw cases; a case count alone would let 56 identical
+re-derives them from the raw cases; a case count alone would let 38 identical
 rows through. An artifact naming a tier the version does not admit is rejected
 by both, and is then measured against the *production* policy, so a bad tier
 can never shrink what is checked.
@@ -626,8 +631,9 @@ vouches for it, in a single step with no diff to review. Source-to-wheel
 binding does not compensate: that attack reuses the legitimate wheel and forges
 only the safety claims about it.
 
-Both ship as `CHANGE_ME` until the promotion flow exists. The release **fails
-closed** while either is unset rather than defaulting to something permissive.
+The signer identity remains `CHANGE_ME`; the OIDC issuer is already
+`https://token.actions.githubusercontent.com`. The release **fails closed**
+while either value is unset rather than defaulting to something permissive.
 Changing either is a trust-root change and is reviewed as one.
 
 ### Artifact locations — repository variables

--- a/scripts/run_safety_qualification.py
+++ b/scripts/run_safety_qualification.py
@@ -611,7 +611,7 @@ def select_release_requirements(
 
     ``auto`` applies the rule a human approved for issue #341 rather than
     inferring one: ``0.x`` builds are governed by the pre-1.0 policy, anything
-    else by the 100-case production policy. The release verifiers re-derive the
+    else by the 80-case production policy. The release verifiers re-derive the
     same rule from the tag independently, so this choice is never trusted.
 
     ``production`` is always available -- opting *up* to more evidence than the
@@ -1043,7 +1043,7 @@ def _parser() -> argparse.ArgumentParser:
         help=(
             "Which named release policy to score against. 'auto' (default) "
             "selects the pre-1.0 policy for a 0.x wheel and the production "
-            "policy otherwise; 'production' always scores the 100-case bar; "
+            "policy otherwise; 'production' always scores the 80-case bar; "
             "'pre-1.0' is refused for a 1.0-or-later wheel"
         ),
     )

--- a/src/agents_shipgate/schemas/safety_qualification.py
+++ b/src/agents_shipgate/schemas/safety_qualification.py
@@ -338,7 +338,7 @@ class SafetyStratumRequirementV1(BaseModel):
 
 
 class SafetyQualificationRequirementsV1(BaseModel):
-    """Qualification thresholds. The CLI always uses the production defaults."""
+    """Qualification thresholds for the named policy selected by wheel version."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -456,15 +456,14 @@ def pre_release_safety_requirements() -> SafetyQualificationRequirementsV1:
 
     Recorded by Pengfei Hu on 2026-08-29 under
     ``docs/release-evidence-policy-decision.md`` (issue #341, Route 2). It
-    governs ``0.x`` tags only; ``1.0`` and later still require the 100-case
+    governs ``0.x`` tags only; ``1.0`` and later still require the 80-case
     production policy, and this constructor is never selected for them.
 
-    Two cases per stratum is the smallest allocation that keeps all 28
-    profile x decision cells non-empty *and* leaves room for a tuning/holdout
-    split in every cell: at one case per cell, ``ceil(1 x 0.20) = 1`` forces
-    that case to be holdout. Dropping a cell to zero would delete coverage of a
-    profile/outcome pair outright, which is a strictness reduction and not a
-    coverage one; the uniform layout is what avoids it at this size.
+    Amendment 3 keeps 21 profile x decision cells: two cases in 17 cells and
+    one case in four approved blocked cells, for 38 total. No cell expects
+    ``insufficient_evidence``. At one case per cell, ``ceil(1 x 0.20) = 1``
+    requires that case to be holdout; a zero-count cell would delete coverage
+    of a profile/outcome pair outright.
 
     What is *enforced* is the holdout floor, not a one-of-each split. A corpus
     that marks more cases holdout is accepted: holdout evidence was never tuned
@@ -535,8 +534,8 @@ def pre_release_safety_requirements() -> SafetyQualificationRequirementsV1:
         minimum_blocked_exact=10,
         minimum_review_exact=14,
         # No corpus case is targeted at `insufficient_evidence`, so there is
-        # no floor to meet. The field stays because it is shipped surface and
-        # the `beta` tier still carries one.
+        # no floor to meet. The field stays for shipped-schema compatibility;
+        # both named policies require zero expected-IE cases.
         minimum_insufficient_evidence_exact=0,
         required_report_schema_version="0.43",
     )
@@ -830,7 +829,7 @@ class SafetyQualificationResultV1(BaseModel):
 
     @model_validator(mode="after")
     def _production_claim_matches_the_tier(self) -> SafetyQualificationResultV1:
-        """``production_qualified`` means the 100-case bar, in every artifact.
+        """``production_qualified`` means the approved beta bar, in every artifact.
 
         Enforced structurally rather than at each gate so the *producer* cannot
         emit the inconsistency in the first place. A pre-1.0 artifact asserting

--- a/tests/test_safety_qualification_release.py
+++ b/tests/test_safety_qualification_release.py
@@ -693,3 +693,77 @@ def test_a_preview_wheel_is_refused_by_the_artifact_that_qualified_the_release(
             qualification_path=qualification,
             tag=f"v{PREVIEW_VERSION}",
         )
+
+
+def test_current_operator_policy_table_matches_both_gate_implementations() -> None:
+    from scripts._release_support import QUALIFICATION_POLICIES
+
+    readme = (REPO_ROOT / 'benchmark/safety-qualification/README.md').read_text()
+    section = readme.split('### Current policy contract\n', 1)[1].split('\n### ', 1)[0]
+    rows = {
+        cells[0]: cells[1:]
+        for line in section.splitlines()
+        if line.startswith('| ')
+        for cells in [[cell.strip() for cell in line.strip('|').split('|')]]
+    }
+    for column, (tier, requirements) in enumerate((
+        ('pre_1_0', pre_release_safety_requirements()),
+        ('beta', production_safety_requirements()),
+    )):
+        counts = {
+            decision: sum(s.count for s in requirements.required_strata if s.expected_decision == decision)
+            for decision in ('passed', 'review_required', 'blocked')
+        }
+        total = sum(counts.values())
+        policy = QUALIFICATION_POLICIES[tier]
+        assert total == policy.case_count
+        assert requirements.minimum_qualified_origins == policy.minimum_qualified_origins
+        expected = {
+            'Cases': str(total),
+            'Strata': str(len(requirements.required_strata)),
+            'Expected passed / review_required / blocked': ' / '.join(map(str, counts.values())),
+            'Qualifying origins, minimum': str(requirements.minimum_qualified_origins),
+            'Safe passes, minimum': f'{requirements.minimum_safe_passes} / {counts["passed"]}',
+            'Review exact, minimum': f'{requirements.minimum_review_exact} / {counts["review_required"]}',
+            'Blocked exact, minimum': f'{requirements.minimum_blocked_exact} / {counts["blocked"]}',
+            'Unsafe auto-passes, maximum': f'{requirements.maximum_unsafe_auto_passes} / {total - counts["passed"]}',
+            "Cohen's kappa, minimum": f'{requirements.minimum_kappa:.2f}',
+            'Holdout per stratum, minimum fraction': f'{requirements.minimum_holdout_fraction_per_stratum:.2f}',
+            'Report schema': f'`{requirements.required_report_schema_version}`',
+        }
+        for name, value in expected.items():
+            assert rows[name][column] == value, (tier, name)
+
+
+def test_current_operator_envelopes_and_version_table_match_the_runner() -> None:
+    from agents_shipgate.schemas.safety_qualification import (
+        SAFETY_CORPUS_SCHEMA_VERSION,
+        SAFETY_QUALIFICATION_SCHEMA_VERSION,
+        SAFETY_RECEIPT_INDEX_SCHEMA_VERSION,
+    )
+    from scripts._release_support import QUALIFICATION_POLICIES
+    from scripts.run_safety_qualification import _parser
+
+    readme = (REPO_ROOT / 'benchmark/safety-qualification/README.md').read_text()
+    runbook = (REPO_ROOT / 'docs/release-runbook.md').read_text()
+    for version in (
+        SAFETY_CORPUS_SCHEMA_VERSION, SAFETY_RECEIPT_INDEX_SCHEMA_VERSION,
+        SAFETY_QUALIFICATION_SCHEMA_VERSION,
+    ):
+        assert f'`{version}`' in readme.split('Current envelopes:', 1)[1].split('\n### ', 1)[0]
+    pre = QUALIFICATION_POLICIES['pre_1_0'].case_count
+    beta = QUALIFICATION_POLICIES['beta'].case_count
+    assert f'| `0.x` (epoch 0, major 0) | `pre_1_0`, or the stronger `beta` | {pre}, or {beta} |' in runbook
+    assert f'| `1.0` and later | `beta` only | {beta} |' in runbook
+    assert f'| unparsable | `beta` only | {beta} |' in runbook
+    assert f'{beta}-case bar' in _parser().format_help()
+
+
+def test_distribution_origin_floor_is_not_the_external_rollout_gate() -> None:
+    text = (REPO_ROOT / 'docs/distribution.md').read_text()
+    beta = production_safety_requirements().minimum_qualified_origins
+    pre = pre_release_safety_requirements().minimum_qualified_origins
+    assert f'combined origin minimum — {beta} real-history,' in text
+    assert f'under the production policy and {pre}\nunder the pre-1.0 one' in text
+    assert 'four-week, three-design-partner rollout' in text
+    assert 'external beta stop condition' in text


### PR DESCRIPTION
Active qualification instructions still asked operators for superseded 56/100-case corpora, old origin floors and v5 results, and described signer trust as mutable environment configuration. Reconcile current runbooks, sourcing introductions, CLI help and policy docstrings with the approved 38/80-case policies, 21 strata, 16/32 origins, v4 corpus/index and v6 result. Preserve dated sourcing/labeling records and all scoring requirements.

Add a current policy table with targeted parity checks against the typed policy and existing stdlib parity contract. State beta human-primary labeling, final source/wheel freeze → unsigned #512 evidence → independent #509 signing → #510 rehearsal, reviewed signer trust versus repository location variables, and the separate four-week/three-partner rollout and pilot decisions. Correct the stale dependency-lock instruction to point to existing locked closures.

Live issue delivery bodies #456/#509/#512/#510 were reconciled by #574 and rechecked; #511 now correctly depends on actual frozen labels/receipts rather than closure/signing of #509. No labels, frozen evidence, trust-root values, release thresholds or publication settings are changed.

Validation:
- 102 qualification/release/coverage tests passed on the rebased main containing #578; whole-repository Ruff passed.
- Schema generator --check passed; no frozen/generated schema changed.
- Working-tree and rebased committed-ref verification passed; fresh complete control.
- Independent coding-agent GitHub review/address round 1 is recorded at `cc88238e`; no actionable findings.
- All nine applicable GitHub checks passed, including full-suite shards and combined coverage; the non-release tag check is intentionally skipped.

Fixes #566. #569 still owns the deliberate report 1.0 freeze and active pre-1.0 retirement before final candidate evidence.