### PR TITLE
Use a canonical private path for pilot baselines

### DIFF
--- a/docs/design-partner-verifier-pilot.md
+++ b/docs/design-partner-verifier-pilot.md
@@ -342,9 +342,18 @@ git checkout <change-ref> && git merge <default-branch>   # or rebase onto it
 
 # Or — leave the PR untouched: snapshot the base ref outside the repository
 git checkout <default-branch>
-agents-shipgate audit --host --save-baseline --baseline-file /tmp/base-grants.json
+pilot_baseline_file="$(python3 -c 'from pathlib import Path; import tempfile; print(Path(tempfile.mkdtemp(prefix="agents-shipgate-pilot-")).resolve() / "base-grants.json")')"
+agents-shipgate audit --host --save-baseline --baseline-file "$pilot_baseline_file"
 git checkout <change-ref>
 ```
+
+Keep `pilot_baseline_file` in the same shell for the drift commands below.
+It names a new private temporary directory, resolved before the snapshot is
+written. This works with macOS's `/tmp` → `/private/tmp` alias and Linux's
+temporary directory without relaxing the baseline reader's no-symlink rule.
+To record the exact path for another shell, run `printf '%s\n' "$pilot_baseline_file"`.
+If a baseline path is refused because it contains a symbolic link, return to the
+base ref and rerun the snapshot recipe above; use the resulting path for drift.
 
 **Never `--save-baseline` from the changed checkout to get past that error.**
 That is what the CLI's own recovery line suggests when the file is missing,
@@ -363,7 +372,7 @@ agents-shipgate check --agent <codex|claude-code|cursor> \
 With the out-of-tree snapshot, pass it to the drift command every time:
 
 ```bash
-agents-shipgate audit --host --drift --baseline-file /tmp/base-grants.json \
+agents-shipgate audit --host --drift --baseline-file "$pilot_baseline_file" \
   --json --out shipgate-drift.json
 ```
 
@@ -463,11 +472,17 @@ Add Agents Shipgate as an advisory reviewer for this agent-capability change.
      b. leave the change branch untouched and keep the snapshot outside the
         repository:
         git checkout <default-branch>
+        pilot_baseline_file="$(python3 -c 'from pathlib import Path; import tempfile; print(Path(tempfile.mkdtemp(prefix="agents-shipgate-pilot-")).resolve() / "base-grants.json")')"
         agents-shipgate audit --host --save-baseline \
-          --baseline-file /tmp/base-grants.json
+          --baseline-file "$pilot_baseline_file"
         git checkout <change-ref>
-        and pass --baseline-file /tmp/base-grants.json to every drift command
-        below.
+        and pass --baseline-file "$pilot_baseline_file" to every drift command
+        below, in the same shell. To record the exact path for another shell:
+        printf '%s\n' "$pilot_baseline_file"
+        The temporary directory is private and resolved first: macOS's /tmp
+        alias must not reach the no-symlink baseline reader. If a path contains
+        a symbolic link, return to the base ref and rerun this snapshot recipe;
+        never replace it by saving a snapshot from the changed checkout.
    Never run --save-baseline from the changed checkout to clear a missing
    baseline error, even though the CLI's recovery line says to record one:
    from that checkout it acknowledges the expansion being reviewed and the

--- a/tests/test_design_partner_pilot.py
+++ b/tests/test_design_partner_pilot.py
@@ -12,7 +12,12 @@ Issue #521.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shlex
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -396,6 +401,90 @@ def test_route_h_makes_the_baseline_reachable_from_the_change():
     assert "acknowledges the very expansion under review" in text or (
         "acknowledges the expansion being reviewed" in text
     ), "the prohibition must say why, or it reads as arbitrary."
+
+
+@pytest.mark.skipif(os.name == "nt" or shutil.which("bash") is None,
+                    reason="The copyable pilot recipe targets macOS/Linux shells.")
+@pytest.mark.parametrize("heading", ["## Pilot Commands", "## Partner Agent Prompt"])
+def test_pilot_snapshot_recipe_resolves_temp_alias_and_keeps_base_evidence(tmp_path, heading):
+    """Execute the published recipe; a symlinked TMPDIR models macOS /tmp.
+
+    The same test runs on Linux CI. Both the readable runbook and copyable
+    agent prompt must preserve the base snapshot and the existing refusal.
+    """
+    workspace = tmp_path / "repository"
+    workspace.mkdir()
+    cli = [sys.executable, str(REPO_ROOT / "shipgate")]
+    environment = {**os.environ, "AGENTS_SHIPGATE_PYTHON": sys.executable}
+
+    def git(*args):
+        result = subprocess.run(["git", *args], cwd=workspace, capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+    def commit(message):
+        git("add", ".claude/settings.json")
+        git("-c", "user.name=Pilot Fixture", "-c", "user.email=pilot@example.invalid",
+            "commit", "-qm", message)
+
+    git("init", "-q", "-b", "pilot-base")
+    settings = workspace / ".claude/settings.json"
+    settings.parent.mkdir()
+    settings.write_text(json.dumps({"permissions": {"allow": ["Read"]}}))
+    commit("base read permission")
+    git("checkout", "-qb", "pilot-change")
+    settings.write_text(json.dumps({"permissions": {"allow": ["Read", "Bash(*)"]}}))
+    commit("change adds shell permission")
+
+    real_temp = tmp_path / "real temporary files"
+    real_temp.mkdir()
+    temp_alias = tmp_path / "temporary alias"
+    temp_alias.symlink_to(real_temp, target_is_directory=True)
+    environment["TMPDIR"] = str(temp_alias)
+    raw = _section(_read(RUNBOOK), heading)
+    start = raw.index("git checkout <default-branch>")
+    finish = raw.index("git checkout <change-ref>", start) + len("git checkout <change-ref>")
+    recipe = "\n".join(line.strip() for line in raw[start:finish].splitlines())
+    recipe = recipe.replace("<default-branch>", "pilot-base").replace("<change-ref>", "pilot-change")
+    output_path = tmp_path / "baseline-path.txt"
+    script = (
+        "set -eu\n"
+        f"agents-shipgate() {{ {shlex.join(cli)} \"$@\"; }}\n"
+        f"python3() {{ {shlex.quote(sys.executable)} \"$@\"; }}\n"
+        + recipe
+        + f"\nprintf '%s\\n' \"$pilot_baseline_file\" > {shlex.quote(str(output_path))}\n"
+    )
+    saved = subprocess.run(["bash", "-c", script], cwd=workspace, env=environment,
+                           capture_output=True, text=True, timeout=60)
+    assert saved.returncode == 0, saved.stdout + saved.stderr
+    baseline = Path(output_path.read_text().strip())
+    assert baseline == baseline.resolve()
+    assert baseline.is_relative_to(real_temp.resolve())
+    assert baseline.parent.stat().st_mode & 0o077 == 0
+    before = baseline.read_bytes()
+    assert b"Bash(*)" not in before
+
+    # Read through the same explicit path the recipe saved, from the changed ref.
+    drift = subprocess.run([*cli, "audit", "--host", "--drift", "--baseline-file",
+                            str(baseline), "--json"], cwd=workspace, env=environment,
+                           capture_output=True, text=True, timeout=60)
+    assert drift.returncode == 0, drift.stdout + drift.stderr
+    payload = json.loads(drift.stdout)
+    assert payload["has_drift"] is True
+    assert any("Bash(*)" in signal for signal in payload["expansion_signals"])
+    assert baseline.read_bytes() == before
+
+    # Resolving the recipe is not relaxing the reader: the alias still fails.
+    aliased_baseline = temp_alias / baseline.relative_to(real_temp.resolve())
+    for operation in ("--drift", "--save-baseline"):
+        refused = subprocess.run([*cli, "audit", "--host", operation, "--baseline-file",
+                                  str(aliased_baseline), "--json"], cwd=workspace,
+                                 env=environment, capture_output=True, text=True, timeout=60)
+        assert refused.returncode == 2, refused.stdout + refused.stderr
+        if operation == "--drift":
+            assert f"symlink at {temp_alias}" in refused.stderr, refused.stderr
+        else:
+            assert f"{aliased_baseline}: the path contains a symbolic link." in refused.stderr
+        assert baseline.read_bytes() == before
 
 
 def test_second_change_window_is_stated_with_its_unobserved_rule():


### PR DESCRIPTION
The Route H recovery recipe saves its out-of-tree baseline under `/tmp`, which is a symbolic link on macOS. Copying it fails the baseline reader/writer's existing no-symlink identity checks before the user can compare their PR.

Both the runbook and copyable partner-agent prompt now create a private temporary directory, resolve it, and retain the resulting baseline path in one quoted shell variable across base/change checkouts. The drift command uses that exact path. The instructions retain the prohibition on saving from the changed checkout and explain how to inspect the path or recover from a symlink refusal.

Closes #550. No baseline identity or trust semantics change.

## Validation

- Two actual-shell regressions execute the published recipes in disposable Git repositories with separate base and change commits. A symlinked temporary root with spaces models macOS's alias and runs unchanged on Linux CI. Both find the changed branch's new `Bash(*)` permission from the base snapshot, preserve baseline bytes, and verify that explicit symlink paths still fail both read and write with their exact existing refusal reasons.
- Pilot/host-audit families: 90 tests pass on macOS. Ruff and diff checks pass. Full frozen-source suite: **9,101 passed, 5 skipped**. Schema drift checks pass. Working and committed verification at `574a991d00c3cb1ad68f5634c24d84abc4eebf50` against `ad2055917` report `passed / mergeable / complete`, and fresh current control confirms all permissions. All applicable final-head Linux CI and aggregate coverage now pass. Independent GitHub COMMENT review [5148370835](https://github.com/ThreeMoonsLab/agents-shipgate/pull/595#pullrequestreview-5148370835) found no in-scope issues and independently passed 32 pilot tests; round 1 has been addressed without a source change. The committed verifier was refreshed against main `15b317a36` and current control again reports `passed / complete` with merge permission.

The synthetic fixture is engineering validation, not a consented partner observation; no pilot/adopter count changes.