### PR TITLE
Miner: retain original scoped base input obligations

### DIFF
--- a/benchmark/miner/README.md
+++ b/benchmark/miner/README.md
@@ -15,7 +15,7 @@ strategy needs at once:
    real repos is the headline extraction-coverage KPI; this measures it
    instead of assuming it.
 
-## What one row records (schema v0.1)
+## What one row records (schema v0.3)
 
 Per PR (`base = merge_commit^1`, `head = merge_commit` — the PR's net
 mainline change, correct for both squash and merge):
@@ -30,13 +30,41 @@ mainline change, correct for both squash and merge):
 | **Receipt (v0.2)** | `verify_verdict, verify_decision, verify_can_merge, verify_trust_root_touched, verify_policy_weakened, verify_cap_added/modified/removed` | Real `verify --base <base'> --head <head''>` with the cold-start manifest committed onto **both** sides; `head''` is re-parented onto `base'` (`commit-tree`) so the three-dot diff is exactly the PR's delta and the injected manifest cannot fire the trust-root signal. Diff-aware `SHIP-VERIFY-*` checks and new-findings gating apply — these columns are the per-PR verdict; the scan columns above remain the cold-start whole-surface state. |
 | Lifecycle | `status` (`evaluated \| trigger_skip \| init_skip \| scan_failed \| error`), `notes` | — |
 
+`verify_input_obligation` (v0.3) is either `null` or a typed
+`kind: unsupported_input` object. It retains the original base/head SHAs,
+selected head scope, a reason and exact Git-observed rename pairs, plus the
+required input action. JSONL carries the object directly; CSV carries JSON in
+that cell. Older rows remain readable with no invented obligation.
+
+For a miner-injected manifest, the original base scope must be a readable Git
+tree before any manifest is copied or committed. A Git-proven absent path
+reports `scoped_base_absent`; incoming Git rename pairs report
+`scoped_base_rename_candidates`. Partial or multiple renames remain observed
+file pairs, not a claim that the directories are the same agent. An unreadable
+comparison reports `scoped_comparison_unreadable`; a file where the directory would
+be reports `scoped_base_not_directory`. None supplies a verifier verdict or a
+capability count. An unrelated deleted directory cannot be chosen as the base
+without actual incoming rename evidence.
+
+Real PR-added manifests still use the existing terminal verifier path and
+keep their trust-root change visible. Its `base_status: missing_manifest`
+means there was no manifest at that base path, not that an empty agent surface
+was evaluated. Likewise `--diff-from` can provide a prior report but does not
+establish the normal successful base scan and subject binding. The independent
+base/head scoped-input contract is tracked in
+[#580](https://github.com/ThreeMoonsLab/agents-shipgate/issues/580).
+Typed obligations make missing answers actionable; they do not satisfy
+[#563](https://github.com/ThreeMoonsLab/agents-shipgate/issues/563)'s fixed-history
+catch bars or turn scan fallback into PR verification. All original history
+and labels below remain unchanged.
+
 `evaluated` means the head scan produced a release decision. When the
 repo-root cold start fails (monorepos), the evaluator retries once at the
 deepest common directory of the changed files (`notes: retry_at:<dir>`) —
 the stripe/ai PR #232 pattern, where the agent lives under `tools/python`.
 
-**Privacy rule:** rows carry public PR metadata, verdicts, check IDs, and
-counts only — never diff text, code excerpts, or report evidence. Same
+**Privacy rule:** rows carry public PR metadata, verdicts, check IDs, counts
+and repository-relative input paths — never diff text, code excerpts, or report evidence. Same
 convention as the adoption-harness CSVs.
 
 ## Run it

--- a/benchmark/miner/evaluate.py
+++ b/benchmark/miner/evaluate.py
@@ -36,6 +36,8 @@ from benchmark.miner.rows import (
     STATUS_SCAN_FAILED,
     STATUS_TRIGGER_SKIP,
     MinedRow,
+    ScopedInputObligation,
+    ScopedInputReason,
 )
 
 _GIT_TIMEOUT = 120
@@ -281,6 +283,16 @@ def _verify_pr(
     state.
     """
 
+    # Read original committed inputs before any apparatus writes. A real
+    # PR-added manifest keeps the existing missing-manifest verifier route;
+    # only our injected manifest needs a supported base surface to copy into.
+    if manifest_injected and subdir:
+        obligation = _scoped_base_obligation(row, repo_path, subdir)
+        if obligation is not None:
+            row.verify_input_obligation = obligation
+            row.notes = _append_note(row.notes, "verify_unsupported_scoped_base")
+            return
+    row.verify_input_obligation = None
     manifest_rel = f"{subdir}/shipgate.yaml" if subdir else "shipgate.yaml"
     head_commit = _commit_manifest(head_wt, manifest_rel)
     if head_commit is None:
@@ -308,6 +320,11 @@ def _verify_pr(
         # Synthetic apparatus: force the identical manifest onto base so it
         # cancels out of the base...head diff — it is not a PR change.
         if not base_manifest.parent.is_dir():
+            # Git proved the scope exists. A missing materialization is a
+            # read/worktree failure, never evidence of an empty base.
+            row.verify_input_obligation = _scope_obligation(
+                row, subdir, "scoped_comparison_unreadable",
+            )
             row.notes = _append_note(row.notes, "verify_base_subdir_missing")
             return
         shutil.copyfile(head_manifest, base_manifest)
@@ -583,6 +600,12 @@ def _capability_delta(
     *,
     subdir: str = "",
 ) -> None:
+    if subdir:
+        obligation = _scoped_base_obligation(row, repo_path, subdir)
+        if obligation is not None:
+            row.verify_input_obligation = obligation
+            row.notes = _append_note(row.notes, "capability_unsupported_scoped_base")
+            return
     head_lock = tmp_path / "head.lock.json"
     if not _capability_export(head_manifest, head_lock):
         row.notes = _append_note(row.notes, "head_lock_failed")
@@ -591,6 +614,9 @@ def _capability_delta(
         _worktree_add(repo_path, base_wt, row.base_sha)
     base_root = (base_wt / subdir) if subdir else base_wt
     if not base_root.is_dir():
+        row.verify_input_obligation = _scope_obligation(
+            row, subdir, "scoped_comparison_unreadable",
+        )
         row.notes = _append_note(row.notes, "base_subdir_missing")
         return
     base_manifest = base_root / "shipgate.yaml"
@@ -627,6 +653,76 @@ def _capability_delta(
         1
         for item in changed
         if isinstance(item, dict) and str(item.get("direction") or "") == "broadened"
+    )
+
+
+def _scope_obligation(
+    row: MinedRow,
+    subdir: str,
+    reason: ScopedInputReason,
+    renames: list[dict[str, str]] | None = None,
+) -> ScopedInputObligation:
+    return {
+        "kind": "unsupported_input",
+        "reason": reason,
+        "base_sha": row.base_sha,
+        "head_sha": row.head_sha,
+        "head_scope": subdir,
+        "observed_renames": renames or [],
+        "next_action": (
+            "restore_readable_comparison_trees" if reason == "scoped_comparison_unreadable"
+            else "provide_supported_scoped_base_comparison"
+        ),
+    }
+
+
+def _scoped_base_obligation(
+    row: MinedRow, repo_path: Path, subdir: str,
+) -> ScopedInputObligation | None:
+    """Describe an unsupported scope using only the original commit trees.
+
+    Git rename records are file-pair observations, not a reviewed assertion
+    that two directories are the same agent. Keep every incoming pair so a
+    partial or ambiguous rename cannot silently select the first old scope.
+    """
+    scope = _git(repo_path, [
+        "--literal-pathspecs", "ls-tree", "-z", row.base_sha, "--", subdir,
+    ])
+    if scope.returncode != 0:
+        return _scope_obligation(row, subdir, "scoped_comparison_unreadable")
+    records = [record for record in scope.stdout.split("\0") if record]
+    if records:
+        if len(records) != 1:
+            return _scope_obligation(row, subdir, "scoped_comparison_unreadable")
+        metadata, separator, path = records[0].partition("\t")
+        if not separator or path != subdir:
+            return _scope_obligation(row, subdir, "scoped_comparison_unreadable")
+        if len(metadata.split()) == 3 and metadata.split()[1] == "tree":
+            return None
+        return _scope_obligation(row, subdir, "scoped_base_not_directory")
+
+    delta = _git(repo_path, [
+        "diff", "--name-status", "-z", "-M", row.base_sha, row.head_sha, "--",
+    ])
+    if delta.returncode != 0 or (delta.stdout and not delta.stdout.endswith("\0")):
+        return _scope_obligation(row, subdir, "scoped_comparison_unreadable")
+    fields = delta.stdout.split("\0")[:-1]
+    renames: list[dict[str, str]] = []
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        width = 3 if status.startswith(("R", "C")) else 2
+        if not status or index + width > len(fields):
+            return _scope_obligation(row, subdir, "scoped_comparison_unreadable")
+        if status.startswith("R"):
+            old, new = fields[index + 1:index + 3]
+            if new.startswith(subdir + "/"):
+                renames.append({"base_path": old, "head_path": new, "git_status": status})
+        index += width
+    return _scope_obligation(
+        row, subdir,
+        "scoped_base_rename_candidates" if renames else "scoped_base_absent",
+        sorted(renames, key=lambda item: (item["head_path"], item["base_path"])),
     )
 
 

--- a/benchmark/miner/rows.py
+++ b/benchmark/miner/rows.py
@@ -1,7 +1,8 @@
-"""Row schema for mined-PR results (miner schema v0.1).
+"""Row schema for mined-PR results (miner schema v0.3).
 
 Privacy rule: rows carry public PR metadata, verdicts, check IDs, and
-counts only — never diff text, code excerpts, or report evidence. The
+counts and repository-relative input paths — never diff text, code excerpts,
+or report evidence. The
 same "no raw transcript text" convention as the adoption-harness CSVs.
 """
 
@@ -12,8 +13,28 @@ import dataclasses
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal, TypedDict
 
-MINER_SCHEMA_VERSION = "0.2"
+MINER_SCHEMA_VERSION = "0.3"
+
+ScopedInputReason = Literal[
+    "scoped_base_absent", "scoped_base_rename_candidates",
+    "scoped_comparison_unreadable", "scoped_base_not_directory",
+]
+
+
+class ScopedInputObligation(TypedDict):
+    """An unavailable comparison input, never a verifier decision."""
+
+    kind: Literal["unsupported_input"]
+    reason: ScopedInputReason
+    base_sha: str
+    head_sha: str
+    head_scope: str
+    observed_renames: list[dict[str, str]]
+    next_action: Literal[
+        "provide_supported_scoped_base_comparison", "restore_readable_comparison_trees",
+    ]
 
 # Row lifecycle states.
 STATUS_EVALUATED = "evaluated"  # head scan produced a release decision
@@ -59,6 +80,9 @@ class MinedRow:
     verify_cap_added: int | None = None
     verify_cap_modified: int | None = None
     verify_cap_removed: int | None = None
+    # v0.3 — retain the precise input obligation when the injected scoped
+    # manifest cannot describe the original base. No receipt is fabricated.
+    verify_input_obligation: ScopedInputObligation | None = None
     status: str = STATUS_ERROR
     notes: str = ""
     schema_version: str = field(default=MINER_SCHEMA_VERSION)
@@ -84,7 +108,13 @@ def write_csv(rows: list[MinedRow], path: Path) -> None:
         for row in rows:
             payload = row.to_json()
             writer.writerow(
-                {key: ("" if value is None else value) for key, value in payload.items()}
+                {
+                    key: (
+                        "" if value is None else
+                        json.dumps(value, sort_keys=True) if isinstance(value, dict) else value
+                    )
+                    for key, value in payload.items()
+                }
             )
 
 

--- a/tests/test_miner_corpus.py
+++ b/tests/test_miner_corpus.py
@@ -10,6 +10,7 @@ wrong number. Network-free — reads only the committed files.
 from __future__ import annotations
 
 import csv
+import json
 from pathlib import Path
 
 import pytest
@@ -17,11 +18,13 @@ import pytest
 from benchmark.miner.labels import WORKSHEET_COLUMNS, build_worksheet
 from benchmark.miner.rows import (
     CSV_COLUMNS,
+    MINER_SCHEMA_VERSION,
     STATUS_ERROR,
     STATUS_EVALUATED,
     STATUS_INIT_SKIP,
     STATUS_SCAN_FAILED,
     STATUS_TRIGGER_SKIP,
+    MinedRow,
     read_jsonl,
     summarize,
 )
@@ -94,10 +97,40 @@ def test_committed_corpus_is_well_formed(jsonl_path: Path) -> None:
             )
 
 
-def _csv_shape(row) -> dict[str, str]:
-    """How write_csv serializes a row: None → "", everything else → str."""
+# Frozen history keeps the header its miner actually emitted. Spell the old
+# schema out: deriving it from the live fields would let a future addition
+# silently redefine the evidence we claim to preserve.
+_V02_COLUMNS = (
+    "repo", "pr_number", "pr_url", "title", "merged_at", "base_sha", "head_sha",
+    "files_changed", "trigger_run", "trigger_rationale", "check_decision",
+    "check_rule_ids", "init_status", "head_decision", "head_blockers",
+    "head_review_items", "evidence_gaps", "tools_scanned", "cap_added",
+    "cap_removed", "cap_changed", "cap_broadened", "verify_verdict",
+    "verify_decision", "verify_can_merge", "verify_trust_root_touched",
+    "verify_policy_weakened", "verify_cap_added", "verify_cap_modified",
+    "verify_cap_removed", "status", "notes", "schema_version",
+)
 
-    return {key: ("" if value is None else str(value)) for key, value in row.to_json().items()}
+
+def _artifact_columns(rows: list[MinedRow]) -> tuple[str, ...]:
+    versions = {row.schema_version for row in rows}
+    assert len(versions) == 1, f"empty or mixed miner schemas: {versions}"
+    version = versions.pop()
+    known = {"0.2": _V02_COLUMNS, MINER_SCHEMA_VERSION: CSV_COLUMNS}
+    assert version in known, f"unrecognized committed miner schema: {version}"
+    return known[version]
+
+
+def _csv_shape(row: MinedRow, columns: tuple[str, ...]) -> dict[str, str]:
+    """Check every field of the artifact's declared schema, including JSON cells."""
+
+    return {
+        key: (
+            "" if value is None else
+            json.dumps(value, sort_keys=True) if isinstance(value, dict) else str(value)
+        )
+        for key, value in row.to_json().items() if key in columns
+    }
 
 
 @pytest.mark.parametrize("jsonl_path", _all_run_jsonl_files(), ids=lambda p: p.name)
@@ -105,12 +138,13 @@ def test_csv_and_jsonl_agree(jsonl_path: Path) -> None:
     csv_path = jsonl_path.with_suffix(".csv")
     assert csv_path.is_file(), f"missing CSV sibling for {jsonl_path.name}"
     jsonl_rows = read_jsonl(jsonl_path)
-    expected = {row.pr_url: _csv_shape(row) for row in jsonl_rows}
+    columns = _artifact_columns(jsonl_rows)
+    expected = {row.pr_url: _csv_shape(row, columns) for row in jsonl_rows}
     assert len(expected) == len(jsonl_rows), f"{jsonl_path.name}: duplicate pr_url"
 
     with csv_path.open(encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
-        assert tuple(reader.fieldnames or ()) == CSV_COLUMNS, (
+        assert tuple(reader.fieldnames or ()) == columns, (
             f"{csv_path.name} header drifted from the row schema"
         )
         csv_rows = list(reader)
@@ -124,7 +158,7 @@ def test_csv_and_jsonl_agree(jsonl_path: Path) -> None:
     for csv_row in csv_rows:
         url = csv_row["pr_url"]
         assert url in expected, f"{csv_path.name}: pr_url {url} absent from {jsonl_path.name}"
-        normalized = {key: csv_row.get(key, "") for key in CSV_COLUMNS}
+        normalized = {key: csv_row.get(key, "") for key in columns}
         assert normalized == expected[url], (
             f"{csv_path.stem}: row {url} differs between CSV and JSONL\n"
             f"  csv:   {normalized}\n  jsonl: {expected[url]}"
@@ -398,14 +432,15 @@ def test_w27_reeval_csv_and_jsonl_agree_and_are_lf_only() -> None:
     assert b"\r" not in REEVAL_JSONL.read_bytes(), "reeval jsonl has CRLF"
     assert b"\r" not in csv_path.read_bytes(), "reeval csv has CRLF"
     jsonl_rows = read_jsonl(REEVAL_JSONL)
-    expected = {row.pr_url: _csv_shape(row) for row in jsonl_rows}
+    columns = _artifact_columns(jsonl_rows)
+    expected = {row.pr_url: _csv_shape(row, columns) for row in jsonl_rows}
     with csv_path.open(encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
-        assert tuple(reader.fieldnames or ()) == CSV_COLUMNS
+        assert tuple(reader.fieldnames or ()) == columns
         csv_rows = list(reader)
     assert len(csv_rows) == len(jsonl_rows)
     for csv_row in csv_rows:
-        normalized = {key: csv_row.get(key, "") for key in CSV_COLUMNS}
+        normalized = {key: csv_row.get(key, "") for key in columns}
         assert normalized == expected[csv_row["pr_url"]]
 
 

--- a/tests/test_miner_scope_inputs.py
+++ b/tests/test_miner_scope_inputs.py
@@ -1,0 +1,198 @@
+"""Original Git scope evidence must survive unsupported miner comparisons."""
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_miner import _commit_all, _init_repo
+
+from benchmark.miner import evaluate
+from benchmark.miner.rows import MinedRow, read_jsonl, write_csv, write_jsonl
+
+
+def _scope_case(
+    tmp_path: Path, kind: str, *, scope: str = 'agents/new scope',
+) -> tuple[Path, MinedRow, str]:
+    repo = _init_repo(tmp_path)
+    (repo / 'README.md').write_text('Root remains outside the selected project.\n')
+    if kind in {'rename', 'partial_rename', 'ambiguous_rename'}:
+        for directory, name in [('old scope', 'agent.py'), ('other scope', 'tool.py')]:
+            path = repo / 'agents' / directory / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f'# unique {name}\n' * 30)
+    elif kind == 'unrelated_removed':
+        old = repo / 'unrelated'
+        old.mkdir()
+        (old / 'different.py').write_text('# unrelated retired project\n')
+    base = _commit_all(repo, 'base')
+    target = repo / scope
+    target.mkdir(parents=True)
+    if kind in {'rename', 'partial_rename', 'ambiguous_rename'}:
+        (repo / 'agents/old scope/agent.py').rename(target / 'agent.py')
+        if kind == 'ambiguous_rename':
+            (repo / 'agents/other scope/tool.py').rename(target / 'tool.py')
+        elif kind == 'partial_rename':
+            (target / 'new.py').write_text('# newly introduced entrypoint\n')
+    else:
+        (target / 'agent.py').write_text('# new project implementation\n')
+    if kind == 'unrelated_removed':
+        (repo / 'unrelated/different.py').unlink()
+    head = _commit_all(repo, 'head')
+    row = MinedRow(
+        repo='local/scope', pr_number=1, pr_url='local://1', title=kind,
+        merged_at='', base_sha=base, head_sha=head,
+    )
+    return repo, row, scope
+
+
+@pytest.mark.parametrize('kind', ['new', 'rename', 'partial_rename', 'ambiguous_rename', 'unrelated_removed'])
+def test_missing_scoped_base_keeps_original_git_input_obligation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kind: str,
+) -> None:
+    repo, row, scope = _scope_case(tmp_path, kind)
+    before = subprocess.check_output(['git', '-C', str(repo), 'status', '--porcelain'])
+    monkeypatch.setattr(evaluate, '_commit_manifest', lambda *a: pytest.fail('unsupported input committed'))
+    evaluate._verify_pr(
+        row, repo, tmp_path / 'base', repo, repo / scope / 'shipgate.yaml', tmp_path,
+        subdir=scope, manifest_injected=True,
+    )
+    obligation = row.verify_input_obligation
+    assert obligation is not None
+    assert obligation['kind'] == 'unsupported_input'
+    assert obligation['base_sha'] == row.base_sha
+    assert obligation['head_sha'] == row.head_sha
+    assert obligation['head_scope'] == scope
+    assert obligation['next_action'] == 'provide_supported_scoped_base_comparison'
+    if 'rename' in kind:
+        assert obligation['reason'] == 'scoped_base_rename_candidates'
+        pairs = obligation['observed_renames']
+        assert len(pairs) == (2 if kind == 'ambiguous_rename' else 1)
+        assert pairs[0]['base_path'] == 'agents/old scope/agent.py'
+        assert pairs[0]['head_path'] == scope + '/agent.py'
+        assert pairs[0]['git_status'] == 'R100'
+    else:
+        assert obligation['reason'] == 'scoped_base_absent'
+        assert obligation['observed_renames'] == []
+    assert row.verify_verdict == ''
+    assert row.verify_can_merge is None
+    assert row.verify_cap_added is None
+    assert not (repo / scope / 'shipgate.yaml').exists()
+    assert subprocess.check_output(['git', '-C', str(repo), 'status', '--porcelain']) == before
+
+
+def test_missing_base_scope_prevents_a_capability_export_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, row, scope = _scope_case(tmp_path, 'new')
+    monkeypatch.setattr(evaluate, '_capability_export', lambda *a: pytest.fail('unbound export'))
+    evaluate._capability_delta(
+        row, repo, tmp_path / 'base', repo, repo / scope / 'shipgate.yaml', tmp_path,
+        subdir=scope,
+    )
+    assert row.verify_input_obligation['reason'] == 'scoped_base_absent'
+    assert row.cap_added is None
+    assert row.cap_removed is None
+
+
+def test_unreadable_base_is_not_absence(tmp_path: Path) -> None:
+    repo, row, scope = _scope_case(tmp_path, 'new')
+    row.base_sha = 'f' * 40
+    obligation = evaluate._scoped_base_obligation(row, repo, scope)
+    assert obligation['reason'] == 'scoped_comparison_unreadable'
+    assert obligation['next_action'] == 'restore_readable_comparison_trees'
+
+
+def test_existing_scope_is_read_from_git_not_injected_files(tmp_path: Path) -> None:
+    repo, row, scope = _scope_case(tmp_path, 'new')
+    row.base_sha = row.head_sha
+    # The scope exists in Git even if its local materialization disappears.
+    (repo / scope / 'agent.py').unlink()
+    (repo / scope).rmdir()
+    assert evaluate._scoped_base_obligation(row, repo, scope) is None
+
+
+@pytest.mark.parametrize('output', ['R100\0old\0', 'A\0unterminated'])
+def test_incomplete_rename_observation_does_not_choose_a_base(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, output: str,
+) -> None:
+    repo, row, scope = _scope_case(tmp_path, 'new')
+    original = evaluate._git
+
+    def truncated(repo: Path, args: list[str], **kwargs: object):
+        if args[0] == 'diff':
+            return subprocess.CompletedProcess(args, 0, output, '')
+        return original(repo, args, **kwargs)
+
+    monkeypatch.setattr(evaluate, '_git', truncated)
+    obligation = evaluate._scoped_base_obligation(row, repo, scope)
+    assert obligation['reason'] == 'scoped_comparison_unreadable'
+    assert obligation['observed_renames'] == []
+
+
+def test_scope_obligation_round_trips_and_legacy_rows_keep_no_invented_obligation(tmp_path: Path) -> None:
+    repo, row, scope = _scope_case(tmp_path, 'rename')
+    row.verify_input_obligation = evaluate._scoped_base_obligation(row, repo, scope)
+    out = tmp_path / 'rows.jsonl'
+    write_jsonl([row], out)
+    assert read_jsonl(out)[0] == row
+    write_csv([row], tmp_path / 'rows.csv')
+    with (tmp_path / 'rows.csv').open() as handle:
+        recorded = next(csv.DictReader(handle))
+    assert json.loads(recorded['verify_input_obligation']) == row.verify_input_obligation
+    legacy = row.to_json()
+    legacy.pop('verify_input_obligation')
+    legacy['schema_version'] = '0.2'
+    out.write_text(json.dumps(legacy) + '\n')
+    assert read_jsonl(out)[0].verify_input_obligation is None
+    assert read_jsonl(out)[0].schema_version == '0.2'
+
+
+def test_real_pr_added_scoped_manifest_retains_terminal_trust_root_review(tmp_path: Path) -> None:
+    repo, row, scope = _scope_case(tmp_path, 'new', scope='agents/new-scope')
+    (repo / scope / 'mcp-tools.json').write_text('{"tools": []}\n')
+    manifest = repo / scope / 'shipgate.yaml'
+    manifest.write_text(
+        'version: "0.1"\n'
+        'project: {name: new-project}\n'
+        'agent: {name: new-agent, declared_purpose: [serve]}\n'
+        'environment: {target: production_like}\n'
+        'tool_sources: [{id: mcp, type: mcp, path: mcp-tools.json}]\n'
+    )
+    row.head_sha = _commit_all(repo, 'real PR adds scoped manifest')
+    base_wt = tmp_path / 'base'
+    # Capability comparison still has no evaluated base. The real manifest's
+    # terminal verifier route must remain available despite that limitation.
+    evaluate._capability_delta(row, repo, base_wt, repo, manifest, tmp_path, subdir=scope)
+    assert row.verify_input_obligation is not None
+    try:
+        evaluate._verify_pr(
+            row, repo, base_wt, repo, manifest, tmp_path,
+            subdir=scope, manifest_injected=False,
+        )
+        assert row.verify_verdict
+        assert row.verify_trust_root_touched is True
+        assert row.verify_can_merge is False
+        assert row.verify_input_obligation is None
+        assert row.cap_added is None
+        result = json.loads((tmp_path / 'verify-reports/verifier.json').read_text())
+        assert result['base_status'] == 'missing_manifest'
+    finally:
+        evaluate._worktree_remove(repo, base_wt)
+
+
+def test_a_file_at_the_old_scope_is_not_an_empty_directory(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / 'agent').write_text('previously a regular file')
+    base = _commit_all(repo, 'base file')
+    (repo / 'agent').unlink()
+    (repo / 'agent').mkdir()
+    (repo / 'agent/new.py').write_text('# new directory')
+    head = _commit_all(repo, 'head directory')
+    row = MinedRow(
+        repo='local/scope', pr_number=1, pr_url='local://1', title='file to directory',
+        merged_at='', base_sha=base, head_sha=head,
+    )
+    assert evaluate._scoped_base_obligation(row, repo, 'agent')['reason'] == 'scoped_base_not_directory'


### PR DESCRIPTION
When a historical PR creates or renames its selected agent directory, the miner now records a typed unsupported-input obligation from the original Git trees before injecting a manifest. It distinguishes absence, incoming file renames, non-directory inputs and unreadable comparisons, retaining the original SHAs and every observed rename pair.

The existing verifier cannot bind independent scoped base/head locations; #580 tracks that bounded engine gap. These rows provide neither a verifier verdict nor capability counts. Real PR-added manifests still reach the existing verifier and retain their trust-root review. Schema 0.3 adds the obligation to JSONL and as a JSON CSV cell; strict version-aware parity checks preserve the frozen 0.2 evidence.

## Validation

- 96 miner-related tests passed, including 13 scope regressions for additions, complete/partial/ambiguous renames, unrelated removals, unreadable trees, real PR manifests and serialization.
- Ruff, working-tree and committed verifier passed; fresh current control is complete.
- Replayed the unchanged W27 google/adk-samples #1975/#1977 refs from this committed source. They report `scoped_base_absent` and `scoped_base_rename_candidates` (four R100 file pairs), respectively. Both retain their head scan but no verifier answer; this does not satisfy #563's catch bars.
- Original historical artifacts, labels, thresholds and declarations are unchanged.
- One independent coding-agent GitHub review/address round completed with no actionable findings (review 5147004022; address comment 5591871198), anchored to 00c04e806d760184c0a2c5655515fefe0b6c7865.
- All nine applicable CI checks passed, including all three test shards and combined coverage; release-tag-consistency is correctly skipped on this PR.

The independently reproduced directory-with-spaces verifier crash is deferred in #581.

Fixes #564. Refs #563, #580, #581, #572.