### PR TITLE
Define the compact-control and receipt-closure validation boundary

### DIFF
--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -553,6 +553,27 @@ for anything reading the artifacts directly. A run can skip the second command
 entirely with `agents-shipgate verify --format control`, which emits the same
 envelope for the run it just performed.
 
+The compact reader validates **every entry in `current-control.json.artifacts`**.
+It does not follow the terminal receipt into optional artifacts absent from that
+map. For example, a successful read does not validate `human-review-request.json`
+merely because the bound receipt references it. Changed, missing, oversized, or
+symlinked receipt-only files leave the compact read unchanged; those same
+conditions on pointer-bound files make it refuse.
+
+For API consumers, `read_current_control(..., capture=...)` returns selected
+bytes from the same pass that validated every pointer entry. `capture` neither
+reduces validation nor adds optional files: a requested unbound key is absent
+from the returned `artifacts`. Consume these captured bytes instead of reopening
+their paths. A consumer that needs a receipt-only artifact must also call
+`load_validated_receipt_artifacts`, compare its returned receipt with the
+pointer-captured `verification_receipt`, and consume the returned closure bytes.
+The full loader rejects invalid optional files. It proves a coherent artifact
+snapshot, not current workspace state or permission to act; retain the currency
+checks below and revalidate before consequential actions. See the
+[consumer boundary and resource bounds](verification-reproducibility.md#current-control-and-receipt-closure)
+for the exact distinction. Standalone renderers such as `agent handoff` do not
+implicitly perform this current-control protocol.
+
 Byte consistency is not generation consistency. A pointer whose artifacts all
 still hash correctly can describe a workspace that one commit has moved past, so
 the reader compares the bound `workspace_identity` against the live repository —

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -11,6 +11,49 @@ The terminal trust root is
 Read it before the handoff or report. A receipt is written last and only after
 all referenced artifacts exist.
 
+## Current control and receipt closure
+
+Artifact integrity and current authority have separate read boundaries:
+
+| Reader | Validated evidence | What it does not establish |
+| --- | --- | --- |
+| `read_current_control` / `agent control` | Every explicit pointer entry, generation consistency, and live workspace currency. `capture` returns selected bytes from that same validated pass. | Integrity of a receipt-only optional file absent from the pointer map. Requesting an unbound capture key returns no bytes for it. |
+| `load_validated_receipt_artifacts` | The complete terminal receipt closure, including optional files, from a bounded private snapshot. | Current workspace state, review eligibility, or operational permission on its own. |
+
+`human-review-request.json` is one such optional artifact. Changing, deleting,
+oversizing, or symlinking it must fail a full-closure read but does not invalidate
+an otherwise current compact pointer. Changing a pointer-bound file fails the
+compact read even with `capture=()`. Successful capture never means all files
+mentioned inside the captured JSON were read.
+
+When a consumer needs both guarantees, capture `verification_receipt` in the
+current-control read, validate the full closure, and compare the returned receipt
+with that captured receipt before consuming any optional bytes. Use the bytes
+returned by the loaders; reopening paths creates a second observation that can
+belong to another run. Preserve the current-control live-workspace checks and
+repeat validation before consequential actions. Full closure validation cannot
+grant a permission denied by current control.
+
+The production control renderers consume captured verifier bytes. The human
+review evaluator additionally validates the full closure, joins the receipts,
+and checks the actual request against its reconstruction. Authorization request
+and execution consumers also validate the full closure; execution revalidates
+immediately before dispatch. Standalone artifact renderers make no implicit
+current-control promise.
+
+The compact contract remains unchanged: a 1 MiB pointer, 256 MiB per bound
+artifact, and up to three read attempts; it has no aggregate artifact budget.
+The full loader defaults to 64 artifacts, 64 MiB per artifact, and 256 MiB total,
+with 4 MiB bounds on the canonical colocated receipt and artifact manifest.
+Both use no-follow regular-file reads. `allowed_artifact_names` rejects unexpected
+references; it does not filter which referenced artifacts are validated. The
+compact read does no additional optional-file I/O; regression tests pin the read
+set independently of `capture`, rather than imposing a timing-dependent limit.
+
+The [normative control recipe](agent-contract-current.md#two-read-entry-points)
+defines freshness and permission routing. These boundaries change neither its
+wire format nor the release decision.
+
 ## Identity graph
 
 ```text

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2037,6 +2037,27 @@ for anything reading the artifacts directly. A run can skip the second command
 entirely with `agents-shipgate verify --format control`, which emits the same
 envelope for the run it just performed.
 
+The compact reader validates **every entry in `current-control.json.artifacts`**.
+It does not follow the terminal receipt into optional artifacts absent from that
+map. For example, a successful read does not validate `human-review-request.json`
+merely because the bound receipt references it. Changed, missing, oversized, or
+symlinked receipt-only files leave the compact read unchanged; those same
+conditions on pointer-bound files make it refuse.
+
+For API consumers, `read_current_control(..., capture=...)` returns selected
+bytes from the same pass that validated every pointer entry. `capture` neither
+reduces validation nor adds optional files: a requested unbound key is absent
+from the returned `artifacts`. Consume these captured bytes instead of reopening
+their paths. A consumer that needs a receipt-only artifact must also call
+`load_validated_receipt_artifacts`, compare its returned receipt with the
+pointer-captured `verification_receipt`, and consume the returned closure bytes.
+The full loader rejects invalid optional files. It proves a coherent artifact
+snapshot, not current workspace state or permission to act; retain the currency
+checks below and revalidate before consequential actions. See the
+[consumer boundary and resource bounds](verification-reproducibility.md#current-control-and-receipt-closure)
+for the exact distinction. Standalone renderers such as `agent handoff` do not
+implicitly perform this current-control protocol.
+
 Byte consistency is not generation consistency. A pointer whose artifacts all
 still hash correctly can describe a workspace that one commit has moved past, so
 the reader compares the bound `workspace_identity` against the live repository —

--- a/src/agents_shipgate/core/current_control.py
+++ b/src/agents_shipgate/core/current_control.py
@@ -479,7 +479,7 @@ class LiveWorkspace:
 class CurrentControlRead:
     """A pointer that was validated against the artifacts it binds.
 
-    ``artifacts`` holds the exact bytes of the keys the caller asked to capture,
+    ``artifacts`` holds the exact bytes of the pointer-bound keys the caller asked to capture,
     taken from the same validated pass that hashed them. A caller that reopens a
     bound artifact afterwards is making a second, unsynchronized read: a run
     republishing in between would let it combine this pointer's identity with a
@@ -505,6 +505,14 @@ def read_current_control(
     only when ``current_control_id`` is unchanged.  A run that republishes
     while this read is in flight makes the read fail rather than return a
     pointer describing one generation and artifacts from another.
+
+    The validated set is exactly ``pointer.artifacts``, not the larger closure
+    embedded in the terminal receipt. ``capture`` selects which validated bytes
+    are returned; it neither narrows validation nor adds receipt-only artifacts.
+    A requested key absent from the pointer is absent from ``artifacts`` too.
+    Consumers of receipt-only artifacts must additionally call
+    ``load_validated_receipt_artifacts``, compare its receipt with the captured
+    ``verification_receipt``, and consume the returned bytes, never reopen files.
 
     Byte consistency is not generation consistency.  A pointer whose artifacts
     all still hash correctly can still describe a workspace that has since

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -668,7 +668,18 @@ def load_validated_receipt_artifacts(
     max_artifact_size: int = 64 * 1024 * 1024,
     max_total_size: int = 256 * 1024 * 1024,
 ) -> tuple[VerificationReceipt, dict[str, bytes]]:
-    """Load receipt-bound artifact bytes from one validated snapshot."""
+    """Load the entire receipt closure as bytes from one validated snapshot.
+
+    Unlike ``read_current_control``, this includes optional artifacts absent
+    from the pointer map. ``allowed_artifact_names`` rejects unexpected names;
+    it does not select a subset to validate. Consume the returned bytes rather
+    than reopening source files after this snapshot has been validated.
+
+    Closure integrity alone establishes neither workspace currency nor action
+    authority. When joining this result to a current-control read, compare the
+    returned receipt with that read's captured ``verification_receipt`` and
+    retain the current-control freshness and consequential-action rechecks.
+    """
 
     with validated_receipt_snapshot(
         receipt_path=receipt_path,

--- a/tests/test_current_control_closure.py
+++ b/tests/test_current_control_closure.py
@@ -1,0 +1,121 @@
+"""Actual optional review evidence distinguishes pointer and receipt guarantees."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.cli.current_workspace import live_workspace
+from agents_shipgate.core import current_control as control
+from agents_shipgate.core.human_review_decision import _current_review
+from agents_shipgate.core.verification_identity import load_validated_receipt_artifacts
+from agents_shipgate.schemas.verification_identity import VerificationReceipt
+from tests.test_authorization_verify_integration import _committed_review_repo, _verify
+
+
+@pytest.fixture
+def review_run(tmp_path):
+    repo = _committed_review_repo(tmp_path)
+    _, report, code = _verify(repo)
+    assert code == 0 and report.release_decision.decision == "review_required"
+    out = repo / "agents-shipgate-reports"
+    assert (out / "human-review-request.json").is_file()
+    return repo, out
+
+
+def _read(repo, out, *, capture=()):
+    return control.read_current_control(
+        out, live=lambda: live_workspace(repo, out), capture=capture,
+    )
+
+
+def _closure(out):
+    return load_validated_receipt_artifacts(
+        receipt_path=out / "verification-receipt.json", root=out,
+    )
+
+
+def _damage(path: Path, mutation: str):
+    if mutation == "changed":
+        path.write_bytes(path.read_bytes() + b" ")
+    elif mutation == "missing":
+        path.unlink()
+    elif mutation == "symlink":
+        target = path.parent / "substitute.json"
+        path.rename(target)
+        try:
+            path.symlink_to(target.name)
+        except OSError:
+            pytest.skip("symlink creation is unavailable")
+    else:
+        assert mutation == "oversized"
+        with path.open("wb") as stream:
+            stream.truncate(control.MAX_BOUND_ARTIFACT_BYTES + 1)
+
+
+@pytest.mark.parametrize("mutation", ["changed", "missing", "symlink", "oversized"])
+def test_optional_damage_does_not_expand_compact_authority(review_run, mutation):
+    repo, out = review_run
+    before = _read(repo, out, capture=("verification_receipt",))
+    receipt, artifacts = _closure(out)
+    assert receipt == VerificationReceipt.model_validate_json(before.artifacts["verification_receipt"])
+    assert "human_review_request_json" in artifacts
+    assert "human_review_request_json" not in before.pointer.artifacts
+    assert not before.pointer.control.permissions.merge
+    assert _current_review(repo, out).receipt_id == receipt.receipt_id
+
+    _damage(out / "human-review-request.json", mutation)
+
+    after = _read(repo, out, capture=("human_review_request_json",))
+    assert after.pointer == before.pointer
+    assert after.artifacts == {}
+    with pytest.raises(ValueError):
+        _closure(out)
+    with pytest.raises(ValueError):
+        _current_review(repo, out)
+
+
+@pytest.mark.parametrize("mutation", ["changed", "missing", "symlink", "oversized"])
+def test_bound_damage_refuses_even_without_capture(review_run, mutation):
+    repo, out = review_run
+    _read(repo, out)
+    _damage(out / "verifier.json", mutation)
+    with pytest.raises(control.CurrentControlUnavailable) as failure:
+        _read(repo, out, capture=())
+    assert failure.value.reason in {"artifact_mismatch", "artifact_unreadable"}
+
+
+def test_capture_changes_returned_bytes_not_validated_read_set(review_run, monkeypatch):
+    repo, out = review_run
+    observed = _read(repo, out)
+    read_paths = []
+    original = control.read_regular_file_beneath
+
+    def record(root, logical_path, **kwargs):
+        read_paths.append(logical_path)
+        return original(root, logical_path, **kwargs)
+
+    monkeypatch.setattr(control, "read_regular_file_beneath", record)
+    expected_reads = Counter(ref.path for ref in observed.pointer.artifacts.values())
+    # Initial pointer, post-artifact confirmation, post-live-observation confirmation.
+    expected_reads["current-control.json"] = 3
+    for capture in [(), ("verifier",), ("human_review_request_json",)]:
+        read_paths.clear()
+        result = _read(repo, out, capture=capture)
+        assert Counter(read_paths) == expected_reads
+        assert set(result.artifacts) == set(capture).intersection(observed.pointer.artifacts)
+        assert "human-review-request.json" not in read_paths
+
+
+def test_full_closure_returns_snapshot_bytes_including_optional_request(review_run):
+    _, out = review_run
+    path = out / "human-review-request.json"
+    expected = path.read_bytes()
+    receipt, artifacts = _closure(out)
+    assert receipt.artifact_manifest.artifacts["human_review_request_json"].size_bytes == len(expected)
+    path.write_bytes(b"changed after snapshot")
+    assert artifacts["human_review_request_json"] == expected
+    with pytest.raises(ValueError):
+        _closure(out)


### PR DESCRIPTION
A successful current-control read validates the pointer's explicit artifact map. Its bound receipt can reference optional files outside that map, including `human-review-request.json`; assuming the compact read validates those files would let a consumer read unvalidated evidence.

This defines the existing boundary in the API docstrings and normative recipes. `capture` only selects returned bytes from the already validated pointer set. Optional-artifact consumers must use the existing full-closure loader, join its receipt to the captured receipt, and consume returned bytes while retaining current-workspace and consequential-action rechecks. The production consumer audit found the review and authorization paths already apply those checks; no bypass is asserted. Default validation, resource bounds, wire contracts, release decisions and authority are unchanged.

Real committed review fixtures distinguish changed, missing, symlinked and oversized optional files from pointer-bound damage. They prove review consumption refuses invalid optional evidence, a missing capture key adds no read or authority, capture choices preserve the read set, and returned closure bytes remain independent of later file edits. Existing generation and freshness regressions remain in place. `llms-full.txt` is regenerated from the normative source.

Closes #552. Parent #572; explicit compatibility boundary before #569.

## Validation

- **137 focused control, review and authorization tests passed**; the new boundary file includes ten real-workflow cases.
- Full local suite: **9,131 passed, 5 skipped**; one stale generated-document assertion and ten packaging setup errors remained. The generated document was corrected. Packaging had stopped during isolated build-dependency installation, before its assertions; it was rerun with that dependency access available. **All 578 affected public-contract, packaging and new boundary tests passed** afterward.
- Whole-tree Ruff and diff checks passed. No runtime behavior changed, so read-set/count assertions verify zero additional optional-file I/O rather than imposing a timing-sensitive threshold.
- Committed verification at `05af13beaf384e05e9dede547bc525de6e19084d` against current main `5c65f19c62a8ba64ce5d98d5be541b13bb762a39` passed; refreshed current-control is `complete`.

Independent GitHub review/address and final CI remain required before merge. This does not establish independent human approval, release qualification or v1.0 readiness.