### PR TITLE
Discovery: match the same-build integration surface enumeration

### DIFF
--- a/.well-known/agents-shipgate.json
+++ b/.well-known/agents-shipgate.json
@@ -328,6 +328,8 @@
     "preflight",
     "capability_lock",
     "capability_lock_diff",
+    "capability_payload",
+    "capability_delta_attestation",
     "capability_standard",
     "attestation",
     "registry",

--- a/docs/distribution-surfaces.md
+++ b/docs/distribution-surfaces.md
@@ -147,6 +147,13 @@ tag, which is the normal state between releases. A surface may name the source
 build only when it also says which channel that is; naming it as though it were
 published was the `rendered-prompt-unpublished-pin` gap, closed by #506.
 
+The main-tree `.well-known/agents-shipgate.json` integration enumeration is
+checked against `contract --json` from the same source build, including missing
+and unsupported entries. The site's discovery copy stays pinned to its released
+tag and is compared only with that tag's contract, never with unreleased main.
+An enumeration entry describes an existing integration format; it does not
+add a CLI command or confer release authority.
+
 Where a surface demonstrates a capability no published release carries, the
 honest output is neither an unresolvable pin nor silence: it is to say so. #506
 renders that sentence into the adoption prompts beside the pin, and the

--- a/tests/test_public_surface_contract.py
+++ b/tests/test_public_surface_contract.py
@@ -773,6 +773,25 @@ def test_the_prose_that_states_the_current_report_schema_states_the_current_one(
     )
 
 
+def test_discovery_integration_surfaces_match_the_same_build_runtime():
+    """Main-tree discovery names exactly what this source contract supports.
+
+    The site's released copy belongs to its tag; it is intentionally not an
+    input to this same-build comparison. Ordering is presentation, not a
+    second capability or compatibility promise.
+    """
+    published = json.loads(_read(".well-known/agents-shipgate.json"))
+    runtime = build_contract_payload().external_integration_surfaces
+    discovered = published["external_integration_surfaces"]
+    assert len(discovered) == len(set(discovered)), "duplicate discovery integration surfaces"
+    missing = sorted(set(runtime) - set(discovered))
+    unexpected = sorted(set(discovered) - set(runtime))
+    assert not missing and not unexpected, (
+        "same-build external_integration_surfaces drift: "
+        f"missing from discovery={missing}; not supported by runtime={unexpected}"
+    )
+
+
 def test_runtime_and_published_versions_propagate_to_metadata_surfaces():
     """Keep the in-tree runtime and latest published tag distinct.
 


### PR DESCRIPTION
The main-tree discovery document omitted `capability_payload` and `capability_delta_attestation` although the same build's runtime contract already supports them. Add those entries and require exact set parity with a named missing/unsupported-entry failure and duplicate guard.

The distribution guide explains the comparison boundary: source discovery is checked against its source build; the site's released copy belongs to its tag. Existing schemas, artifact paths, runtime capabilities and published Action pin remain unchanged.

## Validation

- 831 public-contract, distribution-parity and published-pin tests passed; Ruff passed.
- The new guard failed on the original document naming both omissions; a single-entry removal probe named `capability_payload` exactly.
- Both existing schema paths resolve and match runtime schema/version metadata; the attestation artifact path and published v0.15.0 Action pin agree.
- Working-tree and committed verifier passed; fresh current control is complete.
- One independent coding-agent GitHub review/address round completed with no actionable findings (review 5147091131; address comment 5591993097), anchored to 23eb877d90129078446d88db920097e9e26aa368.
- All nine applicable CI checks passed, including all three test shards and combined coverage; release-tag-consistency is correctly skipped on this PR.

Fixes #553. Refs #572.