### PR TITLE
Identify the rejected authorization prerequisite

### DIFF
--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -237,6 +237,21 @@ grant and `shipgate.human_authorization_evaluation/v1` projection are added to
 the final artifact closure, so the newly written terminal receipt binds the
 authorization result and exact command.
 
+If the verifier cannot construct that authorization context, it keeps
+`authorization_context_invalid` in `authorization.reason_codes` and adds one
+fixed prerequisite code. The suffix names the observed stopping point:
+`report_missing`, `runtime_validation_failed`,
+`replace_refs_inspection_failed`, `replace_refs_present`, `grant_load_failed`,
+`review_set_failed`, `subject_not_committed`, `subject_identity_incomplete`,
+`source_engine_mismatch`, `source_executor_mismatch`, or `request_build_failed`;
+each has the `authorization_context_` prefix. These codes describe context
+construction, not a diagnosis inferred from exception text. Raw exceptions,
+grant contents, signatures and private paths are not included. The rejection
+keeps its existing permissions and contributes no executable authorization
+command or accepted grant artifact. A missing trust policy still reports
+`trust_policy_unavailable` after context construction succeeds; it is a
+different prerequisite, not an interchangeable rejection reason.
+
 Authorization v1 permits only one typed Git-push operation. It binds the exact
 commit whose tree was evaluated, a canonical credential-free HTTPS destination
 whose repository identity matches the verified repository, one full

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -4003,19 +4003,28 @@ def _evaluate_authorization_overlay(
             ),
             None,
         )
+    # Fixed prerequisite names expose where context construction stopped,
+    # without publishing exception text or fragments of an external grant.
+    context_failure = "authorization_context_report_missing"
     try:
         if report is None:
             raise ValueError("authorization requires a release report")
+        context_failure = "authorization_context_runtime_validation_failed"
         ensure_authorization_runtime_is_external(workspace)
+        context_failure = "authorization_context_replace_refs_inspection_failed"
         if active_replace_refs(workspace):
+            context_failure = "authorization_context_replace_refs_present"
             raise ValueError("authorization rejects repositories with Git replace refs")
+        context_failure = "authorization_context_grant_load_failed"
         grant = _load_external_human_authorization(
             authorization_path,
             workspace=workspace,
         )
+        context_failure = "authorization_context_review_set_failed"
         review_items = authorization_review_items(report.release_decision.model_dump(mode="json"))
         git = plan.subject.git
         if git.snapshot_kind != "committed_tree" or git.worktree_overlay_sha256 is not None:
+            context_failure = "authorization_context_subject_not_committed"
             raise ValueError("authorization requires a committed Git subject")
         if not (
             git.base_commit_sha
@@ -4024,11 +4033,14 @@ def _evaluate_authorization_overlay(
             and git.head_tree_sha
             and git.source_head_commit_sha
         ):
+            context_failure = "authorization_context_subject_identity_incomplete"
             raise ValueError("authorization requires complete committed PR tree identity")
         signed_source = grant.statement.request
         if signed_source.source_engine_requirement_id != plan.engine.engine_requirement_id:
+            context_failure = "authorization_context_source_engine_mismatch"
             raise ValueError("authorization source engine differs from the current engine")
         if signed_source.source_executor_id != verifier.executor_id:
+            context_failure = "authorization_context_source_executor_mismatch"
             raise ValueError("authorization source executor differs from the current executor")
         # These two IDs are signer-authenticated provenance labels. Unlike the
         # engine, executor, request, subject, decision, tree, review-set, and
@@ -4036,6 +4048,7 @@ def _evaluate_authorization_overlay(
         # set are not transported into this second verification pass. Copying
         # them preserves the exact signed request; it is not an independent
         # provenance check by this verifier.
+        context_failure = "authorization_context_request_build_failed"
         expected_request = build_human_authorization_request(
             repository_id=git.repository_id,
             source_receipt_id=signed_source.source_receipt_id,
@@ -4054,7 +4067,10 @@ def _evaluate_authorization_overlay(
             operation=grant.statement.request.operation,
         )
     except (OSError, ValueError, json.JSONDecodeError):
-        return AuthorizationEvaluationV1.rejected("authorization_context_invalid"), None
+        return (
+            AuthorizationEvaluationV1.rejected("authorization_context_invalid", context_failure),
+            None,
+        )
 
     evaluation = evaluate_human_authorization(
         grant,

--- a/tests/test_authorization_verify_integration.py
+++ b/tests/test_authorization_verify_integration.py
@@ -697,9 +697,60 @@ def test_plugin_enabled_verification_never_exposes_authorized_command(
     ]
 
 
+_CONTEXT_FAILURES = (
+    "report_missing", "runtime_validation_failed", "replace_refs_inspection_failed",
+    "replace_refs_present", "grant_load_failed", "review_set_failed",
+    "subject_not_committed", "subject_identity_incomplete", "source_engine_mismatch",
+    "source_executor_mismatch", "request_build_failed",
+)
+
+
+def _inject_context_failure(
+    failure: str, *, monkeypatch: pytest.MonkeyPatch, secret: str,
+) -> None:
+    """Fail one overlay prerequisite, leaving the actual verifier plan intact."""
+    original = orchestrator._evaluate_authorization_overlay
+
+    def evaluate(**kwargs):
+        with monkeypatch.context() as scoped:
+            def unavailable(*args, **kwargs):
+                error = (
+                    OSError if failure in {"runtime_validation_failed", "replace_refs_inspection_failed"}
+                    else ValueError
+                )
+                raise error(f"private context: {secret}")
+
+            operations = {
+                "runtime_validation_failed": "ensure_authorization_runtime_is_external",
+                "replace_refs_inspection_failed": "active_replace_refs",
+                "review_set_failed": "authorization_review_items",
+                "request_build_failed": "build_human_authorization_request",
+            }
+            if failure in operations:
+                scoped.setattr(orchestrator, operations[failure], unavailable)
+            elif failure == "replace_refs_present":
+                scoped.setattr(orchestrator, "active_replace_refs", lambda _: True)
+            elif failure == "report_missing":
+                kwargs["report"] = None
+            elif failure in {"subject_not_committed", "subject_identity_incomplete"}:
+                plan = kwargs["plan"]
+                update = (
+                    {"snapshot_kind": "worktree_overlay"}
+                    if failure == "subject_not_committed" else {"base_tree_sha": None}
+                )
+                # Model an incomplete prerequisite only at this evaluation
+                # boundary; the real run/receipt retains its committed plan.
+                git = plan.subject.git.model_copy(update=update)
+                subject = plan.subject.model_copy(update={"git": git})
+                kwargs["plan"] = plan.model_copy(update={"subject": subject})
+            return original(**kwargs)
+
+    monkeypatch.setattr(orchestrator, "_evaluate_authorization_overlay", evaluate)
+
+
 @pytest.mark.parametrize(
     "failure",
-    ["tampered", "expired", "wrong_tree", "missing_trust"],
+    ["tampered", "expired", "wrong_tree", "missing_trust", *_CONTEXT_FAILURES],
 )
 def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
     tmp_path: Path,
@@ -707,11 +758,15 @@ def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
     failure: str,
 ) -> None:
     repo = _committed_review_repo(tmp_path)
+    # Establish the external-runtime fixture before either pass. This makes
+    # prerequisites explicit; it is not a claimed fix for the #548 flake.
+    _install_protected_test_broker_runtime(tmp_path, monkeypatch)
     initial, report, exit_code = _verify(repo)
     assert exit_code == 0
     assert report is not None
     assert initial.control.state == "review_publishable"
     _validated_receipt(repo / "agents-shipgate-reports")
+    first_engine = _load_json(repo / "agents-shipgate-reports" / "verification-plan.json")["engine"]
 
     request = _request_from_first_verification(repo)
     now = datetime.now(UTC)
@@ -725,19 +780,25 @@ def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
         )
 
     grant_request = request
-    if failure == "wrong_tree":
+    if failure in {"wrong_tree", "source_engine_mismatch", "source_executor_mismatch"}:
         grant_request = build_human_authorization_request(
             repository_id=request.repository_id,
             source_receipt_id=request.source_receipt_id,
             source_artifact_set_id=request.source_artifact_set_id,
-            source_engine_requirement_id=request.source_engine_requirement_id,
-            source_executor_id=request.source_executor_id,
+            source_engine_requirement_id=(
+                "sha256:" + "e" * 64 if failure == "source_engine_mismatch"
+                else request.source_engine_requirement_id
+            ),
+            source_executor_id=(
+                "sha256:" + "d" * 64 if failure == "source_executor_mismatch"
+                else request.source_executor_id
+            ),
             verification_request_id=request.verification_request_id,
             subject_id=request.subject_id,
             decision_id=request.decision_id,
             base_commit_sha=request.base_commit_sha,
             merge_base_sha=request.merge_base_sha,
-            base_tree_sha="f" * 40,
+            base_tree_sha="f" * 40 if failure == "wrong_tree" else request.base_tree_sha,
             head_tree_sha=request.head_tree_sha,
             source_head_commit_sha=request.source_head_commit_sha,
             review_items=request.review_items,
@@ -775,12 +836,28 @@ def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
         "default_human_authorization_trust_policy_path",
         lambda: trust_path,
     )
-    _install_protected_test_broker_runtime(tmp_path, monkeypatch)
+    secret = "ghp_" + "S" * 36
+    if failure == "grant_load_failed":
+        grant_path.write_text('{"credential": "' + secret + '"', encoding="utf-8")
+    if failure in _CONTEXT_FAILURES:
+        _inject_context_failure(failure, monkeypatch=monkeypatch, secret=secret)
 
     rejected, rejected_report, rejected_exit = _verify(
         repo,
         authorization=grant_path,
     )
+
+    second_engine = _load_json(repo / "agents-shipgate-reports" / "verification-plan.json")["engine"]
+    assert isinstance(first_engine, dict) and isinstance(second_engine, dict)
+    changed_identity_fields = sorted(
+        key for key in first_engine.keys() | second_engine.keys()
+        if first_engine.get(key) != second_engine.get(key)
+    )
+    if initial.executor_id != rejected.executor_id:
+        changed_identity_fields.append("executor_id")
+    # A context rejection is not an acceptable substitute for missing trust.
+    # If the fixture's engine moves, name the differing fields, not their data.
+    assert not changed_identity_fields, f"Fixture runtime changed: {changed_identity_fields}"
 
     assert rejected_exit == exit_code
     assert rejected_report is not None
@@ -796,8 +873,14 @@ def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
             "authorization_request_mismatch",
         },
         "missing_trust": {"trust_policy_unavailable"},
+        **{
+            kind: {"authorization_context_invalid", f"authorization_context_{kind}"}
+            for kind in _CONTEXT_FAILURES
+        },
     }
     assert expected_reasons[failure] <= set(rejected.authorization.reason_codes)
+    if failure in _CONTEXT_FAILURES:
+        assert set(rejected.authorization.reason_codes) == expected_reasons[failure]
     # Every other case must be rejected for its own reason, never because the
     # fixture grant aged out while the test ran.
     if failure != "expired":
@@ -822,3 +905,5 @@ def test_invalid_authorization_keeps_human_stop_and_receipt_valid(
     assert not (out / "human-authorization.json").exists()
     receipt = _validated_receipt(out)
     assert "human_authorization_json" not in receipt.artifact_manifest.artifacts
+    for artifact in receipt.artifact_manifest.artifacts.values():
+        assert secret.encode() not in (out / artifact.path).read_bytes()


### PR DESCRIPTION
An intermittent missing-trust regression returned only `authorization_context_invalid`, hiding whether context construction stopped at runtime validation, grant loading, committed identity or another prerequisite. The original occurrence remains unattributed.

This bounded change retains that existing rejection code and adds one fixed prerequisite code through the existing `authorization.reason_codes` list. It publishes no exception text or grant fragments. The negative integration fixture now establishes its protected runtime before either verification and compares their engine descriptors/executor identities before enforcing the same precise rejection assertions. Context failure still returns no accepted grant or executable authorization command, and the static release gate retains its result.

Refs #548. This implements the bounded diagnostic slice; it does not claim to have reproduced or fixed the original intermittent cause.

## Validation

- Eleven new context-failure cases exercise the real committed-verifier integration: report, runtime, replacement-ref inspection/presence, malformed external grant, review-set construction, committed/complete subject identity, engine/executor mismatch and request construction. Every case keeps the static gate, validates the terminal receipt and checks all bound artifact bytes for an injected secret sentinel.
- All 15 precise rejection cases and the complete authorization/signature test families pass. The missing-trust case still requires `trust_policy_unavailable`; it never accepts a generic context rejection instead.
- Full frozen-source parallel suite (`pytest -n 8`): 9,099 passed, 5 skipped. The original intermittent failure did not recur. Ruff, generated-schema drift and diff checks pass; no schema changed.
- Against archived base `e3cf199ad`, the same new runtime-failure test fails specifically because the prerequisite code is absent, while the unchanged missing-trust control passes.
- Working-tree and committed verification at `9be72cc40e275e3c2a1dafcc9056d8070b524e0b` against `e3cf199ad` report `passed / mergeable / complete`; the fresh current-control read confirms all permissions. GitHub CI and an independent GitHub coding-agent review/address round are required before merge.

## Remaining uncertainty

The independent investigation ran the actual missing-trust case with two identical engine descriptors and found no differing fields. Moving the launcher fixture makes setup explicit; it is not evidence that launcher timing caused the original failure. A future recurrence must be attributed from its named prerequisite and descriptor differences before a cause-specific repair can be claimed. The existing exception boundary is preserved, including separate handling of Git `ConfigError` failures; this PR does not broaden operational authorization or supply human approval.