### PR TITLE
Explain coverage recovery from typed SDK source evidence

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -15,6 +15,16 @@ for reproducible CI.
 
 ## Qualification coverage diagnostics (v6, #520)
 
+`EvidenceGap.recovery` is optional explanatory metadata (#561) on the existing
+open gap object. `kind` distinguishes `input_unavailable`, `reader_limitation`
+and `unresolved`; `reason` records the loader's typed evidence. Current SDK
+coverage and its limits are documented in [source recovery evidence](docs/qualification-coverage.md#source-recovery-evidence).
+An absent field remains absent when older rows are read. Report v0.43,
+packet v0.18, verifier v0.16 and qualification v6 retain their versions;
+decision-bearing action kinds, declaration authorship and control permissions
+are unchanged. This classification never supplies missing evidence or makes an
+actual IE count as a successful qualification outcome.
+
 `shipgate.safety_qualification` advances v5 → v6 to add `coverage_misses[]`
 and `intervals[].applicability` to the existing result. Both are required on
 v6; the reader checks their counts, cases and applicability against recorded

--- a/docs/packet-schema.v0.18.json
+++ b/docs/packet-schema.v0.18.json
@@ -508,6 +508,30 @@
       "title": "CapabilityTraceEvidenceSummary",
       "type": "object"
     },
+    "CoverageRecovery": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "input_unavailable",
+            "reader_limitation",
+            "unresolved"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "reason"
+      ],
+      "title": "CoverageRecovery",
+      "type": "object"
+    },
     "DeclarationQuestionCoverage": {
       "additionalProperties": false,
       "description": "v0.37: how much of the per-action declaration work is done.\n\nA gap count names a symptom and has no finish line. This is the same facts\nas a task with an end: how many questions this repository was ever asked,\nhow many a reviewed declaration has answered, and how many remain.\n\nThe denominator counts only what both halves can be measured on \u2014 the\n``effect`` and ``authority`` a reviewed declaration answers. An action\nwhose effect the scan established by itself was never asked about and is\nnot counted; an inventory or an ``agent_bindings`` declaration is a human\nanswer too but has no counterfactual to score against, so it is excluded\nrather than guessed at. See\n``agents_shipgate.core.declaration_questions``.\n\nv0.38: the unit is one blank a reviewer fills, so actions answered by the\nsame manifest block are one question. An authority every action of a source\nshares is answered once in that source's ``tool_sources[].authority``\nblock; ``open_questions[].answer_path`` names the block, and\n``subject_kind`` says which id space ``subject_id`` is in.\n\n``total == answered + open`` always. ``open_by_dimension`` sums to\n``open``: a question belongs to exactly one dimension.",
@@ -1227,6 +1251,17 @@
           ],
           "default": null,
           "title": "Policy Id"
+        },
+        "recovery": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoverageRecovery"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "source_ref": {
           "anyOf": [

--- a/docs/qualification-coverage.md
+++ b/docs/qualification-coverage.md
@@ -19,8 +19,36 @@ In `shipgate.safety_qualification/v6`, read `coverage_misses[]` by profile:
   report is reread to produce these diagnostics.
 - `gap_status: unclassified` means that report recorded no named gap rows.
   It remains a counted miss. `named_gaps` says that rows exist; it does not
-  prove their exhaustiveness or identify whether a missing input or a product
-  reader fix resolves the case. That distinction remains [#561](https://github.com/ThreeMoonsLab/agents-shipgate/issues/561).
+  prove their exhaustiveness. A row's optional `recovery` describes the
+  evidence for a missing input or reader limitation only where the loader
+  actually classified it; absence does not assign an owner.
+
+## Source recovery evidence
+
+The optional `evidence_gaps[].recovery` object is copied unchanged from the
+report. Read `kind` and `reason`, not warning prose or `authorable_by`:
+
+| `kind` | SDK evidence in this first supported slice | Next step |
+|---|---|---|
+| `input_unavailable` | Configured SDK entrypoint not found (`sdk_entrypoint_not_found`). The SDK loader currently reports this warning for either required or optional entries; the required-source execution-contract mismatch is tracked in #585. | Restore the existing file named by `next_action.path`; a declaration does not replace it. |
+| `reader_limitation` | Two literal lists of tool names joined by `+` (`sdk_literal_tool_list_concatenation_unsupported`). The binding reader has no branch for this static form. | Retain the source as a reproducer for an Agents Shipgate reader repair. This does not assert what the deployed agent can access. |
+| `unresolved` | An unresolved tools expression (`sdk_tools_expression_unresolved`), or distinct raw source warnings that collapse to one public identity (`ambiguous_warning_identity`). | Establish the missing input or reader limitation before assigning a repair owner. An ambiguous source gets no guessed path. |
+
+Other loaders and SDK warning shapes remain unclassified. A dynamic expression
+is not proof of a product defect. Facts are joined to their own raw source and
+warning before privacy redaction; ambiguity after redaction stays unresolved.
+`source_ref` preserves the observed file/line and `next_action.path` preserves
+the file to inspect. The CLI and report/packet source-warning sections show the
+same remedy. PR summaries retain up to three recovery explanations even when
+the full fix task exceeds the comment budget, and point to the complete report.
+
+This metadata is an additive field on the existing open `EvidenceGap` object,
+including its report v0.43, packet v0.18, verifier v0.16 and qualification v6
+projections. Older rows omit it on round-trip. It adds no verdict, threshold,
+declaration claim, or permission: `review_warning` and `authorable_by` retain
+their existing meaning, and an actual IE remains an exact-score miss.
+
+## Scoring and compatibility
 
 The six existing `intervals[]` metrics keep their numbers, Wilson intervals,
 requirements and `passed` booleans. Read `applicability` before presenting a
@@ -42,6 +70,7 @@ no coverage diagnostics or applicability field. Absence means **not recorded**,
 never zero. A v6 artifact must carry both fields; relabeling those fields as an
 older closed grammar is rejected. Corpus and receipt-index versions stay v4.
 
-This diagnostic slice does not issue signed qualification. The artifact
-read-consistency defect [#559](https://github.com/ThreeMoonsLab/agents-shipgate/issues/559)
-must be resolved before the final candidate scoring in #509.
+This diagnostic slice does not issue signed qualification. The same-byte
+qualification read repair was delivered in [#578](https://github.com/ThreeMoonsLab/agents-shipgate/pull/578).
+Final-wheel collection/scoring in #512 still precedes independent signing in
+#509; neither named recovery nor ordinary tests supply that evidence.

--- a/docs/report-schema.v0.43.json
+++ b/docs/report-schema.v0.43.json
@@ -3239,6 +3239,30 @@
       "title": "ContributionRule",
       "type": "object"
     },
+    "CoverageRecovery": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "input_unavailable",
+            "reader_limitation",
+            "unresolved"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "reason"
+      ],
+      "title": "CoverageRecovery",
+      "type": "object"
+    },
     "DeclarationQuestionCoverage": {
       "additionalProperties": false,
       "description": "v0.37: how much of the per-action declaration work is done.\n\nA gap count names a symptom and has no finish line. This is the same facts\nas a task with an end: how many questions this repository was ever asked,\nhow many a reviewed declaration has answered, and how many remain.\n\nThe denominator counts only what both halves can be measured on \u2014 the\n``effect`` and ``authority`` a reviewed declaration answers. An action\nwhose effect the scan established by itself was never asked about and is\nnot counted; an inventory or an ``agent_bindings`` declaration is a human\nanswer too but has no counterfactual to score against, so it is excluded\nrather than guessed at. See\n``agents_shipgate.core.declaration_questions``.\n\nv0.38: the unit is one blank a reviewer fills, so actions answered by the\nsame manifest block are one question. An authority every action of a source\nshares is answered once in that source's ``tool_sources[].authority``\nblock; ``open_questions[].answer_path`` names the block, and\n``subject_kind`` says which id space ``subject_id`` is in.\n\n``total == answered + open`` always. ``open_by_dimension`` sums to\n``open``: a question belongs to exactly one dimension.",
@@ -4085,6 +4109,17 @@
           ],
           "default": null,
           "title": "Policy Id"
+        },
+        "recovery": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoverageRecovery"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "source_ref": {
           "anyOf": [

--- a/docs/verifier-schema.v0.16.json
+++ b/docs/verifier-schema.v0.16.json
@@ -824,6 +824,30 @@
       "title": "ContributionRule",
       "type": "object"
     },
+    "CoverageRecovery": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "input_unavailable",
+            "reader_limitation",
+            "unresolved"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "reason"
+      ],
+      "title": "CoverageRecovery",
+      "type": "object"
+    },
     "DeclarationQuestionCoverage": {
       "additionalProperties": false,
       "description": "v0.37: how much of the per-action declaration work is done.\n\nA gap count names a symptom and has no finish line. This is the same facts\nas a task with an end: how many questions this repository was ever asked,\nhow many a reviewed declaration has answered, and how many remain.\n\nThe denominator counts only what both halves can be measured on \u2014 the\n``effect`` and ``authority`` a reviewed declaration answers. An action\nwhose effect the scan established by itself was never asked about and is\nnot counted; an inventory or an ``agent_bindings`` declaration is a human\nanswer too but has no counterfactual to score against, so it is excluded\nrather than guessed at. See\n``agents_shipgate.core.declaration_questions``.\n\nv0.38: the unit is one blank a reviewer fills, so actions answered by the\nsame manifest block are one question. An authority every action of a source\nshares is answered once in that source's ``tool_sources[].authority``\nblock; ``open_questions[].answer_path`` names the block, and\n``subject_kind`` says which id space ``subject_id`` is in.\n\n``total == answered + open`` always. ``open_by_dimension`` sums to\n``open``: a question belongs to exactly one dimension.",
@@ -1469,6 +1493,17 @@
           ],
           "default": null,
           "title": "Policy Id"
+        },
+        "recovery": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoverageRecovery"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "source_ref": {
           "anyOf": [

--- a/src/agents_shipgate/ci/release_decision.py
+++ b/src/agents_shipgate/ci/release_decision.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from collections import Counter, defaultdict
 from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
@@ -64,6 +65,7 @@ from agents_shipgate.schemas.bindings import (
     AgentBindingNode,
 )
 from agents_shipgate.schemas.common import Severity
+from agents_shipgate.schemas.coverage_recovery import CoverageRecovery, SourceRecoveryEvidence
 from agents_shipgate.schemas.report import (
     AGENT_AUTHORABLE_GAP_ACTION_KINDS,
     HUMAN_ONLY_GAP_KINDS,
@@ -170,6 +172,7 @@ def build_release_decision(
     fail_on: list[Severity] | None,
     new_findings_only: bool,
     tool_catalog: Sequence[Tool] | None = None,
+    source_recovery_evidence: Sequence[SourceRecoveryEvidence] | None = None,
 ) -> ReleaseDecision:
     """Compute the release decision.
 
@@ -347,7 +350,7 @@ def build_release_decision(
             *binding_gaps,
             *semantic_gaps,
             *report.policy_evidence_gaps,
-            *_evidence_gaps(report, tools),
+            *_evidence_gaps(report, tools, source_recovery_evidence=source_recovery_evidence),
         ],
         semantic_coverage=semantic_coverage,
         identity_coverage=identity_coverage,
@@ -2451,7 +2454,12 @@ def _surface_gap_note(tool: Tool) -> str:
     return f" Unresolved: {', '.join(reasons)}."
 
 
-def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceGap]:
+def _evidence_gaps(
+    report: ReadinessReport,
+    tools: list[Tool],
+    *,
+    source_recovery_evidence: Sequence[SourceRecoveryEvidence] | None = None,
+) -> list[EvidenceGap]:
     """v0.26: one actionable row per measurable evidence gap.
 
     Deterministic projection of the same inputs the counts use:
@@ -2584,6 +2592,10 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
                 ),
             )
         )
+    warning_counts = Counter(report.source_warnings)
+    recovery_by_warning: dict[str, list[SourceRecoveryEvidence]] = defaultdict(list)
+    for fact in source_recovery_evidence or ():
+        recovery_by_warning[fact.warning].append(fact)
     for warning in report.source_warnings:
         if (
             "predates report schema" in warning
@@ -2617,15 +2629,65 @@ def _evidence_gaps(report: ReadinessReport, tools: list[Tool]) -> list[EvidenceG
                     "stops warning, then rerun the scan."
                 ),
             )
-        gaps.append(
-            EvidenceGap(
-                kind="source_warning",
-                subject=warning,
-                why="A source loader degraded while reading declared inputs.",
-                next_action=action,
-            )
+        gap = EvidenceGap(
+            kind="source_warning",
+            subject=warning,
+            why="A source loader degraded while reading declared inputs.",
+            next_action=action,
         )
+        gaps.append(_with_source_recovery(
+            gap,
+            recovery_by_warning.get(warning, []),
+            warning_is_unique=warning_counts[warning] == 1,
+        ))
     return gaps
+
+
+def _with_source_recovery(
+    gap: EvidenceGap,
+    facts: list[SourceRecoveryEvidence],
+    *,
+    warning_is_unique: bool,
+) -> EvidenceGap:
+    """Explain a loader fact without changing any decision-bearing action kind.
+
+    `provide_source` is itself an IE threshold input. The existing action kind
+    and declaration permissions therefore stay exactly as they were; recovery
+    is an independent optional explanation, not another operational route.
+    """
+    if not facts:
+        return gap
+    if (
+        len(facts) != 1
+        or not warning_is_unique
+        or facts[0].recovery.reason == "ambiguous_warning_identity"
+    ):
+        return gap.model_copy(update={
+            "recovery": CoverageRecovery(kind="unresolved", reason="ambiguous_warning_identity"),
+            "next_action": gap.next_action.model_copy(update={
+                "path": None,
+                "why": "More than one input corresponds to this public warning.",
+                "expects": "Review the original inputs to identify the failing source before assigning a repair owner.",
+            }),
+        })
+    fact = facts[0]
+    if fact.recovery.kind == "input_unavailable":
+        why = "The configured OpenAI Agents SDK entrypoint was not found."
+        expects = "Restore the existing entrypoint, then rerun the scan. No declaration replaces the missing file."
+    elif fact.recovery.kind == "reader_limitation":
+        why = "The OpenAI Agents SDK binding reader does not support this literal tool-list concatenation."
+        expects = "Agents Shipgate needs a reader repair for literal tool-list concatenation; retain the source as a reproducer and rerun after the reader supports it."
+    else:
+        why = "The SDK tools expression could not be resolved; the evidence does not establish a repair owner."
+        expects = "Review the tools expression and establish its required static input or reader limitation before choosing a remedy."
+    return gap.model_copy(update={
+        "source_type": fact.source_type,
+        "source_ref": fact.source_ref,
+        "recovery": fact.recovery,
+        "next_action": gap.next_action.model_copy(update={
+            "path": fact.path, "why": why, "expects": expects,
+        }),
+    })
 
 
 # Symbols quoted in a gap's reason before it stops being a sentence.

--- a/src/agents_shipgate/cli/_helpers.py
+++ b/src/agents_shipgate/cli/_helpers.py
@@ -554,7 +554,9 @@ def _print_cli_summary(
     # Grouped by mechanism: six warnings that differ only in the symbol they
     # name are one thing to fix. The raw count is what gates, so both numbers
     # are printed and report.json keeps every warning (#362).
-    warning_groups = group_source_warnings(report.source_warnings)
+    evidence_gaps = report.release_decision.evidence_coverage.evidence_gaps if report.release_decision else ()
+    recoveries = {gap.subject for gap in evidence_gaps if gap.recovery is not None}
+    warning_groups = group_source_warnings(report.source_warnings, evidence_gaps=evidence_gaps)
     if verbose:
         typer.echo(f"Tool count: {report.tool_surface.total_tools}")
         distinct = ""
@@ -578,10 +580,12 @@ def _print_cli_summary(
     typer.echo("Reports:")
     for path in report.generated_reports.values():
         typer.echo(f"- {path}")
-    if verbose and report.source_warnings:
+    if report.source_warnings and (verbose or recoveries):
         typer.echo("")
         typer.echo("Source warnings:")
         for group in warning_groups:
+            if not verbose and not recoveries.intersection(group.warnings):
+                continue
             suffix = f" ({group.count} warnings)" if group.count > 1 else ""
             typer.echo(f"- {group.message}{suffix}")
     typer.echo("")

--- a/src/agents_shipgate/cli/scan/final_report.py
+++ b/src/agents_shipgate/cli/scan/final_report.py
@@ -107,6 +107,7 @@ def _build_final_report(
         heuristics_filter=sanitized.heuristics_filter,
         policy_evidence_gaps=sanitized.policy_evidence_gaps,
         source_omissions=sanitized.source_omissions,
+        source_recovery_evidence=sanitized.source_recovery_evidence,
     )
     if report.release_decision is not None:
         reference_facts = (

--- a/src/agents_shipgate/cli/scan/models.py
+++ b/src/agents_shipgate/cli/scan/models.py
@@ -210,3 +210,4 @@ class _SanitizedSurfaces:
     # load order. Carried separately from ``source_warnings`` because only
     # these are proven omissions — see ``core.surface_exclusions``.
     source_omissions: list[Any]
+    source_recovery_evidence: list[Any]

--- a/src/agents_shipgate/cli/scan/sanitization.py
+++ b/src/agents_shipgate/cli/scan/sanitization.py
@@ -15,7 +15,7 @@ from agents_shipgate.core.baseline import (
     baseline_resolved_fingerprints,
     verify_baseline,
 )
-from agents_shipgate.core.domain import Agent, SourceSurfaceOmission
+from agents_shipgate.core.domain import Agent, LoadedToolSource, SourceSurfaceOmission
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.findings.identity import assign_finding_ids
 from agents_shipgate.core.findings.remediation import annotate_remediation
@@ -37,6 +37,7 @@ from agents_shipgate.core.lenses.tool_surface import (
     enrich_tool_surface_diff_with_source,
 )
 from agents_shipgate.core.privacy import (
+    RedactionStats,
     build_privacy_audit,
     redact_data,
     sanitize_findings,
@@ -44,6 +45,7 @@ from agents_shipgate.core.privacy import (
     sanitize_tools,
 )
 from agents_shipgate.schemas.bindings import AgentBindingGraphAssessment, BindingSurfaceDiff
+from agents_shipgate.schemas.coverage_recovery import CoverageRecovery, SourceRecoveryEvidence
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
 from agents_shipgate.schemas.report import (
     BaselineSummary,
@@ -399,6 +401,7 @@ def _sanitize_for_output(
         toolkit_bounds=decision.context.toolkit_bounds,
         remote_bindings=decision.context.remote_bindings,
     )
+    source_recovery_evidence = _sanitize_source_recovery_evidence(inputs.loaded_sources, privacy_stats)
     privacy_audit = build_privacy_audit(
         privacy_stats,
         output_surfaces=plan.output_surfaces,
@@ -475,7 +478,46 @@ def _sanitize_for_output(
             for loaded in inputs.loaded_sources
             for omission in loaded.omissions
         ],
+        source_recovery_evidence=source_recovery_evidence,
     )
+
+
+def _sanitize_source_recovery_evidence(
+    loaded_sources: list[LoadedToolSource], privacy_stats: RedactionStats,
+) -> list[SourceRecoveryEvidence]:
+    """Join within the original source, then detect public identity collisions.
+
+    Even a warning without a typed repair owns its origin. Redacting it to the
+    same text as a classified warning must not borrow that warning's owner.
+    """
+    public_origins: dict[str, set[tuple[int, str]]] = {}
+    for index, loaded in enumerate(loaded_sources):
+        for warning in loaded.warnings:
+            public = redact_data(warning)
+            public_origins.setdefault(public, set()).add((index, warning))
+    facts = []
+    for loaded in loaded_sources:
+        for fact in loaded.recovery_evidence:
+            if (
+                fact.warning not in loaded.warnings
+                or fact.source_id != loaded.source_id
+                or fact.source_type != loaded.source_type
+            ):
+                # A record that does not name its own source/warning proves
+                # no association. It cannot classify somebody else's gap.
+                continue
+            public = sanitize_model(
+                fact, SourceRecoveryEvidence, stats=privacy_stats,
+                path="source_recovery_evidence[]",
+            )
+            if len(public_origins.get(public.warning, ())) != 1:
+                public = public.model_copy(update={
+                    "recovery": CoverageRecovery(
+                        kind="unresolved", reason="ambiguous_warning_identity"
+                    ),
+                })
+            facts.append(public)
+    return facts
 
 
 def _indeterminate_override_positions(

--- a/src/agents_shipgate/cli/verify/fix_task.py
+++ b/src/agents_shipgate/cli/verify/fix_task.py
@@ -891,7 +891,8 @@ def _insufficient_evidence_remedies(report: ReadinessReport) -> list[str]:
     # render as visibly distinct lines while saying the same thing.
     seen_skeletons: set[str] = set()
     for group in sorted(
-        group_source_warnings(remaining), key=lambda row: row.unprintable
+        group_source_warnings(remaining, evidence_gaps=decision.evidence_coverage.evidence_gaps),
+        key=lambda row: row.unprintable,
     ):
         if group.skeleton in seen_skeletons:
             continue

--- a/src/agents_shipgate/core/domain.py
+++ b/src/agents_shipgate/core/domain.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.schemas.common import Confidence, ProvenanceKind, parse_confidence
+from agents_shipgate.schemas.coverage_recovery import SourceRecoveryEvidence
 from agents_shipgate.schemas.surfaces import ActionEffect
 
 SemanticDimension = Literal["identity", "binding", "effect", "authority"]
@@ -719,6 +720,10 @@ class LoadedToolSource(BaseModel):
     configured_source_id: str | None = None
     tools: list[Tool] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
+    # Explanatory loader evidence, separate from actual surface omissions.
+    recovery_evidence: list[SourceRecoveryEvidence] = Field(
+        default_factory=list, exclude_if=lambda value: not value
+    )
     # Entries this source dropped. Empty for every adapter that has not been
     # taught to record them, which is why the exclusion ledger reports what it
     # can prove rather than guessing from `warnings`.

--- a/src/agents_shipgate/core/findings/report_builder.py
+++ b/src/agents_shipgate/core/findings/report_builder.py
@@ -6,6 +6,7 @@ from agents_shipgate.core.surface_exclusions import build_surface_exclusions
 from agents_shipgate.schemas.bindings import AgentBindingGraphAssessment, BindingSurfaceDiff
 from agents_shipgate.schemas.codex_plugin import CodexPluginSurface
 from agents_shipgate.schemas.common import Severity
+from agents_shipgate.schemas.coverage_recovery import SourceRecoveryEvidence
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
 from agents_shipgate.schemas.report import (
     BaselineSummary,
@@ -72,6 +73,7 @@ def build_report(
     heuristics_filter: HeuristicsFilter | None = None,
     policy_evidence_gaps: list[EvidenceGap] | None = None,
     source_omissions: list[SourceSurfaceOmission] | None = None,
+    source_recovery_evidence: list[SourceRecoveryEvidence] | None = None,
 ) -> ReadinessReport:
     report = ReadinessReport(
         run_id=run_id,
@@ -128,6 +130,7 @@ def build_report(
         ci_mode=ci_mode,
         fail_on=fail_on,
         new_findings_only=new_findings_only,
+        source_recovery_evidence=source_recovery_evidence,
     )
     # v0.35: built from the decision, not beside it. Accounting asks whether
     # a gap row names the excluded subject, so the gaps have to exist first —

--- a/src/agents_shipgate/core/source_warnings.py
+++ b/src/agents_shipgate/core/source_warnings.py
@@ -54,14 +54,19 @@ from __future__ import annotations
 import ast
 import hashlib
 from collections.abc import Callable, Collection, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING
 
 from agents_shipgate.core.evidence_actions import (
     _ESCAPE_PATTERN,
     _WHITESPACE_RUN,
+    display_literal,
     has_visible_content,
     one_line,
 )
+
+if TYPE_CHECKING:
+    from agents_shipgate.schemas.report import EvidenceGap
 
 
 # A warning made only of controls and invisible code points renders as
@@ -368,7 +373,9 @@ class SourceWarningGroup:
         return visible_skeleton(self.message)
 
 
-def group_source_warnings(warnings: Sequence[str]) -> list[SourceWarningGroup]:
+def group_source_warnings(
+    warnings: Sequence[str], *, evidence_gaps: Sequence[EvidenceGap] = (),
+) -> list[SourceWarningGroup]:
     """Fold the rows of a known mechanism; leave everything else alone.
 
     Order is stable: groups appear in first-warning order, and subjects
@@ -427,7 +434,23 @@ def group_source_warnings(warnings: Sequence[str]) -> list[SourceWarningGroup]:
                 warnings=raw,
             )
         )
-    return groups
+    # Recovery is already a typed, source-joined loader fact. Never infer it
+    # from the prose decoder above or from declaration authorship. Attach it
+    # to the existing warning line; counts and raw warning bytes stay intact.
+    remedies: dict[str, list[str]] = {}
+    for gap in evidence_gaps:
+        if gap.kind == "source_warning" and gap.recovery is not None:
+            remedy = one_line(gap.next_action.expects)
+            if gap.source_ref:
+                remedy += f" Source: {display_literal(gap.source_ref)}."
+            remedies.setdefault(gap.subject, []).append(remedy)
+    return [
+        replace(group, message=" ".join([
+            group.message,
+            *dict.fromkeys(text for warning in group.warnings for text in remedies.get(warning, ())),
+        ]))
+        for group in groups
+    ]
 
 
 @dataclass(frozen=True)

--- a/src/agents_shipgate/inputs/openai_sdk_static.py
+++ b/src/agents_shipgate/inputs/openai_sdk_static.py
@@ -24,6 +24,7 @@ from agents_shipgate.inputs.python_static import (
     function_signature,
     parse_python_file,
 )
+from agents_shipgate.schemas.coverage_recovery import CoverageRecovery, SourceRecoveryEvidence
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
     ToolSourceConfig,
@@ -46,10 +47,17 @@ def load_openai_sdk_static_tools(
         )
     path = resolve_input_path(base_dir, entrypoint)
     if not path.exists():
+        warning = f"OpenAI Agents SDK entrypoint not found: {path}"
+        ref = display_path(path, base_dir)
         return LoadedToolSource(
             source_id=source.id,
             source_type="openai_agents_sdk",
-            warnings=[f"OpenAI Agents SDK entrypoint not found: {path}"],
+            warnings=[warning],
+            recovery_evidence=[SourceRecoveryEvidence(
+                warning=warning, source_id=source.id, source_type="openai_agents_sdk",
+                source_ref=ref, path=ref,
+                recovery=CoverageRecovery(kind="input_unavailable", reason="sdk_entrypoint_not_found"),
+            )],
         )
     if path.is_dir():
         python_files = sorted(path.glob("*.py"))
@@ -68,7 +76,7 @@ def load_openai_sdk_static_tools(
         raise InputParseError(
             f"OpenAI Agents SDK source must be a Python file or directory: {path}"
         )
-    binding_warnings, binding_observations = _extract_agent_bindings(
+    binding_warnings, binding_observations, recovery_evidence = _extract_agent_bindings(
         tools, python_files, source, base_dir
     )
     return LoadedToolSource(
@@ -78,6 +86,7 @@ def load_openai_sdk_static_tools(
         toolkit_bounds=toolkit_bounds,
         binding_observations=binding_observations,
         warnings=[*_toolkit_binding_warnings(toolkit_bounds), *binding_warnings],
+        recovery_evidence=recovery_evidence,
     )
 
 
@@ -134,7 +143,7 @@ def _extract_agent_bindings(
     paths: list[Path],
     source: ToolSourceConfig,
     base_dir: Path,
-) -> tuple[list[str], list[AgentBindingObservation]]:
+) -> tuple[list[str], list[AgentBindingObservation], list[SourceRecoveryEvidence]]:
     """Extract exact, local-only ``Agent(..., tools=[...])`` wiring.
 
     This intentionally resolves only literal lists, names bound to literal
@@ -144,6 +153,7 @@ def _extract_agent_bindings(
 
     warnings: list[str] = []
     observations: list[AgentBindingObservation] = []
+    recovery_evidence: list[SourceRecoveryEvidence] = []
     tool_by_name = {tool.name: tool for tool in tools}
     tool_by_name.update(
         {
@@ -185,6 +195,18 @@ def _extract_agent_bindings(
                 )
                 warnings.append(reason)
                 issues.append(reason)
+                literal_concat = _literal_tool_list_concatenation(tools_expr)
+                recovery_evidence.append(SourceRecoveryEvidence(
+                    warning=reason, source_id=source.id, source_type="openai_agents_sdk",
+                    source_ref=pointer, path=source_ref,
+                    recovery=CoverageRecovery(
+                        kind="reader_limitation" if literal_concat else "unresolved",
+                        reason=(
+                            "sdk_literal_tool_list_concatenation_unsupported" if literal_concat
+                            else "sdk_tools_expression_unresolved"
+                        ),
+                    ),
+                ))
                 tools_complete = False
                 names = []
             else:
@@ -224,7 +246,23 @@ def _extract_agent_bindings(
                     issues=issues,
                 )
             )
-    return list(dict.fromkeys(warnings)), observations
+    return list(dict.fromkeys(warnings)), observations, recovery_evidence
+
+
+def _literal_tool_list_concatenation(value: ast.AST | None) -> bool:
+    """One proven reader limitation, never a claim about deployed wiring.
+
+    Python defines addition of two literal lists, but this reader's name-list
+    resolver has no BinOp branch. Calls, unpacking and other expressions do
+    not prove a product-owned repair and deliberately remain unresolved.
+    """
+    return (
+        isinstance(value, ast.BinOp)
+        and isinstance(value.op, ast.Add)
+        and isinstance(value.left, ast.List)
+        and isinstance(value.right, ast.List)
+        and all(isinstance(item, ast.Name) for item in [*value.left.elts, *value.right.elts])
+    )
 
 
 def _assignment_target(node: ast.Assign | ast.AnnAssign) -> str | None:

--- a/src/agents_shipgate/packet/html.py
+++ b/src/agents_shipgate/packet/html.py
@@ -15,6 +15,7 @@ HTML directly to produce ``packet.pdf``.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from html import escape
 from pathlib import Path
 
@@ -52,7 +53,7 @@ from agents_shipgate.schemas.packet import (
     ToolSurfaceDiffSection,
     VerdictLabel,
 )
-from agents_shipgate.schemas.report import ReleaseDecisionItem
+from agents_shipgate.schemas.report import EvidenceGap, ReleaseDecisionItem
 
 _VERDICT_CLASS: dict[VerdictLabel, str] = {
     "PASSED": "verdict verdict-passed",
@@ -147,7 +148,7 @@ def render_packet_html(
     parts.append(_render_memory_isolation(packet.memory_isolation))
     parts.append(_render_human_in_the_loop(packet.human_in_the_loop))
     parts.append(_render_dynamic_scenarios(packet.dynamic_scenarios))
-    parts.append(_render_not_proven(packet.not_proven))
+    parts.append(_render_not_proven(packet.not_proven, packet.release_decision.evidence_coverage.evidence_gaps))
     parts.append("</body></html>\n")
     return "".join(parts)
 
@@ -730,7 +731,7 @@ def _render_dynamic_scenarios(section: DynamicScenariosSection) -> str:
     return "".join(parts)
 
 
-def _render_not_proven(section: NotProvenSection) -> str:
+def _render_not_proven(section: NotProvenSection, evidence_gaps: Sequence[EvidenceGap] = ()) -> str:
     parts = ["<h2>§10 What this packet did NOT prove</h2>"]
     parts.append(f"<p>{escape(section.headline)}</p>")
     parts.append("<ul>")
@@ -742,7 +743,7 @@ def _render_not_proven(section: NotProvenSection) -> str:
         # Grouped by mechanism for the reader; packet.json keeps the raw list
         # so the count that gates stays intact (#362).
         parts.append("<li>Source warnings:<ul>")
-        for group in group_source_warnings(section.source_warnings):
+        for group in group_source_warnings(section.source_warnings, evidence_gaps=evidence_gaps):
             suffix = f" ({group.count} warnings)" if group.count > 1 else ""
             parts.append(f"<li>{escape(group.message)}{suffix}</li>")
         parts.append("</ul></li>")

--- a/src/agents_shipgate/packet/markdown.py
+++ b/src/agents_shipgate/packet/markdown.py
@@ -14,6 +14,7 @@ reviewer-facing artifact.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 from agents_shipgate.core.findings.subject_rollup import top_findings_block
@@ -46,7 +47,7 @@ from agents_shipgate.schemas.packet import (
     SectionStatus,
     ToolSurfaceDiffSection,
 )
-from agents_shipgate.schemas.report import ReleaseDecisionItem
+from agents_shipgate.schemas.report import EvidenceGap, ReleaseDecisionItem
 
 
 def _escape(value: object) -> str:
@@ -156,7 +157,7 @@ def render_packet_markdown(
     _append_memory_isolation(lines, packet.memory_isolation)
     _append_human_in_the_loop(lines, packet.human_in_the_loop)
     _append_dynamic_scenarios(lines, packet.dynamic_scenarios)
-    _append_not_proven(lines, packet.not_proven)
+    _append_not_proven(lines, packet.not_proven, packet.release_decision.evidence_coverage.evidence_gaps)
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -719,7 +720,9 @@ def _append_dynamic_scenarios(lines: list[str], section: DynamicScenariosSection
         lines.append("")
 
 
-def _append_not_proven(lines: list[str], section: NotProvenSection) -> None:
+def _append_not_proven(
+    lines: list[str], section: NotProvenSection, evidence_gaps: Sequence[EvidenceGap] = (),
+) -> None:
     lines.append("## §10 What this packet did NOT prove")
     lines.append("")
     lines.append(_escape(section.headline))
@@ -733,7 +736,7 @@ def _append_not_proven(lines: list[str], section: NotProvenSection) -> None:
         # Grouped by mechanism for the reader; packet.json keeps the raw list
         # so the count that gates stays intact (#362).
         lines.append("- Source warnings:")
-        for group in group_source_warnings(section.source_warnings):
+        for group in group_source_warnings(section.source_warnings, evidence_gaps=evidence_gaps):
             suffix = f" ({group.count} warnings)" if group.count > 1 else ""
             lines.append(f"  - {_escape(group.message)}{suffix}")
     else:

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -668,7 +668,10 @@ def _append_source_warnings(lines: list[str], report: ReadinessReport) -> None:
     # Grouped by mechanism: six warnings that differ only in the symbol they
     # name are one thing to fix, and listing them six times buries it. The
     # JSON keeps every warning — the count gates (#362).
-    groups = group_source_warnings(report.source_warnings)
+    groups = group_source_warnings(
+        report.source_warnings,
+        evidence_gaps=report.release_decision.evidence_coverage.evidence_gaps if report.release_decision else (),
+    )
     lines.extend(["## Source Warnings", ""])
     for group in groups:
         suffix = f" ({group.count} warnings)" if group.count > 1 else ""

--- a/src/agents_shipgate/report/pr_comment.py
+++ b/src/agents_shipgate/report/pr_comment.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 from agents_shipgate.core.declaration_questions import progress_sentence
 from agents_shipgate.core.disclaimers import STATIC_VERDICT_DISCLAIMER
+from agents_shipgate.core.evidence_actions import display_literal
 from agents_shipgate.core.findings.subject_rollup import (
     roll_up_findings,
     top_findings_block,
@@ -206,6 +207,7 @@ def _human_summary_lines(
     assert review is not None
     lines.append(f"- Release gate: `{decision.decision}`")
     lines.append(f"- Reason: {_bounded_prose(decision.reason)}")
+    lines.extend(_coverage_recovery_lines(report))
     if not surface_first:
         lines.extend(capability_lines)
     if capability_lock_diff is not None:
@@ -254,6 +256,31 @@ def _human_summary_lines(
             lines.extend(_policy_change_lines(review))
     lines.extend(_trigger_and_base_summary(verifier))
     lines.extend(_artifact_summary_lines(verifier))
+    return lines
+
+
+def _coverage_recovery_lines(report: ReadinessReport | None) -> list[str]:
+    """Keep typed source remedies visible when the bulky fix task is omitted.
+
+    The existing comment budget can replace fix_task with an artifact pointer.
+    A reader should still see why the source needs input or a reader repair.
+    This is bounded explanatory prose; the preserved control block is authority.
+    """
+    if report is None or report.release_decision is None:
+        return []
+    gaps = [
+        gap for gap in report.release_decision.evidence_coverage.evidence_gaps
+        if gap.kind == "source_warning" and gap.recovery is not None
+    ]
+    lines = []
+    for gap in gaps[:3]:
+        location = (
+            f" Source: {_bounded_identity_code(display_literal(gap.source_ref))}."
+            if gap.source_ref else ""
+        )
+        lines.append(f"- Source recovery: {_bounded_prose(gap.next_action.expects)}{location}")
+    if len(gaps) > 3:
+        lines.append(f"- {len(gaps) - 3} more source recoveries; see report.json evidence gaps.")
     return lines
 
 
@@ -631,6 +658,7 @@ def _render_findings_comment(
             include_release_gate=report is None or not surface_first,
         )
     )
+    lines.extend(_coverage_recovery_lines(report))
     if not surface_first:
         # Keep the exact grouped disclosure ahead of repository-controlled
         # prose. The final row-aware bound may omit later context, but it must

--- a/src/agents_shipgate/schemas/coverage_recovery.py
+++ b/src/agents_shipgate/schemas/coverage_recovery.py
@@ -1,0 +1,35 @@
+"""Optional explanations of who can resolve a measured coverage gap.
+
+These facts neither authorize an edit nor change a release decision. Absence
+means the loader did not classify recovery; dynamic evidence can remain
+explicitly unresolved even when its source location is known.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CoverageRecovery(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["input_unavailable", "reader_limitation", "unresolved"]
+    reason: str
+
+
+class SourceRecoveryEvidence(BaseModel):
+    """A loader's typed observation, joined through its exact warning token.
+
+    The warning is an opaque association token, never parsed for ownership.
+    Source identity is retained before sanitization so two explanations that
+    collapse to the same public warning cannot silently pick a repair owner.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    warning: str
+    source_id: str
+    source_type: str
+    source_ref: str
+    path: str
+    recovery: CoverageRecovery

--- a/src/agents_shipgate/schemas/report.py
+++ b/src/agents_shipgate/schemas/report.py
@@ -32,6 +32,7 @@ from agents_shipgate.schemas.common import (
     Severity,
     SourceReference,
 )
+from agents_shipgate.schemas.coverage_recovery import CoverageRecovery
 from agents_shipgate.schemas.disclaimers import STATIC_VERDICT_DISCLAIMER
 from agents_shipgate.schemas.exclusions import SurfaceExclusionLedger
 from agents_shipgate.schemas.patches import (
@@ -727,6 +728,11 @@ class EvidenceGap(BaseModel):
     policy_id: str | None = Field(default=None, exclude_if=lambda value: value is None)
     why: str
     next_action: EvidenceGapAction
+    # Optional, non-gating explanation from typed loader evidence (#561).
+    # Old reports omit it, meaning unclassified rather than a known owner.
+    recovery: CoverageRecovery | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
     @model_validator(mode="after")
     def _a_human_only_question_is_never_drafted(self) -> EvidenceGap:

--- a/tests/test_coverage_recovery.py
+++ b/tests/test_coverage_recovery.py
@@ -1,0 +1,314 @@
+"""#561: parser facts identify a recovery, never a new verdict or authority."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.ci.release_decision import _evidence_gaps, evidence_below_ie_threshold
+from agents_shipgate.cli._helpers import _print_cli_summary
+from agents_shipgate.cli.main import app
+from agents_shipgate.cli.scan import inputs, run_scan
+from agents_shipgate.cli.scan.sanitization import _sanitize_source_recovery_evidence
+from agents_shipgate.cli.verify.fix_task import _insufficient_evidence_remedies, build_fix_task
+from agents_shipgate.core.domain import LoadedToolSource
+from agents_shipgate.core.privacy import RedactionStats, redact_data
+from agents_shipgate.packet.builder import build_packet_from_report
+from agents_shipgate.packet.html import render_packet_html
+from agents_shipgate.packet.markdown import render_packet_markdown
+from agents_shipgate.report.markdown import render_markdown_report
+from agents_shipgate.report.pr_comment import render_pr_comment
+from agents_shipgate.schemas.coverage_recovery import CoverageRecovery, SourceRecoveryEvidence
+from agents_shipgate.schemas.report import EvidenceGap
+from agents_shipgate.schemas.verifier import VerifierCapabilityReview
+
+ROOT = Path(__file__).resolve().parents[1]
+CASES = [
+    (None, "input_unavailable", "sdk_entrypoint_not_found", "Restore the existing entrypoint"),
+    (
+        "[read_tool] + [other_tool]", "reader_limitation",
+        "sdk_literal_tool_list_concatenation_unsupported", "needs a reader repair",
+    ),
+    (
+        "get_tools()", "unresolved", "sdk_tools_expression_unresolved",
+        "before choosing a remedy",
+    ),
+]
+
+
+def _project(project: Path, expression: str | None) -> Path:
+    project.mkdir(exist_ok=True)
+    (project / "shipgate.yaml").write_text(
+        "version: '0.1'\n"
+        "project: {name: recovery}\n"
+        "agent: {name: recovery, declared_purpose: [read local data]}\n"
+        "environment: {target: local}\n"
+        "tool_sources:\n"
+        "  - {id: sdk, type: openai_agents_sdk, path: agent.py, optional: true}\n",
+        encoding="utf-8",
+    )
+    if expression is not None:
+        (project / "agent.py").write_text(
+            "from agents import Agent, function_tool\n"
+            "@function_tool\n"
+            "def read_tool() -> str:\n"
+            '    return "a"\n'
+            "@function_tool\n"
+            "def other_tool() -> str:\n"
+            '    return "b"\n'
+            f'agent = Agent(name="recovery", tools={expression})\n',
+            encoding="utf-8",
+        )
+    return project
+
+
+def _scan(project: Path, output: Path):
+    report, _ = run_scan(
+        config_path=project / "shipgate.yaml", output_dir=output,
+        formats=["json"], ci_mode="advisory", packet_enabled=False,
+    )
+    return report
+
+
+def _without_recovery(monkeypatch):
+    load_sources = inputs._load_sources
+
+    def unclassified(*args, **kwargs):
+        sources, artifacts = load_sources(*args, **kwargs)
+        return [s.model_copy(update={"recovery_evidence": []}) for s in sources], artifacts
+
+    monkeypatch.setattr(inputs, "_load_sources", unclassified)
+
+
+@pytest.mark.parametrize("expression,kind,reason,remedy", CASES)
+def test_real_loader_recovery_preserves_decision_and_declaration_authorship(
+    tmp_path, monkeypatch, expression, kind, reason, remedy,
+):
+    project = _project(tmp_path / "project", expression)
+    report = _scan(project, tmp_path / "reports")
+    gaps = report.release_decision.evidence_coverage.evidence_gaps
+    gap = next(g for g in gaps if g.recovery is not None)
+    assert gap.recovery == CoverageRecovery(kind=kind, reason=reason)
+    assert gap.source_type == "openai_agents_sdk"
+    assert gap.source_ref == ("agent.py:8" if expression else "agent.py")
+    assert gap.next_action.path == "agent.py"
+    assert remedy in gap.next_action.expects
+    assert gap.next_action.kind == "review_warning"
+    assert gap.next_action.authorable_by == "human"
+    assert gap.next_action.command is None
+    assert gap.next_action.declaration_template is None
+
+    _without_recovery(monkeypatch)
+    original = _scan(project, tmp_path / "original")
+    before = original.release_decision
+    after = report.release_decision
+    assert after.decision == before.decision == "insufficient_evidence"
+    assert report.findings == original.findings
+    assert report.source_warnings == original.source_warnings
+    assert evidence_below_ie_threshold(after.evidence_coverage, tool_count=report.tool_surface.total_tools) == evidence_below_ie_threshold(
+        before.evidence_coverage, tool_count=original.tool_surface.total_tools,
+    )
+    assert after.evidence_coverage.model_dump(exclude={"evidence_gaps"}) == (
+        before.evidence_coverage.model_dump(exclude={"evidence_gaps"})
+    )
+    old_gaps = before.evidence_coverage.evidence_gaps
+    assert len(gaps) == len(old_gaps)
+    for new, old in zip(gaps, old_gaps, strict=True):
+        assert (new.kind, new.subject) == (old.kind, old.subject)
+        # Only the explanation/location is enriched; all operational and
+        # declaration fields remain the exact preceding values.
+        assert new.next_action.model_dump(exclude={"path", "why", "expects"}) == (
+            old.next_action.model_dump(exclude={"path", "why", "expects"})
+        )
+        assert "recovery" not in old.model_dump(mode="json")
+
+
+@pytest.mark.parametrize("expression,kind,reason,remedy", CASES)
+@pytest.mark.parametrize("verbose", [False, True])
+def test_actual_scan_surfaces_keep_named_remedy(tmp_path, capsys, expression, kind, reason, remedy, verbose):
+    report = _scan(_project(tmp_path / "project", expression), tmp_path / "reports")
+    _print_cli_summary(report, "advisory", 0, verbose=verbose)
+    console = capsys.readouterr().out
+    packet = build_packet_from_report(report)
+    for surface in (console, render_markdown_report(report), render_packet_markdown(packet), render_packet_html(packet)):
+        assert "agent.py" in surface
+        assert remedy in surface
+    assert kind in packet.model_dump_json()
+
+
+@pytest.mark.parametrize("expression,kind,reason,remedy", CASES)
+def test_committed_verify_pr_remedy_and_control_permissions_do_not_drift(
+    tmp_path, monkeypatch, expression, kind, reason, remedy,
+):
+    from test_verify import _commit_all, _init_repo
+
+    repo = _project(_init_repo(tmp_path), expression)
+    _commit_all(repo, "SDK coverage example")
+    runner = CliRunner()
+
+    def verify():
+        result = runner.invoke(app, [
+            "verify", "--workspace", str(repo), "--config", "shipgate.yaml",
+            "--base", "HEAD", "--head", "HEAD", "--ci-mode", "advisory",
+            "--format", "json",
+        ])
+        assert result.exit_code == 0, result.output
+        directory = repo / "agents-shipgate-reports"
+        return json.loads((directory / "verifier.json").read_text())
+
+    published = verify()
+    assert published["decision"] == "insufficient_evidence"
+    assert remedy in (repo / "agents-shipgate-reports" / "pr-comment.md").read_text()
+    assert kind in json.dumps(published["release_decision"]["evidence_coverage"])
+    _without_recovery(monkeypatch)
+    unclassified = verify()
+    for key in ("decision", "merge_verdict", "can_merge_without_human"):
+        assert published[key] == unclassified[key]
+    assert published["control"]["state"] == unclassified["control"]["state"]
+    assert published["control"]["permissions"] == unclassified["control"]["permissions"]
+
+
+def _fact(warning: str, source_id="sdk", **updates):
+    return SourceRecoveryEvidence(
+        warning=warning, source_id=source_id, source_type="openai_agents_sdk",
+        source_ref="agent.py:8", path="agent.py",
+        recovery=CoverageRecovery(kind="reader_limitation", reason="observed_reader_gap"),
+    ).model_copy(update=updates)
+
+
+@pytest.mark.parametrize("collision", ["same_text", "redacted", "unclassified", "duplicate_fact"])
+def test_ambiguous_public_warning_cannot_borrow_a_repair_owner(tmp_path, collision):
+    if collision in {"redacted", "unclassified"}:
+        warning_a = "SDK failed: api_key=aaaaaaaaaaaaaaaaaaaaaaaa"
+        warning_b = "SDK failed: api_key=bbbbbbbbbbbbbbbbbbbbbbbb"
+        assert redact_data(warning_a) == redact_data(warning_b)
+    else:
+        warning_a = warning_b = "same SDK warning"
+    a = LoadedToolSource(
+        source_id="a", source_type="openai_agents_sdk", warnings=[warning_a],
+        recovery_evidence=[_fact(warning_a, "a")],
+    )
+    b = LoadedToolSource(
+        source_id="b", source_type="openai_agents_sdk", warnings=[warning_b],
+        recovery_evidence=[] if collision == "unclassified" else [_fact(warning_b, "b")],
+    )
+    sources = [a, b]
+    if collision == "duplicate_fact":
+        a.recovery_evidence.append(a.recovery_evidence[0])
+        sources = [a]
+    facts = _sanitize_source_recovery_evidence(sources, RedactionStats())
+    report = _scan(_project(tmp_path / "project", None), tmp_path / "reports")
+    report.source_warnings = [redact_data(warning_a)]  # public output deduplicates
+    gap = _evidence_gaps(report, [], source_recovery_evidence=facts)[-1]
+    assert gap.recovery == CoverageRecovery(kind="unresolved", reason="ambiguous_warning_identity")
+    assert gap.source_ref is None
+    assert gap.next_action.path is None
+    assert "before assigning a repair owner" in gap.next_action.expects
+    report.release_decision.evidence_coverage.evidence_gaps = [gap]
+    assert "before assigning a repair owner" in "\n".join(_insufficient_evidence_remedies(report))
+    from test_evidence_gap_ranking import _verifier_with
+
+    task = build_fix_task(
+        report, merge_verdict="insufficient_evidence", capability_review=VerifierCapabilityReview(),
+        base_ref="main", head_ref="HEAD",
+    )
+    for style in ("findings", "capability-review"):
+        comment = render_pr_comment(_verifier_with(task, report), report=report, style=style)
+        assert "before assigning a repair owner" in comment
+
+
+@pytest.mark.parametrize("change", [
+    {"source_id": "other"}, {"source_type": "mcp"}, {"warning": "other warning"},
+])
+def test_evidence_must_belong_to_its_raw_source_and_warning(change):
+    source = LoadedToolSource(
+        source_id="sdk", source_type="openai_agents_sdk", warnings=["own warning"],
+        recovery_evidence=[_fact("own warning").model_copy(update=change)],
+    )
+    assert _sanitize_source_recovery_evidence([source], RedactionStats()) == []
+
+
+def test_redaction_keeps_location_and_warning_private():
+    secret = "aaaaaaaaaaaaaaaaaaaaaaaa"
+    warning = f"SDK failed: api_key={secret}"
+    source = LoadedToolSource(
+        source_id="sdk", source_type="openai_agents_sdk", warnings=[warning],
+        recovery_evidence=[_fact(warning, source_ref=f"agent.py?api_key={secret}")],
+    )
+    fact = _sanitize_source_recovery_evidence([source], RedactionStats())[0]
+    assert secret not in fact.model_dump_json()
+    assert fact.recovery.kind == "reader_limitation"
+
+
+@pytest.mark.parametrize("expression", ["[read_tool, other_tool]", "[read_tool]", "[]"])
+def test_supported_syntax_does_not_manufacture_a_recovery(tmp_path, expression):
+    report = _scan(_project(tmp_path / "project", expression), tmp_path / "reports")
+    assert all(gap.recovery is None for gap in report.release_decision.evidence_coverage.evidence_gaps)
+
+
+def test_required_sdk_source_keeps_existing_advisory_execution_result(tmp_path, monkeypatch):
+    project = _project(tmp_path / "project", None)
+    manifest = project / "shipgate.yaml"
+    manifest.write_text(manifest.read_text().replace("optional: true", "optional: false"))
+    monkeypatch.chdir(project)
+    result = CliRunner().invoke(app, ["scan", "--config", str(manifest)])
+    # #585 records the existing required-SDK input-error contract mismatch.
+    # Recovery metadata must not change that execution contract as a side effect.
+    _without_recovery(monkeypatch)
+    original = CliRunner().invoke(app, ["scan", "--config", str(manifest)])
+    assert result.exit_code == original.exit_code == 0
+    assert "Decision: insufficient_evidence" in result.output
+    assert "Decision: insufficient_evidence" in original.output
+
+
+def test_recovery_does_not_rewrite_space_bearing_source_locations(tmp_path, capsys):
+    from test_evidence_gap_ranking import _verifier_with
+
+    project = _project(tmp_path / "project", "[read_tool] + [other_tool]")
+    filename = "agent  tools.py"
+    (project / "agent.py").rename(project / filename)
+    manifest = project / "shipgate.yaml"
+    manifest.write_text(manifest.read_text().replace("agent.py", filename))
+    report = _scan(project, tmp_path / "reports")
+    gap = next(g for g in report.release_decision.evidence_coverage.evidence_gaps if g.recovery)
+    assert gap.source_ref == f"{filename}:8"
+    assert gap.next_action.path == filename
+    _print_cli_summary(report, "advisory", 0)
+    packet = build_packet_from_report(report)
+    for surface in (
+        capsys.readouterr().out, render_markdown_report(report),
+        render_packet_markdown(packet), render_packet_html(packet),
+    ):
+        assert f"Source: {filename}:8" in surface
+    task = build_fix_task(
+        report, merge_verdict="insufficient_evidence", capability_review=VerifierCapabilityReview(),
+        base_ref="main", head_ref="HEAD",
+    )
+    for style in ("findings", "capability-review"):
+        comment = render_pr_comment(_verifier_with(task, report), report=report, style=style)
+        assert f"Source: `{filename}:8`" in comment
+
+
+@pytest.mark.parametrize("schema", [
+    "report-schema.v0.43.json", "packet-schema.v0.18.json", "verifier-schema.v0.16.json",
+])
+def test_recovery_uses_existing_open_evidence_gap_extension(schema):
+    document = json.loads((ROOT / "docs" / schema).read_text())
+    old_gap = json.loads(json.dumps(document["$defs"]["EvidenceGap"]))
+    old_gap["properties"].pop("recovery", None)
+    assert old_gap.get("additionalProperties", True) is True
+    assert "recovery" not in old_gap.get("required", [])
+    # Check against the preceding gap grammar, including its old action
+    # vocabulary. Its openness is what permits this same-version addition.
+    old_gap["$defs"] = document["$defs"]
+    gap = EvidenceGap(
+        kind="source_warning", subject="SDK", why="A source degraded.",
+        next_action={"kind": "review_warning", "why": "Review source.", "expects": "Rerun."},
+        recovery=CoverageRecovery(kind="unresolved", reason="sdk_tools_expression_unresolved"),
+    )
+    jsonschema.validate(gap.model_dump(mode="json"), old_gap)
+    assert EvidenceGap.model_validate(gap.model_dump(mode="json")) == gap

--- a/tests/test_human_review_request.py
+++ b/tests/test_human_review_request.py
@@ -187,6 +187,10 @@ def test_runtime_and_discovery_name_the_same_request_contract():
 # The schema identifiers below are already published. #536 must not silently
 # widen any of them when adding a postcondition to a new, separate artifact.
 # Successor grammars get successor filenames; historical bytes stay readable.
+# #561 adds only explanatory metadata to the existing open EvidenceGap. Its
+# two additive nodes are checked separately below, then removed to compare
+# the entire preceding grammar against its ORIGINAL digest. No control field,
+# constraint, or other schema content is exempted from the freeze.
 FROZEN_CONTROL_SCHEMAS = {
     "verifier-schema.v0.16.json": "cfa834d9bf047d3e39ffed531f19fbd7ed2cd6e82353789dddb7a458dfae408a",
     "agent-handoff-schema.v8.json": "036dc757914a297b34ebb9b7ca10c21869c5c91820fa7f07bda415c1effe30c3",
@@ -201,8 +205,21 @@ FROZEN_CONTROL_SCHEMAS = {
 @pytest.mark.parametrize("filename,digest", FROZEN_CONTROL_SCHEMAS.items())
 def test_review_postcondition_does_not_widen_a_published_control_grammar(filename, digest):
     raw = (Path("docs") / filename).read_bytes()
-    assert hashlib.sha256(raw).hexdigest() == digest
     schema = json.loads(raw)
+    if filename == "verifier-schema.v0.16.json":
+        original = copy.deepcopy(schema)
+        gap = original["$defs"]["EvidenceGap"]
+        assert gap.get("additionalProperties", True) is True
+        assert "recovery" not in gap.get("required", [])
+        assert gap["properties"].pop("recovery") == {
+            "anyOf": [{"$ref": "#/$defs/CoverageRecovery"}, {"type": "null"}],
+            "default": None,
+        }
+        from agents_shipgate.schemas.coverage_recovery import CoverageRecovery
+
+        assert original["$defs"].pop("CoverageRecovery") == CoverageRecovery.model_json_schema()
+        raw = (json.dumps(original, indent=2, sort_keys=True) + "\n").encode()
+    assert hashlib.sha256(raw).hexdigest() == digest
     action = {"actor": "human", "kind": "review", "command": None,
               "expects": None, "why": "Review the exact scope"}
     action_schema = {"$ref": "#/$defs/HumanControlAction", "$defs": schema["$defs"]}

--- a/tests/test_qualification_coverage_misses.py
+++ b/tests/test_qualification_coverage_misses.py
@@ -47,6 +47,33 @@ def test_actual_ie_keeps_named_gaps_and_unclassified_cases(tmp_path):
     assert (metric.numerator, metric.denominator, metric.passed) == (0, 1, False)
 
 
+@pytest.mark.parametrize("expression,expected", [
+    (None, "input_unavailable"),
+    ("[read_tool] + [other_tool]", "reader_limitation"),
+    ("get_tools()", "unresolved"),
+])
+def test_real_sdk_recovery_survives_qualification_without_relabeling(tmp_path, expression, expected):
+    from test_coverage_recovery import _project, _scan
+
+    report = _scan(_project(tmp_path / "project", expression), tmp_path / "reports")
+    gap = next(g for g in report.release_decision.evidence_coverage.evidence_gaps if g.recovery)
+    paths = _fixture(
+        tmp_path,
+        actual_overrides={"case-review_required": "insufficient_evidence"},
+        evidence_gaps={"case-review_required": [gap.model_dump(mode="json")]},
+    )
+    result = _run(paths)
+    miss = next(c for c in result.coverage_misses[0].cases if c.case_id == "case-review_required")
+    assert miss.evidence_gaps[0] == gap
+    assert miss.evidence_gaps[0].recovery.kind == expected
+    assert miss.evidence_gaps[0].next_action.authorable_by == "human"
+    assert result.schema_version == "shipgate.safety_qualification/v6"
+    assert result.qualified is False
+    metric = next(x for x in result.intervals if x.name == "review_exact_rate")
+    assert (metric.numerator, metric.denominator, metric.passed) == (0, 1, False)
+    assert SafetyQualificationResultV1.model_validate(result.model_dump(mode="json")) == result
+
+
 def test_missing_receipt_is_unscored_not_a_zero_miss(tmp_path):
     paths = _fixture(tmp_path)
     index = json.loads(paths[2].read_text())


### PR DESCRIPTION
A configured SDK source currently reports the same generic warning for a missing entrypoint, unsupported literal tool-list concatenation, and an unresolved runtime expression. Reviewers cannot tell whether to restore an input, wait for a reader repair, or establish more evidence.

This change records those distinctions at the parser and carries optional `EvidenceGap.recovery` metadata through existing report, packet, verifier and qualification projections. The CLI and PR keep the named source and remedy visible; raw-source association and post-redaction collisions prevent a guessed repair owner. Existing `review_warning` action kinds, declaration authorship, release thresholds and operational permissions retain their meaning. Older unclassified gaps remain unclassified on round-trip.

Closes #561.

## Validation

- 31 new regression cases cover actual SDK scans, committed verifier/PR runs, three recovery classifications, unchanged verdicts/permissions, ambiguous/redacted warning identities, source-name whitespace and qualification propagation.
- Actual recovery rows validate against the preceding committed report 0.43, packet 0.18 and verifier 0.16 gap grammars; current schema generation is in sync.
- Full local suite executed; its only code assertion was the whole-file verifier schema pin. The original digest remains unchanged and now compares the entire preceding grammar after checking/removing only the two explicit optional diagnostic nodes. All 110 affected recovery/qualification/review-contract tests pass, including the existing rejection of a populated human-control postcondition.
- All 10 packaging tests passed after rerunning their isolated dependency-download step with network access. Ruff, generated-schema drift, and working-tree verification pass. Committed verification on `c44f9f30a38db9d24440027380712b528f6aae6c` against `c079864e8a37209a7712d74197fd1cf1b4ebf06e` returns `passed / mergeable / complete`; a fresh current-control read authorizes PR publication. All nine GitHub CI jobs, including all three suite shards, aggregate coverage, Windows and clean-checkout launchers, passed; the tag-only job was correctly skipped on the PR.

## Boundaries

This is an explanatory extension of existing surfaces, aimed at reducing time from a coverage miss to the correct next action; it adds no CLI command, verdict, schema-version family or execution. Other readers/warning shapes remain unclassified. The SDK reader repair itself is #584; its existing required-missing-source execution mismatch is #585. The inherited source-omission privacy-audit ordering defect is #586. All three are deferred; none is silently fixed or interpreted as qualifying evidence here.

One independent coding-agent GitHub review/address round completed at this exact head: [review](https://github.com/ThreeMoonsLab/agents-shipgate/pull/587#pullrequestreview-5147533214), [address](https://github.com/ThreeMoonsLab/agents-shipgate/pull/587#issuecomment-5592587257). No in-scope findings remained. These reviews are not human release approval, independent qualification signing, or evidence of v1.0 readiness.