### PR TITLE
Require the existing CI checks before merging to main

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,6 +156,10 @@ remain prerequisites. The current release decision is still **no-go**.
 - Repository release immutability and `v*` tag update/deletion protection are
   now enabled and read back, as recorded in
   the [runbook observation](docs/release-runbook.md#effective-configuration-observed--2026-09-09).
+  The [later main-CI checkpoint](docs/release-runbook.md#main-ci-merge-requirements--2026-09-10-utc)
+  adds nine required checks bound to the observed GitHub Actions App, with
+  current-base testing and no bypass actors. Check configuration does not
+  authenticate workflow contents or replace human approval.
   Current main/environment settings still do not establish independent
   workflow/publication review. [#573](https://github.com/ThreeMoonsLab/agents-shipgate/issues/573)
   retains restricted creators/writers, independent review, recovery ownership,

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -712,6 +712,51 @@ evidence. #494 retains accepted operating/recovery duties and #509 retains the
 independent qualification signer. No reviewer, signer, writer, emergency actor
 or personal access claim is supplied by enabling these protections.
 
+### Main CI merge requirements — 2026-09-10 UTC
+
+The later #573 checkpoint adds required CI to the existing
+[Protect main ruleset (15704163)](https://github.com/ThreeMoonsLab/agents-shipgate/rules/15704163).
+The authenticated update and read-back retained its `refs/heads/main` scope,
+empty bypass list and all four existing rules, including every PR-review
+parameter. The only addition was `required_status_checks`:
+
+| Existing workflow | Required check contexts |
+| --- | --- |
+| CI | `test`, `suite (1)`, `suite (2)`, `suite (3)`, `coverage`, `windows-launcher`, `clean-checkout-launcher` |
+| Agents Shipgate | `verify` |
+| Agents Shipgate Self Dogfood | `verify-self` |
+
+All nine entries use `integration_id: 15368`, the `github-actions` App observed
+on the successful PR #624 check runs at
+`1c949f63724d9b5da53352f9cc028dcd4c5bafd8`. The three workflows run on PRs
+without path filters. `release-tag-consistency` is main-only and is not a PR
+requirement. Each shard is required separately, so a failed shard cannot hide
+behind a skipped dependent coverage job.
+
+`strict_required_status_checks_policy: true` requires testing against the
+current base; after main advances, refresh the PR branch and its checks.
+`do_not_enforce_on_create: false` adds no creation exception; the rule matches
+main, not contributor branches. The [effective branch-rule API](https://docs.github.com/en/rest/repos/rules#get-rules-for-a-branch)
+returned the same nine entries and flags for main under ruleset `15704163`.
+The inherited-policy listing still contained only Protect main and Protect
+release tags; tag protection and immutable-release enablement remained in place.
+
+This closes the missing required-check configuration recorded in the earlier
+checkpoint, **not independent workflow review**. App binding identifies the
+check producer, not a workflow path, event or trusted workflow contents.
+[GitHub accepts successful, skipped or neutral check conclusions](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging);
+a required name alone does not prove its test ran. Both Shipgate jobs retain
+their advisory human-review routing. Main still requires zero approving reviews,
+and publication reviewer independence remains unresolved. A policy editor can
+still change these settings. No failed merge, tag mutation or publication was
+attempted as a refusal test.
+
+Re-read the effective main rules and expected App/context names before release.
+A job rename needs a reviewed ruleset transition while the existing required
+contexts still report; otherwise the renamed job can leave PRs waiting forever.
+These settings do not supply a signer, recovery owner, qualified candidate or
+the remaining #573 release evidence.
+
 ### The limit worth stating plainly
 
 The workflow that runs for a tag is **the workflow at that tag** — it is part of


### PR DESCRIPTION
## Summary

The CI workflow described every job as required, but Protect main had no required-status-check rule. Main now requires the nine existing PR check contexts, each bound to the observed GitHub Actions App, with testing against the current base. The two-file runbook/ROADMAP update records the actual setting and its limits.

The rule is additive: all four prior rules, every PR-review parameter, main-only scope and the empty bypass list were preserved. No workflow, check severity, reviewer assignment, signer identity or release-tag creator permission changed. Missing independent workflow/publication review remains a release obligation.

## Type

- [x] Documentation only in the repository; the corresponding GitHub repository setting was applied and read back under the owner's authorization.

## Verification

- The nine context names and App ID 15368 were read from the successful PR #624 check runs at `1c949f63724d9b5da53352f9cc028dcd4c5bafd8`; all three existing workflows have unfiltered PR triggers. The main-only release-tag check is excluded.
- Immediately before the PUT, the current ruleset matched the prepared snapshot. Fresh ruleset and effective main-branch reads afterward matched the exact requested check entries, strict-base flag and absence of a creation exception. Every prior rule/parameter and the no-bypass setting were retained. The inherited listing, tag rule and immutable-release setting were also read back.
- Local full suite: **9,537 passed, five skipped** in 287 seconds. Ruff, diff checks and the new runbook-anchor check passed. All nine required contexts on published head `89c67ac62e21b17c97ffca813fc3b1a820451053` completed successfully: [CI](https://github.com/ThreeMoonsLab/agents-shipgate/actions/runs/34446822440), including all three shards and aggregate coverage, [Shipgate](https://github.com/ThreeMoonsLab/agents-shipgate/actions/runs/34446822340), and [Self Dogfood](https://github.com/ThreeMoonsLab/agents-shipgate/actions/runs/34446822358). The main-only release-tag-consistency job was correctly skipped and is not a required PR context.

## Review/address

The independent [COMMENT review](https://github.com/ThreeMoonsLab/agents-shipgate/pull/625#pullrequestreview-5163610950) found no actionable issues at the exact published head after reading both blobs and fresh effective platform policies. The [author response](https://github.com/ThreeMoonsLab/agents-shipgate/pull/625#issuecomment-5614423082) completes this PR's one review/address loop and #573's third and final formal round in this implementation pass. No subsequent source edits were needed.

## Release-readiness notes

GitHub's required-check semantics allow skipped/neutral conclusions, and an App-bound context does not authenticate a workflow path, event or contents. Each suite shard is required separately, so a failed shard cannot be hidden by its dependent coverage job being skipped. Both Shipgate jobs retain the existing advisory human-review route.

Strict mode requires a refreshed branch and checks when main advances. Future job renames need a reviewed transition while the old required names still report. No failed merge or production tag/asset mutation was used as a refusal probe. Actual independent reviewers/writers, recovery ownership and final-candidate evidence remain outstanding; #573 stays open.

Refs #573, #572, #494, #509.
