### PR TITLE
fix: reconfirm recorded verification input origins (#627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Reconfirm recorded verification inputs before returning current control,
+  including ignored and Git-hidden changes. Preserve each live policy,
+  baseline and comparison origin through portable copying; generated and
+  outside-repository imports remain frozen artifacts. Prepare exports captured
+  auxiliary bytes, and all live reads retain bounded no-follow validation.
+  Legacy external-input plans need a fresh run when their origin is ambiguous.
+  Directory-source membership remains a separate release obligation (#627, #630).
+
 - Route host-only repositories from first discovery to the existing host audit
   without a placeholder manifest. The CLI and zero-install script retain
   ignored and malformed config candidates; incomplete traversal and config

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -139,10 +139,21 @@ repair.
 The subsequent #607 pass reproduced [#627](https://github.com/ThreeMoonsLab/agents-shipgate/issues/627):
 a worktree control refresh can accept a changed declared input whose hash is
 already in the plan but which is absent from the separately revalidated
-dependency set. This is a new P0 release blocker, deferred from that bounded
-implementation. #607 binds its own source and manifest dependencies; #627 owns
-the general currency repair before final candidate/freeze. It does not reopen
-#299's already-delivered input-enumeration repair or count as a #567 review.
+dependency set. The selected #627 pass now reconfirms every recorded input blob
+in both control observations, preserves live auxiliary origins before portable
+copying, and validates frozen/generated copies beneath their bundle root.
+Prepare/worker/assemble retain the same origin distinction; replay alone grants
+no current authority. Missing, aliased, changed and over-budget inputs refuse.
+This general currency repair precedes final candidate/freeze; it does not reopen
+#299's delivered file-enumeration repair or count as a #567 review.
+
+The pass separately reproduced [#630](https://github.com/ThreeMoonsLab/agents-shipgate/issues/630):
+adding an ignored file under a directory-valued source can change a fresh tool
+catalog without changing any recorded input blob. Directory membership is a
+distinct P1 v1.0 release obligation, deferred from #627 rather than silently
+treated as covered by file hashes. Implement its bounded census before the
+final candidate replay and #569 freeze. Neither finding proves runtime reachability
+or supplies the missing historical qualification evidence.
 
 The following sequence and approved release bars still apply. Contract
 convergence, historical catch results, report freeze, actual human ownership,

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -17,7 +17,7 @@ Artifact integrity and current authority have separate read boundaries:
 
 | Reader | Validated evidence | What it does not establish |
 | --- | --- | --- |
-| `read_current_control` / `agent control` | Every explicit pointer entry, generation consistency, and live workspace currency. `capture` returns selected bytes from that same validated pass. | Integrity of a receipt-only optional file absent from the pointer map. Requesting an unbound capture key returns no bytes for it. |
+| `read_current_control` / `agent control` | Every explicit pointer entry, generation consistency, live workspace currency, and the recorded plan input blobs at their declared origins. `capture` returns selected bytes from that same validated pass. | Integrity of a receipt-only optional output file absent from the pointer map, or source-directory membership not recorded in the plan. Requesting an unbound capture key returns no bytes for it. |
 | `load_validated_receipt_artifacts` | The complete terminal receipt closure, including optional files, from a bounded private snapshot. | Current workspace state, review eligibility, or operational permission on its own. |
 
 `human-review-request.json` is one such optional artifact. Changing, deleting,
@@ -47,8 +47,54 @@ The full loader defaults to 64 artifacts, 64 MiB per artifact, and 256 MiB total
 with 4 MiB bounds on the canonical colocated receipt and artifact manifest.
 Both use no-follow regular-file reads. `allowed_artifact_names` rejects unexpected
 references; it does not filter which referenced artifacts are validated. The
-compact read does no additional optional-file I/O; regression tests pin the read
+compact read does no additional optional-output-file I/O; regression tests pin the read
 set independently of `capture`, rather than imposing a timing-dependent limit.
+
+### Recorded input currency
+
+After confirming the live HEAD, tree, base and overlay, the compact reader
+reconfirms the plan's manifest, configured and discovered file inputs, changed
+files, policy packs, baseline, comparison report and diff. A tracked input marked
+`assume-unchanged`, or an ignored input the verifier actually read, still has to
+match. This check runs in both live observations, using the same captured plan
+and receipt; a successful Git status alone cannot preserve authority.
+
+Repository inputs describe the matching local checkout, including files read
+from its evaluated committed tree. A historical HEAD must match first; the
+reader never compares historical source bytes with a different current HEAD.
+A local manifest overlaid on an archived tree remains a `worktree` input.
+Generated historical comparison reports and diffs are checked in the artifact
+bundle, not looked up as source files in the checkout.
+
+`inputs.options.input_origins` version `1` records auxiliary provenance before
+portable copying. Its `external` rows join `input_path` to a `kind` and `path`:
+`worktree` and `git_blob` name a repository-relative original; both the original
+and exported copy must match. `generated` and `external_snapshot` have no live
+path. An outside-repository baseline or supplied comparison report is an
+explicit frozen import: the copy is checked, with no claim that its original
+outside location is still current. Absolute original locations are not exported
+or recovered. Policy loading retains its existing manifest-directory boundary.
+The metadata is engine-owned and hashed into the request; callers cannot supply
+it through behavior options. Legacy plans with ambiguous external inputs require
+a fresh verification, rather than a guessed origin.
+
+`verification prepare` exports the same captured auxiliary bytes and retains
+their roles and origins. Worker replay still validates the immutable request;
+it does not establish that the result grants authority in a changed checkout.
+The assembled pointer undergoes the same live read as a normal verifier result.
+
+Input reads use no-follow, identity-bound regular files, with 64 MiB per file and
+one shared 256 MiB aggregate budget per live observation, including named
+dependency inputs and portable input copies. Artifact traversal is anchored at
+the plan's bundle directory even when reports are outside the workspace. Missing,
+unreadable, aliased, oversized or concurrently replaced inputs refuse the read.
+The existing named absent/present/refused dependency rules still apply.
+
+This validates **recorded file blobs**. Directory-source membership is a separate
+open obligation in [#630](https://github.com/ThreeMoonsLab/agents-shipgate/issues/630):
+adding an ignored source file that was never recorded can change a fresh catalog
+while all recorded blobs remain intact. File currency does not establish a
+complete directory census or close that release blocker.
 
 The [normative control recipe](agent-contract-current.md#two-read-entry-points)
 defines freshness and permission routing. These boundaries change neither its
@@ -80,7 +126,7 @@ binds:
   set, plugin distribution set, and policy catalog; and
 - the normalized task list.
 
-"Every input an adapter reads" is `plan.inputs.tool_sources`, and it covers
+Recorded file inputs an adapter reads appear in `plan.inputs.tool_sources`, covering
 more than the `tool_sources` manifest block. `prompt_files`, the framework
 blocks (`openai_api`, `anthropic`, `google_adk`, `langchain`, `crewai`, `n8n`,
 `codex_plugins`), `validation.evidence`, `checks.policy_packs`, and

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -63,6 +63,10 @@ from agents_shipgate.core.verification_identity import (
     validate_receipt_artifacts,
     worktree_overlay,
 )
+from agents_shipgate.core.verification_input_currency import (
+    auxiliary_input_origin,
+    write_portable_input,
+)
 from agents_shipgate.packet.json_packet import load_packet_json, write_packet_json
 from agents_shipgate.report.json_report import report_json_payload
 from agents_shipgate.schemas.current_control import RECEIPT_ARTIFACT_KEY
@@ -173,6 +177,7 @@ def prepare(
             no_plugins=no_plugins,
             no_heuristics=no_heuristics,
             worktree_overlay_paths=worktree_overlay_paths,
+            artifacts_root=out.parent,
         )
     except InputParseError as exc:
         typer.echo(f"Input parsing error: {exc}", err=True)
@@ -255,6 +260,7 @@ def _build_plan(
     no_plugins: bool,
     no_heuristics: bool,
     worktree_overlay_paths: list[str] | None = None,
+    artifacts_root: Path | None = None,
 ) -> VerificationPlan:
     """Build the worktree or committed-tree plan for ``prepare``."""
 
@@ -280,6 +286,10 @@ def _build_plan(
                 if path is not None
             ],
         ) as captured:
+            auxiliary = _portable_plan_inputs(
+                root=root, input_root=root, artifacts_root=artifacts_root or root,
+                baseline=baseline_path, diff_from=diff_from_path, policies=policy_paths,
+            )
             return build_verification_plan(
                 git_root=root,
                 input_root=root,
@@ -292,9 +302,7 @@ def _build_plan(
                 **git_identity,
                 changed_files=changed,
                 diff_text=diff_text,
-                baseline_path=baseline_path,
-                diff_from_path=diff_from_path,
-                policy_pack_paths=policy_paths,
+                **auxiliary,
                 evaluation_date=resolved_date,
                 options=options,
                 plugins_enabled=False if no_plugins else None,
@@ -326,6 +334,10 @@ def _build_plan(
                 if path is not None
             ],
         ) as captured:
+            auxiliary = _portable_plan_inputs(
+                root=root, input_root=snapshot, artifacts_root=artifacts_root or root,
+                baseline=mapped_baseline_path, diff_from=diff_from_path, policies=mapped_policy_paths,
+            )
             return build_verification_plan(
                 git_root=root,
                 input_root=snapshot,
@@ -338,14 +350,43 @@ def _build_plan(
                 **git_identity,
                 changed_files=changed,
                 diff_text=diff_text,
-                baseline_path=mapped_baseline_path,
-                diff_from_path=diff_from_path,
-                policy_pack_paths=mapped_policy_paths,
+                **auxiliary,
                 evaluation_date=resolved_date,
                 options=options,
                 captured_input_paths=captured,
                 plugins_enabled=False if no_plugins else None,
             )
+
+
+def _portable_plan_inputs(
+    *, root: Path, input_root: Path, artifacts_root: Path,
+    baseline: Path | None, diff_from: Path | None, policies: list[Path],
+) -> dict[str, Any]:
+    origins: dict[Path, dict[str, str | None]] = {}
+    sources: dict[Path, Path] = {}
+
+    def capture(path: Path | None, category: str) -> Path | None:
+        if path is None:
+            return None
+        # Retain the same missing-optional-input behavior as the plan builder.
+        if not path.is_file():
+            return path
+        origin = auxiliary_input_origin(path, input_root=input_root, git_root=root)
+        portable = write_portable_input(
+            path, root=artifacts_root, category=category, source_logical_path=origin["path"]
+        )
+        origins[portable] = origin
+        sources[portable] = path
+        return portable
+
+    return {
+        "policy_pack_paths": [capture(path, "policy-packs") for path in policies],
+        "baseline_path": capture(baseline, "baseline"),
+        "diff_from_path": capture(diff_from, "comparison"),
+        "external_input_root": artifacts_root,
+        "auxiliary_origins": origins,
+        "auxiliary_source_paths": sources,
+    }
 
 
 @contextlib.contextmanager

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -1312,6 +1312,7 @@ def run_verify(
                     human_context=head_human_context,
                     input_root=head_input_root,
                     input_snapshot=head_snapshot,
+                    config_from_worktree=overlay_worktree_manifest,
                     diff_text=diff_text,
                     diff_from_path=base_report,
                     authorization_path=authorization,
@@ -4182,6 +4183,7 @@ def _write_artifacts(
     human_context: HumanArtifactContext | None = None,
     input_root: Path | None = None,
     input_snapshot: StaticInputSnapshot | None = None,
+    config_from_worktree: bool = False,
     diff_text: str = "",
     diff_from_path: Path | None = None,
     authorization_path: Path | None = None,
@@ -4308,11 +4310,16 @@ def _write_artifacts(
         else None
     )
     external_input_root = verifier_path.parent
+    from agents_shipgate.core.verification_input_currency import auxiliary_input_origin
+
     portable_policy_pack_paths = [
         _write_portable_static_input(
             path,
             root=external_input_root,
             category="policy-packs",
+            source_logical_path=auxiliary_input_origin(
+                path, input_root=resolved_input_root, git_root=git_root
+            )["path"],
         )
         for path in policy_pack_paths
     ]
@@ -4329,10 +4336,26 @@ def _write_artifacts(
             baseline_path,
             root=external_input_root,
             category="baseline",
+            source_logical_path=auxiliary_input_origin(
+                baseline_path, input_root=resolved_input_root, git_root=git_root
+            )["path"],
         )
         if baseline_path is not None and baseline_was_captured
         else None
     )
+    auxiliary_origins = {
+        portable: auxiliary_input_origin(original, input_root=resolved_input_root, git_root=git_root)
+        for original, portable in zip(policy_pack_paths, portable_policy_pack_paths, strict=True)
+    }
+    if portable_baseline_path is not None:
+        auxiliary_origins[portable_baseline_path] = auxiliary_input_origin(
+            baseline_path, input_root=resolved_input_root, git_root=git_root
+        )
+    if portable_diff_from_path is not None:
+        auxiliary_origins[portable_diff_from_path] = auxiliary_input_origin(
+            diff_from_path, input_root=resolved_input_root, git_root=git_root,
+            generated=verifier.base_status != "diff_from_provided",
+        )
     logical_config = config_logical_path or (
         config_path.resolve().relative_to(resolved_input_root).as_posix()
         if resolved_input_root in config_path.resolve().parents
@@ -4421,6 +4444,8 @@ def _write_artifacts(
             worktree_overlay_paths=worktree_overlay_paths,
             external_input_root=external_input_root,
             captured_input_paths=captured_input_paths,
+            auxiliary_origins=auxiliary_origins,
+            config_from_worktree=config_from_worktree,
         )
     finally:
         if plan_snapshot_token is not None:
@@ -5417,18 +5442,15 @@ def _write_portable_static_input(
     *,
     root: Path,
     category: str,
+    source_logical_path: str | None = None,
 ) -> Path:
     """Copy one captured external input into the reproducible artifact graph."""
 
-    data = read_static_input_bytes(path, max_bytes=64 * 1024 * 1024)
-    digest = hashlib.sha256(data).hexdigest()
-    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "_", path.name).strip("._")
-    if not safe_name:
-        safe_name = "input"
-    target = root / "verification-inputs" / category / f"{digest[:16]}-{safe_name}"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(data)
-    return target
+    from agents_shipgate.core.verification_input_currency import write_portable_input
+
+    return write_portable_input(
+        path, root=root, category=category, source_logical_path=source_logical_path
+    )
 
 
 def _reject_output_input_overlap(

--- a/src/agents_shipgate/core/current_control.py
+++ b/src/agents_shipgate/core/current_control.py
@@ -42,9 +42,9 @@ from agents_shipgate.core.errors import AgentsShipgateError
 from agents_shipgate.core.verification_identity import (
     plan_worktree_overlay_paths,
     read_regular_file_beneath,
-    validate_dependency_inputs,
     worktree_overlay,
 )
+from agents_shipgate.core.verification_input_currency import validate_current_plan_inputs
 from agents_shipgate.schemas.agent_control import (
     AgentControl,
     FullAgentPermissions,
@@ -768,22 +768,25 @@ def _validate_control_currency(
             path=out_dir,
         )
     _validate_base_currency(out_dir, identity, live, required=grants_authority)
-    if "verification_plan" in artifacts:
-        try:
-            plan = VerificationPlan.model_validate_json(artifacts["verification_plan"])
-            validate_dependency_inputs(plan, root=live.root)
-        except (ValueError, OSError) as exc:
-            raise CurrentControlUnavailable(
-                "workspace_unverifiable",
-                f"The dependency inputs this decision read are no longer current: {exc}",
-                path=out_dir,
-            ) from exc
     if identity.snapshot_kind == "worktree_overlay":
         _validate_worktree_currency(
             out_dir, pointer, live, required=grants_authority, artifacts=artifacts
         )
     elif identity.snapshot_kind == "committed_tree":
         _require_clean_worktree(out_dir, live, required=grants_authority)
+    if "verification_plan" in artifacts:
+        try:
+            plan = VerificationPlan.model_validate_json(artifacts["verification_plan"])
+            plan_parent = Path(pointer.artifacts["verification_plan"].path).parent
+            validate_current_plan_inputs(
+                plan, root=live.root, artifacts_root=out_dir / plan_parent
+            )
+        except (ValueError, OSError) as exc:
+            raise CurrentControlUnavailable(
+                "workspace_unverifiable",
+                f"The recorded source and dependency inputs are no longer current: {exc}",
+                path=out_dir,
+            ) from exc
 
 
 def _validate_worktree_currency(

--- a/src/agents_shipgate/core/static_inputs.py
+++ b/src/agents_shipgate/core/static_inputs.py
@@ -33,6 +33,7 @@ class StaticInputSnapshot:
         excluded_paths: Iterable[Path] = (),
         max_total_bytes: int = DEFAULT_STATIC_INPUT_TOTAL_BYTES,
         max_files: int = DEFAULT_STATIC_INPUT_FILES,
+        budget: IdentityReadBudget | None = None,
     ) -> None:
         self.root = Path(os.path.abspath(os.path.normpath(os.fspath(root))))
         self.max_total_bytes = max_total_bytes
@@ -51,7 +52,7 @@ class StaticInputSnapshot:
         self._present_dependency_paths: set[Path] = set()
         self._unconfirmable_dependency_paths: set[Path] = set()
         self._total_bytes = 0
-        self._budget = IdentityReadBudget(
+        self._budget = budget if budget is not None else IdentityReadBudget(
             max_entries=max_files * 32,
             max_total_bytes=max_total_bytes,
         )

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -188,12 +188,16 @@ def build_verification_plan(
     diff_logical_path: str = "verification-input.diff",
     external_input_root: Path | None = None,
     captured_input_paths: list[Path] | None = None,
+    auxiliary_origins: dict[Path, dict[str, str | None]] | None = None,
+    auxiliary_source_paths: dict[Path, Path] | None = None,
+    config_from_worktree: bool = False,
 ) -> VerificationPlan:
     effective_plugins_enabled = _plugins_enabled(plugins_enabled)
     normalized_options = dict(options)
     # This is reader provenance, never a caller-supplied assertion. Named
     # negative lookups matter as much as the bytes that resolved an import.
     normalized_options.pop("dependency_inputs", None)
+    normalized_options.pop("input_origins", None)
     snapshot = active_static_input_snapshot()
     if snapshot is not None and (snapshot.dependency_paths() or snapshot.absent_dependency_paths() or snapshot.present_dependency_paths() or snapshot.unconfirmable_dependency_paths()):
         normalized_options["dependency_inputs"] = {
@@ -256,7 +260,7 @@ def build_verification_plan(
     config_blob = build_blob(
         path=config_path,
         logical_path=config_logical_path,
-        source="git_blob" if archived_head else "worktree",
+        source="git_blob" if archived_head and not config_from_worktree else "worktree",
     )
     diff_bytes = diff_text.encode("utf-8")
     diff_blob = VerificationBlob(
@@ -272,6 +276,7 @@ def build_verification_plan(
         _lexical_path(path)
         for path in [
             config_path,
+            *(auxiliary_source_paths or {}).values(),
             *policy_pack_paths,
             *([baseline_path] if baseline_path is not None else []),
             *([diff_from_path] if diff_from_path is not None else []),
@@ -298,18 +303,56 @@ def build_verification_plan(
         source="git_blob" if archived_head else "worktree",
     )
     bundle_root = external_input_root or input_root
-    policy_blobs = _blobs(
-        policy_pack_paths,
-        root=bundle_root,
-        source="external_input",
-    )
+    def auxiliary_blob(path: Path | None) -> VerificationBlob | None:
+        if path is not None and auxiliary_source_paths is not None and path in auxiliary_source_paths:
+            # A portable export is not a new observation. Hash the captured
+            # original bytes the adapters read, even when the snapshot is
+            # finished and the newly written copy lives under its root.
+            if snapshot is None or not snapshot.has(auxiliary_source_paths[path]):
+                raise ValueError("portable input must name an already captured source")
+            return build_blob(
+                path=auxiliary_source_paths[path],
+                logical_path=path.relative_to(bundle_root).as_posix(),
+                source="external_input",
+            )
+        return _optional_blob(path, root=bundle_root)
+
+    if auxiliary_source_paths is not None:
+        policy_blobs = sorted(
+            [blob for path in set(policy_pack_paths) if (blob := auxiliary_blob(path)) is not None],
+            key=lambda blob: blob.path,
+        )
+    else:
+        policy_blobs = _blobs(policy_pack_paths, root=bundle_root, source="external_input")
     changed_blobs = _existing_changed_blobs(
         changed_files,
         root=input_root if archived_head else git_root,
         source="git_blob" if archived_head else "worktree",
     )
-    baseline_blob = _optional_blob(baseline_path, root=bundle_root)
-    diff_from_blob = _optional_blob(diff_from_path, root=bundle_root)
+    baseline_blob = auxiliary_blob(baseline_path)
+    diff_from_blob = auxiliary_blob(diff_from_path)
+    from agents_shipgate.core.verification_input_currency import auxiliary_input_origin
+
+    # Preserve the source before portable copies collapse distinct origins.
+    # No caller-supplied option can assert this provenance; producers supply
+    # the mapping beside the actual paths they copied from captured inputs.
+    original_paths = {path.relative_to(bundle_root).as_posix(): path for path in policy_pack_paths}
+    for path, blob in ((baseline_path, baseline_blob), (diff_from_path, diff_from_blob)):
+        if path is not None and blob is not None:
+            original_paths[blob.path] = path
+    external_rows = []
+    for blob in [*policy_blobs, *([baseline_blob] if baseline_blob else []),
+                 *([diff_from_blob] if diff_from_blob else [])]:
+        path = original_paths[blob.path]
+        origin = (
+            auxiliary_origins[path]
+            if auxiliary_origins is not None and path in auxiliary_origins
+            else auxiliary_input_origin(path, input_root=input_root, git_root=git_root)
+        )
+        external_rows.append({"input_path": blob.path, **origin})
+    normalized_options["input_origins"] = {
+        "version": 1, "external": sorted(external_rows, key=lambda row: row["input_path"])
+    }
     inputs_payload = {
         "evaluation_date": evaluation_date,
         "config": config_blob,
@@ -930,7 +973,7 @@ def validate_plan_inputs(
         raise ValueError("plan diff input size does not match")
 
 
-def validate_dependency_inputs(plan: VerificationPlan, *, root: Path) -> None:
+def validate_dependency_inputs(plan: VerificationPlan, *, root: Path, snapshot=None) -> None:
     """Reconfirm reader-selected bytes and named absence, including ignored files."""
 
     from agents_shipgate.core.static_inputs import StaticInputSnapshot
@@ -973,7 +1016,9 @@ def validate_dependency_inputs(plan: VerificationPlan, *, root: Path) -> None:
             "tool_surface_facts.guard_dependencies, repair unreadable paths "
             "and re-run verification before using current authority."
         )
-    snapshot = StaticInputSnapshot(root.resolve())
+    owns_snapshot = snapshot is None
+    if snapshot is None:
+        snapshot = StaticInputSnapshot(root.resolve())
     for row in files:
         data = snapshot.read_bytes(root.resolve() / row["path"])
         if len(data) != row["size_bytes"] or sha256_bytes(data) != row["sha256"]:
@@ -984,7 +1029,8 @@ def validate_dependency_inputs(plan: VerificationPlan, *, root: Path) -> None:
     for path in present:
         if snapshot.bind_dependency_absence(root.resolve() / path):
             raise ValueError("dependency lookup candidate disappeared since verification")
-    snapshot.finish()
+    if owns_snapshot:
+        snapshot.finish()
 
 
 def _manifest_declared_input_paths(*, config_path: Path, input_root: Path) -> list[Path]:

--- a/src/agents_shipgate/core/verification_input_currency.py
+++ b/src/agents_shipgate/core/verification_input_currency.py
@@ -1,0 +1,166 @@
+"""Origin-aware live validation of the input blobs a verification plan binds."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from pathlib import Path
+
+from agents_shipgate.core.static_inputs import (
+    DEFAULT_STATIC_INPUT_FILES,
+    DEFAULT_STATIC_INPUT_TOTAL_BYTES,
+    StaticInputSnapshot,
+    read_static_input_bytes,
+)
+from agents_shipgate.core.trust_roots import IdentityBoundReadSession, IdentityReadBudget
+from agents_shipgate.schemas.verification_identity import VerificationPlan, validate_portable_path
+
+MAX_CURRENCY_INPUT_BYTES = 64 * 1024 * 1024
+MAX_CURRENCY_TOTAL_BYTES = DEFAULT_STATIC_INPUT_TOTAL_BYTES
+
+
+def write_portable_input(
+    path: Path, *, root: Path, category: str, source_logical_path: str | None = None
+) -> Path:
+    """Export exactly the captured auxiliary bytes into the request bundle."""
+
+    data = read_static_input_bytes(path, max_bytes=MAX_CURRENCY_INPUT_BYTES)
+    digest = hashlib.sha256(data).hexdigest()
+    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "_", path.name).strip("._") or "input"
+    # Equal bytes at a/policy.yaml and b/policy.yaml still have two live
+    # origins. Keep both without leaking an absolute checkout/archive path.
+    origin_suffix = (
+        "-" + hashlib.sha256(_portable(source_logical_path).encode()).hexdigest()[:16]
+        if source_logical_path is not None else ""
+    )
+    target = root / "verification-inputs" / category / f"{digest[:16]}{origin_suffix}-{safe_name}"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(data)
+    return target
+
+
+def _portable(value: object) -> str:
+    if not isinstance(value, str) or ":" in value or value == ".":
+        raise ValueError("input origin must be a portable relative file path")
+    return validate_portable_path(value)
+
+
+def auxiliary_input_origin(
+    path: Path, *, input_root: Path, git_root: Path, generated: bool = False
+) -> dict[str, str | None]:
+    """Describe the actual source before its portable copy loses the location.
+
+    Absolute external locations are deliberately not exported. They are imports
+    of captured bytes, whose portable copies (not their former origins) remain
+    the input to this request.
+    """
+
+    if generated:
+        return {"kind": "generated", "path": None}
+    lexical = Path(os.path.abspath(os.path.normpath(os.fspath(path))))
+    for root, kind in (
+        (input_root, "git_blob" if input_root != git_root else "worktree"),
+        (git_root, "worktree"),
+    ):
+        try:
+            relative = lexical.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        return {"kind": kind, "path": validate_portable_path(relative)}
+    return {"kind": "external_snapshot", "path": None}
+
+
+def validate_current_plan_inputs(
+    plan: VerificationPlan, *, root: Path, artifacts_root: Path
+) -> None:
+    """Reconfirm recorded inputs after the caller validates live HEAD/tree.
+
+    Both evaluated-head and worktree blobs must still describe the matching
+    local checkout. Historical/generated/imported inputs instead belong to the
+    captured artifact graph. This is intentionally separate from worker replay.
+    """
+
+    from agents_shipgate.core.verification_identity import validate_dependency_inputs
+
+    blobs = [
+        plan.inputs.config, *plan.inputs.tool_sources, *plan.inputs.changed_files,
+        *plan.inputs.policy_packs, plan.inputs.diff,
+        *([plan.inputs.baseline] if plan.inputs.baseline is not None else []),
+        *([plan.inputs.diff_from] if plan.inputs.diff_from is not None else []),
+    ]
+    portable = {blob.path for blob in blobs if blob.source in {"external_input", "artifact"}}
+    declaration = plan.inputs.options.get("input_origins")
+    origins = {}
+    if declaration is not None:
+        if (
+            not isinstance(declaration, dict)
+            or set(declaration) != {"version", "external"}
+            or type(declaration["version"]) is not int
+            or declaration["version"] != 1
+            or not isinstance(declaration["external"], list)
+        ):
+            raise ValueError("invalid recorded input provenance; re-run verification")
+        for row in declaration["external"]:
+            if not isinstance(row, dict) or set(row) != {"input_path", "kind", "path"}:
+                raise ValueError("invalid external input provenance")
+            if not isinstance(row["kind"], str):
+                raise ValueError("invalid external input origin kind")
+            input_path = _portable(row["input_path"])
+            if input_path in origins or input_path not in portable:
+                raise ValueError("duplicate or unmatched external input provenance")
+            if row["kind"] in {"worktree", "git_blob"}:
+                _portable(row["path"])
+                if row["kind"] == "git_blob" and plan.subject.git.snapshot_kind != "committed_tree":
+                    raise ValueError("worktree request cannot claim a committed input origin")
+            elif row["kind"] in {"generated", "external_snapshot"}:
+                if row["path"] is not None:
+                    raise ValueError("frozen input cannot name a live origin")
+            else:
+                raise ValueError("unknown external input provenance")
+            origins[input_path] = row
+    if set(origins) != portable:
+        raise ValueError("external input origin is unavailable; re-run verification")
+
+    expected: dict[Path, tuple[str, int]] = {}
+    artifact_inputs: dict[Path, tuple[str, int]] = {}
+
+    def bind(target: dict[Path, tuple[str, int]], path: Path, digest: str, size: int) -> None:
+        value = (digest, size)
+        if path in target and target[path] != value:
+            raise ValueError("conflicting input identities for the same path")
+        target[path] = value
+
+    for blob in blobs:
+        _portable(blob.path)
+        if blob.source in {"worktree", "git_blob"}:
+            bind(expected, root / blob.path, blob.sha256, blob.size_bytes)
+        elif blob.source in {"generated", "external_input", "artifact"}:
+            bind(artifact_inputs, Path(blob.path), blob.sha256, blob.size_bytes)
+            origin = origins.get(blob.path)
+            if origin is not None and origin["path"] is not None:
+                bind(expected, root / origin["path"], blob.sha256, blob.size_bytes)
+        else:
+            raise ValueError("unknown recorded input source")
+    # Anchor artifact traversal at the bundle root, including reports outside
+    # the workspace. An immediate-parent anchor would miss an earlier symlink.
+    # Workspace bytes, named dependencies and artifact inputs share one budget.
+    budget = IdentityReadBudget(
+        max_entries=DEFAULT_STATIC_INPUT_FILES * 32,
+        max_total_bytes=MAX_CURRENCY_TOTAL_BYTES,
+    )
+    snapshot = StaticInputSnapshot(root, budget=budget)
+    artifacts = IdentityBoundReadSession(artifacts_root, budget=budget)
+
+    def check(data: bytes, digest: str, size: int) -> None:
+        if len(data) != size or "sha256:" + hashlib.sha256(data).hexdigest() != digest:
+            raise ValueError("recorded input changed since verification")
+
+    for collection, reader in ((expected, snapshot), (artifact_inputs, artifacts)):
+        for path, (digest, size) in collection.items():
+            if size > MAX_CURRENCY_INPUT_BYTES:
+                raise ValueError("recorded input exceeds the currency read limit")
+            check(reader.read_bytes(path, max_bytes=MAX_CURRENCY_INPUT_BYTES), digest, size)
+    validate_dependency_inputs(plan, root=root, snapshot=snapshot)
+    snapshot.finish()
+    artifacts.finish()

--- a/tests/test_current_control_auxiliary_inputs.py
+++ b/tests/test_current_control_auxiliary_inputs.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+import yaml
+from test_current_control import _git, _live, _verify
+from test_current_control import repo as repo  # noqa: F401
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+from agents_shipgate.core.static_inputs import StaticInputSnapshot
+from agents_shipgate.schemas.baseline import BaselineFile
+
+
+def auxiliary(repo, directory, kind):
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / ("policy.yaml" if kind == "policy" else kind + ".json")
+    if kind == "policy":
+        path.write_text('name: Synthetic empty policy\nversion: "1"\nrules: []\n')
+    elif kind == "baseline":
+        path.write_text(BaselineFile(
+            created_at="2026-09-10T00:00:00Z", source_report_run_id="synthetic-empty-baseline"
+        ).model_dump_json())
+    else:
+        _verify(repo, archive_head=False)
+        path.write_bytes((repo / "agents-shipgate-reports/report.json").read_bytes())
+    return path, {"policy_packs": [path]} if kind == "policy" else {kind: path}
+
+
+def current(repo):
+    return read_current_control(repo / "agents-shipgate-reports", live=lambda: _live(repo)).pointer
+
+
+@pytest.mark.parametrize("kind", ["policy", "baseline", "diff_from"])
+@pytest.mark.parametrize("committed", [False, True])
+def test_portable_auxiliary_copy_does_not_erase_repository_origin(repo, kind, committed):
+    path, options = auxiliary(repo, repo / "policy-inputs", kind)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic auxiliary input")
+    _verify(repo, archive_head=committed, **options)
+    current(repo)
+    plan = json.loads((repo / "agents-shipgate-reports/verification-plan.json").read_text())
+    (origin,) = plan["inputs"]["options"]["input_origins"]["external"]
+    assert origin["path"] == path.relative_to(repo).as_posix()
+    assert origin["kind"] == ("git_blob" if committed and kind != "diff_from" else "worktree")
+    _git(repo, "update-index", "--assume-unchanged", path.relative_to(repo).as_posix())
+    path.write_text(path.read_text() + "\n")
+    assert _live(repo).changed_paths == ()
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+    result = CliRunner().invoke(app, [
+        "agent", "control", "--workspace", str(repo),
+        "--reports-dir", str(repo / "agents-shipgate-reports"),
+    ], env={"AGENTS_SHIPGATE_AGENT_MODE": "1"})
+    assert result.exit_code == 4, result.output
+    assert result.stdout == ""
+    assert "workspace_unverifiable" in result.stderr
+    payload = json.loads(result.stderr.splitlines()[-1])
+    assert payload["error"] == "other_error"
+    assert "verify" in payload["next_actions"][0]["command"]
+
+
+@pytest.mark.parametrize("kind", ["policy", "baseline", "diff_from"])
+def test_ignored_auxiliary_input_remains_a_live_dependency(repo, kind):
+    with (repo / ".gitignore").open("a") as handle:
+        handle.write("private-inputs/\n")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-m", "Ignore local auxiliary inputs")
+    path, options = auxiliary(repo, repo / "private-inputs", kind)
+    _verify(repo, archive_head=False, **options)
+    current(repo)
+    path.write_text(path.read_text() + "\n")
+    assert _live(repo).changed_paths == ()
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+
+
+@pytest.mark.parametrize("kind", ["baseline", "diff_from"])
+@pytest.mark.parametrize("mutation", ["bytes", "missing", "symlink"])
+def test_external_import_is_frozen_but_its_portable_bytes_must_remain_current(
+    repo, tmp_path, kind, mutation
+):
+    path, options = auxiliary(repo, tmp_path / "outside", kind)
+    _verify(repo, archive_head=False, **options)
+    before = current(repo)
+    reports = repo / "agents-shipgate-reports"
+    plan = json.loads((reports / "verification-plan.json").read_text())
+    (origin,) = plan["inputs"]["options"]["input_origins"]["external"]
+    assert origin["kind"] == "external_snapshot"
+    assert origin["path"] is None
+    assert str(tmp_path / "outside") not in json.dumps(plan)
+    path.write_text(path.read_text() + "\n")
+    assert current(repo).current_control_id == before.current_control_id
+    portable = reports / origin["input_path"]
+    if mutation == "bytes":
+        portable.write_text(portable.read_text() + "\n")
+    elif mutation == "missing":
+        portable.unlink()
+    else:
+        twin = portable.with_name("identical-copy")
+        twin.write_bytes(portable.read_bytes())
+        portable.unlink()
+        portable.symlink_to(twin.name)
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+
+
+@pytest.mark.parametrize("mutation", ["missing", "directory", "symlink", "hardlink", "fifo"])
+def test_hidden_input_replacement_refuses_boundedly(repo, mutation):
+    _verify(repo, archive_head=False)
+    current(repo)
+    path = repo / "tools.json"
+    _git(repo, "update-index", "--assume-unchanged", "tools.json")
+    if mutation == "hardlink":
+        os.link(path, repo / "agents-shipgate-reports/twin.json")
+    else:
+        data = path.read_bytes()
+        path.unlink()
+        if mutation == "directory":
+            path.mkdir()
+        elif mutation == "symlink":
+            twin = repo / "agents-shipgate-reports/twin.json"
+            twin.write_bytes(data)
+            path.symlink_to(twin)
+        elif mutation == "fifo":
+            if not hasattr(os, "mkfifo"):
+                pytest.skip("FIFO unavailable")
+            os.mkfifo(path)
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+
+
+@pytest.mark.parametrize("observation", [1, 2])
+def test_input_change_while_finishing_the_identity_session_refuses(repo, monkeypatch, observation):
+    _verify(repo, archive_head=False)
+    path = repo / "tools.json"
+    _git(repo, "update-index", "--assume-unchanged", "tools.json")
+    original = StaticInputSnapshot.finish
+    seen = []
+
+    def finish(snapshot):
+        if snapshot.has(path):
+            seen.append(snapshot)
+            if len(seen) == observation:
+                path.write_text(path.read_text() + "\n")
+        return original(snapshot)
+
+    monkeypatch.setattr(StaticInputSnapshot, "finish", finish)
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+    assert len(seen) == observation
+
+
+@pytest.mark.parametrize("committed", [False, True])
+def test_framework_artifact_is_reconfirmed_without_a_tool_source_entry(repo, committed):
+    manifest_path = repo / "shipgate.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text())
+    manifest["openai_api"] = {"prompt_files": ["prompt.md"]}
+    manifest_path.write_text(yaml.safe_dump(manifest))
+    prompt = repo / "prompt.md"
+    prompt.write_text("Look up documentation.\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic framework prompt")
+    _verify(repo, archive_head=committed)
+    current(repo)
+    _git(repo, "update-index", "--assume-unchanged", "prompt.md")
+    prompt.write_text("Changed instructions.\n")
+    assert _live(repo).changed_paths == ()
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)

--- a/tests/test_current_control_input_currency.py
+++ b/tests/test_current_control_input_currency.py
@@ -1,0 +1,65 @@
+"""Current authority must reconfirm evaluated inputs, not only Git's change list."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from test_current_control import _git, _live, _verify
+from test_current_control import repo as repo  # noqa: F401 - shared real-engine fixture
+
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+
+
+@pytest.mark.parametrize("input_name", ["shipgate.yaml", "tools.json", "api.json"])
+@pytest.mark.parametrize("observation", [0, 1, 2])
+def test_git_hidden_declared_input_revokes_current_control(
+    repo: Path, input_name: str, observation: int
+) -> None:
+    if input_name == "api.json":
+        manifest_path = repo / "shipgate.yaml"
+        manifest = yaml.safe_load(manifest_path.read_text())
+        manifest["tool_sources"][0].update(type="openapi", path="api.json")
+        manifest_path.write_text(yaml.safe_dump(manifest))
+        (repo / "api.json").write_text(json.dumps({
+            "openapi": "3.0.3",
+            "info": {"title": "Docs", "version": "1"},
+            "servers": [{"url": "https://docs.example.test"}],
+            "paths": {"/docs": {"get": {
+                "operationId": "docs.lookup",
+                "responses": {"200": {"description": "Document"}},
+            }}},
+        }))
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "GET regression input")
+    _verify(repo, archive_head=False)
+    reports = repo / "agents-shipgate-reports"
+    before = read_current_control(reports, live=lambda: _live(repo))
+    assert before.pointer.control.permissions.update_pr
+    plan = json.loads((reports / "verification-plan.json").read_text())
+    blobs = [plan["inputs"]["config"], *plan["inputs"]["tool_sources"]]
+    assert any(blob["path"] == input_name and blob["source"] == "worktree" for blob in blobs)
+    _git(repo, "update-index", "--assume-unchanged", input_name)
+    path = repo / input_name
+
+    def change():
+        # Even a whitespace-only change invalidates a byte-bound answer.
+        path.write_text(path.read_text() + "\n")
+
+    if observation == 0:
+        change()
+    observed = []
+
+    def observe():
+        state = _live(repo)
+        assert state.changed_paths == ()
+        observed.append(state)
+        if len(observed) == observation:
+            change()
+        return state
+
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=observe, attempts=1)
+    assert len(observed) == max(1, observation)

--- a/tests/test_current_control_input_origins.py
+++ b/tests/test_current_control_input_origins.py
@@ -1,0 +1,245 @@
+"""Recorded blob currency across prepare, replay, imports and live origins."""
+
+from __future__ import annotations
+
+import pytest
+from test_current_control import _git, _live, _verify
+from test_current_control import repo as repo  # noqa: F401
+from test_current_control_auxiliary_inputs import auxiliary, current
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.cli.verification import assemble, worker
+from agents_shipgate.core import verification_input_currency as currency
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+from agents_shipgate.schemas.verification_identity import VerificationPlan
+
+
+def plan_at(reports):
+    return VerificationPlan.model_validate_json((reports / "verification-plan.json").read_bytes())
+
+
+@pytest.mark.parametrize("kind", ["policy", "baseline", "diff_from"])
+@pytest.mark.parametrize("committed", [False, True])
+def test_prepare_exports_auxiliary_bytes_without_losing_their_roles(repo, kind, committed):
+    original, _ = auxiliary(repo, repo / "inputs", kind)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic preparation input")
+    reports = repo / "agents-shipgate-reports"
+    result = CliRunner().invoke(app, [
+        "verification", "prepare", "--workspace", str(repo), "--no-plugins",
+        {"policy": "--policy-pack", "baseline": "--baseline", "diff_from": "--diff-from"}[kind],
+        str(original), "--out", str(reports / "verification-plan.json"),
+        *(["--base", "HEAD", "--head", "HEAD"] if committed else []),
+    ])
+    assert result.exit_code == 0, result.output
+    plan = plan_at(reports)
+    blob = plan.inputs.policy_packs[0] if kind == "policy" else getattr(plan.inputs, kind)
+    assert blob is not None
+    assert (reports / blob.path).read_bytes() == original.read_bytes()
+    assert original.relative_to(repo).as_posix() not in {b.path for b in plan.inputs.tool_sources}
+    (origin,) = plan.inputs.options["input_origins"]["external"]
+    assert origin["path"] == original.relative_to(repo).as_posix()
+    assert origin["kind"] == ("git_blob" if committed and kind != "diff_from" else "worktree")
+    currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    worker(plan_path=reports / "verification-plan.json", workspace=repo,
+           diff_path=reports / "verification-input.diff", out=reports / "replayed-unit.json")
+    _git(repo, "update-index", "--assume-unchanged", original.relative_to(repo).as_posix())
+    original.write_bytes(original.read_bytes() + b"\n")
+    with pytest.raises(ValueError, match="changed"):
+        currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    # Worker replay validates the captured request, not its current local
+    # authority. The frozen portable copy still supplies exactly those bytes.
+    worker(plan_path=reports / "verification-plan.json", workspace=repo,
+           diff_path=reports / "verification-input.diff", out=reports / "replayed-unit.json")
+
+
+@pytest.mark.parametrize("kind", ["policy", "baseline", "diff_from"])
+def test_assembled_control_retains_auxiliary_origin_currency(repo, kind):
+    original, options = auxiliary(repo, repo / "inputs", kind)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic assembly input")
+    _verify(repo, archive_head=True, **options)
+    reports = repo / "agents-shipgate-reports"
+    unit = reports / "replayed-unit.json"
+    worker(plan_path=reports / "verification-plan.json", workspace=repo,
+           diff_path=reports / "verification-input.diff", out=unit)
+    assemble(plan_path=reports / "verification-plan.json", unit_paths=[unit],
+             verifier_path=reports / "verifier.json", artifacts_root=reports,
+             out=reports / "verification-receipt.json")
+    current(repo)
+    _git(repo, "update-index", "--assume-unchanged", original.relative_to(repo).as_posix())
+    original.write_bytes(original.read_bytes() + b"\n")
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+
+
+def test_ignored_live_manifest_overlaid_on_an_archived_head_is_not_a_git_blob(repo):
+    _git(repo, "rm", "--cached", "shipgate.yaml")
+    with (repo / ".gitignore").open("a") as handle:
+        handle.write("shipgate.yaml\n")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-m", "Synthetic local manifest")
+    _verify(repo, archive_head=True)
+    current(repo)
+    assert plan_at(repo / "agents-shipgate-reports").inputs.config.source == "worktree"
+    path = repo / "shipgate.yaml"
+    path.write_bytes(path.read_bytes() + b"\n")
+    assert _live(repo).changed_paths == ()
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+
+
+def test_historical_head_refuses_before_reading_checkout_as_its_inputs(repo, monkeypatch):
+    _verify(repo, archive_head=True)
+    _git(repo, "commit", "--allow-empty", "-m", "Another live head")
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("historical request must not compare inputs with another live HEAD")
+
+    monkeypatch.setattr("agents_shipgate.core.current_control.validate_current_plan_inputs", forbidden)
+    with pytest.raises(CurrentControlUnavailable) as raised:
+        current(repo)
+    assert raised.value.reason == "workspace_changed"
+
+
+@pytest.mark.parametrize("outside", [False, True])
+def test_portable_input_parent_alias_refuses_even_outside_workspace(repo, tmp_path, outside):
+    original, options = auxiliary(repo, repo / "inputs", "baseline")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic baseline")
+    reports = tmp_path / "reports" if outside else repo / "agents-shipgate-reports"
+    _verify(repo, archive_head=True, out=reports, **options)
+    before = read_current_control(reports, live=lambda: _live(repo)).pointer
+    assert before.control.permissions.update_pr
+    tree = reports / "verification-inputs"
+    moved = tmp_path / "relocated-inputs"
+    tree.rename(moved)
+    tree.symlink_to(moved, target_is_directory=True)
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=lambda: _live(repo))
+
+
+@pytest.mark.parametrize("mutation", ["missing", "version", "unknown", "absolute", "duplicate", "unmatched"])
+def test_ambiguous_or_malformed_import_origin_refuses_before_reading(repo, monkeypatch, mutation):
+    _, options = auxiliary(repo, repo / "inputs", "baseline")
+    _verify(repo, archive_head=False, **options)
+    reports = repo / "agents-shipgate-reports"
+    plan = plan_at(reports)
+    # Exercise validation of engine-owned provenance independently from the
+    # outer plan digest checks (which already reject un-rehashed mutation).
+    origins = plan.inputs.options["input_origins"]
+    if mutation == "missing":
+        del plan.inputs.options["input_origins"]
+    elif mutation == "version":
+        origins["version"] = True
+    elif mutation == "unknown":
+        origins["external"][0]["kind"] = "trusted"
+    elif mutation == "absolute":
+        origins["external"][0]["path"] = str(repo / "inputs/baseline.json")
+    elif mutation == "duplicate":
+        origins["external"].append(dict(origins["external"][0]))
+    else:
+        origins["external"][0]["input_path"] = "another-file.json"
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("invalid provenance must refuse before input I/O")
+
+    monkeypatch.setattr(currency, "StaticInputSnapshot", forbidden)
+    with pytest.raises(ValueError):
+        currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+
+
+@pytest.mark.parametrize("limit", ["file", "aggregate"])
+def test_currency_input_reads_have_per_file_and_shared_aggregate_limits(repo, monkeypatch, limit):
+    _, options = auxiliary(repo, repo / "inputs", "baseline")
+    _verify(repo, archive_head=False, **options)
+    current(repo)
+    plan = plan_at(repo / "agents-shipgate-reports")
+    if limit == "file":
+        monkeypatch.setattr(currency, "MAX_CURRENCY_INPUT_BYTES", plan.inputs.config.size_bytes - 1)
+    else:
+        # Each input is small enough; workspace and portable copies together
+        # exhaust the shared budget, without allocating a large fixture.
+        largest = max(b.size_bytes for b in [plan.inputs.config, *plan.inputs.tool_sources])
+        monkeypatch.setattr(currency, "MAX_CURRENCY_TOTAL_BYTES", largest + 1)
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+
+
+def test_generated_base_report_is_an_artifact_not_a_live_source(repo):
+    _git(repo, "branch", "base", "HEAD")
+    (repo / "note.txt").write_text("Unrelated change.\n")
+    _git(repo, "add", "note.txt")
+    _git(repo, "commit", "-m", "Synthetic range")
+    _verify(repo, archive_head=True, base="base")
+    current(repo)
+    reports = repo / "agents-shipgate-reports"
+    plan = plan_at(reports)
+    assert plan.inputs.diff_from is not None
+    (origin,) = plan.inputs.options["input_origins"]["external"]
+    assert origin == {
+        "input_path": plan.inputs.diff_from.path, "kind": "generated", "path": None,
+    }
+    assert not (repo / plan.inputs.diff_from.path).exists()
+    path = reports / plan.inputs.diff_from.path
+    path.write_bytes(path.read_bytes() + b"\n")
+    with pytest.raises(CurrentControlUnavailable):
+        current(repo)
+
+
+def test_legacy_plan_without_external_inputs_needs_no_origin_guess(repo):
+    _verify(repo, archive_head=False)
+    reports = repo / "agents-shipgate-reports"
+    plan = plan_at(reports)
+    del plan.inputs.options["input_origins"]
+    currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+
+
+def test_drive_prefixed_blob_refuses_before_input_io(repo, monkeypatch):
+    _verify(repo, archive_head=False)
+    reports = repo / "agents-shipgate-reports"
+    plan = plan_at(reports)
+    plan.inputs.config.path = "C:shipgate.yaml"
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("drive-prefixed blob must refuse before input I/O")
+
+    monkeypatch.setattr(currency, "StaticInputSnapshot", forbidden)
+    with pytest.raises(ValueError, match="portable"):
+        currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+
+
+@pytest.mark.parametrize("producer", ["verify", "prepare"])
+@pytest.mark.parametrize("committed", [False, True])
+def test_identical_policy_bytes_keep_both_live_origins(repo, producer, committed):
+    first, _ = auxiliary(repo, repo / "a", "policy")
+    second, _ = auxiliary(repo, repo / "b", "policy")
+    assert first.read_bytes() == second.read_bytes()
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Two distinct policy origins")
+    reports = repo / "agents-shipgate-reports"
+    if producer == "verify":
+        _verify(repo, archive_head=committed, policy_packs=[first, second])
+        current(repo)
+    else:
+        result = CliRunner().invoke(app, [
+            "verification", "prepare", "--workspace", str(repo), "--no-plugins",
+            "--policy-pack", str(first), "--policy-pack", str(second),
+            "--out", str(reports / "verification-plan.json"),
+            *(["--base", "HEAD", "--head", "HEAD"] if committed else []),
+        ])
+        assert result.exit_code == 0, result.output
+    plan = plan_at(reports)
+    assert len(plan.inputs.policy_packs) == 2
+    origins = plan.inputs.options["input_origins"]["external"]
+    assert {o["path"] for o in origins} == {"a/policy.yaml", "b/policy.yaml"}
+    currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    _git(repo, "update-index", "--assume-unchanged", "a/policy.yaml")
+    first.write_bytes(first.read_bytes() + b"\n")
+    assert _live(repo).changed_paths == ()
+    with pytest.raises(ValueError, match="changed"):
+        currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    if producer == "verify":
+        with pytest.raises(CurrentControlUnavailable):
+            current(repo)

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -500,9 +500,20 @@ def test_prepare_binds_the_explicit_baseline_and_comparison_report(
 
     for plan, variant in zip(plans, ("a", "b"), strict=True):
         assert plan["inputs"]["baseline"] is not None
-        assert plan["inputs"]["baseline"]["path"] == f"baseline-{variant}.json"
+        assert plan["inputs"]["baseline"]["path"].endswith(f"-baseline-{variant}.json")
         assert plan["inputs"]["diff_from"] is not None
-        assert plan["inputs"]["diff_from"]["path"] == f"comparison-{variant}.json"
+        assert plan["inputs"]["diff_from"]["path"].endswith(f"-comparison-{variant}.json")
+        origins = {
+            row["input_path"]: row for row in plan["inputs"]["options"]["input_origins"]["external"]
+        }
+        for key, name in (("baseline", "baseline"), ("diff_from", "comparison")):
+            blob = plan["inputs"][key]
+            origin = origins[blob["path"]]
+            assert origin["path"] == f"{name}-{variant}.json"
+            assert origin["kind"] == ("git_blob" if committed and key == "baseline" else "worktree")
+            assert (tmp_path / f"out-{variant}" / blob["path"]).read_bytes() == (
+                repo / origin["path"]
+            ).read_bytes()
 
     assert plans[0]["inputs"]["input_set_id"] != plans[1]["inputs"]["input_set_id"]
 


### PR DESCRIPTION
Closes #627. Refs #299, #567, #597, #572. Directory-source membership remains deferred under #630.

A control refresh could return the previous answer after an already-recorded source changed behind Git's overlay observation. Reconfirm every recorded input in both live observations after checking HEAD/tree/base/overlay, using the captured plan and bounded, identity-bound reads. An unchanged request still reads successfully; missing, changed, aliased, oversized or concurrently replaced inputs refuse.

Preserve live policy, baseline and supplied-comparison origins before portable copying. Distinct repository paths remain distinct obligations even when their bytes and basenames match. Evaluated-head sources describe the matching checkout; generated historical artifacts and explicit outside-repository imports are checked beneath the bundle root. No absolute external origin is recovered. Prepare hashes captured original bytes into the exported auxiliary roles; worker replay retains immutable-request semantics, and assembled control undergoes live currency validation.

The compact permission/verdict contract is unchanged. The engine-owned `input_origins` option participates in request identity; ambiguous legacy external-input plans require re-verification. Input files share a 256 MiB budget per observation with a 64 MiB per-file cap. This does not establish directory membership, deployed authority, runtime behavior or v1.0 qualification.

Validation: the full local suite finished with **9,644 passed, 5 skipped**; Ruff and schema consistency passed, and all 24 sample goldens matched. Regression coverage includes the actual control CLI, worktree/committed/overlaid inputs, prepare/worker/assemble, hidden and ignored edits, distinct equal-byte policy origins, legacy/malformed provenance, path aliases/special files, two observations and read budgets. Existing prepare assertions now verify exported bytes and original provenance rather than the old non-exported path spelling.

Independent review/address round 1 on `78ec86631e9f411212894ee97e1d901be63bdc0e`: [review 5165674908](https://github.com/ThreeMoonsLab/agents-shipgate/pull/631#pullrequestreview-5165674908), [address 5616828285](https://github.com/ThreeMoonsLab/agents-shipgate/pull/631#issuecomment-5616828285). All 13 published blobs were checked and 117 focused tests independently passed; no actionable findings remain. No source changes were needed after this formal review. This is coding-agent review, not human qualification.

The review's unobserved portable-name collision uncertainty is P2 #632, deferred without a new v1.0 release bar. The separate explicit-output routing reproduction is recorded under existing #575. #630 remains the concrete directory-membership release obligation.
