### PR TITLE
Name the failed host input and truthful recovery route

### DIFF
--- a/docs/host-boundary-support.md
+++ b/docs/host-boundary-support.md
@@ -67,6 +67,23 @@ For local control, parse `shipgate.agent_boundary_result/v2` and switch on
 `control.state`. Review `input_coverage`, `host_coverage[]`, `affected_hosts[]`,
 `issues[]`, and `excluded_scopes[]` before relying on the result.
 
+When host inventory fails, `violations[].evidence.recovery` carries the observed
+read phase, reason and source, plus configured limits when a resource bound is
+known. The violation title and control explanation name the failed operation;
+its recommendation names the input to restore before rerunning. Read failures,
+directory inventory failures and final snapshot-validation failures remain
+distinct. A final validation failure means the read could not be confirmed as
+coherent; it does not by itself establish concurrent modification as the cause.
+Existing inventory issue kinds and control permissions are unchanged. Older
+snapshots without these private reader facts keep their generic recovery route.
+
+Recovery text and paths are redacted and bounded to 512 characters. Raw
+filesystem exception text and source contents are never copied into this
+recovery evidence. Configured limits describe the bounds the failed operation
+ran under, not a measured amount by which a particular bound was exceeded.
+Failed runs never retry automatically or authorize continuation. Only an
+explicit new valid run can replace the stop under the current-control protocol.
+
 For inventory and drift, parse host-grants v0.2. An incomplete inventory cannot
 be acknowledged as a baseline. A v0.1 baseline, scope mismatch, or incomplete
 comparison is `incomparable`; `--fail-on-drift` exits 20 for both drift and

--- a/src/agents_shipgate/core/agent_boundary.py
+++ b/src/agents_shipgate/core/agent_boundary.py
@@ -62,6 +62,7 @@ from agents_shipgate.core.host_grants import (
     HostBoundarySnapshot,
     build_host_boundary_snapshot,
 )
+from agents_shipgate.core.host_input_failure import safe_failure_text
 from agents_shipgate.core.trust_roots import (
     is_configured_manifest,
     is_portable_repo_path,
@@ -230,6 +231,7 @@ def evaluate_agent_boundary(
                     item.get("message")
                     or "A repository host-boundary source could not be inventoried."
                 ),
+                recovery=host_snapshot.input_failures.get(str(item.get("issue_id"))),
             )
             for item in host_snapshot.inventory.get("issues", [])
             if item.get("blocking")
@@ -314,7 +316,6 @@ def evaluate_agent_boundary(
         changed_files=changed_files,
         violations=combined,
     )
-    combined = _sanitize_violations(combined)
     if input_issues:
         rule = _GENERIC_RULES["INPUT-INCOMPLETE"]
         combined = _dedupe_violations(
@@ -326,13 +327,16 @@ def evaluate_agent_boundary(
                         check_id=rule.check_id,
                         action=rule.action,  # type: ignore[arg-type]
                         risk_level=rule.risk_level,  # type: ignore[arg-type]
-                        title=rule.title,
+                        title=issue.recovery.summary() if issue.recovery else rule.title,
                         path=issue.path,
                         evidence={
                             "kind": "boundary_input_unresolved",
                             "code": issue.code,
+                            **({"recovery": issue.recovery.evidence()} if issue.recovery else {}),
                         },
-                        recommendation=rule.recommendation,
+                        recommendation=(
+                            issue.recovery.recovery() if issue.recovery else rule.recommendation
+                        ),
                     )
                     for issue in input_issues
                 ],
@@ -407,7 +411,10 @@ def evaluate_agent_boundary(
             ]
         )
 
-    diagnostics = _sanitize_diagnostics(diagnostics)
+    # Recovery/fallback rows are appended after adapter evaluation. Sanitize
+    # every final row before deduplication, fingerprints and control projection.
+    combined = _dedupe_violations(_sanitize_violations(combined))
+    diagnostics = _dedupe_diagnostics(_sanitize_diagnostics(diagnostics))
 
     projected = _project_legacy(
         verify_command=verify_command,
@@ -1033,6 +1040,11 @@ def _boundary_summary(decision: str, violations: list[AgentResultViolatedRule]) 
                 f"{len(violations)} coding-agent boundary change(s) need PR-time "
                 "review; verify, then report them."
             )
+        recovery = next(
+            (item for item in violations if item.evidence.get("recovery")), None,
+        )
+        if recovery is not None:
+            return f"{recovery.title} Human review is required before continuation."
         return f"{len(violations)} coding-agent boundary change(s) require human review."
     return f"{len(violations)} coding-agent boundary change(s) block local continuation."
 
@@ -1222,6 +1234,14 @@ def _sanitize_violations(
         item.model_copy(
             update={
                 "title": _sanitize_boundary_string(item.title),
+                # Adapter paths still participate in trust-root/experimental
+                # classification. Only input-failure rows (always outside the
+                # actionable band by rule ID) may be bounded before routing.
+                "path": (
+                    safe_failure_text(item.path)
+                    if item.path is not None and item.id == "BOUNDARY-INPUT-INCOMPLETE"
+                    else item.path
+                ),
                 "evidence": _sanitize_boundary_value(
                     _redact_secret_values(item.evidence)
                 ),
@@ -1237,7 +1257,10 @@ def _sanitize_diagnostics(
 ) -> list[AgentResultDiagnostic]:
     return [
         item.model_copy(
-            update={"message": _sanitize_boundary_string(item.message)}
+            update={
+                "message": safe_failure_text(_sanitize_boundary_string(item.message)),
+                "path": safe_failure_text(item.path) if item.path is not None else None,
+            }
         )
         for item in diagnostics
     ]

--- a/src/agents_shipgate/core/boundary_diff.py
+++ b/src/agents_shipgate/core/boundary_diff.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from agents_shipgate.core.host_input_failure import HostInputFailure
 from agents_shipgate.schemas.agent_result_v1 import AgentResultDiagnostic
 
 
@@ -58,6 +59,7 @@ class BoundaryInputIssue:
     code: str
     path: str
     message: str
+    recovery: HostInputFailure | None = None
 
 
 @dataclass(frozen=True)

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -16,7 +16,7 @@ import re
 import stat
 import sys
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlsplit, urlunsplit
@@ -33,6 +33,11 @@ from agents_shipgate.core.host_boundary import (
     _string_entries,
     _transport_hint,
     _trigger_names,
+)
+from agents_shipgate.core.host_input_failure import (
+    HostInputFailure,
+    HostInventoryReadError,
+    safe_failure_text,
 )
 from agents_shipgate.core.privacy import SENSITIVE_VALUE_KEYS
 from agents_shipgate.core.trust_roots import (
@@ -113,6 +118,20 @@ class HostStaticParseCache:
     )
     _resource_bound_error: str | None = field(default=None, init=False, repr=False)
     _finished: bool = field(default=False, init=False, repr=False)
+    _read_failures: dict[tuple[str, str], HostInputFailure] = field(
+        default_factory=dict, init=False, repr=False,
+    )
+    input_failures: dict[str, HostInputFailure] = field(default_factory=dict, init=False)
+    terminal_failure: HostInputFailure | None = field(default=None, init=False)
+
+    @property
+    def configured_limits(self) -> tuple[tuple[str, int], ...]:
+        return (
+            ("aggregate_entries", self.max_entries),
+            ("aggregate_bytes", self.max_total_bytes),
+            ("repository_entries", MAX_HOST_REPOSITORY_ENTRIES),
+            ("per_file_bytes", MAX_HOST_CONFIG_BYTES),
+        )
 
     def __post_init__(self) -> None:
         self._budget = IdentityReadBudget(
@@ -135,24 +154,47 @@ class HostStaticParseCache:
                 self._reads[key] = (None, self._resource_bound_error)
             else:
                 try:
-                    self._reads[key] = _safe_read(
+                    text, error, failure = _safe_read(
                         path,
                         containment_root=containment_root,
                         reader=self.reader_for(containment_root),
+                        limits=self.configured_limits,
                     )
-                except IdentityReadBudgetExceeded as exc:
-                    self._resource_bound_error = (
-                        "static host-boundary inventory exceeded its aggregate "
-                        f"resource bound ({exc})"
+                    self._reads[key] = (text, error)
+                    if failure is not None:
+                        self._read_failures[key] = failure
+                except IdentityReadBudgetExceeded:
+                    self.terminal_failure = HostInputFailure(
+                        reason="resource_bound_exceeded", phase="source_read",
+                        source=str(path), limits=self.configured_limits,
                     )
+                    self._read_failures[key] = self.terminal_failure
+                    self._resource_bound_error = self.terminal_failure.summary()
                     self._reads[key] = (None, self._resource_bound_error)
                 except (OSError, NotImplementedError, ValueError):
-                    self._reads[key] = (
-                        None,
-                        "symbolic links or filesystem aliases in configuration "
-                        "paths are not followed",
+                    failure = HostInputFailure(
+                        reason="input_unreadable", phase="source_read",
+                        source=str(path), limits=self.configured_limits,
                     )
+                    self._read_failures[key] = failure
+                    self._reads[key] = (None, failure.summary())
         return self._reads[key]
+
+    def read_issue(
+        self, *, path: Path, containment_root: Path, source: str,
+        host: str, kind: str, message: str,
+    ) -> dict[str, Any]:
+        """Bind the exact read's facts to its generated inventory issue identity."""
+        failure = self._read_failures.get(self._key(path, containment_root))
+        if failure is not None:
+            failure = replace(failure, source=source)
+            message = failure.summary() + " " + failure.recovery()
+        issue = _inventory_issue(
+            kind=kind, host=host, source=source, message=message, blocking=True,
+        )
+        if failure is not None:
+            self.input_failures[issue["issue_id"]] = failure
+        return issue
 
     @property
     def resource_bound_error(self) -> str | None:
@@ -168,10 +210,17 @@ class HostStaticParseCache:
         for key in sorted(self._sessions):
             try:
                 self._sessions[key].finish()
-            except IdentityReadBudgetExceeded as exc:
-                self._resource_bound_error = (
-                    "static host-boundary inventory exceeded its aggregate "
-                    f"resource bound ({exc})"
+            except IdentityReadBudgetExceeded:
+                self.terminal_failure = HostInputFailure(
+                    reason="resource_bound_exceeded", phase="snapshot_validation",
+                    source=key, limits=self.configured_limits,
+                )
+                self._resource_bound_error = self.terminal_failure.summary()
+                raise
+            except (OSError, NotImplementedError, ValueError):
+                self.terminal_failure = HostInputFailure(
+                    reason="snapshot_validation_failed", phase="snapshot_validation",
+                    source=key,
                 )
                 raise
         self._finished = True
@@ -229,6 +278,7 @@ class HostBoundarySnapshot:
 
     inventory: dict[str, Any]
     cache: HostStaticParseCache
+    input_failures: dict[str, HostInputFailure] = field(default_factory=dict)
 
 
 def _canonical(value: Any) -> str:
@@ -343,6 +393,8 @@ def _display_path(path: Path, *, root: Path, home: Path) -> str:
 def _inventory_issue(
     *, kind: str, host: str, source: str, message: str, blocking: bool
 ) -> dict[str, Any]:
+    source = safe_failure_text(source)
+    message = safe_failure_text(message)
     return {
         "issue_id": _stable_id("host_issue", kind, host, source, message),
         "kind": kind,
@@ -388,13 +440,17 @@ def _safe_read(
     *,
     containment_root: Path,
     reader: IdentityBoundReadSession | None = None,
-) -> tuple[str | None, str | None]:
+    limits: tuple[tuple[str, int], ...] = (),
+) -> tuple[str | None, str | None, HostInputFailure | None]:
     lexical_root = Path(os.path.abspath(os.path.normpath(os.fspath(containment_root))))
     lexical_path = Path(os.path.abspath(os.path.normpath(os.fspath(path))))
     try:
         relative = lexical_path.relative_to(lexical_root)
     except ValueError:
-        return None, "path is outside the allowlisted static configuration root"
+        failure = HostInputFailure(
+            reason="input_unreadable", phase="source_read", source=str(path),
+        )
+        return None, failure.summary(), failure
     owns_reader = reader is None
     if reader is None:
         reader = IdentityBoundReadSession(
@@ -409,25 +465,24 @@ def _safe_read(
     except IdentityReadBudgetExceeded:
         if not owns_reader:
             raise
-        return None, "static host-boundary read exceeded its aggregate resource bound"
-    except (OSError, NotImplementedError, ValueError) as exc:
-        message = str(exc)
-        if "singly-linked regular file" in message:
-            return None, "configuration path is not one singly-linked regular file"
-        if "file exceeds" in message:
-            return None, f"file exceeds the {MAX_HOST_CONFIG_BYTES}-byte static audit limit"
-        if "changed" in message:
-            return None, "configuration path changed identity while it was read"
-        if isinstance(exc, (OSError, NotImplementedError)):
-            return None, f"file could not be read as UTF-8 ({exc.__class__.__name__})"
-        return None, (
-            "symbolic links or filesystem aliases in configuration paths are "
-            "not followed"
+        failure = HostInputFailure(
+            reason="resource_bound_exceeded", phase="source_read",
+            source=str(path), limits=limits,
         )
+        return None, failure.summary(), failure
+    except (OSError, NotImplementedError, ValueError):
+        failure = HostInputFailure(
+            reason="input_unreadable", phase="source_read",
+            source=str(path), limits=limits,
+        )
+        return None, failure.summary(), failure
     try:
-        return raw.decode("utf-8", errors="strict"), None
+        return raw.decode("utf-8", errors="strict"), None, None
     except UnicodeDecodeError:
-        return None, "file could not be read as UTF-8 (UnicodeDecodeError)"
+        failure = HostInputFailure(
+            reason="input_unreadable", phase="utf8_decode", source=str(path),
+        )
+        return None, failure.summary(), failure
 
 
 def _load_structured(
@@ -440,12 +495,12 @@ def _load_structured(
     )
     if error_kind is not None:
         assert error_message is not None
-        issues.append(_inventory_issue(
+        issues.append(cache.read_issue(
+            path=path, containment_root=containment_root,
             kind=error_kind,
             host=host,
             source=source,
             message=error_message,
-            blocking=True,
         ))
         artifacts.append(_artifact(host=host, scope=scope, source=source, kind=kind, status="failed"))
         return None
@@ -816,7 +871,10 @@ def _collect_file(
     if kind == "instructions":
         text, error = cache.read(path, containment_root=containment_root)
         if error:
-            issues.append(_inventory_issue(kind="unreadable", host=host, source=source, message=error, blocking=True))
+            issues.append(cache.read_issue(
+                path=path, containment_root=containment_root,
+                kind="unreadable", host=host, source=source, message=error,
+            ))
             artifacts.append(_artifact(host=host, scope=scope, source=source, kind=kind, status="failed"))
             return
         assert text is not None
@@ -915,6 +973,7 @@ def _repository_paths(
     root: Path,
     *,
     reader: IdentityBoundReadSession,
+    limits: tuple[tuple[str, int], ...] = (),
 ) -> tuple[list[tuple[Path, str, str, str]], int]:
     """Enumerate repository sources exclusively from the boundary registry."""
 
@@ -933,15 +992,15 @@ def _repository_paths(
                 max_entries=MAX_HOST_REPOSITORY_ENTRIES - visited,
             )
         except IdentityReadBudgetExceeded as exc:
-            raise RuntimeError(
-                "repository host-boundary inventory exceeded its static "
-                "filesystem-entry bound"
-            ) from exc
+            raise HostInventoryReadError(HostInputFailure(
+                reason="resource_bound_exceeded", phase="inventory_enumeration",
+                source=relative_directory.as_posix(), limits=limits,
+            )) from exc
         except (OSError, NotImplementedError, ValueError) as exc:
-            raise RuntimeError(
-                "repository host-boundary inventory could not inspect the "
-                "workspace safely"
-            ) from exc
+            raise HostInventoryReadError(HostInputFailure(
+                reason="input_unreadable", phase="inventory_enumeration",
+                source=relative_directory.as_posix(),
+            )) from exc
         visited += len(names)
         child_directories: list[Path] = []
         for name in names:
@@ -959,10 +1018,10 @@ def _repository_paths(
                         child_directories.append(Path(relative))
                     continue
             except (OSError, ValueError) as exc:
-                raise RuntimeError(
-                    "repository host-boundary inventory could not inspect a "
-                    "workspace entry safely"
-                ) from exc
+                raise HostInventoryReadError(HostInputFailure(
+                    reason="input_unreadable", phase="entry_inspection",
+                    source=relative,
+                )) from exc
             candidates.append((candidate, relative))
         pending.extend(reversed(child_directories))
 
@@ -1054,9 +1113,10 @@ def _collect_claude_project_state(
     data, error_kind, error = cache.parse(path, containment_root=home)
     if error_kind is not None:
         assert error is not None
-        issues.append(_inventory_issue(
+        issues.append(cache.read_issue(
+            path=path, containment_root=home,
             kind=error_kind, host="claude-code", source=source,
-            message=error, blocking=True,
+            message=error,
         ))
         artifacts.append(_artifact(
             host="claude-code", scope="local_static", source=source,
@@ -1183,16 +1243,28 @@ def build_host_boundary_snapshot(
     grants: list[dict[str, Any]] = []
     issues: list[dict[str, Any]] = []
 
-    resource_bound_error: str | None = None
-    identity_snapshot_error: str | None = None
+    inventory_failures: list[HostInputFailure] = []
     try:
         repository_paths, _inventory_entries = _repository_paths(
             root,
             reader=cache.reader_for(root),
+            limits=cache.configured_limits,
         )
-    except (RuntimeError, IdentityReadBudgetExceeded) as exc:
+    except HostInventoryReadError as exc:
         repository_paths = []
-        resource_bound_error = str(exc)
+        inventory_failures.append(exc.failure)
+    except IdentityReadBudgetExceeded:
+        repository_paths = []
+        inventory_failures.append(HostInputFailure(
+            reason="resource_bound_exceeded", phase="inventory_enumeration",
+            source="<repository>", limits=cache.configured_limits,
+        ))
+    except (OSError, NotImplementedError, ValueError):
+        repository_paths = []
+        inventory_failures.append(HostInputFailure(
+            reason="input_unreadable", phase="inventory_enumeration",
+            source="<repository>",
+        ))
     for path, source, host, kind in repository_paths:
         _collect_file(
             path=path, source=source, host=host, scope="repository", kind=kind,
@@ -1228,48 +1300,43 @@ def build_host_boundary_snapshot(
 
     try:
         cache.finish()
-    except IdentityReadBudgetExceeded as exc:
-        resource_bound_error = cache.resource_bound_error or str(exc)
-    except (OSError, NotImplementedError, ValueError) as exc:
-        identity_snapshot_error = (
-            "static host-boundary inventory changed identity while its bounded "
-            f"snapshot was captured ({exc})"
-        )
-    if cache.resource_bound_error is not None:
-        resource_bound_error = cache.resource_bound_error
-    if resource_bound_error is not None:
-        # Aggregate exhaustion can prevent the final identity pass. Do not
-        # retain a partially validated projection as diagnostic grant data.
-        artifacts.clear()
-        grants.clear()
-        for host in ("codex", "claude-code", "cursor", "vscode", "github"):
-            issues.append(
-                _inventory_issue(
-                    kind="unreadable",
-                    host=host,
-                    source="<repository>",
-                    message=resource_bound_error,
-                    blocking=True,
-                )
-            )
-    if identity_snapshot_error is not None:
+    except IdentityReadBudgetExceeded:
+        inventory_failures.append(cache.terminal_failure or HostInputFailure(
+            reason="resource_bound_exceeded", phase="snapshot_validation",
+            source="<repository>", limits=cache.configured_limits,
+        ))
+    except (OSError, NotImplementedError, ValueError):
+        inventory_failures.append(cache.terminal_failure or HostInputFailure(
+            reason="snapshot_validation_failed", phase="snapshot_validation",
+            source="<repository>",
+        ))
+    if inventory_failures:
         # No parsed projection is trustworthy when the final exact-name pass
-        # cannot bind it to the entries that were opened.
+        # or complete inventory cannot bind it to the entries that were opened.
         artifacts.clear()
         grants.clear()
-        for host in ("codex", "claude-code", "cursor", "vscode", "github"):
-            issues.append(
-                _inventory_issue(
-                    kind="unreadable",
-                    host=host,
-                    source="<repository>",
-                    message=identity_snapshot_error,
-                    blocking=True,
+        for failure in dict.fromkeys(inventory_failures):
+            # Use lexical spelling: a second resolve/read would inspect a
+            # different generation and could misattribute the original failure.
+            if Path(failure.source).is_absolute():
+                try:
+                    source = Path(failure.source).relative_to(root).as_posix()
+                except ValueError:
+                    source = failure.source
+                failure = replace(failure, source=source)
+            for host in ("codex", "claude-code", "cursor", "vscode", "github"):
+                issue = _inventory_issue(
+                    kind="unreadable", host=host, source=failure.source,
+                    message=failure.summary() + " " + failure.recovery(), blocking=True,
                 )
-            )
+                issues.append(issue)
+                cache.input_failures[issue["issue_id"]] = failure
 
     artifacts.sort(key=lambda item: (item["host"], item["scope"], item["path"], item["kind"]))
     grants.sort(key=lambda item: item["grant_id"])
+    # A resource failure may first name a source and then invalidate all hosts.
+    # Keep one copy of that same source/host obligation in the inventory too.
+    issues = list({item["issue_id"]: item for item in issues}.values())
     issues.sort(key=lambda item: item["issue_id"])
     payload = {
         "host_grants_inventory_schema_version": HOST_GRANTS_INVENTORY_SCHEMA_VERSION,
@@ -1284,7 +1351,9 @@ def build_host_boundary_snapshot(
         "runtime_session_verified": False,
     }
     inventory = HostGrantsInventoryV2.model_validate(payload).model_dump(mode="json")
-    return HostBoundarySnapshot(inventory=inventory, cache=cache)
+    return HostBoundarySnapshot(
+        inventory=inventory, cache=cache, input_failures=dict(cache.input_failures),
+    )
 
 
 def host_audit_inventory(

--- a/src/agents_shipgate/core/host_input_failure.py
+++ b/src/agents_shipgate/core/host_input_failure.py
@@ -1,0 +1,103 @@
+"""Private facts for a failed static host read; never a control decision."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from agents_shipgate.core.privacy import redact_text
+
+MAX_FAILURE_TEXT = 512
+
+
+def safe_failure_text(value: str) -> str:
+    """Redact before bounding, so truncation cannot expose part of a secret."""
+    from agents_shipgate.core.host_grants import _sanitize_sensitive_string
+
+    text = _sanitize_sensitive_string(redact_text(value) or "")
+    text = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", text)
+    return text if len(text) <= MAX_FAILURE_TEXT else text[:MAX_FAILURE_TEXT - 1] + "…"
+
+
+@dataclass(frozen=True)
+class HostInputFailure:
+    reason: Literal[
+        "resource_bound_exceeded", "input_unreadable", "snapshot_validation_failed"
+    ]
+    phase: Literal[
+        "inventory_enumeration", "entry_inspection", "source_read", "utf8_decode",
+        "snapshot_validation",
+    ]
+    source: str
+    # Known configured limits, not an inferred exceeded counter.
+    limits: tuple[tuple[str, int], ...] = ()
+
+    def evidence(self) -> dict[str, Any]:
+        return {
+            "reason": self.reason,
+            "phase": self.phase,
+            "source": safe_failure_text(self.source),
+            **({"configured_limits": dict(self.limits)} if self.limits else {}),
+        }
+
+    def summary(self) -> str:
+        phase = {
+            "inventory_enumeration": "directory inventory",
+            "entry_inspection": "entry inspection",
+            "source_read": "configuration read",
+            "utf8_decode": "UTF-8 decoding",
+            "snapshot_validation": "final snapshot validation",
+        }[self.phase]
+        failure = {
+            "resource_bound_exceeded": "exceeded a static resource bound",
+            "input_unreadable": "could not complete",
+            "snapshot_validation_failed": "could not confirm a coherent read",
+        }[self.reason]
+        limits = "; ".join(f"{name}={value}" for name, value in self.limits)
+        return safe_failure_text(
+            f"{phase.capitalize()} {failure} at {self._source_label()}."
+            + (f" Configured limits: {limits}." if limits else "")
+        )
+
+    def _source_label(self) -> str:
+        return (
+            "repository root (.)" if self.source in {".", "<repository>"}
+            else safe_failure_text(self.source)
+        )
+
+    def recovery(self) -> str:
+        return safe_failure_text(self._recovery())
+
+    def _recovery(self) -> str:
+        source = self._source_label()
+        if self.reason == "resource_bound_exceeded":
+            return (
+                f"Review the inventory size at {source} against the configured limits "
+                "in the evidence. Supply a complete supported scope before rerunning; "
+                "do not omit required host inputs to clear this stop."
+            )
+        if self.reason == "snapshot_validation_failed":
+            return (
+                f"Ensure the inputs under {source} are accessible and stable, then "
+                "rerun for a new coherent read. Final validation failed; the reader "
+                "did not establish whether concurrent changes caused it."
+            )
+        if self.phase == "utf8_decode":
+            return f"Make {source} a valid UTF-8 configuration file, then rerun."
+        if self.phase in {"inventory_enumeration", "entry_inspection"}:
+            return (
+                f"Restore readable, stable directory entries at {source}, then rerun "
+                "the complete inventory."
+            )
+        return (
+            f"Make {source} available as one readable, singly-linked regular file within "
+            "the static configuration root and configured limits, then rerun; symbolic "
+            "links and filesystem aliases are not followed."
+        )
+
+
+class HostInventoryReadError(RuntimeError):
+    def __init__(self, failure: HostInputFailure) -> None:
+        self.failure = failure
+        super().__init__(failure.summary())

--- a/tests/test_host_audit.py
+++ b/tests/test_host_audit.py
@@ -719,7 +719,7 @@ def test_host_inventory_rejects_protected_addition_after_discovery(
     assert inventory["grants"] == []
     assert any(
         issue["kind"] == "unreadable"
-        and "changed identity" in issue["message"]
+        and "could not confirm a coherent read" in issue["message"]
         and issue["blocking"]
         for issue in inventory["issues"]
     )

--- a/tests/test_host_input_recovery.py
+++ b/tests/test_host_input_recovery.py
@@ -1,0 +1,308 @@
+"""#547: actual failed reads stay denied and explain the observed obligation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.agent_boundary import (
+    _sanitize_violations,
+    build_agent_boundary_result,
+    evaluate_agent_boundary,
+)
+from agents_shipgate.core.boundary_diff import BoundaryInputIssue
+from agents_shipgate.core.codex_boundary import violations_within_agent_actionable_band
+from agents_shipgate.core.host_grants import (
+    HostBoundarySnapshot,
+    HostStaticParseCache,
+    build_host_boundary_snapshot,
+    host_audit_inventory,
+)
+from agents_shipgate.core.host_input_failure import MAX_FAILURE_TEXT
+from agents_shipgate.core.trust_roots import IdentityBoundReadSession
+from agents_shipgate.schemas.agent_result_v1 import AgentResultViolatedRule
+
+
+def _result(workspace: Path, snapshot: HostBoundarySnapshot):
+    return build_agent_boundary_result(evaluate_agent_boundary(
+        workspace=workspace, diff_text="", host_snapshot=snapshot,
+    )).model_dump(mode="json")
+
+
+def _denied(payload: dict) -> list[dict]:
+    assert payload["input_coverage"] == "partial"
+    assert payload["control"]["state"] == "human_review_required"
+    assert not any(payload["control"]["permissions"].values())
+    assert payload["control"]["allowed_next_commands"] == []
+    return [v for v in payload["violations"] if v["evidence"].get("recovery")]
+
+
+def test_directory_error_is_not_misclassified_as_resource_exhaustion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "project").mkdir()
+    original = IdentityBoundReadSession.directory_entries
+
+    def unreadable(self, relative=Path(), **kwargs):
+        if relative == Path("project"):
+            raise PermissionError("arbitrary private filesystem error")
+        return original(self, relative, **kwargs)
+
+    monkeypatch.setattr(IdentityBoundReadSession, "directory_entries", unreadable)
+    snapshot = build_host_boundary_snapshot(tmp_path)
+    payload = _result(tmp_path, snapshot)
+    rows = _denied(payload)
+    assert len(rows) == 1  # shared failure, not one repair per host
+    recovery = rows[0]["evidence"]["recovery"]
+    assert recovery == {
+        "reason": "input_unreadable", "phase": "inventory_enumeration", "source": "project",
+    }
+    assert "project" in payload["control"]["next_action"]["why"]
+    assert "Directory inventory" in payload["control"]["reason"]
+    assert "resource" not in rows[0]["title"]
+    assert snapshot.inventory["artifacts"] == snapshot.inventory["grants"] == []
+
+
+@pytest.mark.parametrize("bound", ["entries", "bytes", "repository_entries"])
+def test_real_resource_limits_are_visible_without_granting_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bound: str,
+) -> None:
+    (tmp_path / ".mcp.json").write_text('{"mcpServers": {}}')
+    cache = HostStaticParseCache(
+        max_entries=1 if bound == "entries" else 10_000,
+        max_total_bytes=1 if bound == "bytes" else 1_000,
+    )
+    if bound == "repository_entries":
+        monkeypatch.setattr("agents_shipgate.core.host_grants.MAX_HOST_REPOSITORY_ENTRIES", 0)
+    snapshot = build_host_boundary_snapshot(tmp_path, cache=cache)
+    rows = _denied(_result(tmp_path, snapshot))
+    assert snapshot.inventory["artifacts"] == snapshot.inventory["grants"] == []
+    issue_ids = [row["issue_id"] for row in snapshot.inventory["issues"]]
+    assert len(issue_ids) == len(set(issue_ids))
+    known = [v["evidence"]["recovery"] for v in rows]
+    assert all(r["reason"] == "resource_bound_exceeded" for r in known)
+    key = {"entries": "aggregate_entries", "bytes": "aggregate_bytes"}.get(bound, bound)
+    expected = 0 if bound == "repository_entries" else 1
+    assert all(r["configured_limits"][key] == expected for r in known)
+    assert any(f"{key}={expected}" in v["title"] for v in rows)
+    if bound == "bytes":
+        assert all(r["source"] == ".mcp.json" for r in known)
+
+
+@pytest.mark.parametrize("failure_kind", ["read", "decode"])
+def test_named_source_failures_keep_their_own_phase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_kind: str,
+) -> None:
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    (claude / "settings.json").write_text("{}")
+    (tmp_path / ".mcp.json").write_text('{"mcpServers": {}}')
+    original = IdentityBoundReadSession.read_bytes
+
+    def read(self, relative, **kwargs):
+        if relative.as_posix() == ".claude/settings.json":
+            if failure_kind == "decode":
+                return b"\xff"
+            # The word 'changed' is deliberately not evidence of snapshot drift.
+            raise ValueError("changed permission: private error text")
+        return original(self, relative, **kwargs)
+
+    monkeypatch.setattr(IdentityBoundReadSession, "read_bytes", read)
+    snapshot = build_host_boundary_snapshot(tmp_path)
+    rows = _denied(_result(tmp_path, snapshot))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["path"] == ".claude/settings.json"
+    assert row["evidence"]["recovery"]["source"] == row["path"]
+    assert row["evidence"]["recovery"]["reason"] == "input_unreadable"
+    assert row["evidence"]["recovery"]["phase"] == (
+        "utf8_decode" if failure_kind == "decode" else "source_read"
+    )
+    assert "private error text" not in json.dumps(snapshot.inventory)
+    assert row["path"] in row["recommendation"]
+    assert all(count == 1 for count in snapshot.cache.read_counts.values())
+    assert all(count == 1 for count in snapshot.cache.parse_counts.values())
+
+
+@pytest.mark.parametrize("failure_kind", ["actual_change", "value_error", "os_error"])
+def test_final_validation_does_not_guess_why_coherent_read_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_kind: str,
+) -> None:
+    source = tmp_path / ".mcp.json"
+    source.write_text('{"mcpServers": {}}')
+    original = IdentityBoundReadSession.finish
+
+    def finish(self):
+        if failure_kind == "actual_change":
+            source.write_text('{"mcpServers": {}, "changed": true}')
+            return original(self)
+        if failure_kind == "os_error":
+            raise OSError("unclassified failure with sensitive context")
+        raise ValueError("unclassified failure with sensitive context")
+
+    monkeypatch.setattr(IdentityBoundReadSession, "finish", finish)
+    snapshot = build_host_boundary_snapshot(tmp_path)
+    payload = _result(tmp_path, snapshot)
+    rows = _denied(payload)
+    assert len(rows) == 1
+    assert rows[0]["evidence"]["recovery"] == {
+        "reason": "snapshot_validation_failed", "phase": "snapshot_validation", "source": ".",
+    }
+    assert "could not confirm a coherent read" in payload["control"]["reason"]
+    assert "did not establish whether concurrent changes" in rows[0]["recommendation"]
+    assert snapshot.inventory["artifacts"] == snapshot.inventory["grants"] == []
+    assert "sensitive context" not in json.dumps(snapshot.inventory)
+
+
+def test_old_snapshot_has_no_invented_recovery_metadata(tmp_path: Path, monkeypatch) -> None:
+    def fail(self):
+        raise ValueError("unclassified")
+
+    monkeypatch.setattr(IdentityBoundReadSession, "finish", fail)
+    current = build_host_boundary_snapshot(tmp_path)
+    old = HostBoundarySnapshot(current.inventory, current.cache)
+    payload = _result(tmp_path, old)
+    assert _denied(payload) == []
+    assert all("recovery" not in v["evidence"] for v in payload["violations"])
+
+
+def test_failure_then_explicit_valid_run_replaces_stop_identity(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / ".mcp.json").write_text('{"mcpServers": {}}')
+    original = IdentityBoundReadSession.finish
+    calls = 0
+
+    def fail_once(self):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("transient failure, no known cause")
+        return original(self)
+
+    monkeypatch.setattr(IdentityBoundReadSession, "finish", fail_once)
+    failed = _result(tmp_path, build_host_boundary_snapshot(tmp_path))
+    _denied(failed)
+    assert calls == 1  # never silently retry into a new authority
+    valid = _result(tmp_path, build_host_boundary_snapshot(tmp_path))
+    assert valid["input_coverage"] == "complete"
+    assert valid["control"]["state"] == "complete"
+    assert failed["audit_id"] != valid["audit_id"]
+    assert failed["control"]["state"] == "human_review_required"
+
+
+@pytest.mark.parametrize("output", ["boundary", "control", "audit"])
+def test_public_cli_recovery_is_bounded_redacted_and_locatable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, output: str,
+) -> None:
+    secret = "ghp_" + "S" * 36
+    folder = "settings TOKEN=" + secret + " " + "long" * 20
+    (tmp_path / folder).mkdir()
+    original = IdentityBoundReadSession.directory_entries
+
+    def fail(self, relative=Path(), **kwargs):
+        if relative.as_posix() == folder:
+            raise OSError(f"{secret} https://user:password@host/private?token=SECRET " + "x" * 5000)
+        return original(self, relative, **kwargs)
+
+    monkeypatch.setattr(IdentityBoundReadSession, "directory_entries", fail)
+    args = ["audit", "--host", "--json"] if output == "audit" else [
+        "check", "--format", "agent-control-json" if output == "control" else "agent-boundary-json",
+    ]
+    if output != "audit":
+        diff = tmp_path / "empty.diff"
+        diff.write_text("")
+        args.extend(["--diff", str(diff)])
+    invoked = CliRunner().invoke(app, [*args, "--workspace", str(tmp_path)])
+    assert invoked.exit_code == 0, invoked.output
+    assert secret not in invoked.output
+    assert "user:password" not in invoked.output
+    assert "private?token" not in invoked.output
+    assert "x" * 100 not in invoked.output
+    payload = json.loads(invoked.output)
+    if output == "boundary":
+        rows = _denied(payload)
+        assert len(rows) == 1
+        assert rows[0]["path"].startswith("settings TOKEN=")
+        assert len(rows[0]["path"]) <= MAX_FAILURE_TEXT
+        assert "\n" not in rows[0]["path"]
+        assert "settings TOKEN=" in payload["control"]["next_action"]["why"]
+    elif output == "control":
+        assert payload["control_state"] == "human_review_required"
+        assert not any(payload["permissions"].values())
+        assert "settings TOKEN=" in payload["reason"]
+    else:
+        assert payload["issues"]
+        assert all(len(i["message"]) <= MAX_FAILURE_TEXT for i in payload["issues"])
+        assert all("\n" not in i["source"] for i in payload["issues"])
+
+
+def test_multiple_read_failures_are_associated_by_issue_identity(tmp_path: Path) -> None:
+    for folder in ("pkg a", "pkg b"):
+        (tmp_path / folder).mkdir()
+        (tmp_path / folder / ".mcp.json").write_bytes(b"\xff")
+    snapshot = build_host_boundary_snapshot(tmp_path)
+    payload = _result(tmp_path, snapshot)
+    rows = _denied(payload)
+    assert {r["path"] for r in rows} == {"pkg a/.mcp.json", "pkg b/.mcp.json"}
+    assert all(r["evidence"]["recovery"]["source"] == r["path"] for r in rows)
+    assert all(r["path"] in r["recommendation"] for r in rows)
+    assert _result(tmp_path, snapshot) == payload
+    assert host_audit_inventory(tmp_path, snapshot=snapshot) == snapshot.inventory
+
+
+def test_fallback_rows_are_sanitized_before_dedupe_and_identity(tmp_path: Path) -> None:
+    def build(secret: str):
+        return build_agent_boundary_result(evaluate_agent_boundary(
+            workspace=tmp_path, diff_text="", input_issues=[
+                BoundaryInputIssue(
+                    code="host_inventory_unreadable",
+                    path=f"TOKEN={secret}\n" + "long-path/" * 100,
+                    message=f"TOKEN={secret}\n" + "large-error " * 100,
+                ),
+            ],
+        )).model_dump(mode="json")
+
+    first = build("ghp_" + "A" * 36)
+    second = build("ghp_" + "B" * 36)
+    assert first == second  # redacted private values do not affect control identity
+    _denied(first)
+    for row in first["violations"]:
+        assert len(row["path"]) <= MAX_FAILURE_TEXT
+        assert "\n" not in row["path"]
+    for row in first["diagnostics"]:
+        assert len(row["message"]) <= MAX_FAILURE_TEXT
+
+
+def test_recovery_path_bounding_cannot_soften_other_rows_trust_root_classification() -> None:
+    row = AgentResultViolatedRule(
+        id="BOUNDARY-PROTECTED-SURFACE-UNCLASSIFIED",
+        check_id="SHIP-AGENT-BOUNDARY-PROTECTED-SURFACE-UNCLASSIFIED",
+        action="require_review", risk_level="medium",
+        title="Instruction change", path="long-directory/" * 40 + "AGENTS.md",
+        evidence={}, recommendation="Review the instruction change.",
+    )
+    sanitized = _sanitize_violations([row])
+    assert sanitized[0].path == row.path
+    assert not violations_within_agent_actionable_band([row])
+    assert not violations_within_agent_actionable_band(sanitized)
+    assert violations_within_agent_actionable_band([
+        row.model_copy(update={"path": row.path[:MAX_FAILURE_TEXT]}),
+    ])  # losing the basename really would remove this row's gate classification
+
+
+def test_existing_closed_schemas_accept_recovery_projection(tmp_path: Path, monkeypatch) -> None:
+    import jsonschema
+
+    def fail(self):
+        raise ValueError("no coherent read")
+
+    monkeypatch.setattr(IdentityBoundReadSession, "finish", fail)
+    snapshot = build_host_boundary_snapshot(tmp_path)
+    for name, payload in (
+        ("agent-boundary-result-schema.v2.json", _result(tmp_path, snapshot)),
+        ("host-grants-inventory-schema.v0.2.json", snapshot.inventory),
+    ):
+        jsonschema.validate(payload, json.loads((Path("docs") / name).read_text()))


### PR DESCRIPTION
When host inventory fails, `check` currently reduces the explanation to “Boundary input is incomplete,” even when the reader knows the failed directory, configuration file, capture phase or resource limits. It can also describe an unclassified final-validation failure as a proven identity change.

This change carries private read facts into the existing inventory issues, violation evidence, recommendations and control explanation. A read failure names its own source; a resource failure publishes its configured limits; final snapshot validation requests a new coherent read without inferring a race. Failure rows are redacted, bounded and deduplicated before control identity is computed. Existing adapter paths still retain the exact spelling needed for trust-root classification. Every incomplete-input result continues to deny all permissions, and no automatic retry or new control/schema surface is added.

Closes #547.

## Validation

- 18 new regression cases cover actual entry/byte/repository budgets, directory and file failures, invalid UTF-8, real post-read modification, unclassified final-validation errors, named multi-source association, CLI/control/audit privacy, old snapshots, schema compatibility and explicit fresh-run recovery.
- Full local suite: 9,087 passed, 5 skipped. Expanded boundary/control/current-control regressions passed after the path-routing guard; all 76 recovery/inventory tests passed after final deduplication and wording adjustments. The long-path guard proves that truncating an adapter path would otherwise change its trust-root classification.
- Ruff, generated-schema drift and diff checks pass. Existing boundary v2 and host-inventory v0.2 schemas accept the emitted recovery projections without modification.
- Committed verification at `5ed4b4452254102d2ddd7a8ee92a376781be6883` against `1d4c0f841b1d11f5f8e822d60263aa55cd77ded5` returns `passed / mergeable / complete`; a fresh current-control read authorizes publication. Independent GitHub coding-agent review round 1 is complete with no actionable in-scope findings: [review](https://github.com/ThreeMoonsLab/agents-shipgate/pull/589#pullrequestreview-5147815911). All nine applicable GitHub CI jobs passed, including three suite shards and aggregate coverage; the tag-only check was correctly skipped on this PR. [Address round 1](https://github.com/ThreeMoonsLab/agents-shipgate/pull/589#issuecomment-5592970809) records the clean review and deferred findings.

## Boundaries

The private facts describe observed read failures, not deployed permissions or root causes inferred from exception prose. Deeper reader-level entry/mismatch diagnostics are tracked separately in #588 and deferred. The review also reproduced inherited raw host artifact paths; their privacy/identity repair is separately deferred in #590. This change does not diagnose the intermittent authorization-overlay failure in #548 or establish release qualification, independent human approval, pilot adoption or v1.0 readiness.