### PR TITLE
Preserve product identity recovery from discovery evidence

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -403,9 +403,13 @@ is not evidence. Doctor's placeholder diagnostic carries the same review route.
 A selectable product declaration remains a coding-agent edit and names its
 source file. No setup permission changes.
 
-Init reuses its current discovery result; doctor recomputes only for an actual
-unresolved `agent.name`, under that manifest's directory rather than a wider
-workspace or sibling project. The recovery facts participate in `input_id`;
+Init reuses its current discovery result when its workspace is the loaded
+manifest's directory; an existing manifest reached through a link to another
+directory gets fresh discovery at the resolved target. Doctor also recomputes
+there, only for an actual unresolved `agent.name`, rather than using a wider
+workspace or a sibling project. Edit locations retain the caller's manifest
+spelling; product-name guidance names the actual source file. The recovery
+facts participate in `input_id`;
 saved discovery JSON is never a routing input. Capped, ambiguous or partly
 unparsed discovery cannot establish test/template-only evidence. Broader
 unresolved-name recovery remains unchanged, and doctor does not offer a

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -394,6 +394,24 @@ to be corrected later — it is a declaration nobody made, and Shipgate treats i
 as evidence. Every other placeholder (a tool-source path, a project name) is
 ordinary repository reading and stays coding-agent work.
 
+`agent.name` has one contextual exception (#543). When fresh discovery has
+resolved the manifest scope, read the complete Python inventory and found names
+only in test/template code, `init` and `doctor` ask a person to choose the product
+identity or supply product code that establishes it. The route names the field
+and line even after purpose has been supplied; an arbitrary nonempty replacement
+is not evidence. Doctor's placeholder diagnostic carries the same review route.
+A selectable product declaration remains a coding-agent edit and names its
+source file. No setup permission changes.
+
+Init reuses its current discovery result; doctor recomputes only for an actual
+unresolved `agent.name`, under that manifest's directory rather than a wider
+workspace or sibling project. The recovery facts participate in `input_id`;
+saved discovery JSON is never a routing input. Capped, ambiguous or partly
+unparsed discovery cannot establish test/template-only evidence. Broader
+unresolved-name recovery remains unchanged, and doctor does not offer a
+higher-cap retry it has no flag to consume. These facts describe the current
+invocation; they do not provide a verifier snapshot or release authority.
+
 Matching is on every segment, not the leaf, because `collect_placeholders` names
 a list item by its own text: a `CHANGE_ME` under `declared_purpose: [...]` is
 reported as `agent.declared_purpose.CHANGE_ME`.

--- a/src/agents_shipgate/cli/_register_doctor.py
+++ b/src/agents_shipgate/cli/_register_doctor.py
@@ -15,6 +15,7 @@ from agents_shipgate.cli.agent_mode import (
     emit_agent_mode_error_routing as _emit_agent_mode_error_routing,
 )
 from agents_shipgate.cli.diagnostics import diagnose_doctor, top_next_actions
+from agents_shipgate.cli.discovery.identity_recovery import discover_agent_name
 from agents_shipgate.cli.discovery.placeholders import collect_placeholders
 from agents_shipgate.cli.scan.inspect import (
     MANIFEST_SNAPSHOT_KEY,
@@ -136,6 +137,11 @@ def _doctor_failure_routing(
         # and the reason already names the defect.
         text = ""
     placeholders = collect_placeholders(text)
+    name_recovery = (
+        discover_agent_name(path, placeholders)
+        if not any(diag.severity == "block" for diag in diagnostics)
+        else None
+    )
     recheck = recheck_command or render_command(
         ["doctor", "--config", str(path.resolve()), "--json"]
     )
@@ -157,6 +163,7 @@ def _doctor_failure_routing(
         manifest_bytes=manifest_bytes,
         manifest_display_path=str(path),
         recheck_command=recheck,
+        name_recovery=name_recovery,
     )
 
 
@@ -356,11 +363,13 @@ def register(app: typer.Typer) -> None:
             # same input language.
             manifest_text = decode_manifest(manifest_bytes, path)
             placeholders = collect_placeholders(manifest_text)
+            name_recovery = discover_agent_name(path, placeholders)
             diagnostics = diagnose_doctor(
                 payload,
                 manifest_path=path,
                 manifest_text=manifest_text,
                 placeholders=placeholders,
+                name_recovery=name_recovery,
             )
             manifest_workspace = (workspace or path.parent).resolve()
             routing = setup_control_envelope(
@@ -394,11 +403,13 @@ def register(app: typer.Typer) -> None:
                         # rather than for most of it.
                         payload.get("adoption"),
                         placeholders,
+                        name_recovery.identity_facts if name_recovery else None,
                     ),
                 ),
                 reason=_doctor_reason(payload, path),
                 diagnostics=diagnostics,
                 placeholders=placeholders,
+                name_recovery=name_recovery,
                 manifest_display_path=str(path),
                 advance=_doctor_advance(path, workspace=manifest_workspace),
                 advance_kind="verify",

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -37,6 +37,7 @@ from agents_shipgate.cli.discovery.gitignore_block import (
     GitignoreOutcomeStatus,
     ensure_reports_gitignore,
 )
+from agents_shipgate.cli.discovery.identity_recovery import classify_agent_name, needs_agent_name
 from agents_shipgate.cli.discovery.local_contract import LOCAL_CONTRACT_RELATIVE_PATH
 from agents_shipgate.cli.discovery.local_review import (
     LocalReviewExcludeOutcome,
@@ -1965,6 +1966,11 @@ def register(app: typer.Typer) -> None:
         control_placeholders, control_manifest_bytes, manifest_defect = _manifest_placeholders(
             target, template=template, placeholders=placeholders, write=write
         )
+        name_recovery = (
+            classify_agent_name(detect_result)
+            if not minimal and needs_agent_name(control_placeholders)
+            else None
+        )
         # One read of the pack the manifest on disk carries, shared by the route
         # and by the `control_pack` block of the payload. Reading it twice would
         # let a route be selected against one answer and reported beside
@@ -2037,6 +2043,7 @@ def register(app: typer.Typer) -> None:
                     manifest_exit,
                     agent_instructions_exit,
                     control_placeholders,
+                    name_recovery.identity_facts if name_recovery else None,
                     manifest_defect,
                     advance_decision,
                     # Not carried by the action, and between them they decide
@@ -2090,22 +2097,27 @@ def register(app: typer.Typer) -> None:
             advance_alternatives=scope_actions[1:],
             recheck_command=_doctor_command(target),
             placeholders=control_placeholders,
+            name_recovery=name_recovery,
             manifest_display_path=str(target),
             human_review_suffix=(
-                "A human must decide whether to keep this setup provisional "
-                "or adopt it durably. If approved, use `"
-                + render_command(
-                    [
-                        "init",
-                        "--workspace",
-                        str(workspace_resolved),
-                        "--write",
-                        "--json",
-                    ]
+                "A human must also decide whether to adopt this provisional setup durably."
+                if local_review and not scope_refused and name_recovery and name_recovery.human_reason
+                else (
+                    "A human must decide whether to keep this setup provisional "
+                    "or adopt it durably. If approved, use `"
+                    + render_command(
+                        [
+                            "init",
+                            "--workspace",
+                            str(workspace_resolved),
+                            "--write",
+                            "--json",
+                        ]
+                    )
+                    + "`."
+                    if local_review and not scope_refused
+                    else None
                 )
-                + "`."
-                if local_review and not scope_refused
-                else None
             ),
             exit_code=max(manifest_exit, agent_instructions_exit) or None,
         )

--- a/src/agents_shipgate/cli/_register_init.py
+++ b/src/agents_shipgate/cli/_register_init.py
@@ -37,7 +37,11 @@ from agents_shipgate.cli.discovery.gitignore_block import (
     GitignoreOutcomeStatus,
     ensure_reports_gitignore,
 )
-from agents_shipgate.cli.discovery.identity_recovery import classify_agent_name, needs_agent_name
+from agents_shipgate.cli.discovery.identity_recovery import (
+    classify_agent_name,
+    discover_agent_name,
+    needs_agent_name,
+)
 from agents_shipgate.cli.discovery.local_contract import LOCAL_CONTRACT_RELATIVE_PATH
 from agents_shipgate.cli.discovery.local_review import (
     LocalReviewExcludeOutcome,
@@ -1967,8 +1971,12 @@ def register(app: typer.Typer) -> None:
             target, template=template, placeholders=placeholders, write=write
         )
         name_recovery = (
-            classify_agent_name(detect_result)
-            if not minimal and needs_agent_name(control_placeholders)
+            (
+                classify_agent_name(detect_result)
+                if target.resolve().parent == workspace_resolved
+                else discover_agent_name(target, control_placeholders)
+            )
+            if not minimal and not manifest_defect and needs_agent_name(control_placeholders)
             else None
         )
         # One read of the pack the manifest on disk carries, shared by the route

--- a/src/agents_shipgate/cli/diagnostics.py
+++ b/src/agents_shipgate/cli/diagnostics.py
@@ -22,6 +22,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from agents_shipgate.cli.discovery.identity_recovery import AgentNameRecovery
 from agents_shipgate.core.adopter_text import (
     DUPLICATE_ACROSS_ARTIFACTS,
     DUPLICATE_TOOL_IN_SOURCE,
@@ -730,6 +731,7 @@ def diagnose_doctor(
     manifest_path: Path,
     manifest_text: str,
     placeholders: list[dict[str, Any]] | None = None,
+    name_recovery: AgentNameRecovery | None = None,
 ) -> list[Diagnostic]:
     """Diagnostics for ``doctor --json``.
 
@@ -907,6 +909,27 @@ def diagnose_doctor(
             target = (
                 f"{manifest_rel}:{line}" if line is not None else manifest_rel
             )
+            if entry.get("path") == "agent.name" and name_recovery is not None:
+                if name_recovery.human_reason:
+                    actions.append(NextAction(
+                        kind="review",
+                        path=target,
+                        why=f"{target} (agent.name): {name_recovery.human_reason}",
+                        expects="A reviewed product identity or product code that establishes it.",
+                    ))
+                    continue
+                if name_recovery.state == "product" and name_recovery.product_path:
+                    actions.append(NextAction(
+                        kind="edit",
+                        path=target,
+                        why=(
+                            f"Read the product agent name in {name_recovery.product_path} "
+                            f"relative to {manifest_path.parent} and replace CHANGE_ME "
+                            "at field 'agent.name'."
+                        ),
+                        expects="agent.name matches the supported product declaration.",
+                    ))
+                    continue
             actions.append(
                 NextAction(
                     kind="edit",

--- a/src/agents_shipgate/cli/diagnostics.py
+++ b/src/agents_shipgate/cli/diagnostics.py
@@ -924,7 +924,7 @@ def diagnose_doctor(
                         path=target,
                         why=(
                             f"Read the product agent name in {name_recovery.product_path} "
-                            f"relative to {manifest_path.parent} and replace CHANGE_ME "
+                            "and replace CHANGE_ME "
                             "at field 'agent.name'."
                         ),
                         expects="agent.name matches the supported product declaration.",

--- a/src/agents_shipgate/cli/discovery/identity_recovery.py
+++ b/src/agents_shipgate/cli/discovery/identity_recovery.py
@@ -1,0 +1,96 @@
+"""Private, invocation-local evidence for recovering an unresolved agent name."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from agents_shipgate.cli.discovery.signals import (
+    _non_product_origin,
+    detect_workspace,
+    select_agent_name,
+)
+from agents_shipgate.core.errors import DiscoveryError
+from agents_shipgate.schemas.detect import DetectResult
+
+
+@dataclass(frozen=True)
+class AgentNameRecovery:
+    state: Literal["product", "non_product_only", "unresolved"]
+    facts: dict[str, object]
+    product_path: str | None = None
+
+    @property
+    def identity_facts(self) -> dict[str, object]:
+        return {"state": self.state, "facts": self.facts, "product_path": self.product_path}
+
+    @property
+    def human_reason(self) -> str | None:
+        if self.state != "non_product_only":
+            return None
+        return (
+            "Readable names are from test/template code. A person must choose "
+            "agent.name or supply product code; an arbitrary nonempty value is not evidence."
+        )
+
+
+def needs_agent_name(placeholders: Sequence[Mapping[str, object]]) -> bool:
+    return any(entry.get("path") == "agent.name" for entry in placeholders)
+
+
+def classify_agent_name(result: DetectResult) -> AgentNameRecovery:
+    """Classify only the names this discovery read, never an absence of agents.
+
+    Coverage and scope outrank selection. A capped or partly unreadable census
+    cannot establish that its test names are the only readable candidates.
+    No warning/rationale prose or saved discovery artifact is a routing input.
+    """
+    candidates = [
+        candidate for candidate in result.agent_name_candidates
+        if candidate.role != "workspace_dir"
+    ]
+    signals = result.workspace_signals
+    facts = {
+        "candidates": [candidate.model_dump(mode="json", exclude={"rationale", "rank_score"})
+                       for candidate in candidates],
+        "agent_scope": result.agent_scope,
+        "agent_scope_truncated": result.agent_scope_truncated,
+        "python_parse_truncated": result.python_parse_truncated,
+        "python_file_count": signals.python_file_count,
+        "python_file_total": signals.python_file_total,
+    }
+    if (
+        result.agent_scope != "single"
+        or result.agent_scope_truncated
+        or result.python_parse_truncated
+        or signals.python_file_count != signals.python_file_total
+    ):
+        return AgentNameRecovery("unresolved", facts)
+    selected = select_agent_name(candidates)
+    if selected is not None:
+        return AgentNameRecovery("product", facts, selected.path)
+    if candidates and all(
+        candidate.path is not None and _non_product_origin(candidate.path) is not None
+        for candidate in candidates
+    ):
+        return AgentNameRecovery("non_product_only", facts)
+    return AgentNameRecovery("unresolved", facts)
+
+
+def discover_agent_name(
+    manifest_path: Path, placeholders: Sequence[Mapping[str, object]],
+) -> AgentNameRecovery | None:
+    """Fresh doctor evidence, scoped to this manifest rather than its siblings.
+
+    Discovery failure does not replace the existing manifest/source failure.
+    Doctor has no parse-cap override, so offer no higher-cap retry it cannot
+    consume. Broader unresolved-name recovery remains outside this slice.
+    """
+    if not needs_agent_name(placeholders):
+        return None
+    try:
+        return classify_agent_name(detect_workspace(manifest_path.parent.resolve()))
+    except DiscoveryError:
+        return AgentNameRecovery("unresolved", {"discovery_failed": True})

--- a/src/agents_shipgate/cli/discovery/identity_recovery.py
+++ b/src/agents_shipgate/cli/discovery/identity_recovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal
 
@@ -91,6 +91,14 @@ def discover_agent_name(
     if not needs_agent_name(placeholders):
         return None
     try:
-        return classify_agent_name(detect_workspace(manifest_path.parent.resolve()))
+        # Source inspection resolves the manifest itself before choosing its
+        # directory. A link's parent can contain an unrelated product or tests.
+        root = manifest_path.resolve().parent
+        recovery = classify_agent_name(detect_workspace(root))
+        return replace(
+            recovery,
+            facts={**recovery.facts, "workspace": str(root)},
+            product_path=str(root / recovery.product_path) if recovery.product_path else None,
+        )
     except DiscoveryError:
         return AgentNameRecovery("unresolved", {"discovery_failed": True})

--- a/src/agents_shipgate/cli/setup_control.py
+++ b/src/agents_shipgate/cli/setup_control.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Literal
 
 from agents_shipgate.cli.diagnostics import ranked_diagnostics
+from agents_shipgate.cli.discovery.identity_recovery import AgentNameRecovery
 from agents_shipgate.cli.discovery.placeholders import human_owned_placeholders
 from agents_shipgate.core.agent_control import derive_agent_control
 from agents_shipgate.core.agent_control_envelope import envelope_from_setup
@@ -210,6 +211,7 @@ def setup_control_envelope(
     placeholders: Sequence[Mapping[str, object]] | None = None,
     manifest_display_path: str | None = None,
     human_review_suffix: str | None = None,
+    name_recovery: AgentNameRecovery | None = None,
     execution: AgentControlExecution = "succeeded",
     exit_code: int | None = None,
 ) -> SetupRouting:
@@ -256,6 +258,13 @@ def setup_control_envelope(
 
     ordered = ranked_diagnostics(list(diagnostics))
     pending_human = human_owned_placeholders(placeholders)
+    identity_reason = None
+    if name_recovery is not None and name_recovery.human_reason:
+        pending_human = [
+            entry for entry in (placeholders or [])
+            if entry in pending_human or entry.get("path") == "agent.name"
+        ]
+        identity_reason = name_recovery.human_reason
     alternatives = [diag.next_actions[0] for diag in ordered]
 
     blocking = next((diag for diag in ordered if diag.severity == "block"), None)
@@ -275,6 +284,10 @@ def setup_control_envelope(
             pending_human,
             manifest_display_path,
             reserved_suffix=human_review_suffix,
+            review_tail=(
+                f" require a human decision. {identity_reason}"
+                if identity_reason else _PLACEHOLDER_REVIEW_TAIL
+            ),
         )
         selected = NextAction(
             kind="review",
@@ -380,6 +393,7 @@ def setup_failure_routing(
     manifest_display_path: str | None = None,
     recheck_command: str | None = None,
     routing_facts: object = None,
+    name_recovery: AgentNameRecovery | None = None,
 ) -> SetupRouting:
     """The shared envelope for a setup command that could not finish.
 
@@ -450,6 +464,7 @@ def setup_failure_routing(
                 action_kind,
                 [item.model_dump(mode="json") for item in ranked_diagnostics(list(diagnostics))],
                 routing_facts,
+                name_recovery.identity_facts if name_recovery else None,
             ),
         ),
         reason=reason,
@@ -463,6 +478,7 @@ def setup_failure_routing(
         recheck_command=recheck_command,
         execution="failed",
         exit_code=exit_code,
+        name_recovery=name_recovery,
     )
 
 
@@ -585,6 +601,7 @@ def _placeholder_review_why(
     manifest_display_path: str | None,
     *,
     reserved_suffix: str | None = None,
+    review_tail: str = _PLACEHOLDER_REVIEW_TAIL,
 ) -> str:
     """Name the exact fields and lines a person has to fill in.
 
@@ -610,7 +627,7 @@ def _placeholder_review_why(
         return len(text.encode("utf-8"))
 
     suffix = f" {reserved_suffix}" if reserved_suffix else ""
-    budget = MAX_ENVELOPE_PROSE_BYTES - size(_PLACEHOLDER_REVIEW_TAIL) - size(suffix)
+    budget = MAX_ENVELOPE_PROSE_BYTES - size(review_tail) - size(suffix)
     manifest = manifest_display_path or "shipgate.yaml"
     # The manifest is named once and the lines refer to it, rather than repeated
     # per entry. Repeating it spent the whole budget on a deep absolute path
@@ -662,7 +679,7 @@ def _placeholder_review_why(
             break
         used += (2 if shown else 0) + size(candidate)
         shown.append(candidate)
-    return prefix + ", ".join(shown) + _PLACEHOLDER_REVIEW_TAIL + suffix
+    return prefix + ", ".join(shown) + review_tail + suffix
 
 
 def _basename(path: str) -> str:

--- a/tests/test_agent_name_recovery.py
+++ b/tests/test_agent_name_recovery.py
@@ -276,3 +276,51 @@ def test_init_refused_scope_outranks_name_obligation(tmp_path):
     assert payload["manifest_status"] == "refused_unresolved_scope"
     assert "test/template" not in payload["next_actions"][0]["why"]
     assert not any(payload["control"]["permissions"].values())
+
+
+@pytest.mark.parametrize("product_at_target", [True, False])
+@pytest.mark.parametrize("command", ["doctor", "init"])
+def test_linked_manifest_recovers_from_loaded_project_not_link_directory(
+    tmp_path, product_at_target, command,
+):
+    actual, alias = tmp_path / "actual", tmp_path / "alias"
+    actual_source = "agent.py" if product_at_target else NON_PRODUCT_PATHS[0]
+    alias_source = NON_PRODUCT_PATHS[0] if product_at_target else "agent.py"
+    _agent(actual, actual_source, "ActualAssistant")
+    _agent(alias, alias_source, "UnrelatedAssistant")
+    target = _manifest(actual)
+    link = alias / "shipgate.yaml"
+    link.symlink_to(target)
+    if command == "doctor":
+        payload = _doctor(link)
+    else:
+        result = runner.invoke(app, ["init", "--workspace", str(alias), "--write", "--json"])
+        assert result.exit_code == 2, result.output
+        payload = json.loads(result.stdout)
+    if product_at_target:
+        assert payload["control"]["control_state"] == "agent_action_required"
+        if command == "doctor":
+            action = payload["next_actions"][0]
+            assert str(actual / "agent.py") in action["why"]
+            assert str(alias / "agent.py") not in action["why"]
+            assert action["path"].startswith(str(link))
+    else:
+        _human_identity(payload)
+    assert not any(payload["control"]["permissions"].values())
+    assert link.is_symlink()
+    assert yaml.safe_load(target.read_text())["agent"]["name"] == "CHANGE_ME"
+
+
+def test_linked_manifest_source_failure_keeps_actual_identity_obligation(tmp_path, monkeypatch):
+    actual, alias = tmp_path / "actual", tmp_path / "alias"
+    _agent(actual, NON_PRODUCT_PATHS[0])
+    _agent(alias, "agent.py", "UnrelatedAssistant")
+    target = _manifest(actual)
+    (actual / "mcp.tools.json").write_text("not JSON")
+    link = alias / "shipgate.yaml"
+    link.symlink_to(target)
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    result = runner.invoke(app, ["doctor", "--config", str(link), "--json"])
+    assert result.exit_code == 3, result.output
+    error = json.loads(next(line for line in result.stderr.splitlines() if line.startswith("{")))
+    _human_identity(error)

--- a/tests/test_agent_name_recovery.py
+++ b/tests/test_agent_name_recovery.py
@@ -1,0 +1,278 @@
+"""#543: a rejected fixture identity must not become an arbitrary edit later."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.discovery import identity_recovery
+from agents_shipgate.cli.discovery.identity_recovery import classify_agent_name
+from agents_shipgate.cli.discovery.signals import detect_workspace
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.errors import DiscoveryError
+
+runner = CliRunner()
+NON_PRODUCT_PATHS = [
+    "eval/test_agent.py",
+    "skills/recipe/resources/templates/app/agent.py",
+]
+
+
+def _write(workspace: Path, name: str, text: str) -> Path:
+    path = workspace / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _agent(workspace: Path, path: str, name: str = "FixtureAgent") -> Path:
+    return _write(workspace, path,
+        f'from google.adk.agents import Agent\nroot_agent = Agent(name="{name}")\n')
+
+
+def _tools(workspace: Path) -> None:
+    _write(workspace, "mcp.tools.json", json.dumps({"tools": [{
+        "name": "lookup", "description": "Read local fixture metadata.",
+        "inputSchema": {"type": "object", "properties": {}},
+    }]}))
+
+
+def _manifest(workspace: Path) -> Path:
+    _tools(workspace)
+    return _write(workspace, "shipgate.yaml", yaml.safe_dump({
+        "version": "0.1", "project": {"name": "identity-fixture"},
+        "agent": {"name": "CHANGE_ME", "declared_purpose": ["Read fixture metadata"]},
+        "environment": {"target": "local"},
+        "tool_sources": [{"id": "lookup", "type": "mcp", "path": "mcp.tools.json"}],
+    }, sort_keys=False))
+
+
+def _doctor(manifest: Path, *, workspace: Path | None = None) -> dict:
+    args = ["doctor", "--config", str(manifest), "--json"]
+    if workspace is not None:
+        args.extend(["--workspace", str(workspace)])
+    result = runner.invoke(app, args)
+    assert result.exit_code == 0, result.output
+    payloads = json.loads(result.stdout)
+    return next(p for p in payloads if Path(p["config"]).resolve() == manifest.resolve())
+
+
+def _human_identity(payload: dict) -> None:
+    control = payload["control"]
+    assert control["control_state"] == "human_review_required"
+    assert not any(control["permissions"].values())
+    assert control["next_action"]["command"] is None
+    assert len(payload["next_actions"]) == 1
+    action = payload["next_actions"][0]
+    assert action["kind"] == "review"
+    assert action["why"] == control["next_action"]["why"]
+    assert "agent.name" in action["why"]
+    assert "test/template" in action["why"]
+    assert "arbitrary nonempty" in action["why"]
+    for diagnostic in payload.get("diagnostics", []):
+        for offered in diagnostic["next_actions"]:
+            if "agent.name" in offered["why"]:
+                assert offered["kind"] == "review"
+
+
+@pytest.mark.parametrize("source", NON_PRODUCT_PATHS)
+def test_init_then_purpose_only_edit_preserves_identity_obligation(tmp_path, source):
+    _agent(tmp_path, source)
+    _tools(tmp_path)
+    result = runner.invoke(app, ["init", "--workspace", str(tmp_path), "--write", "--json"])
+    assert result.exit_code == 0, result.output
+    _human_identity(json.loads(result.stdout))
+    manifest = tmp_path / "shipgate.yaml"
+    data = yaml.safe_load(manifest.read_text())
+    assert data["agent"]["name"] == "CHANGE_ME"
+    # A fixture supplies only purpose. Identity remains the actual unresolved field.
+    data["agent"]["declared_purpose"] = ["Read fixture metadata"]
+    manifest.write_text(yaml.safe_dump(data, sort_keys=False))
+    _human_identity(_doctor(manifest))
+
+
+@pytest.mark.parametrize("product", ["aaa_product.py", "zzz_product.py"])
+def test_product_declaration_remains_agent_recoverable(tmp_path, product):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    _agent(tmp_path, product, "BillingAssistant")
+    manifest = _manifest(tmp_path)
+    payload = _doctor(manifest)
+    assert payload["control"]["control_state"] == "agent_action_required"
+    assert not any(payload["control"]["permissions"].values())
+    action = payload["next_actions"][0]
+    assert action["kind"] == "edit"
+    assert product in action["why"]
+    assert action["path"] == payload["control"]["next_action"]["path"]
+    assert "supported product declaration" in action["expects"]
+
+
+def test_doctor_recomputes_identity_without_manifest_change(tmp_path):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    manifest = _manifest(tmp_path)
+    original = manifest.read_bytes()
+    before = _doctor(manifest)
+    _human_identity(before)
+    # A saved result is deliberately stale; doctor must not consume it.
+    _write(tmp_path, "detect.json", detect_workspace(tmp_path).model_dump_json())
+    product = _agent(tmp_path, "agent.py", "BillingAssistant")
+    after = _doctor(manifest)
+    assert after["control"]["control_state"] == "agent_action_required"
+    assert after["control"]["input_id"] != before["control"]["input_id"]
+    product.unlink()
+    restored = _doctor(manifest)
+    _human_identity(restored)
+    assert restored["control"]["input_id"] == before["control"]["input_id"]
+    assert manifest.read_bytes() == original
+
+
+def test_workspace_doctor_does_not_borrow_a_sibling_name(tmp_path):
+    scoped = tmp_path / "scoped"
+    _agent(scoped, NON_PRODUCT_PATHS[0])
+    manifest = _manifest(scoped)
+    _agent(tmp_path / "sibling", "agent.py", "SiblingAssistant")
+    _human_identity(_doctor(manifest, workspace=tmp_path))
+
+
+@pytest.mark.parametrize("condition", ["cap", "ambiguous", "scope_cap", "unparsed", "unknown"])
+def test_incomplete_discovery_is_not_non_product_only(tmp_path, condition):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    detected = detect_workspace(tmp_path)
+    assert classify_agent_name(detected).state == "non_product_only"
+    changes = {
+        "cap": {"python_parse_truncated": True},
+        "ambiguous": {"agent_scope": "ambiguous"},
+        "scope_cap": {"agent_scope_truncated": True},
+        "unparsed": {"workspace_signals": detected.workspace_signals.model_copy(
+            update={"python_file_total": detected.workspace_signals.python_file_total + 1})},
+        "unknown": {"agent_scope": "unknown"},
+    }
+    assert classify_agent_name(detected.model_copy(update=changes[condition])).state == "unresolved"
+
+
+@pytest.mark.parametrize("broken", [b"not valid python !!!", b"\xff"])
+def test_unparsed_python_prevents_conclusive_identity_classification(tmp_path, broken):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    (tmp_path / "broken.py").write_bytes(broken)
+    detected = detect_workspace(tmp_path)
+    assert not detected.python_parse_truncated
+    assert detected.workspace_signals.python_file_count < detected.workspace_signals.python_file_total
+    assert classify_agent_name(detected).state == "unresolved"
+
+
+def test_real_cap_is_not_reoffered_as_unusable_doctor_retry(tmp_path, monkeypatch):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    _agent(tmp_path, "zzz.py", "ProductAssistant")
+    manifest = _manifest(tmp_path)
+    monkeypatch.setattr(identity_recovery, "detect_workspace",
+                        lambda workspace: detect_workspace(workspace, max_python_files=1))
+    payload = _doctor(manifest)
+    assert "test/template" not in json.dumps(payload["control"])
+    assert "--max-python-files" not in json.dumps(payload["next_actions"])
+
+
+def test_discovery_failure_preserves_existing_doctor_recovery(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    def refuse(workspace):
+        raise DiscoveryError("private failure detail")
+    monkeypatch.setattr(identity_recovery, "detect_workspace", refuse)
+    payload = _doctor(manifest)
+    assert not any(payload["control"]["permissions"].values())
+    assert "private failure detail" not in json.dumps(payload)
+    assert "test/template" not in json.dumps(payload["control"])
+
+
+def test_resolved_identity_does_not_trigger_extra_discovery(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    manifest.write_text(manifest.read_text().replace("CHANGE_ME", "ReviewedFixture"))
+    def unexpected(workspace):
+        pytest.fail("No identity placeholder; no discovery is needed")
+    monkeypatch.setattr(identity_recovery, "detect_workspace", unexpected)
+    assert _doctor(manifest)["control"]["control_state"] == "agent_action_required"
+
+
+@pytest.mark.parametrize("flags", [[], ["--minimal"], ["--minimal", "--write"]])
+def test_dry_run_and_minimal_keep_existing_precedence(tmp_path, flags):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    result = runner.invoke(app, ["init", "--workspace", str(tmp_path), "--json", *flags])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert not any(payload["control"]["permissions"].values())
+    assert "test/template" not in payload["next_actions"][0]["why"]
+    if "--write" not in flags:
+        assert payload["control"]["control_state"] == "agent_action_required"
+        assert not (tmp_path / "shipgate.yaml").exists()
+
+
+def test_existing_manifest_identity_controls_init_not_new_template(tmp_path):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    manifest = _manifest(tmp_path)
+    before = manifest.read_bytes()
+    result = runner.invoke(app, ["init", "--workspace", str(tmp_path), "--write", "--json"])
+    assert result.exit_code == 2, result.output
+    _human_identity(json.loads(result.stdout))
+    assert manifest.read_bytes() == before
+
+
+def test_source_failure_keeps_identity_in_agent_mode_error(tmp_path, monkeypatch):
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    manifest = _manifest(tmp_path)
+    (tmp_path / "mcp.tools.json").write_text("not JSON")
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    result = runner.invoke(app, ["doctor", "--config", str(manifest), "--json"])
+    assert result.exit_code == 3, result.output
+    error = json.loads(next(line for line in result.stderr.splitlines() if line.startswith("{")))
+    _human_identity(error)
+
+
+def test_invalid_manifest_outranks_identity_discovery(tmp_path, monkeypatch):
+    manifest = _write(tmp_path, "shipgate.yaml", "agent: {name: CHANGE_ME}\n")
+    def unexpected(workspace):
+        pytest.fail("A loader rejection must not trigger name discovery")
+    monkeypatch.setattr(identity_recovery, "detect_workspace", unexpected)
+    monkeypatch.setenv("AGENTS_SHIPGATE_AGENT_MODE", "1")
+    result = runner.invoke(app, ["doctor", "--config", str(manifest), "--json"])
+    assert result.exit_code == 2, result.output
+    error = json.loads(next(line for line in result.stderr.splitlines() if line.startswith("{")))
+    assert error["control"]["control_state"] == "agent_action_required"
+
+
+def test_provisional_setup_keeps_identity_and_durable_choice_within_control_budget(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _agent(tmp_path, NON_PRODUCT_PATHS[0])
+    _tools(tmp_path)
+    result = runner.invoke(app, ["init", "--workspace", str(tmp_path), "--local-review", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _human_identity(payload)
+    assert "adopt this provisional setup durably" in payload["control"]["next_action"]["why"]
+    assert len(payload["control"]["next_action"]["why"].encode()) <= 400
+
+
+def test_cross_module_name_is_evidence_without_reopening_the_declaration_path(tmp_path):
+    manifest = _manifest(tmp_path)
+    _write(tmp_path, "config.py", 'AGENT_NAME = "BillingAssistant"\n')
+    _write(tmp_path, "agent.py", 'from google.adk.agents import Agent\n'
+           'from config import AGENT_NAME\nroot_agent = Agent(name=AGENT_NAME)\n')
+    before = _doctor(manifest)
+    assert before["next_actions"][0]["kind"] == "edit"
+    _write(tmp_path, "config.py", 'AGENT_NAME = "SupportAssistant"\n')
+    after = _doctor(manifest)
+    assert after["next_actions"][0]["kind"] == "edit"
+    assert before["control"]["input_id"] != after["control"]["input_id"]
+
+
+def test_init_refused_scope_outranks_name_obligation(tmp_path):
+    for project in ("first", "second"):
+        _write(tmp_path / project, "pyproject.toml", f'[project]\nname = "{project}"\n')
+        _agent(tmp_path / project, "agent.py", f"{project}Assistant")
+    result = runner.invoke(app, ["init", "--workspace", str(tmp_path), "--write", "--json"])
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload["manifest_status"] == "refused_unresolved_scope"
+    assert "test/template" not in payload["next_actions"][0]["why"]
+    assert not any(payload["control"]["permissions"].values())


### PR DESCRIPTION
A workspace whose readable agent names live only in tests/templates can leave `agent.name: CHANGE_ME`. Init then asks only for purpose, and doctor later offers an arbitrary “real value” edit for the unresolved identity. This loses the reason discovery rejected those names.

Init reuses its invocation's discovery when it describes the loaded manifest directory; an existing linked manifest gets fresh discovery at the resolved target. Doctor also recomputes under that resolved directory only when the name is unresolved, and its product guidance names the actual source file while edit locations retain the caller's manifest spelling. A complete, single-scope result containing only non-product names makes that field a human identity/source decision, including source-failure recovery; a selectable product declaration remains a coding-agent edit naming its file. The same private recovery facts drive diagnostic/control projections and input identity. Setup permissions, global placeholder ownership and public schemas remain unchanged. Provisional setup keeps both identity and durable-adoption choices within the existing compact prose budget.

Closes #543. Broader capped/unparsed/unsupported name recovery remains in #592; the pre-existing stale placeholder example is #593.

## Validation

- 30 new regressions cover the test and scaffolding origins, purpose-only edits, both product-file orders, product addition/removal without manifest edits, ignored stale detection JSON, manifest-local scope, cap/scope ambiguity and unparsed Python, source failure, invalid manifests, dry-run/minimal/existing/provisional setup, cross-module name constants, both directions of linked-manifest scope for init/doctor and linked source-failure recovery.
- The new tests and existing setup/discovery families pass: 394 tests. Ruff, generated-schema drift and diff checks pass; no schema files changed.
- Archived base `ad2055917` fails the same two real init regressions because the human action omits `agent.name`. Only imports of the new private classifier were removed from that test copy; neither selected regression uses them.
- Full frozen-source parallel suite: **9,130 passed, 5 skipped**. Working and committed verification at `4cc48c77fc9a834141a913d3e4de143c773d2100` against `ad2055917` report `passed / mergeable / complete`; fresh current control confirms all permissions. GitHub CI and the required independent review/address round remain required before merge.

## Limits

The classifier says the readable names found are from tests/templates; it does not prove no product agent exists. Incomplete or ambiguous discovery never becomes that classification. Doctor offers no capped retry it cannot consume. These are fresh invocation-local facts, not a generation-consistent verifier snapshot or human approval. Existing loader/scope refusal precedence remains intact.

## Review/address

Round 1 [5148191260](https://github.com/ThreeMoonsLab/agents-shipgate/pull/594#pullrequestreview-5148191260) found that a linked manifest could load the target project's tools while recovering its name from the alias directory. Commit `4cc48c77` aligns both init and doctor with the loader's resolved directory and adds five real CLI regressions. All five fail against the original reviewed head `c7c50090`; the corrected recovery families and full suite pass. The final prose clarification documents init's linked-manifest exception. A second independent coding-agent review and final-head CI are required before merge; neither review supplies human approval.
