### PR TITLE
Connect declared OpenAPI operations to approval predicates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,9 +74,13 @@ SDK guard evidence, and [#606](https://github.com/ThreeMoonsLab/agents-shipgate/
 compares a closed Boolean function and its literal source Agent membership.
 Both keep capability dependency coverage incomplete and finding-exclusion
 eligibility false. A return value is not an action effect or approval:
-[#607](https://github.com/ThreeMoonsLab/agents-shipgate/issues/607), a deferred
-sub-issue of #557, owns the newly isolated operation-to-policy-predicate
-relationship. #557 and #515 remain open; these source models do not satisfy
+[#607](https://github.com/ThreeMoonsLab/agents-shipgate/issues/607), originally
+deferred from #606's implementation pass, owns the isolated operation-to-policy-predicate
+relationship. The subsequent engineering pass selects a bounded OpenAPI DELETE
+profile: join actual source/capability/approval-predicate evidence, rebuild the
+Git base, and report declared target changes separately from missing approval.
+[The profile contract](docs/operation-attribution.md) preserves unresolved inputs,
+unknown deployed reachability and false exclusion eligibility. #557 and #515 remain open; these source models do not satisfy
 the TypeScript MongoDB acceptance case or historical safety bars.
 
 [#612](https://github.com/ThreeMoonsLab/agents-shipgate/pull/612) closes #545 and #516. It separates
@@ -115,7 +119,7 @@ continues to route that concrete plan to a human. The rejected optional PR
 trigger for #570 remains absent, but the existing manual workflow now runs.
 
 Newly discovered issues #575/#577/#580/#581, #584–#586, #588/#590, #592/#593,
-#596–#598/#601, #607, #609–#611, #613/#615/#617/#618/#620 remain separately deferred; they are not silently
+#596–#598/#601, #609–#611, #613/#615/#617/#618/#620 remain separately deferred; they are not silently
 added to this implementation pass or counted as repairs. #609 documents a frozen
 preflight schema URL/discriminator mismatch; the current successor uses a fresh
 version without rewriting historical bytes. #610 owns the distinct compatibility
@@ -131,6 +135,14 @@ inventories. #620 requires measurement before sharing walks with
 different coverage and identity guarantees. None is counted as repaired:
 #568's discovery routes the #613 defect to inspection and claims no audit
 repair.
+
+The subsequent #607 pass reproduced [#627](https://github.com/ThreeMoonsLab/agents-shipgate/issues/627):
+a worktree control refresh can accept a changed declared input whose hash is
+already in the plan but which is absent from the separately revalidated
+dependency set. This is a new P0 release blocker, deferred from that bounded
+implementation. #607 binds its own source and manifest dependencies; #627 owns
+the general currency repair before final candidate/freeze. It does not reopen
+#299's already-delivered input-enumeration repair or count as a #567 review.
 
 The following sequence and approved release bars still apply. Contract
 convergence, historical catch results, report freeze, actual human ownership,
@@ -209,7 +221,7 @@ reader, control and publication work need not wait for each other.
 | Live authority | #567: reconfirm overlay contents/metadata and resolved base/merge base in the shared control reader | Same-path/base interleavings cannot return stale authority; unchanged reads and actual CLI consumers still work |
 | Offline evidence | #559: capture bounded bytes once for hash validation and parsing across qualification inputs | Interleaved replacements cannot be scored as bound data; existing containment and identity joins remain enforced |
 | Historical workflow | [#563](https://github.com/ThreeMoonsLab/agents-shipgate/issues/563) reviewed scope and [#564](https://github.com/ThreeMoonsLab/agents-shipgate/issues/564) new/renamed base inputs can start together | Same 19 SHAs/labels reach truthful verifier outcomes and restore the existing catch bars; no fabricated authority or scope |
-| Change attribution | [#557](https://github.com/ThreeMoonsLab/agents-shipgate/issues/557) shared-helper/import/configuration evidence and [#607](https://github.com/ThreeMoonsLab/agents-shipgate/issues/607) operation/predicate attribution **before** [#515](https://github.com/ThreeMoonsLab/agents-shipgate/issues/515) default diff scope | Paired standing-weakness, improvement and widened-capability fixtures; incomplete dependency coverage remains explicit; #607 is deferred from this implementation pass, so this route remains pending |
+| Change attribution | [#557](https://github.com/ThreeMoonsLab/agents-shipgate/issues/557) shared-helper/import/configuration evidence and [#607](https://github.com/ThreeMoonsLab/agents-shipgate/issues/607) operation/predicate attribution **before** [#515](https://github.com/ThreeMoonsLab/agents-shipgate/issues/515) default diff scope | #607's subsequent pass compares bounded OpenAPI declared targets and the actual approval predicate; broader dependency coverage, TypeScript `cal-1` and historical qualification remain pending before any default/gate change |
 | Prose and structure | [#545](https://github.com/ThreeMoonsLab/agents-shipgate/issues/545) classification **before** completing [#516](https://github.com/ThreeMoonsLab/agents-shipgate/issues/516) | Final verifier, local check and preflight distinguish prose edits from structured grants/hooks/CI; malformed structure remains visible |
 | Cold entry and CI | [#568](https://github.com/ThreeMoonsLab/agents-shipgate/issues/568) routes host-only repositories correctly; [#570](https://github.com/ThreeMoonsLab/agents-shipgate/issues/570) defines final-wheel/Action pin provenance | Supported Route H reaches a useful review without a placeholder manifest; local and generated CI name the intended engine/contract |
 

--- a/docs/operation-attribution.md
+++ b/docs/operation-attribution.md
@@ -1,0 +1,98 @@
+# Declared operation attribution
+
+An unchanged missing-approval finding and a narrower operation are different
+facts. Agents Shipgate reports them separately in the existing
+`tool_surface_facts.operation_attributions[]` and
+`tool_surface_diff.operation_comparisons[]` blocks (#607). These optional
+diagnostics do not change a finding, fingerprint, support classification,
+baseline, exit code or release decision. Every exclusion flag remains false.
+
+For example, an OpenAPI DELETE operation whose declared document IDs change
+from `[alpha, beta]` to `[alpha]` has a **narrowed declared target domain**.
+If the agent still has no declared approval policy, its approval predicate is
+still a **standing weakness**. The report never calls that narrowing approval,
+nor does it claim the server enforces the enum. An actual supplied approval
+declaration can resolve the predicate; a caller parameter named `approved`
+cannot. Declaration changes continue through the existing release review.
+
+## What the first profile establishes
+
+`openapi_delete/v1` reads a bounded declared HTTP request surface directly from
+the captured OpenAPI bytes, before parameter normalization loses locations or
+merges request-body properties. The manifest must select one OpenAPI source,
+without auxiliary framework blocks or an SDK entrypoint: other files can
+change selector/binding resolution or contribute effective approval. This
+first profile refuses that wider dependency problem rather than silently
+ignoring those files, including optional policy artifacts. It supports:
+
+- OpenAPI **3.0.3**, literal DELETE and explicit `operationId`;
+- one effective literal HTTPS server, including operation/path/root overrides;
+- a fixed path template with up to four required scalar string path parameters,
+  simple serialization, at most 32 literal enum values per parameter, and
+  operation-level parameter overrides identified by `(in, name)`;
+- explicit security alternatives, preserving their OR/AND structure, with
+  literal HTTP basic/bearer or header API-key scheme declarations;
+- at most 256 declared URLs, with a conservative 16 KiB expansion budget.
+
+Duplicate keys, aliases/merges, ambiguous parameters, dynamic servers, unknown
+configuration, request bodies, callbacks, query/header/cookie parameters,
+references and unsupported schema composition cannot complete this profile.
+The existing reader still exposes its ordinary supported inventory; this is
+an attribution refusal, not a new parser error or a weaker gate. Other HTTP
+methods receive no operation attribution in this version.
+
+Each observed row joins the source observation to exactly one canonical tool
+and the existing capability-policy subject, then to
+`SHIP-POLICY-APPROVAL-MISSING`. It retains the source and manifest byte digests,
+operation pointer, canonical/capability IDs, structural `openapi_method` claim,
+the effective control pack's full identity, actual approval predicate, and
+supplied static binding evidence. Approval provenance includes the manifest
+policy list and any selected action-level approval declaration. This is an
+explanatory projection of the same check inputs, not new `Finding.support`.
+
+An unbound catalog operation has no in-scope action-policy subject to join.
+Agents Shipgate does not generate a binding or an effect/authority declaration
+to create one. Mixed artifact families, semantic conflicts and ambiguous
+canonical membership remain unresolved. Overall dependency coverage stays
+`incomplete`; **deployed reachability and runtime behavior remain unknown**.
+
+## Which comparisons are trustworthy
+
+Committed `verify` reconstructs the base from its Git tree with the current
+reader. OpenAPI bases are rescanned even when a report cache and its adjacent
+checksum agree: that checksum establishes byte consistency, not provenance.
+The reconstruction is carried privately in memory; a public report cannot
+set a flag to acquire it. Other source families keep their report cache after
+the archived manifest establishes that they contain no OpenAPI source.
+
+The head's captured operation and manifest bytes also enter the verification
+dependency record, so an ignored source or policy edit can invalidate the current-control read.
+The ordinary receipt and live-workspace checks remain required before using
+any report. Raw hashes in an old report are not a substitute for those checks.
+
+`scan --diff-from` and `verify --diff-from` accept report comparison inputs,
+but **never grant reconstructed operation provenance**. Their operation
+comparison remains unresolved. No/missing base, one-sided operation records,
+changed operation/capability or dependency identity, changed security/control
+configuration, changed binding evidence, or redacted evidence also prevent a
+complete comparison. In particular, a reader can omit a referenced Path Item;
+absence of its operation row does not prove an addition or removal.
+
+For two supported, consistently identified operations, the report compares
+literal target sets independently from the missing-approval predicate. A
+predicate may remain missing, remain declared, become missing, or be resolved
+by a supplied declaration. New deployed reachability is never inferred.
+
+## Release boundary and validation
+
+The regression inputs are isolated synthetic fixtures, not deployed wiring,
+human qualification labels, runtime observations or release certification.
+Paired scans and committed-repository tests exercise narrowing/widening,
+declaration provenance, unsupported inputs, forged cache bytes, supplied
+reports, redaction and current-control drift. Existing native findings and
+their gate behavior are asserted unchanged by the attribution projection.
+
+#557 still owns broader reader dependency closure. #515 owns any future
+decision consumption, including its TypeScript MongoDB `cal-1` case; #563/#312
+still require independently reviewed historical evidence. This OpenAPI
+profile does not satisfy those acceptance bars or freeze report 1.0 (#569).

--- a/docs/report-schema.v0.43.json
+++ b/docs/report-schema.v0.43.json
@@ -4028,6 +4028,105 @@
       "title": "DeclaredIntention",
       "type": "object"
     },
+    "DeclaredOperation": {
+      "additionalProperties": false,
+      "properties": {
+        "declared_targets": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Declared Targets",
+          "type": "array"
+        },
+        "inputs": {
+          "items": {
+            "$ref": "#/$defs/OperationInput"
+          },
+          "title": "Inputs",
+          "type": "array"
+        },
+        "method": {
+          "title": "Method",
+          "type": "string"
+        },
+        "observation_id": {
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "path_template": {
+          "title": "Path Template",
+          "type": "string"
+        },
+        "reader_profile": {
+          "const": "openapi_delete/v1",
+          "default": "openapi_delete/v1",
+          "title": "Reader Profile",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "security_contract": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Security Contract"
+        },
+        "server": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Server"
+        },
+        "source_id": {
+          "title": "Source Id",
+          "type": "string"
+        },
+        "source_pointer": {
+          "title": "Source Pointer",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "observed",
+            "unresolved",
+            "ambiguous",
+            "redacted"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "tool_name": {
+          "title": "Tool Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_id",
+        "observation_id",
+        "tool_name",
+        "method",
+        "path_template",
+        "source_pointer",
+        "status",
+        "reason"
+      ],
+      "title": "DeclaredOperation",
+      "type": "object"
+    },
     "EffectSemanticEvidence": {
       "additionalProperties": false,
       "properties": {
@@ -5640,6 +5739,305 @@
         "tool_name"
       ],
       "title": "Misalignment",
+      "type": "object"
+    },
+    "OperationAttribution": {
+      "additionalProperties": false,
+      "properties": {
+        "binding_claim_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Binding Claim Ids",
+          "type": "array"
+        },
+        "capability_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Capability Id"
+        },
+        "check_id": {
+          "const": "SHIP-POLICY-APPROVAL-MISSING",
+          "default": "SHIP-POLICY-APPROVAL-MISSING",
+          "title": "Check Id",
+          "type": "string"
+        },
+        "control_pack_identity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Control Pack Identity"
+        },
+        "declared_binding_path": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Declared Binding Path",
+          "type": "array"
+        },
+        "dependency_coverage": {
+          "const": "incomplete",
+          "default": "incomplete",
+          "title": "Dependency Coverage",
+          "type": "string"
+        },
+        "deployed_reachability": {
+          "const": "unknown",
+          "default": "unknown",
+          "title": "Deployed Reachability",
+          "type": "string"
+        },
+        "finding_exclusion_eligible": {
+          "const": false,
+          "default": false,
+          "title": "Finding Exclusion Eligible",
+          "type": "boolean"
+        },
+        "finding_fingerprints": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Finding Fingerprints",
+          "type": "array"
+        },
+        "missing_approval": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Missing Approval"
+        },
+        "operation": {
+          "$ref": "#/$defs/DeclaredOperation"
+        },
+        "predicates": {
+          "items": {
+            "$ref": "#/$defs/OperationPredicate"
+          },
+          "title": "Predicates",
+          "type": "array"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "observed",
+            "unresolved",
+            "ambiguous",
+            "redacted"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Id"
+        }
+      },
+      "required": [
+        "operation",
+        "status",
+        "reason"
+      ],
+      "title": "OperationAttribution",
+      "type": "object"
+    },
+    "OperationComparison": {
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperationAttribution"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "approval_predicate": {
+          "default": "unresolved",
+          "enum": [
+            "standing_weakness",
+            "still_declared",
+            "resolved_by_declaration",
+            "newly_missing",
+            "unresolved"
+          ],
+          "title": "Approval Predicate",
+          "type": "string"
+        },
+        "base_tree": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Tree"
+        },
+        "before": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperationAttribution"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "declared_target_domain": {
+          "default": "unresolved",
+          "enum": [
+            "unchanged",
+            "narrowed",
+            "widened",
+            "changed",
+            "unresolved"
+          ],
+          "title": "Declared Target Domain",
+          "type": "string"
+        },
+        "deployed_reachability": {
+          "const": "unknown",
+          "default": "unknown",
+          "title": "Deployed Reachability",
+          "type": "string"
+        },
+        "evidence_source": {
+          "default": "unavailable",
+          "enum": [
+            "reconstructed_git_base",
+            "unavailable"
+          ],
+          "title": "Evidence Source",
+          "type": "string"
+        },
+        "finding_exclusion_eligible": {
+          "const": false,
+          "default": false,
+          "title": "Finding Exclusion Eligible",
+          "type": "boolean"
+        },
+        "observation_id": {
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "observation_id",
+        "reason"
+      ],
+      "title": "OperationComparison",
+      "type": "object"
+    },
+    "OperationInput": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "role": {
+          "enum": [
+            "openapi_document",
+            "manifest"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "role"
+      ],
+      "title": "OperationInput",
+      "type": "object"
+    },
+    "OperationPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "claim_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Claim Ids",
+          "type": "array"
+        },
+        "contributing_pointers": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Contributing Pointers",
+          "type": "array"
+        },
+        "observed": {
+          "title": "Observed",
+          "type": "string"
+        },
+        "predicate": {
+          "enum": [
+            "effect",
+            "approval_obligation",
+            "missing_approval_policy"
+          ],
+          "title": "Predicate",
+          "type": "string"
+        },
+        "source_pointer": {
+          "title": "Source Pointer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "predicate",
+        "observed",
+        "source_pointer"
+      ],
+      "title": "OperationPredicate",
       "type": "object"
     },
     "PolicyApprovalRouting": {
@@ -7402,6 +7800,13 @@
           "title": "Notes",
           "type": "array"
         },
+        "operation_comparisons": {
+          "items": {
+            "$ref": "#/$defs/OperationComparison"
+          },
+          "title": "Operation Comparisons",
+          "type": "array"
+        },
         "policy_drift": {
           "items": {
             "$ref": "#/$defs/ToolSurfacePolicyDrift"
@@ -7616,6 +8021,13 @@
             "$ref": "#/$defs/GuardDependencyEvidence"
           },
           "title": "Guard Dependencies",
+          "type": "array"
+        },
+        "operation_attributions": {
+          "items": {
+            "$ref": "#/$defs/OperationAttribution"
+          },
+          "title": "Operation Attributions",
           "type": "array"
         },
         "policies": {

--- a/src/agents_shipgate/cli/scan/orchestrator.py
+++ b/src/agents_shipgate/cli/scan/orchestrator.py
@@ -8,6 +8,7 @@ from agents_shipgate.ci.github_summary import write_github_step_summary
 from agents_shipgate.cli.discovery.placeholders import manifest_placeholder_fields
 from agents_shipgate.core.capability_lock import build_capability_lock
 from agents_shipgate.core.errors import AgentsShipgateError, ConfigError
+from agents_shipgate.core.operation_attribution import ReconstructedOperationBase
 from agents_shipgate.report.human_order import HumanArtifactContext
 from agents_shipgate.schemas.capabilities import CapabilityLockFileV1
 from agents_shipgate.schemas.report import ReadinessReport
@@ -48,6 +49,7 @@ def run_scan(
     capability_lock_callback: Callable[[CapabilityLockFileV1], None] | None = None,
     human_context_callback: Callable[[HumanArtifactContext], None] | None = None,
     manifest_text: str | None = None,
+    operation_base: ReconstructedOperationBase | None = None,
 ) -> tuple[ReadinessReport, int]:
     """Run a full scan pipeline. Returns ``(report, exit_code)``.
 
@@ -82,6 +84,7 @@ def run_scan(
             capability_lock_callback=capability_lock_callback,
             human_context_callback=human_context_callback,
             manifest_text=manifest_text,
+            operation_base=operation_base,
         )
     except AgentsShipgateError as exc:
         # Every recovery route that names a file to edit needs the manifest
@@ -143,6 +146,7 @@ def _run_scan(
     capability_lock_callback: Callable[[CapabilityLockFileV1], None] | None,
     human_context_callback: Callable[[HumanArtifactContext], None] | None,
     manifest_text: str | None,
+    operation_base: ReconstructedOperationBase | None,
 ) -> tuple[ReadinessReport, int]:
     """The pipeline itself. Split from :func:`run_scan` so the manifest the
     run read can be attached to any failure on the way out, in one place."""
@@ -228,6 +232,7 @@ def _run_scan(
             decision=decision,
             plan=plan,
             plugins_enabled=plugins_enabled,
+            operation_base=operation_base,
         )
     with _perf.phase("build_final_report"):
         report, public_report_payload = _build_final_report(

--- a/src/agents_shipgate/cli/scan/sanitization.py
+++ b/src/agents_shipgate/cli/scan/sanitization.py
@@ -36,6 +36,12 @@ from agents_shipgate.core.lenses.tool_surface import (
     disabled_tool_surface_diff,
     enrich_tool_surface_diff_with_source,
 )
+from agents_shipgate.core.operation_attribution import (
+    ReconstructedOperationBase,
+    build_operation_attributions,
+    compare_operations,
+    invalidate_redacted_operations,
+)
 from agents_shipgate.core.privacy import (
     RedactionStats,
     build_privacy_audit,
@@ -47,6 +53,7 @@ from agents_shipgate.core.privacy import (
 from agents_shipgate.schemas.bindings import AgentBindingGraphAssessment, BindingSurfaceDiff
 from agents_shipgate.schemas.coverage_recovery import CoverageRecovery, SourceRecoveryEvidence
 from agents_shipgate.schemas.manifest import AgentsShipgateManifest
+from agents_shipgate.schemas.operation_attribution import OperationAttribution
 from agents_shipgate.schemas.report import (
     BaselineSummary,
     CapabilityRuntimeEvidence,
@@ -88,6 +95,7 @@ def _sanitize_for_output(
     decision: _ChecksDecision,
     plan: _OutputPlan,
     plugins_enabled: bool | None,
+    operation_base: ReconstructedOperationBase | None = None,
 ) -> _SanitizedSurfaces:
     """Phase 7: privacy redaction of every value that flows into a
     report or packet — STABILITY contract: runs BEFORE any file is
@@ -401,6 +409,13 @@ def _sanitize_for_output(
         toolkit_bounds=decision.context.toolkit_bounds,
         remote_bindings=decision.context.remote_bindings,
         guard_dependencies=decision.context.guard_dependencies,
+        operation_attributions=build_operation_attributions(
+            context=decision.context,
+            sources=inputs.loaded_sources,
+            findings=public_findings,
+            config_path=config_path,
+        ),
+        operation_base=operation_base,
     )
     source_recovery_evidence = _sanitize_source_recovery_evidence(inputs.loaded_sources, privacy_stats)
     privacy_audit = build_privacy_audit(
@@ -608,6 +623,8 @@ def _public_tool_surfaces(
     toolkit_bounds=(),
     remote_bindings=(),
     guard_dependencies=(),
+    operation_attributions=(),
+    operation_base=None,
 ):
     public_tool_surface_facts = sanitize_model(
         build_tool_surface_facts(
@@ -635,6 +652,21 @@ def _public_tool_surfaces(
                 public.source_behavior.returns = []
                 public.source_behavior.binding = None
                 public.source_behavior.configuration_reads = None
+    public_operations = [
+        sanitize_model(row, OperationAttribution, stats=privacy_stats,
+                       path="tool_surface_facts.operation_attributions[]")
+        for row in operation_attributions
+    ]
+    invalidate_redacted_operations(operation_attributions, public_operations)
+    public_tool_surface_facts.operation_attributions = public_operations
+    if operation_base is not None:
+        public_base_operations = [
+            sanitize_model(row, OperationAttribution, stats=privacy_stats,
+                           path="tool_surface_diff.operation_comparisons.base[]")
+            for row in operation_base.rows
+        ]
+        invalidate_redacted_operations(operation_base.rows, public_base_operations)
+        operation_base = ReconstructedOperationBase(tree=operation_base.tree, rows=tuple(public_base_operations))
     if diffs.diff_reference_error:
         public_tool_surface_diff = disabled_tool_surface_diff(
             redact_data(
@@ -650,6 +682,7 @@ def _public_tool_surfaces(
             public_findings,
             reference=public_diff_reference,
         )
+    public_tool_surface_diff.operation_comparisons = compare_operations(public_operations, operation_base)
     # v0.19 reviewer-grade provenance: enrich tool-surface diff
     # controls (and any other reason-bearing rows) with the public
     # tool path:line citation so the rendered report.json and packet

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -75,6 +75,7 @@ from agents_shipgate.core.manifest_provenance import (
     manifest_provenance,
     provisional_manifest_note,
 )
+from agents_shipgate.core.operation_attribution import ReconstructedOperationBase
 from agents_shipgate.core.static_inputs import (
     StaticInputSnapshot,
     activate_static_input_snapshot,
@@ -935,6 +936,12 @@ def run_verify(
         )
     static_snapshot_token = activate_static_input_snapshot(static_snapshot)
 
+    operation_base = None
+
+    def capture_base_operations(tree, rows):
+        nonlocal operation_base
+        operation_base = ReconstructedOperationBase(tree=tree, rows=tuple(rows))
+
     try:
         if diff_from is not None:
             base_status = "diff_from_provided"
@@ -960,6 +967,7 @@ def run_verify(
                 no_heuristics=no_heuristics,
                 verbose=verbose,
                 evaluation_date=verification_date,
+                operation_callback=capture_base_operations,
             )
             base_notes.extend(cache_notes)
 
@@ -1150,6 +1158,7 @@ def run_verify(
                     manifest_text=(
                         head_manifest_text if archive_head else worktree_manifest_text
                     ),
+                    operation_base=operation_base,
                 )
             except AgentsShipgateError as exc:
                 # `run_scan` records the manifest it read, and when the head is
@@ -1345,6 +1354,7 @@ def _prepare_base_report(
     no_heuristics: bool,
     verbose: bool,
     evaluation_date: str,
+    operation_callback=None,
 ) -> tuple[
     VerifierBaseStatus,
     str | None,
@@ -1368,7 +1378,8 @@ def _prepare_base_report(
         no_heuristics=no_heuristics,
         evaluation_date=evaluation_date,
     )
-    if cache_report.exists() and _cache_report_valid(cache_report):
+    cache_valid = cache_report.exists() and _cache_report_valid(cache_report)
+    if cache_valid and operation_callback is None:
         base_lock, lock_notes = _load_cached_capability_lock(cache_report)
         return (
             "succeeded",
@@ -1377,7 +1388,7 @@ def _prepare_base_report(
             base_lock,
             [f"Base report resolved for tree {base_tree}.", *lock_notes],
         )
-    if cache_report.exists():
+    if cache_report.exists() and not cache_valid:
         notes.append("Discarded base cache entry whose content hash did not validate.")
         cache_report.unlink(missing_ok=True)
 
@@ -1423,6 +1434,29 @@ def _prepare_base_report(
                 None,
                 [f"Base tree does not contain {config_relative.as_posix()}."],
             )
+
+        # A checksum beside a cached report proves bytes agree, not that the
+        # operation model was read from this Git tree. Inspect the archived
+        # manifest before accepting a cache hit. OpenAPI bases are rescanned;
+        # other readers retain the cache and cannot contribute operation rows.
+        # The callback is private and never populated from report decoding.
+        try:
+            base_manifest = load_manifest_text(
+                read_static_input_bytes(base_config).decode("utf-8"), source=base_config
+            )
+        except (AgentsShipgateError, OSError, UnicodeError):
+            base_manifest = None
+        if (
+            operation_callback is not None
+            and base_manifest is not None
+            and not any(source.type == "openapi" for source in base_manifest.tool_sources)
+        ):
+            operation_callback(base_tree, [])
+            if cache_valid:
+                base_lock, lock_notes = _load_cached_capability_lock(cache_report)
+                return "succeeded", base_tree, cache_report, base_lock, [
+                    f"Base report resolved for tree {base_tree}.", *lock_notes
+                ]
 
         base_capability_lock: CapabilityLockFileV1 | None = None
 
@@ -1489,6 +1523,8 @@ def _prepare_base_report(
                 None,
                 ["Base scan did not produce report.json; diff enrichment disabled."],
             )
+        if operation_callback is not None:
+            operation_callback(base_tree, base_report_model.tool_surface_facts.operation_attributions)
         # Base diff evidence is never patch-applicable. Strip checkout/output
         # coordinates so identical commits produce identical cached inputs
         # across worktrees and clones.

--- a/src/agents_shipgate/core/domain.py
+++ b/src/agents_shipgate/core/domain.py
@@ -10,6 +10,7 @@ from agents_shipgate.core.heuristics import is_broad_scope
 from agents_shipgate.schemas.common import Confidence, ProvenanceKind, parse_confidence
 from agents_shipgate.schemas.coverage_recovery import SourceRecoveryEvidence
 from agents_shipgate.schemas.guard_dependencies import GuardDependencyEvidence
+from agents_shipgate.schemas.operation_attribution import DeclaredOperation
 from agents_shipgate.schemas.surfaces import ActionEffect
 
 SemanticDimension = Literal["identity", "binding", "effect", "authority"]
@@ -745,6 +746,7 @@ class LoadedToolSource(BaseModel):
     binding_observations: list[AgentBindingObservation] = Field(default_factory=list)
     # Reader-owned observations, never derived from catalog annotations.
     guard_dependencies: list[GuardDependencyEvidence] = Field(default_factory=list)
+    operation_evidence: list[DeclaredOperation] = Field(default_factory=list)
     # For a reviewed tool inventory declared with
     # ``<framework>.tool_inventories[].source_id``: the id of the source whose
     # surface this file enumerates. ``build_tool_identity_catalog`` turns it

--- a/src/agents_shipgate/core/operation_attribution.py
+++ b/src/agents_shipgate/core/operation_attribution.py
@@ -1,0 +1,290 @@
+"""Join a source operation to the predicate that actually emitted a finding.
+
+No serialized report can create ReconstructedOperationBase. Only the verifier's
+fresh archived scan supplies it; this distinction is never a public Boolean.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+
+from agents_shipgate.config.loader import load_manifest_text
+from agents_shipgate.core.capability_policy import subject_requires_approval_review
+from agents_shipgate.core.control_packs import resolve_control_pack
+from agents_shipgate.core.errors import AgentsShipgateError
+from agents_shipgate.core.static_inputs import active_static_input_snapshot, read_static_input_text
+from agents_shipgate.core.tool_identity import ToolSelectorIndex
+from agents_shipgate.inputs.common import MAX_INPUT_FILE_BYTES
+from agents_shipgate.inputs.openapi_operation_contract import unambiguous_document
+from agents_shipgate.schemas.operation_attribution import (
+    OperationAttribution,
+    OperationComparison,
+    OperationInput,
+    OperationPredicate,
+)
+
+
+@dataclass(frozen=True)
+class ReconstructedOperationBase:
+    tree: str
+    rows: tuple[OperationAttribution, ...]
+
+
+def build_operation_attributions(*, context, sources, findings, config_path):
+    operations = [row for source in sources for row in source.operation_evidence]
+    if not operations:
+        return []
+    members = defaultdict(list)
+    for subject in context.capability_policy_subjects:
+        for observation in subject.tool.observation_ids:
+            members[observation].append(subject)
+    manifest_input = None
+    try:
+        text = read_static_input_text(config_path, max_bytes=MAX_INPUT_FILE_BYTES)
+        parsed = load_manifest_text(text, source=config_path)
+        # Compare every declaration, ignoring only invocation/presentation fields.
+        excluded = {"ci", "output"}
+        if unambiguous_document(text) and parsed.model_dump(
+            exclude=excluded
+        ) == context.manifest.model_dump(exclude=excluded):
+            manifest_input = OperationInput(
+                path=config_path.name,
+                sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                role="manifest",
+            )
+            snapshot = active_static_input_snapshot()
+            if snapshot is not None and snapshot.contains(config_path):
+                snapshot.mark_dependency_input(config_path)
+    except (AgentsShipgateError, OSError, UnicodeError):
+        pass
+    pack = resolve_control_pack(context.manifest)
+    selectors = ToolSelectorIndex.build(context.tools)
+    result = []
+    for operation in operations:
+        operation = operation.model_copy(deep=True)
+        row = OperationAttribution(
+            operation=operation, status="unresolved", reason=operation.reason
+        )
+        result.append(row)
+        candidates = members[operation.observation_id]
+        if len(candidates) != 1 or len(candidates[0].tool.observation_ids) != 1:
+            row.status, row.reason = "ambiguous", "canonical_subject_not_unique"
+            continue
+        subject = candidates[0]
+        row.tool_id, row.capability_id = subject.tool.id, subject.fact.id
+        if manifest_input is not None:
+            operation.inputs.append(manifest_input)
+        if operation.status != "observed":
+            continue
+        if (
+            manifest_input is None
+            or len(context.manifest.tool_sources) != 1
+            or len(sources) != 1
+            or any(source.type != "openapi" for source in context.manifest.tool_sources)
+            or any(
+                getattr(context.manifest, family) is not None
+                for family in (
+                    "openai_api",
+                    "anthropic",
+                    "google_adk",
+                    "langchain",
+                    "crewai",
+                    "codex_plugins",
+                    "n8n",
+                    "validation",
+                )
+            )
+            or getattr(context.manifest.agent.sdk, "entrypoint", None)
+        ):
+            row.reason = "policy_dependency_not_closed_by_profile"
+            continue
+        assessment = subject.tool.semantic_assessment
+        if (
+            assessment is None
+            or assessment.effect.issues
+            or assessment.authority.issues
+            or assessment.identity.issues
+            or assessment.binding.issues
+        ):
+            row.reason = "semantic_evidence_unresolved_or_conflicting"
+            continue
+        row.binding_claim_ids = [claim.claim_id for claim in assessment.binding.claims]
+        row.declared_binding_path = list(assessment.binding.reachable_path)
+        claims = [
+            claim
+            for claim in assessment.effect.claims
+            if claim.policy_eligible
+            and claim.value == "destructive"
+            and claim.source == "openapi_method"
+            and claim.source_pointer == operation.source_pointer
+        ]
+        if len(claims) != 1 or subject.tool.name != operation.tool_name:
+            row.reason = "structural_effect_claim_or_operation_identity_unresolved"
+            continue
+        missing = subject_requires_approval_review(subject, pack=pack)
+        matched = [
+            finding
+            for finding in findings
+            if finding.check_id == row.check_id and finding.capability_refs == [subject.fact.id]
+        ]
+        if (missing and len(matched) != 1) or (not missing and matched):
+            row.reason = "finding_predicate_join_unresolved"
+            continue
+        if missing:
+            evidence = matched[0].capability_policy_evidence
+            if (
+                evidence is None
+                or evidence.capability_id != subject.fact.id
+                or evidence.matched_predicates.get("missing_approval_policy") is not True
+            ):
+                row.reason = "finding_predicate_join_unresolved"
+                continue
+        row.finding_fingerprints = [finding.fingerprint for finding in matched]
+        row.control_pack_identity = json.dumps(
+            pack.run_identity(), sort_keys=True, separators=(",", ":")
+        )
+        row.missing_approval = missing
+        approval_pointers = ["/policies/require_approval_for_tools"]
+        for index, declaration in enumerate(context.manifest.action_surface.actions):
+            resolution = selectors.resolve(declaration)
+            if (
+                resolution.resolved
+                and resolution.matches[0].id == subject.tool.id
+                and declaration.approval is not None
+            ):
+                approval_pointers.append(f"/action_surface/actions/{index}/approval")
+        row.predicates = [
+            OperationPredicate(
+                predicate="effect",
+                observed="destructive",
+                claim_ids=[claims[0].claim_id],
+                source_pointer=operation.source_pointer,
+            ),
+            OperationPredicate(
+                predicate="approval_obligation",
+                observed=str("approval.required" in pack.obligations_for("destructive")).lower(),
+                source_pointer="/policies/control_pack",
+            ),
+            OperationPredicate(
+                predicate="missing_approval_policy",
+                observed=str(not subject.effective_approval_required).lower(),
+                source_pointer="/policies/require_approval_for_tools",
+                contributing_pointers=approval_pointers,
+            ),
+        ]
+        row.status, row.reason = (
+            "observed",
+            "declared_operation_joined_to_existing_approval_predicate",
+        )
+    return sorted(
+        result, key=lambda row: (row.operation.observation_id, row.operation.source_pointer)
+    )
+
+
+def compare_operations(current, base: ReconstructedOperationBase | None):
+    before, after = defaultdict(list), defaultdict(list)
+    for row in base.rows if base else ():
+        before[row.operation.observation_id].append(row)
+    for row in current:
+        after[row.operation.observation_id].append(row)
+    result = []
+    for observation in sorted(before.keys() | after.keys()):
+        old, new = before[observation], after[observation]
+        row = OperationComparison(
+            observation_id=observation,
+            before=old[0] if len(old) == 1 else None,
+            after=new[0] if len(new) == 1 else None,
+            reason="reconstructed_base_unavailable",
+        )
+        result.append(row)
+        if base is None:
+            continue
+        row.evidence_source, row.base_tree = "reconstructed_git_base", base.tree
+        if (
+            len(old) > 1
+            or len(new) > 1
+            or any(
+                item.status != "observed" or item.operation.status != "observed"
+                for item in [*old, *new]
+            )
+        ):
+            row.reason = "unresolved_or_ambiguous_operation_evidence"
+            continue
+        if not old or not new:
+            row.reason = "operation_absence_not_proven_by_reader_census"
+            continue
+        left, right = old[0], new[0]
+        if [(item.role, item.path) for item in left.operation.inputs] != [
+            (item.role, item.path) for item in right.operation.inputs
+        ]:
+            row.reason = "operation_dependency_identity_changed"
+            continue
+        if (
+            left.tool_id,
+            left.capability_id,
+            left.operation.source_id,
+            left.operation.tool_name,
+            left.operation.reader_profile,
+            left.operation.source_pointer,
+        ) != (
+            right.tool_id,
+            right.capability_id,
+            right.operation.source_id,
+            right.operation.tool_name,
+            right.operation.reader_profile,
+            right.operation.source_pointer,
+        ):
+            row.reason = "operation_or_capability_identity_changed"
+            continue
+        if (
+            left.operation.security_contract != right.operation.security_contract
+            or left.control_pack_identity != right.control_pack_identity
+        ):
+            row.reason = "security_or_obligation_configuration_changed"
+            continue
+        if (
+            left.binding_claim_ids != right.binding_claim_ids
+            or left.declared_binding_path != right.declared_binding_path
+        ):
+            row.reason = "declared_binding_evidence_changed_reachability_unresolved"
+            continue
+        previous, following = (
+            set(left.operation.declared_targets),
+            set(right.operation.declared_targets),
+        )
+        row.declared_target_domain = (
+            "unchanged"
+            if previous == following
+            else "narrowed"
+            if following < previous
+            else "widened"
+            if previous < following
+            else "changed"
+        )
+        row.approval_predicate = (
+            "standing_weakness"
+            if left.missing_approval and right.missing_approval
+            else "still_declared"
+            if not left.missing_approval and not right.missing_approval
+            else "resolved_by_declaration"
+            if left.missing_approval
+            else "newly_missing"
+        )
+        row.reason = "declared_target_domain_and_approval_predicate_compared_separately"
+    return result
+
+
+def invalidate_redacted_operations(original, public):
+    for old, new in zip(original, public, strict=True):
+        if old != new:
+            new.status, new.reason = "redacted", "operation_predicate_evidence_redacted"
+            new.predicates = []
+            new.missing_approval = None
+            new.control_pack_identity = None
+            new.operation.status = "redacted"
+            new.operation.declared_targets = []
+            new.operation.security_contract = None
+            new.operation.inputs = []

--- a/src/agents_shipgate/inputs/openapi.py
+++ b/src/agents_shipgate/inputs/openapi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, ClassVar, Literal
@@ -13,11 +14,13 @@ from agents_shipgate.core.domain import (
     Tool,
 )
 from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.static_inputs import active_static_input_snapshot, read_static_input_text
+from agents_shipgate.inputs import common as input_common
 from agents_shipgate.inputs.common import (
     HTTP_METHODS,
     PositionIndex,
     json_pointer_escape,
-    load_structured_file_with_positions,
+    load_structured_text_with_positions,
     manifest_relative_path,
     resolve_input_path,
     schema_to_parameters,
@@ -26,6 +29,10 @@ from agents_shipgate.inputs.common import (
     tool_name_warning,
 )
 from agents_shipgate.inputs.coverage import BoundaryCell, SourceCoverage
+from agents_shipgate.inputs.openapi_operation_contract import (
+    operation_evidence,
+    unambiguous_document,
+)
 from agents_shipgate.inputs.protocol import LoadedAdapterResult
 from agents_shipgate.schemas.manifest import (
     AgentsShipgateManifest,
@@ -39,7 +46,13 @@ MAX_SCHEMA_RESOLVE_NODES = 5000
 def load_openapi_tools(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSource:
     assert source.path is not None
     path = resolve_input_path(base_dir, source.path)
-    document, positions = load_structured_file_with_positions(path)
+    if not path.exists():
+        raise InputParseError(f"Input file not found: {path}")
+    try:
+        text = read_static_input_text(path, max_bytes=input_common.MAX_INPUT_FILE_BYTES)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise InputParseError(f"Unable to read input file {path}: {exc}") from exc
+    document, positions = load_structured_text_with_positions(text, source=path)
     if not isinstance(document, dict):
         raise InputParseError(f"OpenAPI file must contain an object: {path}")
     if "openapi" not in document:
@@ -52,6 +65,9 @@ def load_openapi_tools(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSo
     tools: list[Tool] = []
     warnings: list[str] = []
     seen_names: set[str] = set()
+    operation_rows = []
+    document_unambiguous = unambiguous_document(text)
+    document_digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
     for api_path, path_item in paths.items():
         if not isinstance(path_item, dict):
             raise InputParseError(f"OpenAPI path item {api_path} must be an object")
@@ -97,12 +113,22 @@ def load_openapi_tools(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSo
                     "external or missing refs are left as metadata."
                 )
             tools.append(tool)
+            if method_lower == "delete":
+                operation_rows.append(operation_evidence(
+                    document=document, document_digest=document_digest,
+                    source=source, tool=tool, path_item=path_item,
+                    operation=operation, document_unambiguous=document_unambiguous,
+                ))
 
+    snapshot = active_static_input_snapshot()
+    if operation_rows and snapshot is not None and snapshot.contains(path):
+        snapshot.mark_dependency_input(path)
     return LoadedToolSource(
         source_id=source.id,
         source_type="openapi",
         tools=tools,
         warnings=warnings,
+        operation_evidence=operation_rows,
     )
 
 

--- a/src/agents_shipgate/inputs/openapi.py
+++ b/src/agents_shipgate/inputs/openapi.py
@@ -117,7 +117,8 @@ def load_openapi_tools(source: ToolSourceConfig, base_dir: Path) -> LoadedToolSo
                 operation_rows.append(operation_evidence(
                     document=document, document_digest=document_digest,
                     source=source, tool=tool, path_item=path_item,
-                    operation=operation, document_unambiguous=document_unambiguous,
+                    method_key=method, operation=operation,
+                    document_unambiguous=document_unambiguous,
                 ))
 
     snapshot = active_static_input_snapshot()

--- a/src/agents_shipgate/inputs/openapi_operation_contract.py
+++ b/src/agents_shipgate/inputs/openapi_operation_contract.py
@@ -48,7 +48,8 @@ def unambiguous_document(text: str) -> bool:
 
 
 def operation_evidence(
-    *, document, document_digest, source, tool, path_item, operation, document_unambiguous
+    *, document, document_digest, source, tool, path_item, method_key, operation,
+    document_unambiguous
 ):
     row = DeclaredOperation(
         source_id=source.id,
@@ -66,6 +67,10 @@ def operation_evidence(
     try:
         if not document_unambiguous:
             raise ValueError("ambiguous_document")
+        # The compatibility loader normalizes methods; proof must instead
+        # name a case-sensitive key that exists in the captured document.
+        if method_key != "delete":
+            raise ValueError("noncanonical_method_key")
         if document.get("openapi") != "3.0.3" or row.method != "DELETE":
             raise ValueError("unsupported_version_or_method")
         if not isinstance(operation.get("operationId"), str) or not operation["operationId"]:

--- a/src/agents_shipgate/inputs/openapi_operation_contract.py
+++ b/src/agents_shipgate/inputs/openapi_operation_contract.py
@@ -1,0 +1,228 @@
+"""A finite declared DELETE request domain, captured before Tool normalization."""
+
+from __future__ import annotations
+
+import itertools
+import json
+import math
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+import yaml
+
+from agents_shipgate.core.tool_identity import source_observation_id
+from agents_shipgate.schemas.operation_attribution import DeclaredOperation, OperationInput
+
+MAX_TARGET_BYTES = 16 * 1024
+
+
+def unambiguous_document(text: str) -> bool:
+    """Reject duplicate keys, merges, aliases and non-string mapping keys.
+
+    This is a proof-profile refusal, not a change to the supported source loader.
+    In particular, a last-key-wins loader result cannot prove uniqueness.
+    """
+    try:
+        root = yaml.compose(text)
+        todo, seen = [root], set()
+        while todo:
+            node = todo.pop()
+            if node is None or id(node) in seen or len(seen) >= 5000:
+                return False
+            seen.add(id(node))
+            if isinstance(node, yaml.MappingNode):
+                keys = set()
+                for key, value in node.value:
+                    if not isinstance(key, yaml.ScalarNode) or key.tag != "tag:yaml.org,2002:str":
+                        return False
+                    if key.value in keys:
+                        return False
+                    keys.add(key.value)
+                    todo.append(value)
+            elif isinstance(node, yaml.SequenceNode):
+                todo.extend(node.value)
+        return True
+    except (yaml.YAMLError, RecursionError, ValueError):
+        return False
+
+
+def operation_evidence(
+    *, document, document_digest, source, tool, path_item, operation, document_unambiguous
+):
+    row = DeclaredOperation(
+        source_id=source.id,
+        observation_id=source_observation_id(tool, source.id),
+        tool_name=tool.name,
+        method=tool.annotations["httpMethod"],
+        path_template=tool.annotations["path"],
+        source_pointer=tool.source_pointer,
+        status="unresolved",
+        reason="unsupported_declared_operation_profile",
+        inputs=[
+            OperationInput(path=tool.source_path, sha256=document_digest, role="openapi_document")
+        ],
+    )
+    try:
+        if not document_unambiguous:
+            raise ValueError("ambiguous_document")
+        if document.get("openapi") != "3.0.3" or row.method != "DELETE":
+            raise ValueError("unsupported_version_or_method")
+        if not isinstance(operation.get("operationId"), str) or not operation["operationId"]:
+            raise ValueError("literal_operation_id_required")
+        if set(operation) - {
+            "operationId",
+            "summary",
+            "description",
+            "tags",
+            "externalDocs",
+            "responses",
+            "deprecated",
+            "security",
+            "parameters",
+            "servers",
+        }:
+            raise ValueError("unmodeled_operation_dependency")
+        if "$ref" in path_item or any(key in operation for key in ("requestBody", "callbacks")):
+            raise ValueError("unmodeled_operation_dependency")
+        servers = operation.get("servers", path_item.get("servers", document.get("servers")))
+        if not isinstance(servers, list) or len(servers) != 1 or not isinstance(servers[0], dict):
+            raise ValueError("one_literal_server_required")
+        server = servers[0]
+        if set(server) - {"url", "description"} or not isinstance(server.get("url"), str):
+            raise ValueError("server_configuration_unresolved")
+        if len(server["url"]) > 2048 or len(row.path_template) > 1024:
+            raise ValueError("declared_target_byte_limit")
+        url = urlsplit(server["url"])
+        if (
+            url.scheme != "https"
+            or not url.netloc
+            or url.username
+            or url.password
+            or url.query
+            or url.fragment
+            or "{" in server["url"]
+            or "}" in server["url"]
+        ):
+            raise ValueError("server_configuration_unresolved")
+        if not re.fullmatch(
+            r"https://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9_/-]*)?", server["url"]
+        ):
+            raise ValueError("server_encoding_unresolved")
+        # Avoid path encoding, traversal and serialization equivalence guesses.
+        template = row.path_template
+        if not re.fullmatch(r"/(?:[A-Za-z0-9_/-]|\{[A-Za-z_][A-Za-z0-9_]*\})*", template):
+            raise ValueError("path_template_unresolved")
+        names = re.findall(r"\{([^}]+)\}", template)
+        if len(set(names)) != len(names) or len(names) > 4:
+            raise ValueError("path_parameter_identity_unresolved")
+        parameters: dict[tuple[str, str], dict[str, Any]] = {}
+        for entries in (path_item.get("parameters", []), operation.get("parameters", [])):
+            if not isinstance(entries, list):
+                raise ValueError("parameters_unresolved")
+            local = set()
+            for param in entries:
+                if not isinstance(param, dict) or set(param) - {
+                    "in",
+                    "name",
+                    "required",
+                    "schema",
+                    "description",
+                    "style",
+                    "explode",
+                }:
+                    raise ValueError("parameter_configuration_unresolved")
+                if (
+                    param.get("in") != "path"
+                    or param.get("name") not in names
+                    or param.get("required") is not True
+                ):
+                    raise ValueError("non_path_or_optional_parameter")
+                key = (param["in"], param["name"])
+                if key in local:
+                    raise ValueError("duplicate_parameter")
+                local.add(key)
+                if (
+                    param.get("style", "simple") != "simple"
+                    or param.get("explode", False) is not False
+                ):
+                    raise ValueError("parameter_serialization_unresolved")
+                parameters[key] = param
+        if {key[1] for key in parameters} != set(names):
+            raise ValueError("path_parameter_missing")
+        domains = []
+        for name in names:
+            schema = parameters[("path", name)].get("schema")
+            if (
+                not isinstance(schema, dict)
+                or set(schema) - {"type", "enum", "description"}
+                or schema.get("type") != "string"
+            ):
+                raise ValueError("finite_string_enum_required")
+            values = schema.get("enum")
+            if (
+                not isinstance(values, list)
+                or not 1 <= len(values) <= 32
+                or any(
+                    not isinstance(value, str)
+                    or len(value) > 128
+                    or not re.fullmatch(r"[A-Za-z0-9_-]+", value)
+                    for value in values
+                )
+            ):
+                raise ValueError("finite_string_enum_required")
+            domains.append(sorted(set(values)))
+        if math.prod(map(len, domains)) > 256:
+            raise ValueError("declared_target_limit")
+        maximum_length = (
+            len(server["url"]) + len(template) + sum(max(map(len, domain)) for domain in domains)
+        )
+        if math.prod(map(len, domains)) * maximum_length > MAX_TARGET_BYTES:
+            raise ValueError("declared_target_byte_limit")
+        security = operation.get("security", document.get("security"))
+        if not isinstance(security, list):
+            raise ValueError("explicit_security_required")
+        schemes = document.get("components", {}).get("securitySchemes", {})
+        used = {}
+        for alternative in security:
+            if not isinstance(alternative, dict):
+                raise ValueError("security_unresolved")
+            for name, scopes in alternative.items():
+                scheme = schemes.get(name)
+                if scopes != [] or not isinstance(scheme, dict):
+                    raise ValueError("security_unresolved")
+                if scheme.get("type") == "http":
+                    valid = scheme.get("scheme") in {"bearer", "basic"} and not set(scheme) - {
+                        "type",
+                        "scheme",
+                        "bearerFormat",
+                        "description",
+                    }
+                else:
+                    valid = (
+                        scheme.get("type") == "apiKey"
+                        and scheme.get("in") == "header"
+                        and isinstance(scheme.get("name"), str)
+                        and not set(scheme) - {"type", "in", "name", "description"}
+                    )
+                if not valid:
+                    raise ValueError("security_unresolved")
+                used[name] = scheme
+        targets = []
+        for values in itertools.product(*domains):
+            path = template
+            for name, value in zip(names, values, strict=True):
+                path = path.replace("{" + name + "}", value)
+            targets.append(server["url"].rstrip("/") + path)
+        row.server = server["url"]
+        row.declared_targets = sorted(set(targets))
+        row.security_contract = json.dumps(
+            {"alternatives": security, "schemes": used}, sort_keys=True, separators=(",", ":")
+        )
+        row.status = "observed"
+        row.reason = "finite_declared_delete_domain_runtime_unverified"
+    except (ValueError, TypeError, AttributeError) as exc:
+        row.reason = (
+            str(exc) if isinstance(exc, ValueError) else "malformed_operation_configuration"
+        )
+    return row

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -827,6 +827,15 @@ def _append_tool_surface_diff(lines: list[str], report: ReadinessReport) -> None
         if len(visible_guards) > 8:
             lines.append(f"{len(visible_guards) - 8} more guard comparisons in report.json.")
         lines.append("")
+    if diff.operation_comparisons:
+        lines.extend(["### Declared operation attribution", "", "OpenAPI declaration comparison only; runtime enforcement and deployed reachability remain unknown. No finding is excluded.", ""])
+        for row in diff.operation_comparisons[:8]:
+            subject = row.after or row.before
+            name = subject.operation.tool_name if subject else row.observation_id
+            lines.append(f"- {_safe_markdown_text(name)}: declared targets {row.declared_target_domain}; approval predicate {row.approval_predicate.replace('_', ' ')}. {_safe_markdown_text(row.reason)}.")
+        if len(diff.operation_comparisons) > 8:
+            lines.append(f"{len(diff.operation_comparisons) - 8} more operation comparisons in report.json.")
+        lines.append("")
     if not diff.enabled:
         note = diff.notes[0] if diff.notes else "No comparison source was available."
         lines.extend(

--- a/src/agents_shipgate/schemas/operation_attribution.py
+++ b/src/agents_shipgate/schemas/operation_attribution.py
@@ -1,0 +1,87 @@
+"""Declared operation/predicate attribution; never runtime or merge authority."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OperationInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    role: Literal["openapi_document", "manifest"]
+
+
+class DeclaredOperation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reader_profile: Literal["openapi_delete/v1"] = "openapi_delete/v1"
+    source_id: str
+    observation_id: str
+    tool_name: str
+    method: str
+    path_template: str
+    source_pointer: str
+    status: Literal["observed", "unresolved", "ambiguous", "redacted"]
+    reason: str
+    server: str | None = None
+    # Fully expanded, finite *declared* URLs, not server-enforced permissions.
+    declared_targets: list[str] = Field(default_factory=list)
+    security_contract: str | None = None
+    inputs: list[OperationInput] = Field(default_factory=list)
+
+
+class OperationPredicate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    predicate: Literal["effect", "approval_obligation", "missing_approval_policy"]
+    observed: str
+    claim_ids: list[str] = Field(default_factory=list)
+    source_pointer: str
+    contributing_pointers: list[str] = Field(default_factory=list)
+
+
+class OperationAttribution(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operation: DeclaredOperation
+    tool_id: str | None = None
+    capability_id: str | None = None
+    binding_claim_ids: list[str] = Field(default_factory=list)
+    declared_binding_path: list[str] = Field(default_factory=list)
+    check_id: Literal["SHIP-POLICY-APPROVAL-MISSING"] = "SHIP-POLICY-APPROVAL-MISSING"
+    finding_fingerprints: list[str] = Field(default_factory=list)
+    status: Literal["observed", "unresolved", "ambiguous", "redacted"]
+    reason: str
+    predicates: list[OperationPredicate] = Field(default_factory=list)
+    control_pack_identity: str | None = None
+    missing_approval: bool | None = None
+    dependency_coverage: Literal["incomplete"] = "incomplete"
+    deployed_reachability: Literal["unknown"] = "unknown"
+    finding_exclusion_eligible: Literal[False] = False
+
+
+class OperationComparison(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    observation_id: str
+    before: OperationAttribution | None = None
+    after: OperationAttribution | None = None
+    evidence_source: Literal["reconstructed_git_base", "unavailable"] = "unavailable"
+    base_tree: str | None = None
+    declared_target_domain: Literal["unchanged", "narrowed", "widened", "changed", "unresolved"] = (
+        "unresolved"
+    )
+    approval_predicate: Literal[
+        "standing_weakness",
+        "still_declared",
+        "resolved_by_declaration",
+        "newly_missing",
+        "unresolved",
+    ] = "unresolved"
+    reason: str
+    deployed_reachability: Literal["unknown"] = "unknown"
+    finding_exclusion_eligible: Literal[False] = False

--- a/src/agents_shipgate/schemas/surfaces.py
+++ b/src/agents_shipgate/schemas/surfaces.py
@@ -9,6 +9,7 @@ from agents_shipgate.schemas.guard_dependencies import (
     GuardDependencyComparison,
     GuardDependencyEvidence,
 )
+from agents_shipgate.schemas.operation_attribution import OperationAttribution, OperationComparison
 from agents_shipgate.schemas.semantic import ToolSemanticEvidence
 
 ToolSurfaceDiffBaseKind = Literal["none", "report", "baseline"]
@@ -95,6 +96,7 @@ class ToolSurfaceFacts(BaseModel):
     controls: list[ToolSurfaceControlFact] = Field(default_factory=list)
     policies: list[ToolSurfacePolicyFact] = Field(default_factory=list)
     guard_dependencies: list[GuardDependencyEvidence] = Field(default_factory=list, exclude_if=lambda value: not value)
+    operation_attributions: list[OperationAttribution] = Field(default_factory=list, exclude_if=lambda value: not value)
 
 
 class ToolSurfaceDiffBase(BaseModel):
@@ -257,6 +259,7 @@ class ToolSurfaceDiff(BaseModel):
     )
     notes: list[str] = Field(default_factory=list)
     guard_comparisons: list[GuardDependencyComparison] = Field(default_factory=list, exclude_if=lambda value: not value)
+    operation_comparisons: list[OperationComparison] = Field(default_factory=list, exclude_if=lambda value: not value)
 
 
 ActionEffect = Literal[

--- a/tests/test_openapi_operation_attribution.py
+++ b/tests/test_openapi_operation_attribution.py
@@ -95,6 +95,38 @@ def test_real_delete_finding_has_exact_claim_and_dependency_join(tmp_path):
     assert row.deployed_reachability == "unknown"
 
 
+@pytest.mark.parametrize("method_key", ["delete", "DELETE", "Delete"])
+def test_observed_operation_requires_canonical_source_method_key(tmp_path, method_key):
+    root = tmp_path / "repo"
+    workspace(root)
+    before = scan(root, tmp_path / "before")
+    document = spec()
+    path_item = document["paths"]["/documents/{id}"]
+    path_item[method_key] = path_item.pop("delete")
+    workspace(root, document)
+    after = scan(root, tmp_path / "after")
+    (row,) = after.tool_surface_facts.operation_attributions
+    base = ReconstructedOperationBase(
+        "a" * 40, tuple(before.tool_surface_facts.operation_attributions)
+    )
+    (comparison,) = compare_operations(after.tool_surface_facts.operation_attributions, base)
+    if method_key == "delete":
+        assert row.status == "observed"
+        captured = json.loads((root / "api.json").read_text())
+        for token in row.operation.source_pointer.removeprefix("/").split("/"):
+            captured = captured[token.replace("~1", "/").replace("~0", "~")]
+        assert captured == path_item[method_key]
+        assert comparison.declared_target_domain == "unchanged"
+    else:
+        assert row.status == row.operation.status == "unresolved"
+        assert row.operation.reason == "noncanonical_method_key"
+        assert row.operation.declared_targets == []
+        assert row.predicates == []
+        assert comparison.declared_target_domain == "unresolved"
+        assert comparison.approval_predicate == "unresolved"
+    assert comparison.finding_exclusion_eligible is False
+
+
 @pytest.mark.parametrize(
     "values,direction",
     [

--- a/tests/test_openapi_operation_attribution.py
+++ b/tests/test_openapi_operation_attribution.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+
+import pytest
+import yaml
+
+from agents_shipgate.cli.scan.orchestrator import run_scan
+from agents_shipgate.core.operation_attribution import (
+    ReconstructedOperationBase,
+    compare_operations,
+)
+
+
+def spec(values=("alpha", "beta")):
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Archived documents", "version": "1"},
+        "servers": [{"url": "https://example.test/api"}],
+        "security": [],
+        "paths": {
+            "/documents/{id}": {
+                "delete": {
+                    "operationId": "remove_document",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string", "enum": list(values)},
+                        }
+                    ],
+                    "responses": {"204": {"description": "Removed"}},
+                }
+            }
+        },
+    }
+
+
+def workspace(root, document=None, *, approval=False):
+    root.mkdir(exist_ok=True)
+    manifest = {
+        "version": "0.1",
+        "project": {"name": "documents", "owner": "test"},
+        "agent": {"name": "document_helper", "declared_purpose": ["Manage document records"]},
+        "environment": {"target": "local"},
+        "tool_sources": [{"id": "documents", "type": "openapi", "path": "api.json"}],
+        # Deliberately synthetic test input, never release qualification or
+        # an assertion about deployed wiring. The unbound negative removes it.
+        "agent_bindings": {
+            "declarations": [
+                {
+                    "agent": "root",
+                    "complete": True,
+                    "tools": [{"tool": "remove_document", "source_id": "documents"}],
+                    "handoffs": [],
+                    "reason": "Synthetic isolated policy-check regression fixture",
+                }
+            ]
+        },
+        "policies": {"require_approval_for_tools": ["remove_document"] if approval else []},
+        "ci": {"mode": "advisory"},
+    }
+    (root / "shipgate.yaml").write_text(yaml.safe_dump(manifest))
+    (root / "api.json").write_text(json.dumps(document or spec()))
+    return manifest
+
+
+def scan(root, out):
+    report, _ = run_scan(config_path=root / "shipgate.yaml", output_dir=out, plugins_enabled=False)
+    return report
+
+
+def test_real_delete_finding_has_exact_claim_and_dependency_join(tmp_path):
+    root = tmp_path / "repo"
+    workspace(root)
+    report = scan(root, tmp_path / "reports")
+    (row,) = report.tool_surface_facts.operation_attributions
+    assert row.status == "observed", row
+    finding = next(f for f in report.findings if f.check_id == row.check_id)
+    assert row.finding_fingerprints == [finding.fingerprint]
+    assert finding.capability_refs == [row.capability_id]
+    assert row.predicates[0].claim_ids
+    assert row.missing_approval is True
+    assert finding.support is None  # Attribution must not alter gating support.
+    assert row.operation.declared_targets == [
+        "https://example.test/api/documents/alpha",
+        "https://example.test/api/documents/beta",
+    ]
+    for evidence in row.operation.inputs:
+        assert evidence.sha256 == hashlib.sha256((root / evidence.path).read_bytes()).hexdigest()
+    assert row.finding_exclusion_eligible is False
+    assert row.deployed_reachability == "unknown"
+
+
+@pytest.mark.parametrize(
+    "values,direction",
+    [
+        (("alpha", "beta"), "unchanged"),
+        (("alpha",), "narrowed"),
+        (("alpha", "beta", "gamma"), "widened"),
+    ],
+)
+def test_domain_comparison_does_not_resolve_missing_approval(tmp_path, values, direction):
+    root = tmp_path / "repo"
+    workspace(root)
+    old = scan(root, tmp_path / "before")
+    workspace(root, spec(values))
+    new = scan(root, tmp_path / "after")
+    base = ReconstructedOperationBase(
+        "a" * 40, tuple(old.tool_surface_facts.operation_attributions)
+    )
+    (comparison,) = compare_operations(new.tool_surface_facts.operation_attributions, base)
+    assert comparison.declared_target_domain == direction, comparison
+    assert comparison.approval_predicate == "standing_weakness"
+    assert old.release_decision.decision == new.release_decision.decision
+    assert {f.fingerprint for f in old.findings} == {f.fingerprint for f in new.findings}
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "query_boolean",
+        "missing_parameter",
+        "server_variable",
+        "external_ref",
+        "schema_composition",
+        "duplicate_parameter",
+        "callback",
+        "missing_security",
+        "unknown_security",
+        "operation_body",
+    ],
+)
+def test_unmodeled_input_cannot_be_attributed(tmp_path, mutation):
+    document = spec()
+    operation = document["paths"]["/documents/{id}"]["delete"]
+    parameter = operation["parameters"][0]
+    if mutation == "query_boolean":
+        operation["parameters"].append(
+            {"name": "approved", "in": "query", "schema": {"type": "boolean"}}
+        )
+    elif mutation == "missing_parameter":
+        operation["parameters"] = []
+    elif mutation == "server_variable":
+        document["servers"] = [
+            {"url": "https://{host}/", "variables": {"host": {"default": "example.test"}}}
+        ]
+    elif mutation == "external_ref":
+        parameter["schema"] = {"$ref": "https://example.test/schema.json"}
+    elif mutation == "schema_composition":
+        parameter["schema"] = {"allOf": [parameter["schema"]]}
+    elif mutation == "duplicate_parameter":
+        operation["parameters"].append(copy.deepcopy(parameter))
+    elif mutation == "callback":
+        operation["callbacks"] = {}
+    elif mutation == "missing_security":
+        del document["security"]
+    elif mutation == "unknown_security":
+        document["security"] = [{"undeclared": []}]
+    elif mutation == "operation_body":
+        operation["requestBody"] = {}
+    root = tmp_path / "repo"
+    workspace(root, document)
+    report = scan(root, tmp_path / "reports")
+    (row,) = report.tool_surface_facts.operation_attributions
+    assert row.status != "observed"
+    assert row.finding_exclusion_eligible is False
+
+
+def test_supplied_report_never_grants_reconstructed_provenance(tmp_path):
+    root = tmp_path / "repo"
+    workspace(root)
+    scan(root, tmp_path / "base")
+    report, _ = run_scan(
+        config_path=root / "shipgate.yaml",
+        output_dir=tmp_path / "after",
+        diff_from_path=tmp_path / "base/report.json",
+        plugins_enabled=False,
+    )
+    (row,) = report.tool_surface_diff.operation_comparisons
+    assert row.evidence_source == "unavailable"
+    assert row.declared_target_domain == "unresolved"
+
+
+@pytest.mark.parametrize(
+    "mutation", ["duplicate_key", "unbound", "conflicting_effect", "long_server", "target_budget"]
+)
+def test_evidence_refusals_preserve_unknown(tmp_path, mutation, monkeypatch):
+    root = tmp_path / "repo"
+    manifest = workspace(root)
+    if mutation == "duplicate_key":
+        text = (root / "api.json").read_text()
+        (root / "api.json").write_text(
+            text.replace('"security": []', '"security": [{"unknown": []}], "security": []')
+        )
+    elif mutation == "unbound":
+        del manifest["agent_bindings"]
+        (root / "shipgate.yaml").write_text(yaml.safe_dump(manifest))
+    elif mutation == "conflicting_effect":
+        manifest["action_surface"] = {"actions": [{"tool": "remove_document", "effect": "read"}]}
+        (root / "shipgate.yaml").write_text(yaml.safe_dump(manifest))
+    elif mutation == "long_server":
+        document = spec()
+        document["servers"] = [{"url": "https://example.test/" + "a" * 2048}]
+        (root / "api.json").write_text(json.dumps(document))
+    else:
+        from agents_shipgate.inputs import openapi_operation_contract
+
+        monkeypatch.setattr(openapi_operation_contract, "MAX_TARGET_BYTES", 1)
+    report = scan(root, tmp_path / "reports")
+    (row,) = report.tool_surface_facts.operation_attributions
+    assert row.status != "observed"
+    assert row.finding_exclusion_eligible is False
+
+
+@pytest.mark.parametrize(
+    "mutation", ["operation_rename", "path_change", "security_change", "unresolved_base_reference"]
+)
+def test_identity_configuration_and_missing_base_never_prove_improvement(tmp_path, mutation):
+    root = tmp_path / "repo"
+    document = spec()
+    if mutation == "unresolved_base_reference":
+        document["paths"]["/documents/{id}"] = {"$ref": "#/components/pathItems/Documents"}
+    workspace(root, document)
+    old = scan(root, tmp_path / "before")
+    document = spec()
+    if mutation == "operation_rename":
+        document["paths"]["/documents/{id}"]["delete"]["operationId"] = "erase_document"
+    elif mutation == "path_change":
+        document["paths"]["/records/{id}"] = document["paths"].pop("/documents/{id}")
+    elif mutation == "security_change":
+        document["components"] = {
+            "securitySchemes": {"bearer": {"type": "http", "scheme": "bearer"}}
+        }
+        document["security"] = [{"bearer": []}]
+    manifest = workspace(root, document)
+    if mutation == "operation_rename":
+        manifest["agent_bindings"]["declarations"][0]["tools"][0]["tool"] = "erase_document"
+        (root / "shipgate.yaml").write_text(yaml.safe_dump(manifest))
+    new = scan(root, tmp_path / "after")
+    base = ReconstructedOperationBase(
+        "a" * 40, tuple(old.tool_surface_facts.operation_attributions)
+    )
+    comparisons = compare_operations(new.tool_surface_facts.operation_attributions, base)
+    assert comparisons
+    assert all(row.declared_target_domain == "unresolved" for row in comparisons)
+    assert all(row.approval_predicate == "unresolved" for row in comparisons)
+    if mutation == "operation_rename":
+        (row,) = comparisons
+        assert row.before.capability_id != row.after.capability_id
+        assert row.reason == "operation_or_capability_identity_changed"
+
+
+def test_operation_overrides_preserve_parameter_location_and_security_alternatives(tmp_path):
+    root = tmp_path / "repo"
+    document = spec()
+    path = document["paths"]["/documents/{id}"]
+    path["parameters"] = copy.deepcopy(path["delete"]["parameters"])
+    path["parameters"][0]["schema"]["enum"] = ["outer"]
+    path["servers"] = [{"url": "https://path.example.test"}]
+    path["delete"]["servers"] = [{"url": "https://operation.example.test"}]
+    document["components"] = {
+        "securitySchemes": {
+            "bearer": {"type": "http", "scheme": "bearer"},
+            "key": {"type": "apiKey", "in": "header", "name": "X-Api-Key"},
+        }
+    }
+    path["delete"]["security"] = [{"bearer": [], "key": []}, {"key": []}]
+    workspace(root, document)
+    report = scan(root, tmp_path / "report")
+    (row,) = report.tool_surface_facts.operation_attributions
+    assert row.operation.status == "observed"
+    assert row.operation.declared_targets == [
+        "https://operation.example.test/documents/alpha",
+        "https://operation.example.test/documents/beta",
+    ]
+    assert json.loads(row.operation.security_contract)["alternatives"] == [
+        {"bearer": [], "key": []},
+        {"key": []},
+    ]
+
+
+def test_duplicate_yaml_keys_and_aliases_are_profile_refusals(tmp_path):
+    from agents_shipgate.inputs.openapi_operation_contract import unambiguous_document
+
+    assert not unambiguous_document("value: one\nvalue: two\n")
+    assert not unambiguous_document("a: &a {x: y}\nb: *a\n")
+    assert not unambiguous_document("a: &a {x: y}\nb: {<<: *a}\n")
+
+
+def test_conflicting_canonical_evidence_cannot_compare(tmp_path):
+    root = tmp_path / "repo"
+    workspace(root)
+    report = scan(root, tmp_path / "report")
+    (attribution,) = report.tool_surface_facts.operation_attributions
+    base = ReconstructedOperationBase("a" * 40, (attribution, attribution.model_copy(deep=True)))
+    (row,) = compare_operations([attribution], base)
+    assert row.declared_target_domain == "unresolved"
+    assert row.finding_exclusion_eligible is False
+
+
+@pytest.mark.parametrize("family", ["openai_api", "anthropic"])
+def test_independent_policy_artifact_is_not_a_closed_manifest_dependency(tmp_path, family):
+    root = tmp_path / "repo"
+    manifest = workspace(root)
+    manifest[family] = {"policy_rules": ["approval.json"]}
+    (root / "shipgate.yaml").write_text(yaml.safe_dump(manifest))
+    (root / "approval.json").write_text(json.dumps({"approval_required": []}))
+    old = scan(root, tmp_path / "before")
+    (root / "approval.json").write_text(json.dumps({"approval_required": ["remove_document"]}))
+    new = scan(root, tmp_path / "after")
+    for report in (old, new):
+        (row,) = report.tool_surface_facts.operation_attributions
+        assert row.status == "unresolved"
+        assert row.reason == "policy_dependency_not_closed_by_profile"
+    assert any(f.check_id == "SHIP-POLICY-APPROVAL-MISSING" for f in old.findings)
+    assert not any(f.check_id == "SHIP-POLICY-APPROVAL-MISSING" for f in new.findings)
+    base = ReconstructedOperationBase(
+        "a" * 40, tuple(old.tool_surface_facts.operation_attributions)
+    )
+    assert all(
+        row.approval_predicate == "unresolved"
+        for row in compare_operations(new.tool_surface_facts.operation_attributions, base)
+    )
+
+
+def test_additional_get_catalog_cannot_be_an_unrecorded_identity_dependency(tmp_path):
+    root = tmp_path / "repo"
+    manifest = workspace(root)
+    other = spec()
+    path = other["paths"]["/documents/{id}"]
+    path["get"] = path.pop("delete")
+    path["get"]["operationId"] = "lookup_document"
+    (root / "other.json").write_text(json.dumps(other))
+    manifest["tool_sources"].append({"id": "other", "type": "openapi", "path": "other.json"})
+    (root / "shipgate.yaml").write_text(yaml.safe_dump(manifest))
+    report = scan(root, tmp_path / "reports")
+    (row,) = report.tool_surface_facts.operation_attributions
+    assert row.status == "unresolved"
+    assert row.reason == "policy_dependency_not_closed_by_profile"

--- a/tests/test_operation_attribution_verification.py
+++ b/tests/test_operation_attribution_verification.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+
+import pytest
+import yaml
+from test_current_control import _live, _verify
+from test_openapi_operation_attribution import scan, spec, workspace
+
+from agents_shipgate.cli.verify import orchestrator
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+
+
+def git(root, *args):
+    return subprocess.run(
+        ["git", *args], cwd=root, check=True, text=True, capture_output=True
+    ).stdout.strip()
+
+
+def repository(tmp_path):
+    root = tmp_path / "repo"
+    workspace(root)
+    (root / ".gitignore").write_text("agents-shipgate-reports/\n")
+    git(root, "init", "-q", "-b", "main")
+    git(root, "config", "user.name", "Test User")
+    git(root, "config", "user.email", "test@example.test")
+    git(root, "add", ".")
+    git(root, "commit", "-qm", "Synthetic declared-operation base")
+    return root
+
+
+@pytest.mark.parametrize(
+    "values,direction", [(("alpha",), "narrowed"), (("alpha", "beta", "gamma"), "widened")]
+)
+def test_committed_verify_reconstructs_operation_predicate_evidence(tmp_path, values, direction):
+    root = repository(tmp_path)
+    base = git(root, "rev-parse", "HEAD")
+    (root / "api.json").write_text(json.dumps(spec(values)))
+    git(root, "add", "api.json")
+    git(root, "commit", "-qm", "Change declared targets")
+    _verify(root, base=base)
+    report = json.loads((root / "agents-shipgate-reports/report.json").read_text())
+    (row,) = report["tool_surface_diff"]["operation_comparisons"]
+    assert row["evidence_source"] == "reconstructed_git_base"
+    assert row["base_tree"] == git(root, "rev-parse", base + "^{tree}")
+    assert row["declared_target_domain"] == direction, row
+    assert row["approval_predicate"] == "standing_weakness"
+    assert row["before"]["operation"]["inputs"] != row["after"]["operation"]["inputs"]
+    assert row["finding_exclusion_eligible"] is False
+    plan = json.loads((root / "agents-shipgate-reports/verification-plan.json").read_text())
+    dependencies = plan["inputs"]["options"]["dependency_inputs"]["files"]
+    assert "api.json" in {item["path"] for item in dependencies}
+    read_current_control(root / "agents-shipgate-reports", live=_live(root))
+
+
+def test_self_consistent_forged_cache_is_rebuilt(tmp_path, monkeypatch):
+    root = repository(tmp_path)
+    base = git(root, "rev-parse", "HEAD")
+    cache = tmp_path / "cache" / "entry" / "report.json"
+    monkeypatch.setattr(orchestrator, "_cache_report_path", lambda **kwargs: cache)
+    _verify(root, base=base)
+    cached = json.loads(cache.read_text())
+    cached["tool_surface_facts"]["operation_attributions"][0]["operation"]["declared_targets"] = [
+        "https://example.test/forged"
+    ]
+    cache.write_text(json.dumps(cached))
+    # Both files are writable by a local report producer; they prove no origin.
+    cache.with_suffix(".sha256").write_text(hashlib.sha256(cache.read_bytes()).hexdigest())
+    assert orchestrator._cache_report_valid(cache)
+    _verify(root, base=base)
+    report = json.loads((root / "agents-shipgate-reports/report.json").read_text())
+    (row,) = report["tool_surface_diff"]["operation_comparisons"]
+    assert row["declared_target_domain"] == "unchanged", row
+    assert "forged" not in json.dumps(row)
+
+
+def test_action_approval_declaration_is_attributed_to_its_actual_pointer(tmp_path):
+    root = repository(tmp_path)
+    base = git(root, "rev-parse", "HEAD")
+    manifest = yaml.safe_load((root / "shipgate.yaml").read_text())
+    # Synthetic test declaration: exercises an existing input route, not a
+    # generated declaration or an assertion about a real deployed agent.
+    manifest["action_surface"] = {
+        "actions": [{"tool": "remove_document", "approval": {"required": True}}]
+    }
+    (root / "shipgate.yaml").write_text(yaml.safe_dump(manifest))
+    git(root, "add", "shipgate.yaml")
+    git(root, "commit", "-qm", "Synthetic approval declaration")
+    _verify(root, base=base)
+    report = json.loads((root / "agents-shipgate-reports/report.json").read_text())
+    (row,) = report["tool_surface_diff"]["operation_comparisons"]
+    assert row["approval_predicate"] == "resolved_by_declaration", row
+    pointers = row["after"]["predicates"][2]["contributing_pointers"]
+    assert "/action_surface/actions/0/approval" in pointers
+    assert row["finding_exclusion_eligible"] is False
+
+
+@pytest.mark.parametrize("changed_file", ["api.json", "shipgate.yaml"])
+def test_live_control_rejects_ignored_source_drift(tmp_path, changed_file):
+    root = repository(tmp_path)
+    _verify(root, archive_head=False)
+    reports = root / "agents-shipgate-reports"
+    read_current_control(reports, live=_live(root))
+    git(root, "update-index", "--assume-unchanged", changed_file)
+    if changed_file == "api.json":
+        (root / changed_file).write_text(json.dumps(spec(("gamma",))))
+    else:
+        manifest = yaml.safe_load((root / changed_file).read_text())
+        manifest["policies"]["require_approval_for_tools"] = ["remove_document"]
+        (root / changed_file).write_text(yaml.safe_dump(manifest))
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=_live(root))
+
+
+def test_redaction_disables_comparison_and_removes_evidence_digests(tmp_path):
+    root = tmp_path / "repo"
+    document = spec()
+    document["servers"] = [{"url": "https://example.test/sk-live-1234567890abcdefghijklmnopqrstuv"}]
+    workspace(root, document)
+    report = scan(root, tmp_path / "reports")
+    (row,) = report.tool_surface_facts.operation_attributions
+    assert row.status == "redacted", row
+    assert not row.operation.declared_targets
+    assert not row.operation.inputs
+    payload = (tmp_path / "reports/report.json").read_text()
+    assert "1234567890abcdefghijklmnopqrstuv" not in payload
+    assert hashlib.sha256((root / "api.json").read_bytes()).hexdigest() not in json.dumps(
+        row.model_dump()
+    )

--- a/tests/test_verify_weakening.py
+++ b/tests/test_verify_weakening.py
@@ -250,20 +250,20 @@ def _commit(repo: Path, message: str) -> None:
     )
 
 
-def _sample_repo(tmp_path: Path) -> tuple[Path, Path]:
+def _sample_repo(tmp_path: Path, *, sample_dir: Path = SAMPLE.parent) -> tuple[Path, Path]:
     """Copy the sample agent into a fresh git repo. Returns (repo, manifest)."""
     import shutil
 
     repo = tmp_path / "repo"
     sample_dst = repo / "samples" / "support_refund_agent"
     sample_dst.parent.mkdir(parents=True)
-    shutil.copytree(Path(__file__).resolve().parent.parent / SAMPLE.parent, sample_dst)
+    shutil.copytree(Path(__file__).resolve().parent.parent / sample_dir, sample_dst)
     return repo, sample_dst / "shipgate.yaml"
 
 
-def _weakened_repo(tmp_path: Path) -> Path:
+def _weakened_repo(tmp_path: Path, *, sample_dir: Path = SAMPLE.parent) -> Path:
     """A repo whose HEAD downgrades the declared gate strict -> advisory."""
-    repo, manifest_path = _sample_repo(tmp_path)
+    repo, manifest_path = _sample_repo(tmp_path, sample_dir=sample_dir)
     declared = manifest_path.read_text(encoding="utf-8")
     manifest_path.write_text(
         declared.replace("ci:\n  mode: advisory", "ci:\n  mode: strict"),
@@ -410,7 +410,10 @@ def test_base_cache_from_the_pre_fix_epoch_is_not_reused(tmp_path, monkeypatch):
     """
     from agents_shipgate.cli.verify import orchestrator as verify_orchestrator
 
-    repo = _weakened_repo(tmp_path)
+    # OpenAPI bases now rebuild operation evidence independently of the cache
+    # (#607). Keep this cache-epoch positive control on a cached MCP base; the
+    # OpenAPI forged-cache regression covers its separate reconstruction path.
+    repo = _weakened_repo(tmp_path, sample_dir=Path("samples/clean_read_only_agent"))
     monkeypatch.setattr(
         verify_orchestrator, "BASE_CACHE_KEY_EPOCH", _PRE_298_CACHE_EPOCH
     )


### PR DESCRIPTION
A narrower declared operation can still lack approval. This joins a bounded OpenAPI DELETE operation to the existing `SHIP-POLICY-APPROVAL-MISSING` capability predicate, then reports declared target-domain changes separately from whether approval is still missing. It implements #607's operation/predicate relationship; it does not consume that evidence to exclude findings.

The `openapi_delete/v1` profile reads raw captured OpenAPI 3.0.3 bytes before normalization, preserves observation/canonical/capability IDs, structural effect claim IDs, effective control-pack identity, actual approval contributors and supplied binding provenance. It requires a single OpenAPI source, literal HTTPS server, finite required string-enum path parameters and explicit bounded security configuration. References, duplicate keys/aliases, unknown configuration, auxiliary framework inputs, ambiguous subjects and conflicting declarations remain unresolved. Target expansion is bounded by count and bytes.

Committed verification carries a private freshly reconstructed Git base. A self-consistent report cache or supplied `--diff-from` report cannot manufacture it. Source and manifest bytes enter the existing dependency currency checks. One-sided observations do not prove addition/removal; changed identity/security/binding and redacted evidence refuse comparison. Existing JSON/Markdown surfaces carry the typed attribution and its limitations. Native finding support, fingerprints and gate decisions remain unchanged, every exclusion flag is false, and deployed reachability remains unknown.

The isolated regression declarations are synthetic test inputs, not generated production declarations or qualification evidence. #557's broader reader closure, #515's TypeScript MongoDB `cal-1` and default/scope migration, and #563/#312's independently reviewed history remain open. Newly reproduced general declared-input currency defect #627 is P0 and deferred from this implementation; this PR contains only its own source/manifest dependencies. ROADMAP.md records #607's subsequent implementation pass and #627 before final candidate/freeze.

Validation: **9,582 passed, 5 skipped** in the completed full local suite (247.22 seconds); 40 focused operation tests and nine compatibility/verification regressions passed. Focused coverage includes real committed base/head, standing approval weakness under narrowed/widened targets, actual action-level declaration pointers, server/parameter/security overrides, forged cache bytes, supplied reports, separate policy files, unbound/conflicting/missing inputs, redaction and Git-hidden source/manifest currency. The full-suite regressions preserve zero-install size-error parity and cache-epoch protection on a cached MCP base. Ruff and generated-schema checks passed; all 24 sample golden artifacts are unchanged. Committed base/head verification and its fresh current-control read passed.

Formal review round 1 found that the compatibility loader normalized a noncanonical method key before the new profile could validate its source pointer. The profile now refuses uppercase/mixed-case methods, and the canonical positive case walks the captured JSON pointer. The general loader compatibility question is separately deferred in #629.

Refs #607, #557, #515, #563, #627, #629, #572.

Two independent coding-agent review/address loops: [round 1](https://github.com/ThreeMoonsLab/agents-shipgate/pull/628#pullrequestreview-5164824844) / [address](https://github.com/ThreeMoonsLab/agents-shipgate/pull/628#issuecomment-5615879370), then [round 2](https://github.com/ThreeMoonsLab/agents-shipgate/pull/628#pullrequestreview-5164984984), which confirmed the fix with no further in-scope findings. These reviews are not independent human release qualification.
