### PR TITLE
Compare imported SDK guard predicates with bound input evidence

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -164,6 +164,52 @@ before attributing a finding to the change. #515's default diff scope remains
 open on dependency-proof prerequisite #557; this comparison does not exclude
 standing findings from the release decision.
 
+For the OpenAI Agents SDK, the current reader also carries
+`tool_surface_facts.guard_dependencies` and compares them in
+`tool_surface_diff.guard_comparisons`. An unchanged tool declaration can now
+point to an imported Boolean guard whose allowed inputs changed. The report
+preserves the tool observation and canonical capability identity, the call
+and guard definition locations, the input file digests, and the base/head
+predicate tables. Bit `i` in each `allowed_inputs` integer represents the
+Boolean value of `parameters[i]`; the parameter list is sorted and bounded
+to eight names. A widened set permits more Boolean inputs, a narrowed set
+permits fewer, and equal sets describe equivalent predicates in that domain.
+
+This first reader profile (`sdk_boolean_guard/v1`) handles a direct sibling
+relative import through empty package initializers, followed by a first
+`if not guard(...): return False` (or `return None`) in a module-level tool.
+The imported function has one return expression composed of Boolean
+parameters, constants, `and`, `or`, and `not`. Calls in predicates, configuration
+indirection, module/package ambiguity, executable initializers, rebinding,
+unsupported signatures, missing inputs and reader limits remain unresolved.
+An older report with no record does not establish absence of a guard.
+
+These are **source-predicate comparisons**. They do not establish deployed
+Python import resolution, downstream effects, or complete capability
+dependency coverage. Every row reports `dependency_coverage: incomplete` and
+`finding_exclusion_eligible: false`; all findings and the current release
+decision remain unchanged. A user-supplied `--diff-from` report is comparison
+input, not authenticated proof of its claimed source evidence. Redacted or
+ambiguous records cannot yield a predicate direction. The Markdown report
+shows up to eight relevant comparisons; JSON retains the full list.
+
+Verification binds the reader's captured dependency bytes and named absent
+import candidates in `verification-plan.json` under
+`inputs.options.dependency_inputs`. A current-control read checks
+them again, including ignored files and newly appearing packages that ordinary
+Git status would miss. Committed comparisons read each side's archived Git
+tree. This input binding does not turn a bounded predicate into a complete
+dependency closure; #557 and #515 retain that remaining obligation.
+
+An attempted guard read that fails before bytes can be captured (such as a
+symlink, oversized input or non-regular file) is explicitly unconfirmable.
+`agent control` then uses its existing `workspace_unverifiable` refusal;
+repair the unreadable path and re-run verification before using current
+authority. This does not replace the report's release decision. A missing
+candidate whose absence was captured, or an unsupported predicate whose bytes
+were read, remains confirmable. Durable typed refusal identities are deferred
+separately; an exception string is not sufficient evidence of stable inputs.
+
 Scope deltas distinguish tool-required scopes from manifest-declared scopes.
 If the same literal scope moves between those kinds, the diff reports one
 removed scope and one added scope so the JSON preserves the source of the

--- a/docs/report-schema.v0.43.json
+++ b/docs/report-schema.v0.43.json
@@ -4820,6 +4820,276 @@
       "title": "FindingSupport",
       "type": "object"
     },
+    "GuardDependencyComparison": {
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GuardDependencyEvidence"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "before": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GuardDependencyEvidence"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "direction": {
+          "enum": [
+            "predicate_unchanged",
+            "predicate_widened",
+            "predicate_narrowed",
+            "predicate_changed",
+            "unresolved"
+          ],
+          "title": "Direction",
+          "type": "string"
+        },
+        "finding_exclusion_eligible": {
+          "const": false,
+          "default": false,
+          "title": "Finding Exclusion Eligible",
+          "type": "boolean"
+        },
+        "observation_id": {
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Id"
+        },
+        "tool_name": {
+          "title": "Tool Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "observation_id",
+        "tool_name",
+        "direction",
+        "reason"
+      ],
+      "title": "GuardDependencyComparison",
+      "type": "object"
+    },
+    "GuardDependencyEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "absent_paths": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Absent Paths",
+          "type": "array"
+        },
+        "allowed_inputs": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Allowed Inputs",
+          "type": "array"
+        },
+        "call_line": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Call Line"
+        },
+        "dependency_coverage": {
+          "const": "incomplete",
+          "default": "incomplete",
+          "title": "Dependency Coverage",
+          "type": "string"
+        },
+        "finding_exclusion_eligible": {
+          "const": false,
+          "default": false,
+          "title": "Finding Exclusion Eligible",
+          "type": "boolean"
+        },
+        "guard_line": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Guard Line"
+        },
+        "guard_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Guard Path"
+        },
+        "guard_symbol": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Guard Symbol"
+        },
+        "inputs": {
+          "items": {
+            "$ref": "#/$defs/GuardInputEvidence"
+          },
+          "title": "Inputs",
+          "type": "array"
+        },
+        "observation_id": {
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "parameters": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Parameters",
+          "type": "array"
+        },
+        "reader_profile": {
+          "const": "sdk_boolean_guard/v1",
+          "default": "sdk_boolean_guard/v1",
+          "title": "Reader Profile",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "source_id": {
+          "title": "Source Id",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "observed",
+            "unresolved",
+            "ambiguous",
+            "redacted"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Id"
+        },
+        "tool_line": {
+          "minimum": 1,
+          "title": "Tool Line",
+          "type": "integer"
+        },
+        "tool_name": {
+          "title": "Tool Name",
+          "type": "string"
+        },
+        "tool_path": {
+          "title": "Tool Path",
+          "type": "string"
+        },
+        "tool_symbol": {
+          "title": "Tool Symbol",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_id",
+        "observation_id",
+        "tool_name",
+        "tool_path",
+        "tool_symbol",
+        "tool_line",
+        "status",
+        "reason"
+      ],
+      "title": "GuardDependencyEvidence",
+      "type": "object"
+    },
+    "GuardInputEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "role": {
+          "enum": [
+            "tool_module",
+            "guard_module",
+            "package_initializer"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "role"
+      ],
+      "title": "GuardInputEvidence",
+      "type": "object"
+    },
     "HeuristicsFilter": {
       "additionalProperties": false,
       "description": "v0.21: top-level envelope describing the ``--no-heuristics``\nfilter pass.\n\nEmitted on every report regardless of whether the flag was set, so\nconsumers always read the same shape. When the flag is unset,\n``enabled=False`` and the count fields are zero \u2014 the active\nfinding set is unchanged. When the flag is set, every finding whose\n``provenance_kind`` is in ``excluded_provenance_kinds`` is marked\n``suppressed=True`` with ``suppression_reason=\"filtered by\n--no-heuristics\"`` BEFORE the release decision is built, so heuristic\nfindings can no longer gate release. Filtered findings stay in\n``findings[]`` for transparency; the audit envelope here records\naggregate counts.\n\nEarns the contract weight of ``Finding.provenance_kind`` (shipped\nv0.15) by giving it a first-class consumer. Same shape pattern as\n``PrivacyAudit``: an envelope that proves the filter ran and tells\na reviewer/agent which findings were excluded and why.",
@@ -6918,6 +7188,13 @@
         "finding_deltas": {
           "$ref": "#/$defs/ToolSurfaceFindingDeltas"
         },
+        "guard_comparisons": {
+          "items": {
+            "$ref": "#/$defs/GuardDependencyComparison"
+          },
+          "title": "Guard Comparisons",
+          "type": "array"
+        },
         "high_risk_effects": {
           "items": {
             "$ref": "#/$defs/ToolSurfaceHighRiskEffectChange"
@@ -7146,6 +7423,13 @@
             "$ref": "#/$defs/ToolSurfaceControlFact"
           },
           "title": "Controls",
+          "type": "array"
+        },
+        "guard_dependencies": {
+          "items": {
+            "$ref": "#/$defs/GuardDependencyEvidence"
+          },
+          "title": "Guard Dependencies",
           "type": "array"
         },
         "policies": {

--- a/samples/support_refund_agent/expected/report.json
+++ b/samples/support_refund_agent/expected/report.json
@@ -1121,7 +1121,7 @@
             ],
             "evidence": "readOnlyHint: true on the reviewed SDK inventory; the description states the preview is rendered locally",
             "reason": "The name carries 'email', but this action renders a draft and has no send path or credential.",
-            "manifest_path": "shipgate.yaml#action_surface.actions[tool='send_email_preview'].override"
+            "manifest_path": "shipgate.yaml#action_surface.actions[6].override"
           },
           {
             "subject": "support.search_kb [support_mcp_tools]",
@@ -1136,7 +1136,7 @@
             ],
             "evidence": "readOnlyHint: true and idempotentHint: true on the MCP export; the only scope is support:kb:read",
             "reason": "The word 'refund' appears in the article text this tool searches, not in anything it changes.",
-            "manifest_path": "shipgate.yaml#action_surface.actions[tool='support.search_kb'].override"
+            "manifest_path": "shipgate.yaml#action_surface.actions[0].override"
           }
         ],
         "declaration_review": {
@@ -3589,6 +3589,36 @@
         "value_hash": "148a37733a582ec1",
         "summary": "Search query intentionally accepts free text."
       }
+    ],
+    "guard_dependencies": [
+      {
+        "reader_profile": "sdk_boolean_guard/v1",
+        "source_id": "openai_sdk_static",
+        "observation_id": "obs_v1_68344b9fde158f18db1f3476cf06003414968e6d82488d8f376eebfecbc8bfb3",
+        "tool_id": "tool_v2_2c9ee6ae2b9f0259ba2dad40a30fb18a8bdc3a732ffc207936fdd49c80e1bc9e",
+        "tool_name": "send_email_preview",
+        "tool_path": "agents/refund_agent.py",
+        "tool_symbol": "send_email_preview",
+        "tool_line": 5,
+        "guard_symbol": null,
+        "guard_path": null,
+        "guard_line": null,
+        "call_line": null,
+        "status": "unresolved",
+        "reason": "guard_not_in_supported_position",
+        "parameters": [],
+        "allowed_inputs": [],
+        "inputs": [
+          {
+            "path": "agents/refund_agent.py",
+            "sha256": "eabce7221a892ed71373f5dd54b11d1c92007091d5257e214bcdff6cc1a4824d",
+            "role": "tool_module"
+          }
+        ],
+        "absent_paths": [],
+        "dependency_coverage": "incomplete",
+        "finding_exclusion_eligible": false
+      }
     ]
   },
   "tool_surface_diff": {
@@ -3630,6 +3660,45 @@
     },
     "notes": [
       "No --diff-from report or v0.3 baseline snapshot was provided."
+    ],
+    "guard_comparisons": [
+      {
+        "observation_id": "obs_v1_68344b9fde158f18db1f3476cf06003414968e6d82488d8f376eebfecbc8bfb3",
+        "tool_id": "tool_v2_2c9ee6ae2b9f0259ba2dad40a30fb18a8bdc3a732ffc207936fdd49c80e1bc9e",
+        "tool_name": "send_email_preview",
+        "direction": "unresolved",
+        "reason": "base_or_head_guard_evidence_unavailable",
+        "before": null,
+        "after": {
+          "reader_profile": "sdk_boolean_guard/v1",
+          "source_id": "openai_sdk_static",
+          "observation_id": "obs_v1_68344b9fde158f18db1f3476cf06003414968e6d82488d8f376eebfecbc8bfb3",
+          "tool_id": "tool_v2_2c9ee6ae2b9f0259ba2dad40a30fb18a8bdc3a732ffc207936fdd49c80e1bc9e",
+          "tool_name": "send_email_preview",
+          "tool_path": "agents/refund_agent.py",
+          "tool_symbol": "send_email_preview",
+          "tool_line": 5,
+          "guard_symbol": null,
+          "guard_path": null,
+          "guard_line": null,
+          "call_line": null,
+          "status": "unresolved",
+          "reason": "guard_not_in_supported_position",
+          "parameters": [],
+          "allowed_inputs": [],
+          "inputs": [
+            {
+              "path": "agents/refund_agent.py",
+              "sha256": "eabce7221a892ed71373f5dd54b11d1c92007091d5257e214bcdff6cc1a4824d",
+              "role": "tool_module"
+            }
+          ],
+          "absent_paths": [],
+          "dependency_coverage": "incomplete",
+          "finding_exclusion_eligible": false
+        },
+        "finding_exclusion_eligible": false
+      }
     ]
   },
   "action_surface_facts": {

--- a/src/agents_shipgate/cli/scan/decision.py
+++ b/src/agents_shipgate/cli/scan/decision.py
@@ -147,6 +147,7 @@ def _run_checks_and_decide(
         # HEAD-side agent -> remote bindings, carried into the tool-surface
         # facts so the base report can be compared against them (#538).
         remote_bindings=tools_and_agent.remote_bindings,
+        guard_dependencies=tools_and_agent.guard_dependencies,
         # Pre-override ``ci`` block, so the Tier B weakening checks judge the
         # declared gate instead of this invocation's (#298).
         declared_ci=declared_ci,

--- a/src/agents_shipgate/cli/scan/models.py
+++ b/src/agents_shipgate/cli/scan/models.py
@@ -28,6 +28,7 @@ from agents_shipgate.core.lenses.tool_surface import ToolSurfaceDiffReference
 from agents_shipgate.core.privacy import RedactionStats
 from agents_shipgate.schemas.bindings import AgentBindingGraphAssessment, BindingSurfaceDiff
 from agents_shipgate.schemas.codex_plugin import CodexPluginSurface
+from agents_shipgate.schemas.guard_dependencies import GuardDependencyEvidence
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest, CiConfig
 from agents_shipgate.schemas.report import PolicyAudit
 from agents_shipgate.schemas.surfaces import ActionDeclarationFacts, ActionSurfaceFacts
@@ -105,6 +106,7 @@ class _ToolsAndAgent:
     # Agent -> remote tool-surface bindings, aggregated across all loaded
     # sources. Empty for every workspace with no recognized remote binding.
     remote_bindings: list[AgentRemoteBinding] = field(default_factory=list)
+    guard_dependencies: list[GuardDependencyEvidence] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/src/agents_shipgate/cli/scan/sanitization.py
+++ b/src/agents_shipgate/cli/scan/sanitization.py
@@ -400,6 +400,7 @@ def _sanitize_for_output(
         privacy_stats=privacy_stats,
         toolkit_bounds=decision.context.toolkit_bounds,
         remote_bindings=decision.context.remote_bindings,
+        guard_dependencies=decision.context.guard_dependencies,
     )
     source_recovery_evidence = _sanitize_source_recovery_evidence(inputs.loaded_sources, privacy_stats)
     privacy_audit = build_privacy_audit(
@@ -606,6 +607,7 @@ def _public_tool_surfaces(
     privacy_stats,
     toolkit_bounds=(),
     remote_bindings=(),
+    guard_dependencies=(),
 ):
     public_tool_surface_facts = sanitize_model(
         build_tool_surface_facts(
@@ -616,11 +618,17 @@ def _public_tool_surfaces(
             public_anthropic_artifacts,
             toolkit_bounds,
             remote_bindings,
+            guard_dependencies,
         ),
         ToolSurfaceFacts,
         stats=privacy_stats,
         path="tool_surface_facts",
     )
+    for original, public in zip(guard_dependencies, public_tool_surface_facts.guard_dependencies, strict=True):
+        if public != original:
+            public.status = "redacted"
+            public.reason = "guard_evidence_redacted"
+            public.allowed_inputs = []
     if diffs.diff_reference_error:
         public_tool_surface_diff = disabled_tool_surface_diff(
             redact_data(

--- a/src/agents_shipgate/cli/scan/tools_agent.py
+++ b/src/agents_shipgate/cli/scan/tools_agent.py
@@ -4,6 +4,7 @@ import logging
 
 from agents_shipgate.core.agent_bindings import resolve_agent_binding_graph
 from agents_shipgate.core.domain import LoadedToolSource
+from agents_shipgate.core.guard_dependencies import associate_guard_dependencies
 from agents_shipgate.core.risk_hints import enrich_tools_with_risk_hints
 from agents_shipgate.core.semantic_assessment import attach_semantic_assessments
 from agents_shipgate.core.source_warnings import withdraw_completed_adk_tool_warnings
@@ -196,4 +197,5 @@ def _build_tools_and_agent(
         warnings=warnings,
         toolkit_bounds=toolkit_bounds,
         remote_bindings=remote_bindings,
+        guard_dependencies=associate_guard_dependencies(inputs.loaded_sources, tool_catalog),
     )

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -244,7 +244,10 @@ BASE_CACHE_KEEP_ENTRIES = 16
 #     a ``target_file`` naming a base archive that no longer exists. A cached
 #     report is admitted on its hash, so a poisoned entry would be served
 #     verbatim until its base tree changed.
-BASE_CACHE_KEY_EPOCH = 4
+# 5 — bounded imported-guard evidence retains each base source/dependency
+#     snapshot (#557). Older cached reports contain no comparable record;
+#     they must be regenerated rather than interpreted as guard absence.
+BASE_CACHE_KEY_EPOCH = 5
 MAX_HUMAN_AUTHORIZATION_BYTES = 1024 * 1024
 MAX_WORKTREE_MANIFEST_BYTES = 4 * 1024 * 1024
 MAX_WORKTREE_CHANGED_FILE_BYTES = 64 * 1024 * 1024

--- a/src/agents_shipgate/core/context.py
+++ b/src/agents_shipgate/core/context.py
@@ -28,6 +28,7 @@ from agents_shipgate.core.lenses.tool_surface import ToolSurfaceDiffReference
 from agents_shipgate.inputs.common import PositionIndex
 from agents_shipgate.schemas.bindings import AgentBindingGraphAssessment
 from agents_shipgate.schemas.capabilities import CapabilityFactV1
+from agents_shipgate.schemas.guard_dependencies import GuardDependencyEvidence
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest, CiConfig
 from agents_shipgate.schemas.report import CapabilityRuntimeEvidence, EvidenceGap
 from agents_shipgate.schemas.surfaces import ActionSurfaceFacts
@@ -96,6 +97,7 @@ class ScanContext:
     # ``core.remote_bindings`` for the one encode/decode contract. Empty when
     # no source declares a recognized remote binding.
     remote_bindings: list[AgentRemoteBinding] = field(default_factory=list)
+    guard_dependencies: list[GuardDependencyEvidence] = field(default_factory=list)
     # Computed once during verify and shared by all boundary Finding projections.
     agent_boundary: AgentBoundaryAssessment | None = None
     # The manifest's ``ci`` block as declared on disk, before ``--ci-mode`` /

--- a/src/agents_shipgate/core/current_control.py
+++ b/src/agents_shipgate/core/current_control.py
@@ -42,6 +42,7 @@ from agents_shipgate.core.errors import AgentsShipgateError
 from agents_shipgate.core.verification_identity import (
     plan_worktree_overlay_paths,
     read_regular_file_beneath,
+    validate_dependency_inputs,
     worktree_overlay,
 )
 from agents_shipgate.schemas.agent_control import (
@@ -759,6 +760,16 @@ def _validate_control_currency(
             path=out_dir,
         )
     _validate_base_currency(out_dir, identity, live, required=grants_authority)
+    if "verification_plan" in artifacts:
+        try:
+            plan = VerificationPlan.model_validate_json(artifacts["verification_plan"])
+            validate_dependency_inputs(plan, root=live.root)
+        except (ValueError, OSError) as exc:
+            raise CurrentControlUnavailable(
+                "workspace_unverifiable",
+                f"The dependency inputs this decision read are no longer current: {exc}",
+                path=out_dir,
+            ) from exc
     if identity.snapshot_kind == "worktree_overlay":
         _validate_worktree_currency(
             out_dir, pointer, live, required=grants_authority, artifacts=artifacts

--- a/src/agents_shipgate/core/domain.py
+++ b/src/agents_shipgate/core/domain.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.schemas.common import Confidence, ProvenanceKind, parse_confidence
 from agents_shipgate.schemas.coverage_recovery import SourceRecoveryEvidence
+from agents_shipgate.schemas.guard_dependencies import GuardDependencyEvidence
 from agents_shipgate.schemas.surfaces import ActionEffect
 
 SemanticDimension = Literal["identity", "binding", "effect", "authority"]
@@ -742,6 +743,8 @@ class LoadedToolSource(BaseModel):
     # separate from Tool.annotations so catalog-controlled metadata can never
     # become authority-bearing binding evidence.
     binding_observations: list[AgentBindingObservation] = Field(default_factory=list)
+    # Reader-owned observations, never derived from catalog annotations.
+    guard_dependencies: list[GuardDependencyEvidence] = Field(default_factory=list)
     # For a reviewed tool inventory declared with
     # ``<framework>.tool_inventories[].source_id``: the id of the source whose
     # surface this file enumerates. ``build_tool_identity_catalog`` turns it

--- a/src/agents_shipgate/core/guard_dependencies.py
+++ b/src/agents_shipgate/core/guard_dependencies.py
@@ -1,0 +1,126 @@
+"""Associate private observations and compare source predicates, never findings."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from agents_shipgate.core.domain import LoadedToolSource, Tool
+from agents_shipgate.schemas.guard_dependencies import (
+    GuardDependencyComparison,
+    GuardDependencyEvidence,
+)
+
+
+def associate_guard_dependencies(
+    sources: list[LoadedToolSource], tools: list[Tool]
+) -> list[GuardDependencyEvidence]:
+    members: dict[str, list[Tool]] = defaultdict(list)
+    for tool in tools:
+        for observation_id in tool.observation_ids:
+            members[observation_id].append(tool)
+    result = []
+    for source in sources:
+        for evidence in source.guard_dependencies:
+            candidates = members[evidence.observation_id]
+            if len(candidates) == 1:
+                result.append(
+                    evidence.model_copy(
+                        update={"tool_id": candidates[0].id, "tool_name": candidates[0].name}
+                    )
+                )
+            else:
+                result.append(
+                    evidence.model_copy(
+                        update={
+                            "tool_id": None,
+                            "status": "ambiguous",
+                            "reason": "capability_observation_not_unique",
+                        }
+                    )
+                )
+    return sorted(result, key=lambda row: (row.observation_id, row.tool_path, row.tool_line))
+
+
+def _valid_predicate(row: GuardDependencyEvidence) -> bool:
+    count = len(row.parameters)
+    return (
+        row.status == "observed"
+        and row.tool_id is not None
+        and count <= 8
+        and row.parameters == sorted(set(row.parameters))
+        and row.allowed_inputs == sorted(set(row.allowed_inputs))
+        and all(type(mask) is int and 0 <= mask < 1 << count for mask in row.allowed_inputs)
+        and row.guard_path is not None
+        and row.guard_line is not None
+        and row.call_line is not None
+        and bool(row.inputs)
+        and len({item.path for item in row.inputs}) == len(row.inputs)
+        and any(item.path == row.tool_path and item.role == "tool_module" for item in row.inputs)
+        and any(item.path == row.guard_path and item.role == "guard_module" for item in row.inputs)
+    )
+
+
+def compare_guard_dependencies(
+    current: list[GuardDependencyEvidence], base: list[GuardDependencyEvidence]
+) -> list[GuardDependencyComparison]:
+    before: dict[str, list[GuardDependencyEvidence]] = defaultdict(list)
+    after: dict[str, list[GuardDependencyEvidence]] = defaultdict(list)
+    for row in base:
+        before[row.observation_id].append(row)
+    for row in current:
+        after[row.observation_id].append(row)
+    comparisons = []
+    for key in sorted(before.keys() | after.keys()):
+        old_rows, new_rows = before[key], after[key]
+        old = old_rows[0] if len(old_rows) == 1 else None
+        new = new_rows[0] if len(new_rows) == 1 else None
+        subject = new or old or (new_rows or old_rows)[0]
+        direction = "unresolved"
+        reason = "base_or_head_guard_evidence_unavailable"
+        if len(old_rows) > 1 or len(new_rows) > 1:
+            reason = "duplicate_guard_observation"
+        elif old is not None and new is not None:
+            if not _valid_predicate(old) or not _valid_predicate(new):
+                reason = "predicate_or_dependency_evidence_unresolved"
+            elif (
+                old.tool_id,
+                old.source_id,
+                old.tool_path,
+                old.tool_symbol,
+                old.guard_path,
+                old.guard_symbol,
+                old.parameters,
+            ) != (
+                new.tool_id,
+                new.source_id,
+                new.tool_path,
+                new.tool_symbol,
+                new.guard_path,
+                new.guard_symbol,
+                new.parameters,
+            ):
+                reason = "guard_subject_or_parameter_domain_changed"
+            else:
+                previous, following = set(old.allowed_inputs), set(new.allowed_inputs)
+                direction = (
+                    "predicate_unchanged"
+                    if previous == following
+                    else "predicate_widened"
+                    if previous < following
+                    else "predicate_narrowed"
+                    if following < previous
+                    else "predicate_changed"
+                )
+                reason = "Compare the bounded Boolean source predicate only; downstream effects, runtime wiring and whole-capability dependency coverage remain unproved. No finding is excluded."
+        comparisons.append(
+            GuardDependencyComparison(
+                observation_id=key,
+                tool_id=subject.tool_id,
+                tool_name=subject.tool_name,
+                direction=direction,
+                reason=reason,
+                before=old,
+                after=new,
+            )
+        )
+    return comparisons

--- a/src/agents_shipgate/core/lenses/tool_surface.py
+++ b/src/agents_shipgate/core/lenses/tool_surface.py
@@ -15,6 +15,7 @@ from agents_shipgate.core.artifact_models import (
 from agents_shipgate.core.domain import AgentRemoteBinding, Tool, ToolkitScopeBound
 from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.core.findings.identity import _canonicalize_for_fingerprint
+from agents_shipgate.core.guard_dependencies import compare_guard_dependencies
 from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.core.lenses.finding_comparison import finding_comparison_notes
 from agents_shipgate.core.remote_bindings import remote_binding_facts
@@ -25,6 +26,7 @@ from agents_shipgate.core.toolkit_scope import toolkit_bound_facts
 from agents_shipgate.schemas.baseline import BaselineFile
 from agents_shipgate.schemas.bindings import AgentBindingGraphAssessment
 from agents_shipgate.schemas.capability_change import EffectivePolicy
+from agents_shipgate.schemas.guard_dependencies import GuardDependencyEvidence
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
     PolicyToolEntry,
@@ -96,10 +98,12 @@ def build_tool_surface_facts(
     anthropic_artifacts: AnthropicArtifacts | None,
     toolkit_bounds: list[ToolkitScopeBound] | tuple[ToolkitScopeBound, ...] = (),
     remote_bindings: list[AgentRemoteBinding] | tuple[AgentRemoteBinding, ...] = (),
+    guard_dependencies: list[GuardDependencyEvidence] | tuple[GuardDependencyEvidence, ...] = (),
 ) -> ToolSurfaceFacts:
     del findings  # Reserved for future evidence projections.
     return ToolSurfaceFacts(
         tools=_tool_facts(tools),
+        guard_dependencies=list(guard_dependencies),
         scopes=_scope_facts(manifest, tools),
         controls=_control_facts(manifest, tools, api_artifacts, anthropic_artifacts),
         policies=_policy_facts_with_carried_bounds(
@@ -236,6 +240,7 @@ def compute_tool_surface_diff(
             )
         return ToolSurfaceDiff(
             enabled=False,
+            guard_comparisons=compare_guard_dependencies(current.guard_dependencies, []),
             base=diff_base,
             summary=_summary_from_diff_parts(finding_deltas=finding_deltas),
             finding_deltas=finding_deltas,
@@ -264,6 +269,7 @@ def compute_tool_surface_diff(
         notes.extend(reference.notes)
     return ToolSurfaceDiff(
         enabled=True,
+        guard_comparisons=compare_guard_dependencies(current.guard_dependencies, base.guard_dependencies),
         base=_diff_base(reference),
         summary=summary,
         tools=tool_changes,

--- a/src/agents_shipgate/core/static_inputs.py
+++ b/src/agents_shipgate/core/static_inputs.py
@@ -46,6 +46,10 @@ class StaticInputSnapshot:
             for path in excluded_paths
         }
         self._entries: dict[Path, bytes] = {}
+        self._dependency_paths: set[Path] = set()
+        self._absent_dependency_paths: set[Path] = set()
+        self._present_dependency_paths: set[Path] = set()
+        self._unconfirmable_dependency_paths: set[Path] = set()
         self._total_bytes = 0
         self._budget = IdentityReadBudget(
             max_entries=max_files * 32,
@@ -105,6 +109,45 @@ class StaticInputSnapshot:
 
     def paths(self) -> list[Path]:
         return sorted(self._entries)
+
+    def mark_dependency_input(self, path: Path) -> None:
+        """Select already captured reader bytes for live dependency currency."""
+
+        key, _relative = self._key(path)
+        if key not in self._entries or self._finished:
+            raise ValueError("dependency input was not captured by this active snapshot")
+        self._dependency_paths.add(key)
+
+    def bind_dependency_absence(self, path: Path) -> bool:
+        """Capture a named absent lookup candidate, including its parent listing."""
+
+        key, _relative = self._key(path)
+        names = self.bind_directory(key.parent)
+        if key.name in names:
+            self._present_dependency_paths.add(key)
+            return False
+        self._absent_dependency_paths.add(key)
+        return True
+
+    def dependency_paths(self) -> list[Path]:
+        return sorted(self._dependency_paths)
+
+    def absent_dependency_paths(self) -> list[Path]:
+        return sorted(self._absent_dependency_paths)
+
+    def present_dependency_paths(self) -> list[Path]:
+        return sorted(self._present_dependency_paths)
+
+    def mark_unconfirmable_dependency(self, path: Path) -> None:
+        """An attempted read without captured bytes grants no current identity."""
+
+        key, _relative = self._key(path)
+        if self._finished:
+            raise ValueError("static input snapshot is already finalized")
+        self._unconfirmable_dependency_paths.add(key)
+
+    def unconfirmable_dependency_paths(self) -> list[Path]:
+        return sorted(self._unconfirmable_dependency_paths)
 
     def read_bytes(
         self,

--- a/src/agents_shipgate/core/tool_identity.py
+++ b/src/agents_shipgate/core/tool_identity.py
@@ -836,14 +836,7 @@ def _observations(
                     },
                 )
             seen[key] = (read_index, _source_file(tool))
-            observation_id = _stable_id(
-                "obs_v1",
-                {
-                    "source_type": tool.source_type,
-                    "source_id": source_id,
-                    "native_locator": locator,
-                },
-            )
+            observation_id = source_observation_id(tool, source_id)
             tool.native_locator = locator
             tool.observation_id = observation_id
             tool.observation_ids = [observation_id]
@@ -856,6 +849,16 @@ def _observations(
             tool.provider = source_id
             observations.append(tool)
     return observations
+
+
+def source_observation_id(tool: Tool, source_id: str) -> str:
+    """Identity shared by a source reader and the canonical catalog join."""
+
+    return _stable_id("obs_v1", {
+        "source_type": tool.source_type,
+        "source_id": source_id,
+        "native_locator": _native_locator(tool),
+    })
 
 
 def _source_file(tool: Tool) -> str | None:

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -191,6 +191,32 @@ def build_verification_plan(
 ) -> VerificationPlan:
     effective_plugins_enabled = _plugins_enabled(plugins_enabled)
     normalized_options = dict(options)
+    # This is reader provenance, never a caller-supplied assertion. Named
+    # negative lookups matter as much as the bytes that resolved an import.
+    normalized_options.pop("dependency_inputs", None)
+    snapshot = active_static_input_snapshot()
+    if snapshot is not None and (snapshot.dependency_paths() or snapshot.absent_dependency_paths() or snapshot.present_dependency_paths() or snapshot.unconfirmable_dependency_paths()):
+        normalized_options["dependency_inputs"] = {
+            "files": sorted(
+                [{"path": path.relative_to(input_root).as_posix(),
+                  "sha256": sha256_bytes(snapshot.read_bytes(path)),
+                  "size_bytes": len(snapshot.read_bytes(path))}
+                 for path in snapshot.dependency_paths()],
+                key=lambda row: row["path"],
+            ),
+            "absent_paths": sorted(
+                path.relative_to(input_root).as_posix()
+                for path in snapshot.absent_dependency_paths()
+            ),
+            "present_paths": sorted(
+                path.relative_to(input_root).as_posix()
+                for path in snapshot.present_dependency_paths()
+            ),
+            "unconfirmable_paths": sorted(
+                path.relative_to(input_root).as_posix()
+                for path in snapshot.unconfirmable_dependency_paths()
+            ),
+        }
     normalized_options["plugins_enabled"] = effective_plugins_enabled
     overlay_paths = sorted(
         set(changed_files if worktree_overlay_paths is None else worktree_overlay_paths)
@@ -855,6 +881,8 @@ def validate_plan_inputs(
 ) -> None:
     """Fail closed unless every portable plan blob matches the supplied root."""
 
+    validate_dependency_inputs(plan, root=root)
+
     blobs = [
         plan.inputs.config,
         *plan.inputs.tool_sources,
@@ -889,6 +917,63 @@ def validate_plan_inputs(
         raise ValueError("plan diff input hash does not match")
     if resolved_diff.stat().st_size != plan.inputs.diff.size_bytes:
         raise ValueError("plan diff input size does not match")
+
+
+def validate_dependency_inputs(plan: VerificationPlan, *, root: Path) -> None:
+    """Reconfirm reader-selected bytes and named absence, including ignored files."""
+
+    from agents_shipgate.core.static_inputs import StaticInputSnapshot
+
+    declaration = plan.inputs.options.get("dependency_inputs")
+    if declaration is None:
+        return
+    if not isinstance(declaration, dict) or set(declaration) != {"files", "absent_paths", "present_paths", "unconfirmable_paths"}:
+        raise ValueError("invalid dependency input identity")
+    files, absent, present = declaration["files"], declaration["absent_paths"], declaration["present_paths"]
+    unconfirmable = declaration["unconfirmable_paths"]
+    if not all(isinstance(value, list) for value in (files, absent, present, unconfirmable)):
+        raise ValueError("invalid dependency input identity")
+    paths = []
+    for row in files:
+        if not isinstance(row, dict) or set(row) != {"path", "sha256", "size_bytes"}:
+            raise ValueError("invalid dependency file identity")
+        digest = row["sha256"]
+        if (not isinstance(digest, str) or len(digest) != 71
+                or not digest.startswith("sha256:")
+                or any(char not in "0123456789abcdef" for char in digest[7:])
+                or type(row["size_bytes"]) is not int or row["size_bytes"] < 0):
+            raise ValueError("invalid dependency file identity")
+        paths.append(row["path"])
+    for values in (paths, absent, present, unconfirmable):
+        if any(
+            not isinstance(path, str) or not path or Path(path).is_absolute()
+            or ".." in Path(path).parts or Path(path).as_posix() != path
+            or "\\" in path or ":" in path
+            for path in values
+        ):
+            raise ValueError("dependency input escapes supplied root")
+        if values != sorted(set(values)):
+            raise ValueError("dependency input paths must be sorted and unique")
+    if (set(paths) | set(present)) & set(absent):
+        raise ValueError("dependency input is both present and absent")
+    if unconfirmable:
+        raise ValueError(
+            "A guard dependency could not be captured. Inspect "
+            "tool_surface_facts.guard_dependencies, repair unreadable paths "
+            "and re-run verification before using current authority."
+        )
+    snapshot = StaticInputSnapshot(root.resolve())
+    for row in files:
+        data = snapshot.read_bytes(root.resolve() / row["path"])
+        if len(data) != row["size_bytes"] or sha256_bytes(data) != row["sha256"]:
+            raise ValueError("dependency input changed since verification")
+    for path in absent:
+        if not snapshot.bind_dependency_absence(root.resolve() / path):
+            raise ValueError("dependency lookup candidate appeared since verification")
+    for path in present:
+        if snapshot.bind_dependency_absence(root.resolve() / path):
+            raise ValueError("dependency lookup candidate disappeared since verification")
+    snapshot.finish()
 
 
 def _manifest_declared_input_paths(*, config_path: Path, input_root: Path) -> list[Path]:

--- a/src/agents_shipgate/inputs/openai_sdk_static.py
+++ b/src/agents_shipgate/inputs/openai_sdk_static.py
@@ -12,7 +12,7 @@ from agents_shipgate.core.domain import (
     ToolkitScopeBound,
 )
 from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id
+from agents_shipgate.inputs.common import load_text_file, resolve_input_path, stable_tool_id
 from agents_shipgate.inputs.config_trace import trace_config_binding
 from agents_shipgate.inputs.coverage import BoundaryCell, SourceCoverage
 from agents_shipgate.inputs.protocol import LoadedAdapterResult
@@ -24,7 +24,12 @@ from agents_shipgate.inputs.python_static import (
     function_signature,
     parse_python_file,
 )
+from agents_shipgate.inputs.sdk_guard_dependencies import (
+    guard_module_metadata,
+    read_guard_dependency,
+)
 from agents_shipgate.schemas.coverage_recovery import CoverageRecovery, SourceRecoveryEvidence
+from agents_shipgate.schemas.guard_dependencies import GuardDependencyEvidence
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
     ToolSourceConfig,
@@ -65,12 +70,14 @@ def load_openai_sdk_static_tools(
             raise InputParseError(f"OpenAI Agents SDK source directory has no Python files: {path}")
         tools: list[Tool] = []
         toolkit_bounds: list[ToolkitScopeBound] = []
+        guard_dependencies: list[GuardDependencyEvidence] = []
         for python_file in python_files:
-            file_tools, file_bounds = _load_python_file(python_file, source, base_dir)
+            file_tools, file_bounds, file_guards = _load_python_file(python_file, source, base_dir)
             tools.extend(file_tools)
             toolkit_bounds.extend(file_bounds)
+            guard_dependencies.extend(file_guards)
     elif path.suffix.lower() == ".py":
-        tools, toolkit_bounds = _load_python_file(path, source, base_dir)
+        tools, toolkit_bounds, guard_dependencies = _load_python_file(path, source, base_dir)
         python_files = [path]
     else:
         raise InputParseError(
@@ -87,6 +94,7 @@ def load_openai_sdk_static_tools(
         binding_observations=binding_observations,
         warnings=[*_toolkit_binding_warnings(toolkit_bounds), *binding_warnings],
         recovery_evidence=recovery_evidence,
+        guard_dependencies=guard_dependencies,
     )
 
 
@@ -119,9 +127,12 @@ def _load_python_file(
     path: Path,
     source: ToolSourceConfig,
     base_dir: Path,
-) -> tuple[list[Tool], list[ToolkitScopeBound]]:
+) -> tuple[list[Tool], list[ToolkitScopeBound], list[GuardDependencyEvidence]]:
     try:
-        tree = parse_python_file(path, label="OpenAI Agents SDK")
+        source_text = load_text_file(path)
+        tree = ast.parse(source_text, filename=str(path))
+    except SyntaxError as exc:
+        raise InputParseError(f"Unable to parse OpenAI Agents SDK entrypoint {path}: {exc.msg}") from exc
     except InputParseError as exc:
         message = str(exc).replace(
             "OpenAI Agents SDK Python entrypoint",
@@ -130,12 +141,17 @@ def _load_python_file(
         raise InputParseError(message) from exc
     ref = display_path(path, base_dir)
     decorator_names = _function_tool_decorator_names(tree)
-    tools = [
-        _function_to_tool(node, source, ref, decorator_names)
-        for node in ast.walk(tree)
-        if _is_function_tool(node, decorator_names)
+    definitions = [node for node in ast.walk(tree) if _is_function_tool(node, decorator_names)]
+    tools = [_function_to_tool(node, source, ref, decorator_names) for node in definitions]
+    source_sha256, source_within_limits = guard_module_metadata(tree, source_text)
+    guards = [
+        read_guard_dependency(
+            tree=tree, source_sha256=source_sha256, source_within_limits=source_within_limits,
+            path=path, root=base_dir, tool=tool, definition=node,
+        )
+        for tool, node in zip(tools, definitions, strict=True)
     ]
-    return tools, _detect_toolkit_bounds(tree, ref)
+    return tools, _detect_toolkit_bounds(tree, ref), guards
 
 
 def _extract_agent_bindings(

--- a/src/agents_shipgate/inputs/sdk_guard_dependencies.py
+++ b/src/agents_shipgate/inputs/sdk_guard_dependencies.py
@@ -1,0 +1,391 @@
+"""Read a deliberately small, static imported Boolean guard profile.
+
+No imports or application code execute. An observed predicate is a fact about
+the selected source definition, not proof of deployed Python wiring, the
+effect after the guard, or the capability's complete dependency closure.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+from itertools import islice
+from pathlib import Path
+
+from agents_shipgate.core.domain import Tool
+from agents_shipgate.core.static_inputs import (
+    active_static_input_snapshot,
+    read_static_input_bytes,
+)
+from agents_shipgate.core.tool_identity import source_observation_id
+from agents_shipgate.core.trust_roots import IdentityBoundReadSession
+from agents_shipgate.schemas.guard_dependencies import (
+    GuardDependencyEvidence,
+    GuardInputEvidence,
+)
+
+MAX_GUARD_BYTES = 256 * 1024
+MAX_GUARD_AST_NODES = 4096
+MAX_BOOLEAN_PARAMETERS = 8
+
+
+def guard_module_metadata(tree: ast.Module, source_text: str) -> tuple[str, bool]:
+    """Compute source evidence once, even when a large module defines many tools."""
+
+    data = source_text.encode("utf-8")
+    bounded = (
+        len(data) <= MAX_GUARD_BYTES
+        and sum(1 for _ in islice(ast.walk(tree), MAX_GUARD_AST_NODES + 1)) <= MAX_GUARD_AST_NODES
+    )
+    return hashlib.sha256(data).hexdigest(), bounded
+
+
+class _Unresolved(ValueError):
+    pass
+
+
+def _body(node: ast.Module | ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.stmt]:
+    body = node.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        return body[1:]
+    return body
+
+
+def _read(path: Path, root: Path, role: str, evidence: GuardDependencyEvidence) -> ast.Module:
+    snapshot = active_static_input_snapshot()
+    if path.resolve() != path or not path.is_relative_to(root):
+        if snapshot is not None and snapshot.contains(path):
+            snapshot.mark_unconfirmable_dependency(path)
+        raise _Unresolved("dependency_path_not_contained_or_aliased")
+    if _absent(path, root, evidence):
+        raise _Unresolved("dependency_input_unavailable")
+    try:
+        data = read_static_input_bytes(path, max_bytes=MAX_GUARD_BYTES)
+    except (OSError, ValueError):
+        if snapshot is not None and snapshot.contains(path):
+            snapshot.mark_unconfirmable_dependency(path)
+        raise
+    if snapshot is not None and snapshot.contains(path):
+        snapshot.mark_dependency_input(path)
+    tree = ast.parse(data.decode("utf-8"), filename=str(path))
+    if sum(1 for _ in ast.walk(tree)) > MAX_GUARD_AST_NODES:
+        raise _Unresolved("dependency_ast_limit")
+    evidence.inputs.append(
+        GuardInputEvidence(
+            path=path.relative_to(root).as_posix(),
+            sha256=hashlib.sha256(data).hexdigest(),
+            role=role,
+        )
+    )
+    return tree
+
+
+def _absent(path: Path, root: Path, evidence: GuardDependencyEvidence) -> bool:
+    snapshot = active_static_input_snapshot()
+    if snapshot is not None and snapshot.contains(path):
+        absent = snapshot.bind_dependency_absence(path)
+    else:
+        session = IdentityBoundReadSession(root, max_entries=10000, max_total_bytes=MAX_GUARD_BYTES)
+        absent = path.name not in session.directory_entries(path.parent.relative_to(root))
+        session.finish()
+    if absent:
+        evidence.absent_paths.append(path.relative_to(root).as_posix())
+    return absent
+
+
+def _plain_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    args = node.args
+    return not (
+        args.posonlyargs
+        or args.kwonlyargs
+        or args.vararg
+        or args.kwarg
+        or args.defaults
+        or args.kw_defaults
+        or getattr(node, "type_params", ())
+    )
+
+
+def _simple_annotation(node: ast.AST | None) -> bool:
+    return (
+        node is None
+        or isinstance(node, ast.Name)
+        or (isinstance(node, ast.Constant) and (node.value is None or isinstance(node.value, str)))
+    )
+
+
+def _safe_definition(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    return (
+        _plain_signature(node)
+        and _simple_annotation(node.returns)
+        and all(_simple_annotation(arg.annotation) for arg in node.args.args)
+    )
+
+
+def _module_bindings(tree: ast.Module, guard_local: str) -> list[ast.ImportFrom]:
+    """Reject rebinding/executed construction rather than infer import order."""
+
+    imports = []
+    bindings: dict[str, int] = {}
+    for statement in _body(tree):
+        names: list[str]
+        if isinstance(statement, ast.ImportFrom):
+            if statement.module == "agents" and statement.level == 0:
+                if any(
+                    a.name not in {"Agent", "function_tool"} or a.asname for a in statement.names
+                ):
+                    raise _Unresolved("unsupported_sdk_import")
+            elif statement.level != 1 or not statement.module or "." in statement.module:
+                raise _Unresolved("unsupported_import_resolution")
+            if any(a.name == "*" for a in statement.names):
+                raise _Unresolved("wildcard_import")
+            imports.append(statement)
+            names = [a.asname or a.name for a in statement.names]
+        elif isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not _safe_definition(statement):
+                raise _Unresolved("definition_time_expression")
+            if any(
+                not isinstance(d, ast.Name) or d.id != "function_tool"
+                for d in statement.decorator_list
+            ):
+                raise _Unresolved("unsupported_tool_decorator")
+            names = [statement.name]
+        elif (
+            isinstance(statement, ast.Assign)
+            and len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+        ):
+            value = statement.value
+            if (
+                not isinstance(value, ast.Call)
+                or not isinstance(value.func, ast.Name)
+                or value.func.id != "Agent"
+            ):
+                raise _Unresolved("module_execution_or_configuration")
+            if any(
+                isinstance(
+                    child, (ast.Call, ast.Lambda, ast.NamedExpr, ast.comprehension, ast.Attribute)
+                )
+                for child in ast.walk(value)
+                if child is not value
+            ):
+                raise _Unresolved("dynamic_agent_configuration")
+            names = [statement.targets[0].id]
+        else:
+            raise _Unresolved("module_execution_or_configuration")
+        for name in names:
+            bindings[name] = bindings.get(name, 0) + 1
+    if any(count != 1 for count in bindings.values()):
+        raise _Unresolved("ambiguous_module_binding")
+    if bindings.get(guard_local) != 1:
+        raise _Unresolved("guard_import_not_unique")
+    return imports
+
+
+def _predicate(node: ast.expr, values: dict[str, bool]) -> bool:
+    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in values:
+        return values[node.id]
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not _predicate(node.operand, values)
+    if isinstance(node, ast.BoolOp) and isinstance(node.op, (ast.And, ast.Or)):
+        # Visit every operand: short-circuiting must never conceal unsupported
+        # configuration or a dynamic call in an unreachable-looking branch.
+        operands = [_predicate(item, values) for item in node.values]
+        return all(operands) if isinstance(node.op, ast.And) else any(operands)
+    raise _Unresolved("predicate_dependency_not_supported")
+
+
+def _shadows_guard(definition: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:
+    """Every Python binding form matters, including ones after the first call.
+
+    Conservatively include nested scopes: this profile does not prove their
+    execution/closure relationships and must not guess that a binding is inert.
+    """
+
+    for node in ast.walk(definition):
+        if (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, (ast.Store, ast.Del))
+            and node.id == name
+        ):
+            return True
+        if isinstance(node, ast.arg) and node.arg == name:
+            return True
+        if (
+            node is not definition
+            and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+            and node.name == name
+        ):
+            return True
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and any(
+            (alias.asname or alias.name.split(".")[0]) == name for alias in node.names
+        ):
+            return True
+        if isinstance(node, (ast.Global, ast.Nonlocal)) and name in node.names:
+            return True
+        if isinstance(node, (ast.ExceptHandler, ast.MatchAs, ast.MatchStar)) and node.name == name:
+            return True
+        if isinstance(node, ast.MatchMapping) and node.rest == name:
+            return True
+    return False
+
+
+def read_guard_dependency(
+    *,
+    tree: ast.Module,
+    source_sha256: str,
+    source_within_limits: bool,
+    path: Path,
+    root: Path,
+    tool: Tool,
+    definition: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> GuardDependencyEvidence:
+    root = root.resolve()
+    path = path.absolute()
+    evidence = GuardDependencyEvidence(
+        source_id=tool.source_id or "",
+        observation_id=source_observation_id(tool, tool.source_id or ""),
+        tool_name=tool.name,
+        tool_path=tool.source_ref or "",
+        tool_symbol=definition.name,
+        tool_line=definition.lineno,
+        status="unresolved",
+        reason="guard_not_in_supported_position",
+    )
+    try:
+        evidence.inputs.append(
+            GuardInputEvidence(
+                path=path.relative_to(root).as_posix(),
+                sha256=source_sha256,
+                role="tool_module",
+            )
+        )
+        snapshot = active_static_input_snapshot()
+        if snapshot is not None and snapshot.contains(path):
+            snapshot.mark_dependency_input(path)
+        if definition not in tree.body:
+            raise _Unresolved("nested_tool_definition")
+        if not source_within_limits:
+            raise _Unresolved("tool_module_limit")
+        body = _body(definition)
+        if not body or not isinstance(body[0], ast.If) or body[0].orelse:
+            raise _Unresolved("guard_not_in_supported_position")
+        guard = body[0]
+        if (
+            not isinstance(guard.test, ast.UnaryOp)
+            or not isinstance(guard.test.op, ast.Not)
+            or not isinstance(guard.test.operand, ast.Call)
+        ):
+            raise _Unresolved("guard_not_in_supported_position")
+        call = guard.test.operand
+        if not isinstance(call.func, ast.Name) or call.keywords:
+            raise _Unresolved("dynamic_guard_call")
+        if (
+            len(guard.body) != 1
+            or not isinstance(guard.body[0], ast.Return)
+            or not (
+                guard.body[0].value is None
+                or isinstance(guard.body[0].value, ast.Constant)
+                and guard.body[0].value.value in (None, False)
+            )
+        ):
+            raise _Unresolved("denial_not_a_literal_early_return")
+        evidence.call_line = call.lineno
+        imports = _module_bindings(tree, call.func.id)
+        if _shadows_guard(definition, call.func.id):
+            raise _Unresolved("guard_shadowed_in_tool")
+        matches = [
+            (statement, alias)
+            for statement in imports
+            for alias in statement.names
+            if (alias.asname or alias.name) == call.func.id
+        ]
+        if len(matches) != 1 or matches[0][0].level != 1:
+            raise _Unresolved("guard_import_not_unique")
+        imported, alias = matches[0]
+        evidence.guard_symbol = alias.name
+        module = path.parent / f"{imported.module}.py"
+        evidence.guard_path = module.relative_to(root).as_posix()
+        if not _absent(path.parent / str(imported.module), root, evidence):
+            raise _Unresolved("ambiguous_module_package_candidate")
+        # Empty package initializers are the only supported static wiring.
+        parent = path.parent
+        while parent == root or root in parent.parents:
+            initializer = parent / "__init__.py"
+            if _absent(initializer, root, evidence):
+                if parent == root and parent != path.parent:
+                    break
+                raise _Unresolved("package_initializer_unavailable")
+            init_tree = _read(initializer, root, "package_initializer", evidence)
+            if _body(init_tree):
+                raise _Unresolved("package_initializer_execution")
+            if parent == root:
+                break
+            parent = parent.parent
+        guard_tree = _read(module, root, "guard_module", evidence)
+        functions = [node for node in _body(guard_tree) if isinstance(node, ast.FunctionDef)]
+        if len(functions) != len(_body(guard_tree)) or any(
+            node.decorator_list or not _safe_definition(node) for node in functions
+        ):
+            raise _Unresolved("guard_module_execution_or_configuration")
+        targets = [node for node in functions if node.name == alias.name]
+        if len(targets) != 1:
+            raise _Unresolved("ambiguous_guard_definition")
+        target = targets[0]
+        evidence.guard_line = target.lineno
+        predicate_body = _body(target)
+        if (
+            len(predicate_body) != 1
+            or not isinstance(predicate_body[0], ast.Return)
+            or predicate_body[0].value is None
+        ):
+            raise _Unresolved("predicate_dependency_not_supported")
+        parameters = target.args.args
+        tool_parameters = {arg.arg: arg for arg in definition.args.args}
+        if (
+            not _plain_signature(definition)
+            or len(call.args) != len(parameters)
+            or len(parameters) > MAX_BOOLEAN_PARAMETERS
+        ):
+            raise _Unresolved("unsupported_guard_arguments")
+        if any(
+            not isinstance(arg.annotation, ast.Name) or arg.annotation.id != "bool"
+            for arg in parameters
+        ):
+            raise _Unresolved("predicate_parameters_not_boolean")
+        names = []
+        for arg in call.args:
+            if not isinstance(arg, ast.Name) or arg.id not in tool_parameters:
+                raise _Unresolved("guard_argument_configuration_or_expression")
+            annotation = tool_parameters[arg.id].annotation
+            if not isinstance(annotation, ast.Name) or annotation.id != "bool":
+                raise _Unresolved("guard_argument_not_boolean")
+            names.append(arg.id)
+        if len(set(arg.arg for arg in parameters)) != len(parameters):
+            raise _Unresolved("ambiguous_predicate_parameter")
+        evidence.parameters = sorted(set(names))
+        allowed = []
+        for mask in range(1 << len(evidence.parameters)):
+            values = {name: bool(mask & (1 << i)) for i, name in enumerate(evidence.parameters)}
+            arguments = {
+                parameter.arg: values[name]
+                for parameter, name in zip(parameters, names, strict=True)
+            }
+            if _predicate(predicate_body[0].value, arguments):
+                allowed.append(mask)
+        evidence.allowed_inputs = allowed
+        evidence.status = "observed"
+        evidence.reason = "bounded_source_predicate_only"
+    except _Unresolved as exc:
+        evidence.reason = str(exc)
+        evidence.status = "ambiguous" if "ambiguous" in evidence.reason else "unresolved"
+    except (OSError, UnicodeDecodeError, SyntaxError, ValueError, RecursionError):
+        evidence.reason = "dependency_input_unavailable"
+    return evidence

--- a/src/agents_shipgate/inputs/sdk_guard_dependencies.py
+++ b/src/agents_shipgate/inputs/sdk_guard_dependencies.py
@@ -58,7 +58,14 @@ def _body(node: ast.Module | ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast
 
 def _read(path: Path, root: Path, role: str, evidence: GuardDependencyEvidence) -> ast.Module:
     snapshot = active_static_input_snapshot()
-    if path.resolve() != path or not path.is_relative_to(root):
+    try:
+        contained = path.is_relative_to(root) and path.resolve() == path
+    except (OSError, RuntimeError):
+        # Python 3.11/3.12 raise RuntimeError for a symlink loop; newer
+        # pathlib versions can raise OSError instead. Both are failed input
+        # resolution, not evidence that the dependency was absent or read.
+        contained = False
+    if not contained:
         if snapshot is not None and snapshot.contains(path):
             snapshot.mark_unconfirmable_dependency(path)
         raise _Unresolved("dependency_path_not_contained_or_aliased")

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -805,6 +805,20 @@ def _append_tool_surface(lines: list[str], report: ReadinessReport) -> None:
 def _append_tool_surface_diff(lines: list[str], report: ReadinessReport) -> None:
     diff = report.tool_surface_diff
     lines.extend(["## Tool Surface Diff", ""])
+    visible_guards = [row for row in diff.guard_comparisons if
+                      (row.before is not None and row.before.status == "observed") or
+                      (row.after is not None and row.after.status == "observed")]
+    if visible_guards:
+        lines.extend(["### Imported guard evidence", "",
+            "Boolean source predicates only; dependency coverage is incomplete and no finding is excluded.", ""])
+        for comparison in visible_guards[:8]:
+            before, after = comparison.before, comparison.after
+            def location(row):
+                return f"{row.guard_path}:{row.guard_line}" if row and row.guard_path else "unavailable"
+            lines.append(f"- {_safe_markdown_text(comparison.tool_name)}: {comparison.direction.replace('_', ' ')}; base `{_safe_markdown_text(location(before))}`, head `{_safe_markdown_text(location(after))}`.")
+        if len(visible_guards) > 8:
+            lines.append(f"{len(visible_guards) - 8} more guard comparisons in report.json.")
+        lines.append("")
     if not diff.enabled:
         note = diff.notes[0] if diff.notes else "No comparison source was available."
         lines.extend(

--- a/src/agents_shipgate/schemas/guard_dependencies.py
+++ b/src/agents_shipgate/schemas/guard_dependencies.py
@@ -1,0 +1,61 @@
+"""Source-reader evidence for one bounded guard, never release authority."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GuardInputEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    role: Literal["tool_module", "guard_module", "package_initializer"]
+
+
+class GuardDependencyEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reader_profile: Literal["sdk_boolean_guard/v1"] = "sdk_boolean_guard/v1"
+    source_id: str
+    observation_id: str
+    tool_id: str | None = None
+    tool_name: str
+    tool_path: str
+    tool_symbol: str
+    tool_line: int = Field(ge=1)
+    guard_symbol: str | None = None
+    guard_path: str | None = None
+    guard_line: int | None = Field(default=None, ge=1)
+    call_line: int | None = Field(default=None, ge=1)
+    status: Literal["observed", "unresolved", "ambiguous", "redacted"]
+    reason: str
+    # Bit i represents parameters[i]. These are syntactic Boolean inputs,
+    # not executions, a claim about the downstream effect, or a safe verdict.
+    parameters: list[str] = Field(default_factory=list)
+    allowed_inputs: list[int] = Field(default_factory=list)
+    inputs: list[GuardInputEvidence] = Field(default_factory=list)
+    absent_paths: list[str] = Field(default_factory=list)
+    dependency_coverage: Literal["incomplete"] = "incomplete"
+    finding_exclusion_eligible: Literal[False] = False
+
+
+class GuardDependencyComparison(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    observation_id: str
+    tool_id: str | None = None
+    tool_name: str
+    direction: Literal[
+        "predicate_unchanged",
+        "predicate_widened",
+        "predicate_narrowed",
+        "predicate_changed",
+        "unresolved",
+    ]
+    reason: str
+    before: GuardDependencyEvidence | None = None
+    after: GuardDependencyEvidence | None = None
+    finding_exclusion_eligible: Literal[False] = False

--- a/src/agents_shipgate/schemas/surfaces.py
+++ b/src/agents_shipgate/schemas/surfaces.py
@@ -5,6 +5,10 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agents_shipgate.schemas.common import BaselineStatus, Confidence, Severity
+from agents_shipgate.schemas.guard_dependencies import (
+    GuardDependencyComparison,
+    GuardDependencyEvidence,
+)
 from agents_shipgate.schemas.semantic import ToolSemanticEvidence
 
 ToolSurfaceDiffBaseKind = Literal["none", "report", "baseline"]
@@ -90,6 +94,7 @@ class ToolSurfaceFacts(BaseModel):
     scopes: list[ToolSurfaceScopeFact] = Field(default_factory=list)
     controls: list[ToolSurfaceControlFact] = Field(default_factory=list)
     policies: list[ToolSurfacePolicyFact] = Field(default_factory=list)
+    guard_dependencies: list[GuardDependencyEvidence] = Field(default_factory=list, exclude_if=lambda value: not value)
 
 
 class ToolSurfaceDiffBase(BaseModel):
@@ -251,6 +256,7 @@ class ToolSurfaceDiff(BaseModel):
         default_factory=ToolSurfaceFindingDeltas
     )
     notes: list[str] = Field(default_factory=list)
+    guard_comparisons: list[GuardDependencyComparison] = Field(default_factory=list, exclude_if=lambda value: not value)
 
 
 ActionEffect = Literal[

--- a/tests/test_guard_dependency_verification.py
+++ b/tests/test_guard_dependency_verification.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+import yaml
+from test_current_control import _live, _verify
+from test_sdk_guard_dependencies import AGENT, read_workspace, write_workspace
+
+from agents_shipgate.cli.scan.orchestrator import run_scan
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+from agents_shipgate.core.static_inputs import (
+    StaticInputSnapshot,
+    activate_static_input_snapshot,
+    reset_static_input_snapshot,
+)
+from agents_shipgate.core.verification_identity import (
+    build_verification_plan,
+    validate_dependency_inputs,
+)
+
+
+def _git(root, *args):
+    return subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, check=True, text=True
+    ).stdout.strip()
+
+
+def _workspace(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    manifest = write_workspace(root)
+    (root / "shipgate.yaml").write_text(
+        yaml.safe_dump(manifest.model_dump(mode="json", exclude_none=True))
+    )
+    (root / ".gitignore").write_text(
+        "agents-shipgate-reports/\nrefund_agent/guards/\n/__init__.py\n"
+    )
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.name", "Test User")
+    _git(root, "config", "user.email", "test@example.test")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "base")
+    return root, manifest
+
+
+@pytest.mark.parametrize(
+    "predicate,direction",
+    [
+        ("approved", "predicate_widened"),
+        ("False", "predicate_narrowed"),
+        ("within_limit and approved", "predicate_unchanged"),
+    ],
+)
+def test_real_paired_repository_preserves_findings_and_guard_provenance(
+    tmp_path, predicate, direction
+):
+    root, manifest = _workspace(tmp_path)
+    old, _ = run_scan(
+        config_path=root / "shipgate.yaml",
+        output_dir=tmp_path / "base-report",
+        plugins_enabled=False,
+    )
+    write_workspace(root, predicate)
+    new, _ = run_scan(
+        config_path=root / "shipgate.yaml",
+        output_dir=tmp_path / "head-report",
+        diff_from_path=tmp_path / "base-report/report.json",
+        plugins_enabled=False,
+    )
+    (row,) = new.tool_surface_diff.guard_comparisons
+    assert row.direction == direction
+    assert row.before.guard_path == row.after.guard_path == "refund_agent/guards.py"
+    assert row.before.inputs != row.after.inputs
+    assert {f.fingerprint for f in old.findings} == {f.fingerprint for f in new.findings}
+    assert old.release_decision.decision == new.release_decision.decision
+    assert new.tool_surface_diff.policy_drift == []
+    assert new.tool_surface_diff.finding_deltas.new_findings == []
+    markdown = (tmp_path / "head-report/report.md").read_text()
+    assert direction.replace("_", " ") in markdown and "no finding is excluded" in markdown
+
+
+def test_actual_committed_verify_reads_guard_from_each_archived_tree(tmp_path):
+    root, _ = _workspace(tmp_path)
+    base = _git(root, "rev-parse", "HEAD")
+    write_workspace(root, "approved")
+    _git(root, "add", "refund_agent/guards.py")
+    _git(root, "commit", "-qm", "weaken shared predicate")
+    _verify(root, base=base)
+    report = json.loads((root / "agents-shipgate-reports/report.json").read_text())
+    (row,) = report["tool_surface_diff"]["guard_comparisons"]
+    assert row["direction"] == "predicate_widened"
+    assert row["before"]["allowed_inputs"] != row["after"]["allowed_inputs"]
+    plan = json.loads((root / "agents-shipgate-reports/verification-plan.json").read_text())
+    dependency_inputs = plan["inputs"]["options"]["dependency_inputs"]
+    assert "refund_agent/guards.py" in {r["path"] for r in dependency_inputs["files"]}
+    assert "refund_agent/guards" in dependency_inputs["absent_paths"]
+    assert "__init__.py" in dependency_inputs["absent_paths"]
+
+
+@pytest.mark.parametrize("mutation", ["guard_bytes", "package", "root_initializer"])
+@pytest.mark.parametrize("committed", [False, True])
+def test_current_control_rejects_changed_dependency_including_ignored_candidates(
+    tmp_path, mutation, committed
+):
+    root, _ = _workspace(tmp_path)
+    _verify(root, archive_head=committed)
+    out = root / "agents-shipgate-reports"
+    read_current_control(out, live=_live(root))
+    if mutation == "guard_bytes":
+        # An ignored dependency is still an input. The ordinary Git overlay
+        # cannot serve as a substitute for comparing the captured bytes.
+        _git(root, "update-index", "--assume-unchanged", "refund_agent/guards.py")
+        (root / "refund_agent/guards.py").write_text(
+            "def permitted(a: bool, b: bool):\n    return True\n"
+        )
+    elif mutation == "package":
+        (root / "refund_agent/guards").mkdir()
+    else:
+        (root / "__init__.py").write_text("raise RuntimeError('never execute')\n")
+    assert _git(root, "status", "--porcelain") == ""
+    with pytest.raises(CurrentControlUnavailable, match="dependency"):
+        read_current_control(out, live=_live(root))
+
+
+def test_dependency_bytes_and_absence_are_in_same_input_identity(tmp_path):
+    root, manifest = _workspace(tmp_path)
+    plans = []
+    for predicate in ("approved", "approved and within_limit"):
+        write_workspace(root, predicate)
+        snapshot = StaticInputSnapshot(root)
+        token = activate_static_input_snapshot(snapshot)
+        try:
+            read_workspace(root, manifest)
+            plans.append(
+                build_verification_plan(
+                    git_root=root,
+                    input_root=root,
+                    config_path=root / "shipgate.yaml",
+                    config_logical_path="shipgate.yaml",
+                    base_ref=None,
+                    head_ref="HEAD",
+                    archived_head=True,
+                    repository_id="https://example.test/fixture.git",
+                    base_commit_sha=None,
+                    base_tree_sha=None,
+                    head_commit_sha="a" * 40,
+                    head_tree_sha="b" * 40,
+                    merge_base_sha=None,
+                    changed_files=[],
+                    diff_text="",
+                    baseline_path=None,
+                    diff_from_path=None,
+                    policy_pack_paths=[],
+                    evaluation_date="2026-09-08",
+                    options={},
+                    plugins_enabled=False,
+                    captured_input_paths=snapshot.paths(),
+                )
+            )
+            snapshot.finish()
+        finally:
+            reset_static_input_snapshot(token)
+    assert plans[0].inputs.input_set_id != plans[1].inputs.input_set_id
+    validate_dependency_inputs(plans[1], root=root)
+    with pytest.raises(ValueError, match="dependency input changed"):
+        validate_dependency_inputs(plans[0], root=root)
+    (root / "refund_agent/guards").mkdir()
+    with pytest.raises(ValueError, match="lookup candidate appeared"):
+        validate_dependency_inputs(plans[1], root=root)
+
+
+def test_source_secrets_are_not_exposed_as_guard_evidence(tmp_path):
+    root, _ = _workspace(tmp_path)
+    sentinel = "sk-proj-" + "A1b2C3d4E5f6" * 5
+    path = root / "refund_agent/agent.py"
+    path.write_text(
+        AGENT.replace("Synthetic refund guard fixture; no tool executes during a scan.", sentinel)
+    )
+    report, _ = run_scan(
+        config_path=root / "shipgate.yaml", output_dir=tmp_path / "reports", plugins_enabled=False
+    )
+    for path in (tmp_path / "reports").iterdir():
+        if path.is_file():
+            assert sentinel not in path.read_text(errors="replace")
+    assert "ast" not in report.tool_surface_facts.guard_dependencies[0].model_dump()
+
+
+@pytest.mark.parametrize("missing", ["guards.py", "__init__.py"])
+@pytest.mark.parametrize("committed", [False, True])
+def test_recovery_of_missing_ignored_dependency_invalidates_control(tmp_path, missing, committed):
+    root, _ = _workspace(tmp_path)
+    path = root / "refund_agent" / missing
+    data = path.read_bytes()
+    _git(root, "rm", str(path.relative_to(root)))
+    with (root / ".gitignore").open("a") as handle:
+        handle.write(f"/refund_agent/{missing}\n")
+    _git(root, "add", ".gitignore")
+    _git(root, "commit", "-qm", "missing dependency")
+    _verify(root, archive_head=committed)
+    out = root / "agents-shipgate-reports"
+    read_current_control(out, live=_live(root))
+    path.write_bytes(data)
+    assert _git(root, "status", "--porcelain") == ""
+    with pytest.raises(CurrentControlUnavailable, match="dependency"):
+        read_current_control(out, live=_live(root))
+
+
+def test_redacted_parameter_cannot_produce_an_equal_predicate_claim(tmp_path):
+    root, _ = _workspace(tmp_path)
+    secret = "AKIAABCDEFGHIJKLMNOP"
+    for name in ("agent.py", "guards.py"):
+        path = root / "refund_agent" / name
+        path.write_text(path.read_text().replace("approved", secret))
+    first, _ = run_scan(
+        config_path=root / "shipgate.yaml", output_dir=tmp_path / "base", plugins_enabled=False
+    )
+    assert first.tool_surface_facts.guard_dependencies[0].status == "redacted"
+    second, _ = run_scan(
+        config_path=root / "shipgate.yaml",
+        output_dir=tmp_path / "head",
+        diff_from_path=tmp_path / "base/report.json",
+        plugins_enabled=False,
+    )
+    assert second.tool_surface_diff.guard_comparisons[0].direction == "unresolved"
+    for folder in ("base", "head"):
+        for path in (tmp_path / folder).iterdir():
+            if path.is_file():
+                assert secret not in path.read_text(errors="replace")
+
+
+@pytest.mark.parametrize("committed", [False, True])
+def test_removing_ignored_conflicting_package_invalidates_control(tmp_path, committed):
+    root, _ = _workspace(tmp_path)
+    path = root / "refund_agent/guards"
+    path.mkdir()
+    # A committed scan does not see untracked files, so only the worktree run
+    # records this conflict. In committed mode use a tracked package and hide
+    # its removal from Git's ordinary working-tree status.
+    if committed:
+        marker = path / "__init__.py"
+        marker.write_text("")
+        _git(root, "add", "-f", "refund_agent/guards/__init__.py")
+        _git(root, "commit", "-qm", "ambiguous import")
+        _git(root, "update-index", "--assume-unchanged", "refund_agent/guards/__init__.py")
+    _verify(root, archive_head=committed)
+    out = root / "agents-shipgate-reports"
+    read_current_control(out, live=_live(root))
+    if committed:
+        marker.unlink()
+    path.rmdir()
+    assert _git(root, "status", "--porcelain") == ""
+    with pytest.raises(CurrentControlUnavailable, match="dependency"):
+        read_current_control(out, live=_live(root))
+
+
+@pytest.mark.parametrize("kind", ["symlink", "oversized", "directory"])
+def test_uncaptured_helper_cannot_supply_current_authority(tmp_path, kind):
+    root, _ = _workspace(tmp_path)
+    path = root / "refund_agent/guards.py"
+    valid = path.read_bytes()
+    _git(root, "rm", "refund_agent/guards.py")
+    with (root / ".gitignore").open("a") as handle:
+        handle.write("/refund_agent/guards.py\n")
+    _git(root, "add", ".gitignore")
+    _git(root, "commit", "-qm", "external helper")
+    if kind == "symlink":
+        external = tmp_path / "external.py"
+        external.write_bytes(valid)
+        try:
+            path.symlink_to(external)
+        except OSError:
+            pytest.skip("symlink creation unavailable")
+    elif kind == "oversized":
+        path.write_bytes(b"#" * (256 * 1024 + 1))
+    else:
+        path.mkdir()
+    _verify(root, archive_head=False)
+    out = root / "agents-shipgate-reports"
+    plan = json.loads((out / "verification-plan.json").read_text())
+    assert plan["inputs"]["options"]["dependency_inputs"]["unconfirmable_paths"] == [
+        "refund_agent/guards.py"
+    ]
+    with pytest.raises(CurrentControlUnavailable, match="dependency could not be captured"):
+        read_current_control(out, live=_live(root))
+    if kind == "directory":
+        path.rmdir()
+    else:
+        path.unlink()
+    path.write_bytes(valid)
+    assert _git(root, "status", "--porcelain") == ""
+    with pytest.raises(CurrentControlUnavailable, match="dependency could not be captured"):
+        read_current_control(out, live=_live(root))
+    _verify(root, archive_head=False)
+    read_current_control(out, live=_live(root))

--- a/tests/test_guard_dependency_verification.py
+++ b/tests/test_guard_dependency_verification.py
@@ -255,21 +255,22 @@ def test_removing_ignored_conflicting_package_invalidates_control(tmp_path, comm
         read_current_control(out, live=_live(root))
 
 
-@pytest.mark.parametrize("kind", ["symlink", "oversized", "directory"])
-def test_uncaptured_helper_cannot_supply_current_authority(tmp_path, kind):
+@pytest.mark.parametrize("kind", ["symlink", "oversized", "directory", "symlink_loop"])
+@pytest.mark.parametrize("relative", ["refund_agent/guards.py", "refund_agent/__init__.py"])
+def test_uncaptured_helper_cannot_supply_current_authority(tmp_path, kind, relative):
     root, _ = _workspace(tmp_path)
-    path = root / "refund_agent/guards.py"
+    path = root / relative
     valid = path.read_bytes()
-    _git(root, "rm", "refund_agent/guards.py")
+    _git(root, "rm", relative)
     with (root / ".gitignore").open("a") as handle:
-        handle.write("/refund_agent/guards.py\n")
+        handle.write(f"/{relative}\n")
     _git(root, "add", ".gitignore")
     _git(root, "commit", "-qm", "external helper")
-    if kind == "symlink":
+    if kind in {"symlink", "symlink_loop"}:
         external = tmp_path / "external.py"
         external.write_bytes(valid)
         try:
-            path.symlink_to(external)
+            path.symlink_to(path.name if kind == "symlink_loop" else external)
         except OSError:
             pytest.skip("symlink creation unavailable")
     elif kind == "oversized":
@@ -280,7 +281,7 @@ def test_uncaptured_helper_cannot_supply_current_authority(tmp_path, kind):
     out = root / "agents-shipgate-reports"
     plan = json.loads((out / "verification-plan.json").read_text())
     assert plan["inputs"]["options"]["dependency_inputs"]["unconfirmable_paths"] == [
-        "refund_agent/guards.py"
+        relative
     ]
     with pytest.raises(CurrentControlUnavailable, match="dependency could not be captured"):
         read_current_control(out, live=_live(root))

--- a/tests/test_sdk_guard_dependencies.py
+++ b/tests/test_sdk_guard_dependencies.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.core.guard_dependencies import (
+    associate_guard_dependencies,
+    compare_guard_dependencies,
+)
+from agents_shipgate.core.static_inputs import (
+    StaticInputSnapshot,
+    activate_static_input_snapshot,
+    reset_static_input_snapshot,
+)
+from agents_shipgate.core.tool_identity import build_tool_identity_catalog
+from agents_shipgate.inputs.openai_sdk_static import load_openai_sdk_static_tools
+from agents_shipgate.schemas.manifest import AgentsShipgateManifest, ToolIdentityConfig
+
+AGENT = '''from agents import Agent, function_tool
+from .guards import permitted as allowed
+
+@function_tool
+def refund(approved: bool, within_limit: bool) -> bool:
+    """Synthetic refund guard fixture; no tool executes during a scan."""
+    if not allowed(approved, within_limit):
+        return False
+    return True
+
+agent = Agent(name="Refund", tools=[refund])
+'''
+
+
+def write_workspace(
+    root: Path, predicate: str = "approved and within_limit"
+) -> AgentsShipgateManifest:
+    package = root / "refund_agent"
+    package.mkdir(exist_ok=True)
+    (package / "__init__.py").write_text("")
+    (package / "agent.py").write_text(AGENT)
+    (package / "guards.py").write_text(
+        f"def permitted(approved: bool, within_limit: bool) -> bool:\n    return {predicate}\n"
+    )
+    return AgentsShipgateManifest.model_validate(
+        {
+            "version": "0.1",
+            "project": {"name": "guard-evidence-fixture"},
+            "agent": {"name": "Refund", "declared_purpose": ["exercise static guard comparison"]},
+            "environment": {"target": "local"},
+            "tool_sources": [
+                {"id": "sdk", "type": "openai_agents_sdk", "path": "refund_agent/agent.py"}
+            ],
+            "output": {"directory": "agents-shipgate-reports", "formats": ["markdown", "json"]},
+        }
+    )
+
+
+def read_workspace(root: Path, manifest: AgentsShipgateManifest):
+    loaded = load_openai_sdk_static_tools(manifest.tool_sources[0], manifest, root)
+    tools, _ = build_tool_identity_catalog([loaded], ToolIdentityConfig())
+    return associate_guard_dependencies([loaded], tools)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "direction"),
+    [
+        ("approved and within_limit", "approved", "predicate_widened"),
+        ("approved", "approved and within_limit", "predicate_narrowed"),
+        ("approved and within_limit", "within_limit and approved", "predicate_unchanged"),
+        ("approved", "within_limit", "predicate_changed"),
+        ("False", "True", "predicate_widened"),
+    ],
+)
+def test_imported_guard_comparison_preserves_actual_source_evidence(tmp_path, old, new, direction):
+    manifest = write_workspace(tmp_path, old)
+    before = read_workspace(tmp_path, manifest)
+    declaration = (tmp_path / "refund_agent/agent.py").read_bytes()
+    write_workspace(tmp_path, new)
+    after = read_workspace(tmp_path, manifest)
+    assert (tmp_path / "refund_agent/agent.py").read_bytes() == declaration
+    assert before[0].status == after[0].status == "observed"
+    (comparison,) = compare_guard_dependencies(after, before)
+    assert comparison.direction == direction
+    assert comparison.before.guard_path == comparison.after.guard_path == "refund_agent/guards.py"
+    assert comparison.before.guard_line == comparison.after.guard_line == 1
+    assert comparison.before.call_line == 7
+    assert (
+        after[0].inputs[-1].sha256
+        == hashlib.sha256((tmp_path / "refund_agent/guards.py").read_bytes()).hexdigest()
+    )
+    assert comparison.finding_exclusion_eligible is False
+    assert after[0].dependency_coverage == "incomplete"
+
+
+@pytest.mark.parametrize(
+    ("path", "contents", "reason"),
+    [
+        (
+            "refund_agent/guards.py",
+            "def permitted(a: bool, b: bool):\n    return a and setting\n",
+            "predicate_dependency_not_supported",
+        ),
+        (
+            "refund_agent/guards.py",
+            "def permitted(a: bool, b: bool):\n    return True or dynamic()\n",
+            "predicate_dependency_not_supported",
+        ),
+        (
+            "refund_agent/guards.py",
+            "import os\ndef permitted(a: bool, b: bool):\n    return True\n",
+            "guard_module_execution_or_configuration",
+        ),
+        (
+            "refund_agent/guards.py",
+            "def permitted(a: bool, b: bool):\n    return True\ndef permitted(a: bool, b: bool):\n    return False\n",
+            "ambiguous_guard_definition",
+        ),
+        (
+            "refund_agent/guards.py",
+            "def permitted(a: bool, b: bool):\n    if a:\n        return b\n    return False\n",
+            "predicate_dependency_not_supported",
+        ),
+        (
+            "refund_agent/__init__.py",
+            "raise RuntimeError('must never execute')\n",
+            "package_initializer_execution",
+        ),
+        (
+            "refund_agent/agent.py",
+            AGENT.replace("return True", "allowed = lambda a, b: True\n    return True"),
+            "guard_shadowed_in_tool",
+        ),
+        (
+            "refund_agent/agent.py",
+            AGENT.replace("from .guards import permitted as allowed", "from .guards import *"),
+            "wildcard_import",
+        ),
+        (
+            "refund_agent/agent.py",
+            AGENT.replace("from .guards", "from guards"),
+            "unsupported_import_resolution",
+        ),
+        (
+            "refund_agent/agent.py",
+            AGENT.replace(
+                "if not allowed(approved, within_limit):",
+                "if not allowed(approved, configuration):",
+            ),
+            "guard_argument_configuration_or_expression",
+        ),
+        (
+            "refund_agent/agent.py",
+            AGENT.replace("return False", "raise PermissionError('no')"),
+            "denial_not_a_literal_early_return",
+        ),
+        (
+            "refund_agent/agent.py",
+            AGENT + "\nallowed = None\n",
+            "module_execution_or_configuration",
+        ),
+    ],
+)
+def test_unknown_dependencies_never_mean_no_influence(tmp_path, path, contents, reason):
+    manifest = write_workspace(tmp_path)
+    before = read_workspace(tmp_path, manifest)
+    (tmp_path / path).write_text(contents)
+    after = read_workspace(tmp_path, manifest)
+    assert after[0].status in {"unresolved", "ambiguous"}
+    assert after[0].reason == reason
+    (comparison,) = compare_guard_dependencies(after, before)
+    assert comparison.direction == "unresolved"
+    assert comparison.finding_exclusion_eligible is False
+
+
+def test_package_candidate_or_missing_guard_is_unresolved(tmp_path):
+    manifest = write_workspace(tmp_path)
+    package = tmp_path / "refund_agent/guards"
+    package.mkdir()
+    (row,) = read_workspace(tmp_path, manifest)
+    assert row.reason == "ambiguous_module_package_candidate"
+    package.rmdir()
+    (tmp_path / "refund_agent/guards.py").unlink()
+    (row,) = read_workspace(tmp_path, manifest)
+    assert row.status == "unresolved" and row.reason == "dependency_input_unavailable"
+
+
+def test_snapshot_captures_guard_bytes_and_negative_import_lookup(tmp_path):
+    manifest = write_workspace(tmp_path)
+    snapshot = StaticInputSnapshot(tmp_path)
+    token = activate_static_input_snapshot(snapshot)
+    try:
+        (row,) = read_workspace(tmp_path, manifest)
+        assert row.status == "observed"
+        assert (tmp_path / "refund_agent/guards.py") in snapshot.dependency_paths()
+        assert (tmp_path / "refund_agent/guards") in snapshot.absent_dependency_paths()
+        assert (tmp_path / "__init__.py") in snapshot.absent_dependency_paths()
+        (tmp_path / "refund_agent/guards").mkdir()
+        with pytest.raises(ValueError, match="changed (?:identity|entries)"):
+            snapshot.finish()
+    finally:
+        reset_static_input_snapshot(token)
+
+
+def test_roundtrip_missing_duplicate_or_invalid_predicate_stays_unresolved(tmp_path):
+    manifest = write_workspace(tmp_path)
+    (row,) = read_workspace(tmp_path, manifest)
+    roundtripped = type(row).model_validate_json(row.model_dump_json())
+    assert roundtripped == row
+    assert compare_guard_dependencies([row], [])[0].direction == "unresolved"
+    assert compare_guard_dependencies([row, row], [row])[0].direction == "unresolved"
+    corrupt = row.model_copy(update={"allowed_inputs": [999]})
+    assert compare_guard_dependencies([corrupt], [row])[0].direction == "unresolved"
+
+
+def test_observation_membership_survives_an_inventory_primary(tmp_path):
+    manifest = write_workspace(tmp_path)
+    loaded = load_openai_sdk_static_tools(manifest.tool_sources[0], manifest, tmp_path)
+    tools, _ = build_tool_identity_catalog([loaded], ToolIdentityConfig())
+    member = tools[0].observation_ids[0]
+    primary = tools[0].model_copy(
+        update={
+            "id": "reviewed-canonical-tool",
+            "name": "inventory-refund",
+            "source_type": "mcp",
+            "source_ref": "inventory.json",
+            "observation_id": "inventory-member",
+            "observation_ids": ["inventory-member", member],
+        }
+    )
+    (row,) = associate_guard_dependencies([loaded], [primary])
+    assert row.tool_id == "reviewed-canonical-tool"
+    assert row.observation_id == member and row.guard_path == "refund_agent/guards.py"
+    (ambiguous,) = associate_guard_dependencies([loaded], [primary, tools[0]])
+    assert ambiguous.tool_id is None and ambiguous.status == "ambiguous"
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        "from .guards import permitted as allowed",
+        "import builtins as allowed",
+        "def allowed(a, b):\n        return True",
+        "class allowed:\n        pass",
+        "try:\n        pass\n    except Exception as allowed:\n        pass",
+        "match approved:\n        case allowed:\n            pass",
+        "global allowed",
+        "nonlocal allowed",
+    ],
+)
+def test_later_binding_cannot_look_like_the_module_guard(tmp_path, binding):
+    manifest = write_workspace(tmp_path)
+    (tmp_path / "refund_agent/agent.py").write_text(
+        AGENT.replace("    return True", f"    {binding}\n    return True")
+    )
+    (row,) = read_workspace(tmp_path, manifest)
+    assert row.status == "unresolved" and row.reason == "guard_shadowed_in_tool"
+
+
+def test_shared_guard_associates_each_caller_but_not_an_unrelated_tool(tmp_path):
+    manifest = write_workspace(tmp_path)
+    second = AGENT.split("@function_tool", 1)[1].split("agent =", 1)[0]
+    second = "@function_tool" + second.replace("def refund(", "def refund_second(")
+    unrelated = "@function_tool\ndef lookup(approved: bool) -> bool:\n    return approved\n\n"
+    path = tmp_path / "refund_agent/agent.py"
+    path.write_text(
+        AGENT.replace("agent =", second + unrelated + "agent =").replace(
+            "tools=[refund]", "tools=[refund, refund_second, lookup]"
+        )
+    )
+    before = read_workspace(tmp_path, manifest)
+    guard = tmp_path / "refund_agent/guards.py"
+    guard.write_text(guard.read_text().replace("approved and within_limit", "approved"))
+    comparisons = compare_guard_dependencies(read_workspace(tmp_path, manifest), before)
+    assert {row.tool_name for row in comparisons if row.direction == "predicate_widened"} == {
+        "refund",
+        "refund_second",
+    }
+    assert next(row for row in comparisons if row.tool_name == "lookup").direction == "unresolved"
+
+
+def test_reader_limit_keeps_tool_and_explicit_unknown(tmp_path, monkeypatch):
+    from agents_shipgate.inputs import sdk_guard_dependencies
+
+    manifest = write_workspace(tmp_path)
+    monkeypatch.setattr(sdk_guard_dependencies, "MAX_GUARD_AST_NODES", 2)
+    (row,) = read_workspace(tmp_path, manifest)
+    assert row.tool_id and row.status == "unresolved" and row.reason == "tool_module_limit"


### PR DESCRIPTION
A shared imported guard can be weakened while the SDK tool declaration and finding fingerprints remain unchanged. The existing finding buckets give the reviewer no dependency evidence for that change.

This adds reader-owned evidence for a bounded OpenAI Agents SDK Boolean guard profile. Each row preserves its canonical observation/capability, call and definition locations, source/dependency digests and Boolean input domain. Base/head comparisons distinguish unchanged, wider, narrower and otherwise changed predicates; unavailable, ambiguous, redacted and unsupported evidence stays unresolved. Markdown shows relevant comparisons and JSON retains the full typed records. The records use separate fields rather than generic policy drift, so a guard improvement is not projected as capability broadening.

The verifier binds actual dependency bytes and named present/absent import candidates in its input identity. Current-control reads recheck those inputs for both committed and worktree pointers, including ignored paths. Attempted reads that could not capture bytes remain explicitly unconfirmable and use the existing workspace-unverifiable refusal until repaired and reverified. Base cache epoch advances so earlier reports are regenerated.

Refs #557. This is its first bounded reader/evidence implementation: every row retains incomplete dependency coverage and `finding_exclusion_eligible: false`. Existing findings and the release decision are unchanged. Full capability dependency closure, #312's fixed-history safety measurement and #515's default scope change remain open.

## Validation

- Actual paired repository scans and committed base/head verification prove that a guard-only change identifies its callers and carries evidence from each side. Old main's CLI preserves equal fingerprints and emits no guard evidence for the same pair.
- Shared callers, canonical observation membership, duplicate/invalid evidence, Boolean equivalence, dynamic/configuration cases, reader limits, late Python bindings and public redaction have targeted regressions.
- Real current-control tests cover changed helper bytes, appearing/disappearing ignored package candidates, missing-to-present helper/initializer recovery, and refused symlink/oversize/directory input followed by repair.
- Review-corrected frozen-source full suite: **9,193 passed, 5 skipped**. All **124 focused guard, input-identity and current-control tests** pass, including helper and package-initializer self-referential symlinks failing against the reviewed head and recovering after repair. Ruff, diff and generated-schema checks pass. Final-head independent review and CI remain required before merge.

Independent pre-PR review reproduced binding and currency gaps; the corrective regressions fail against the earlier implementation. Deferred follow-ups: #596 engine-aware base-cache identity, #597 durable typed refusal evidence, #598 concurrent local check/test inventory recovery. No historical labels, partner observations, signing, release qualification or publication are claimed.

Committed verification for `518928c383c5f233964832aec861fd18d7d23ebe` against `47de37034a94e9709a018bd8b2b20bd53274b34b` passed. The refreshed current-control is `complete` with commit/push/PR/merge permissions; this is source-change evidence only, not v1.0 release qualification.