### PR TITLE
fix: bind reader-selected input directory membership (#630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,20 @@
 
 ## Unreleased
 
+- Bind reader-selected input directory names and no-follow entry kinds in the
+  verification plan. Both current-control observations and worker replay now
+  reject changed membership, including ignored additions with unchanged file
+  hashes. Exact output exclusions work across archived and live trees without
+  hiding new source siblings. Cached listings retain bounds; refused captures
+  remain explicit. Plans without directory capture require a fresh run (#630).
+
 - Reconfirm recorded verification inputs before returning current control,
   including ignored and Git-hidden changes. Preserve each live policy,
   baseline and comparison origin through portable copying; generated and
   outside-repository imports remain frozen artifacts. Prepare exports captured
   auxiliary bytes, and all live reads retain bounded no-follow validation.
   Legacy external-input plans need a fresh run when their origin is ambiguous.
-  Directory-source membership remains a separate release obligation (#627, #630).
+  Directory-source membership is captured separately below (#627).
 
 - Route host-only repositories from first discovery to the existing host audit
   without a placeholder manifest. The CLI and zero-install script retain

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,11 +149,24 @@ This general currency repair precedes final candidate/freeze; it does not reopen
 
 The pass separately reproduced [#630](https://github.com/ThreeMoonsLab/agents-shipgate/issues/630):
 adding an ignored file under a directory-valued source can change a fresh tool
-catalog without changing any recorded input blob. Directory membership is a
-distinct P1 v1.0 release obligation, deferred from #627 rather than silently
-treated as covered by file hashes. Implement its bounded census before the
-final candidate replay and #569 freeze. Neither finding proves runtime reachability
-or supplies the missing historical qualification evidence.
+catalog without changing any recorded input blob. The selected #630 repair
+binds reader-selected names and no-follow entry kinds in the same bounded input
+session, across worktree/committed capture, both current observations, and worker
+replay. Exact report exclusions preserve source siblings; incidental file and
+negative-lookup parents are not new directory dependencies. Older plans without
+capture need a fresh run. This repair precedes final candidate replay and #569
+freeze; it does not remove static reader coverage limits, prove runtime
+reachability, or supply the missing historical qualification evidence.
+
+The #630 implementation review separately reproduced
+[#633](https://github.com/ThreeMoonsLab/agents-shipgate/issues/633): a Codex plugin
+component alias is resolved before capture, so retargeting it changes the next
+skill surface while the previously resolved files and directory rows remain
+valid. This is a lost lexical lookup, not missing membership of an already
+recorded directory. Keep its P1 repair after #630 and before final input-set
+qualification/#569 freeze; it is deferred from this census PR. The reproduction
+uses the actual loader and input-currency validator, not a demonstrated merge
+permission bypass.
 
 The following sequence and approved release bars still apply. Contract
 convergence, historical catch results, report freeze, actual human ownership,

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -17,7 +17,7 @@ Artifact integrity and current authority have separate read boundaries:
 
 | Reader | Validated evidence | What it does not establish |
 | --- | --- | --- |
-| `read_current_control` / `agent control` | Every explicit pointer entry, generation consistency, live workspace currency, and the recorded plan input blobs at their declared origins. `capture` returns selected bytes from that same validated pass. | Integrity of a receipt-only optional output file absent from the pointer map, or source-directory membership not recorded in the plan. Requesting an unbound capture key returns no bytes for it. |
+| `read_current_control` / `agent control` | Every explicit pointer entry, generation consistency, live workspace currency, the recorded plan input blobs at their declared origins, and reader-selected directory membership. `capture` returns selected bytes from that same validated pass. | Integrity of a receipt-only optional output file absent from the pointer map, or directories the input readers never enumerated. Requesting an unbound capture key returns no bytes for it. |
 | `load_validated_receipt_artifacts` | The complete terminal receipt closure, including optional files, from a bounded private snapshot. | Current workspace state, review eligibility, or operational permission on its own. |
 
 `human-review-request.json` is one such optional artifact. Changing, deleting,
@@ -90,11 +90,49 @@ the plan's bundle directory even when reports are outside the workspace. Missing
 unreadable, aliased, oversized or concurrently replaced inputs refuse the read.
 The existing named absent/present/refused dependency rules still apply.
 
-This validates **recorded file blobs**. Directory-source membership is a separate
-open obligation in [#630](https://github.com/ThreeMoonsLab/agents-shipgate/issues/630):
-adding an ignored source file that was never recorded can change a fresh catalog
-while all recorded blobs remain intact. File currency does not establish a
-complete directory census or close that release blocker.
+`inputs.options.input_directories` version `1` binds the directories the input
+readers actually enumerate, including empty directories. Each row names a
+repository-relative `path` (`.` is the root) and sorted `members` with a lexical
+`name` and no-follow `kind` (`file`, `directory`, `symlink`, or `special`). The
+`source` distinguishes `git_blob` capture from `worktree` capture. This metadata
+is engine-owned, hashed into `input_set_id`, and reconfirmed with file bytes in
+one bounded session in both current-control observations and worker replay.
+An ignored addition, deletion, rename, or member kind change invalidates it,
+even when every previously recorded file blob still matches (#630).
+
+Only source discovery publishes these rows. Lexical parents inspected to read a
+file and parents inspected for a named absent dependency are not whole-directory
+inputs. The SDK/framework readers keep their top-level Python selection, Codex
+plugin skills keep their two-level selection, and other readers retain their
+existing recursive/skip boundaries. This is a census of those selected
+directories, not proof that every repository file or dynamic tool was analyzed.
+File parsing caps and coverage limitations still apply independently.
+A component lookup resolved away before capture cannot be recovered from the
+resulting directory rows: the reproduced Codex plugin alias-retarget case is
+still a separate P1 obligation in [#633](https://github.com/ThreeMoonsLab/agents-shipgate/issues/633).
+This census does not claim that every reader retains such lexical lookups.
+
+`excluded_paths` records Git metadata and the exact generated report subtree,
+mapped into the archive for committed capture. A live output-only parent such
+as `build/artifacts` is projected away only along that exact output prefix;
+adding `build/agent.ts` or even an unrelated empty directory makes it visible.
+These projection probes bind identity for the session but do not become source
+rows. A selected input cannot itself be the excluded output directory.
+
+Directory capture shares the identity-read budget with file inputs and caps
+selected directory rows plus members at 100,000. Cached listings obey the same
+per-directory bound as fresh listings. Names and kinds are rechecked before the
+session completes. A refused enumeration remains in `unconfirmable_paths` even
+if an adapter recovers; a partial or over-budget census grants no current
+identity. A selected Conductor JSON symlink is refused before resolution can
+erase its lexical identity.
+
+A captured empty `directories` list means the readers enumerated no source
+directories. Missing metadata means capture is unknown: older plans and direct
+builder fallback plans need a fresh `verify` or `verification prepare` before
+current reads or worker replay. A matching snapshot context alone does not
+attest that adapter loading occurred. Existing historical receipt integrity
+remains readable and does not grant current authority.
 
 The [normative control recipe](agent-contract-current.md#two-read-entry-points)
 defines freshness and permission routing. These boundaries change neither its

--- a/src/agents_shipgate/cli/verification.py
+++ b/src/agents_shipgate/cli/verification.py
@@ -273,6 +273,7 @@ def _build_plan(
         with _captured_inputs(
             config_path=root / config_relative,
             input_root=root,
+            excluded_paths=[artifacts_root] if artifacts_root is not None else [],
             policy_pack_paths=policy_paths,
             plugins_enabled=False if no_plugins else None,
             # The overlay set is HEAD-relative and ``changed`` is merge-base-
@@ -323,6 +324,8 @@ def _build_plan(
         with _captured_inputs(
             config_path=snapshot / config_relative,
             input_root=snapshot,
+            excluded_paths=[snapshot / artifacts_root.relative_to(root)]
+            if artifacts_root is not None and (artifacts_root == root or root in artifacts_root.parents) else [],
             policy_pack_paths=mapped_policy_paths,
             plugins_enabled=False if no_plugins else None,
             changed_files=changed,
@@ -398,6 +401,7 @@ def _captured_inputs(
     plugins_enabled: bool | None,
     changed_files: list[str],
     plan_inputs: list[Path],
+    excluded_paths: tuple[Path, ...] | list[Path] = (),
 ) -> Iterator[list[Path]]:
     """Yield the paths the adapters opened, with their bytes still bound.
 
@@ -446,6 +450,7 @@ def _captured_inputs(
     # refuses to read it at all.
     snapshot = StaticInputSnapshot(
         resolved_root,
+        excluded_paths=excluded_paths,
         external_paths=[
             path
             for path in plan_inputs

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -1046,7 +1046,9 @@ def run_verify(
             # already does for a worktree run.
             head_snapshot = StaticInputSnapshot(
                 head_tree_dir,
-                excluded_paths=[out_dir],
+                excluded_paths=[_map_optional_tree_path(
+                    git_root=git_root, tree_dir=head_tree_dir, path=out_dir,
+                )],
             )
             # Read the manifest once, here, and hand those exact bytes to the
             # scan. `load_manifest_with_positions` otherwise parses it twice —

--- a/src/agents_shipgate/core/input_directory_identity.py
+++ b/src/agents_shipgate/core/input_directory_identity.py
@@ -1,0 +1,80 @@
+"""Validate and reconfirm reader-selected input directory membership."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents_shipgate.core.static_inputs import DEFAULT_STATIC_INPUT_FILES, StaticInputSnapshot
+from agents_shipgate.schemas.verification_identity import VerificationPlan, validate_portable_path
+
+
+def _path(value: object, *, root_allowed: bool = False) -> str:
+    if (not isinstance(value, str) or ":" in value
+            or (value == "." and not root_allowed)):
+        raise ValueError("invalid directory input path")
+    return validate_portable_path(value)
+
+
+def directory_input_exclusions(plan: VerificationPlan) -> list[str]:
+    """Validate the whole census before any filesystem access or exclusions."""
+
+    raw = plan.inputs.options.get("input_directories")
+    if raw is None:
+        raise ValueError("input directory capture is unavailable; re-run verification")
+    if (not isinstance(raw, dict)
+            or set(raw) != {"version", "source", "excluded_paths", "directories", "unconfirmable_paths"}
+            or type(raw["version"]) is not int or raw["version"] != 1
+            or raw["source"] != ("git_blob" if plan.subject.git.snapshot_kind == "committed_tree" else "worktree")
+            or not all(isinstance(raw[key], list) for key in (
+                "excluded_paths", "directories", "unconfirmable_paths"
+            ))):
+        raise ValueError("invalid input directory identity")
+    for key in ("excluded_paths", "unconfirmable_paths"):
+        values = [_path(value, root_allowed=key == "unconfirmable_paths") for value in raw[key]]
+        if values != sorted(set(values)):
+            raise ValueError("directory input paths must be sorted and unique")
+    if ".git" not in raw["excluded_paths"]:
+        raise ValueError("directory input identity lacks its metadata exclusion")
+    if raw["unconfirmable_paths"]:
+        raise ValueError("an input directory could not be captured; repair it and re-run verification")
+    paths = []
+    entries = 0
+    for row in raw["directories"]:
+        if not isinstance(row, dict) or set(row) != {"path", "members"}:
+            raise ValueError("invalid input directory row")
+        path = _path(row["path"], root_allowed=True)
+        if any(Path(path) == Path(excluded) or Path(excluded) in Path(path).parents
+               for excluded in raw["excluded_paths"]):
+            raise ValueError("input directory overlaps an excluded path")
+        paths.append(path)
+        if not isinstance(row["members"], list):
+            raise ValueError("invalid input directory members")
+        entries += len(row["members"]) + 1
+        if entries > DEFAULT_STATIC_INPUT_FILES:
+            raise ValueError("input directory census exceeds its aggregate entry limit")
+        names = []
+        for member in row["members"]:
+            if (not isinstance(member, dict) or set(member) != {"name", "kind"}
+                    or not isinstance(member["kind"], str)
+                    or member["kind"] not in {"file", "directory", "symlink", "special"}):
+                raise ValueError("invalid input directory member")
+            name = _path(member["name"])
+            if "/" in name:
+                raise ValueError("directory member must be one lexical name")
+            names.append(name)
+        if names != sorted(set(names)):
+            raise ValueError("directory members must be sorted and unique")
+    if paths != sorted(set(paths)):
+        raise ValueError("input directories must be sorted and unique")
+    return raw["excluded_paths"]
+
+
+def validate_directory_inputs(plan: VerificationPlan, *, snapshot: StaticInputSnapshot) -> None:
+    """Use the same session as file bytes and the same source-discovery projection."""
+
+    raw = plan.inputs.options["input_directories"]
+    for row in raw["directories"]:
+        snapshot.enumerate_input_directory(snapshot.root / row["path"])
+    observed = snapshot.input_directory_identity(source=raw["source"])
+    if observed["directories"] != raw["directories"]:
+        raise ValueError("input directory membership changed since verification")

--- a/src/agents_shipgate/core/static_inputs.py
+++ b/src/agents_shipgate/core/static_inputs.py
@@ -51,6 +51,13 @@ class StaticInputSnapshot:
         self._absent_dependency_paths: set[Path] = set()
         self._present_dependency_paths: set[Path] = set()
         self._unconfirmable_dependency_paths: set[Path] = set()
+        self._input_directories: dict[Path, tuple[tuple[str, str], ...]] = {}
+        self._unconfirmable_input_directories: set[Path] = set()
+        self._directory_members = 0
+        # These exclusions apply only to source discovery, never to file reads
+        # or named negative lookups. Git metadata is not an agent tool surface.
+        self._discovery_exclusions = self._excluded_paths | {self.root / ".git"}
+        self._output_only: dict[Path, bool] = {}
         self._total_bytes = 0
         self._budget = budget if budget is not None else IdentityReadBudget(
             max_entries=max_files * 32,
@@ -175,7 +182,7 @@ class StaticInputSnapshot:
         return data
 
     def bind_directory(self, path: Path) -> tuple[str, ...]:
-        """Bind one directory inventory to the graph-scoped snapshot."""
+        """Bind an incidental inventory for this session, not future currency."""
 
         if self._finished:
             raise ValueError("static input snapshot is already finalized")
@@ -186,6 +193,106 @@ class StaticInputSnapshot:
         )
         session, relative = self._session_for(key)
         return session.directory_entries(relative, max_entries=self.max_files)
+
+    def mark_unconfirmable_input_directory(self, path: Path) -> None:
+        """Keep a refused directory lookup visible even if an adapter recovers."""
+
+        if self._finished:
+            raise ValueError("static input snapshot is already finalized")
+        key = Path(os.path.abspath(path))
+        key.relative_to(self.root)
+        self._unconfirmable_input_directories.add(key)
+
+    def enumerate_input_directory(self, path: Path) -> tuple[str, ...]:
+        """Record a reader-selected inventory, including empty directories.
+
+        Merely reading a file or checking a named absent import does not select
+        its whole parent as an input. Only readers that discover inputs through
+        this API publish membership obligations in the verification plan.
+        """
+
+        key = Path(os.path.abspath(os.path.normpath(os.fspath(
+            path if path.is_absolute() else self.root / path
+        ))))
+        try:
+            if self._finished or (key != self.root and self.root not in key.parents):
+                raise ValueError("input directory is outside the active snapshot")
+            if self.excludes(key) or key == self.root / ".git":
+                raise ValueError("input directory overlaps excluded verification output")
+            cached = self._input_directories.get(key)
+            if cached is not None:
+                return tuple(name for name, _kind in cached)
+            names = self.bind_directory(key)
+            session, relative = self._session_for(key)
+            members = []
+            for name in names:
+                child = key / name
+                if child in self._discovery_exclusions:
+                    continue
+                kind = session.directory_entry_kind(relative / name)
+                if kind == "directory" and self._is_output_only_ancestor(child):
+                    continue
+                members.append((name, kind))
+            if self._directory_members + len(members) + 1 > self.max_files:
+                raise ValueError("input directory census exceeds its aggregate entry limit")
+            self._directory_members += len(members) + 1
+            self._input_directories[key] = tuple(members)
+            return tuple(name for name, _kind in members)
+        except (OSError, ValueError):
+            self._unconfirmable_input_directories.add(key)
+            raise
+
+    def _is_output_only_ancestor(self, path: Path) -> bool:
+        """Project away only scaffolding on an exact output-path prefix.
+
+        A live build/reports directory need not exist in an archived tree. But
+        build/agent.ts or even build/other-empty-directory is a real new source
+        member. Never inspect arbitrary sibling subtrees to call them empty.
+        These identity-bound inspections do not select directories as inputs.
+        """
+
+        if not any(path in excluded.parents for excluded in self._discovery_exclusions):
+            return False
+        if path in self._output_only:
+            return self._output_only[path]
+        names = self.bind_directory(path)
+        session, relative = self._session_for(path)
+        result = True
+        for name in names:
+            child = path / name
+            if child in self._discovery_exclusions:
+                continue
+            kind = session.directory_entry_kind(relative / name)
+            if kind != "directory" or not self._is_output_only_ancestor(child):
+                result = False
+                break
+        self._output_only[path] = result
+        return result
+
+    def input_directory_identity(self, *, source: str) -> dict[str, object]:
+        """Export the selected census, never incidental lexical parents."""
+
+        return {
+            "version": 1,
+            "source": source,
+            "excluded_paths": sorted(
+                path.relative_to(self.root).as_posix()
+                for path in self._discovery_exclusions
+                if path == self.root or self.root in path.parents
+            ),
+            "directories": [
+                {"path": path.relative_to(self.root).as_posix(),
+                 "members": [{"name": name, "kind": kind} for name, kind in members]}
+                for path, members in sorted(
+                    self._input_directories.items(),
+                    key=lambda item: item[0].relative_to(self.root).as_posix(),
+                )
+            ],
+            "unconfirmable_paths": sorted(
+                path.relative_to(self.root).as_posix()
+                for path in self._unconfirmable_input_directories
+            ),
+        }
 
     def finish(self) -> None:
         """Reject any identity or directory-membership change since capture."""

--- a/src/agents_shipgate/core/trust_roots.py
+++ b/src/agents_shipgate/core/trust_roots.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import os
 import posixpath
 import stat
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Literal
 
@@ -282,6 +282,7 @@ class IdentityReadBudget:
 class _DirectoryIdentitySnapshot:
     names: frozenset[str]
     observed: dict[str, os.stat_result]
+    entry_kinds: dict[str, str] = field(default_factory=dict)
 
 
 class IdentityBoundReadSession:
@@ -403,6 +404,10 @@ class IdentityBoundReadSession:
                 raise ValueError("inventory path is not a directory")
             directory = self.root / relative
         snapshot = self._snapshot(directory, max_entries=max_entries)
+        if max_entries is not None and len(snapshot.names) > max_entries:
+            raise IdentityReadBudgetExceeded(
+                "directory inventory exceeded its static filesystem entry bound"
+            )
         return tuple(sorted(snapshot.names))
 
     def finish(self) -> None:
@@ -420,6 +425,10 @@ class IdentityBoundReadSession:
                 raise ValueError(
                     "directory entries changed while identity-bound files were read"
                 )
+            for name, expected_kind in sorted(snapshot.entry_kinds.items()):
+                requested = directory / name
+                if _directory_member_kind(requested) != expected_kind:
+                    raise ValueError("directory entry kind changed while inputs were read")
             for name, expected in sorted(snapshot.observed.items()):
                 if name not in current_names:
                     raise ValueError("path changed lexical identity while it was read")
@@ -436,6 +445,29 @@ class IdentityBoundReadSession:
                 ):
                     raise ValueError("path changed identity while it was read")
         self._finished = True
+
+    def directory_entry_kind(self, relative: Path) -> str:
+        """Observe one enumerated name's no-follow kind, without reading bytes.
+
+        Unread siblings need a kind obligation, not a file-content obligation.
+        Files actually consumed still use read_bytes and its stronger identity
+        checks. Unsafe kinds are described without following or opening them.
+        """
+
+        if self._finished or relative.is_absolute() or ".." in relative.parts or not relative.name:
+            raise ValueError("invalid directory entry observation")
+        directory = self.root / relative.parent
+        if directory not in self._snapshots:
+            self.directory_entries(relative.parent)
+        snapshot = self._snapshots[directory]
+        if relative.name not in snapshot.names:
+            raise ValueError("directory entry changed lexical identity")
+        kind = _directory_member_kind(self.root / relative)
+        previous = snapshot.entry_kinds.get(relative.name)
+        if previous is not None and previous != kind:
+            raise ValueError("directory entry kind changed while inputs were read")
+        snapshot.entry_kinds[relative.name] = kind
+        return kind
 
     def _inspect_components(
         self,
@@ -860,6 +892,19 @@ def inspect_lexical_path_identity(
             return PathIdentityIssue(kind="reparse_point", requested=requested)
         current = requested
     return None
+
+
+def _directory_member_kind(path: Path) -> str:
+    """Classify an enumerated name without following or opening its target."""
+
+    metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or _is_reparse_point(metadata) or _is_junction(path):
+        return "symlink"
+    if stat.S_ISDIR(metadata.st_mode):
+        return "directory"
+    if stat.S_ISREG(metadata.st_mode):
+        return "file"
+    return "special"
 
 
 def _is_reparse_point(metadata: os.stat_result) -> bool:

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -198,7 +198,12 @@ def build_verification_plan(
     # negative lookups matter as much as the bytes that resolved an import.
     normalized_options.pop("dependency_inputs", None)
     normalized_options.pop("input_origins", None)
+    normalized_options.pop("input_directories", None)
     snapshot = active_static_input_snapshot()
+    if snapshot is not None and snapshot.root == input_root and captured_input_paths is not None:
+        normalized_options["input_directories"] = snapshot.input_directory_identity(
+            source="git_blob" if archived_head else "worktree",
+        )
     if snapshot is not None and (snapshot.dependency_paths() or snapshot.absent_dependency_paths() or snapshot.present_dependency_paths() or snapshot.unconfirmable_dependency_paths()):
         normalized_options["dependency_inputs"] = {
             "files": sorted(
@@ -935,42 +940,12 @@ def validate_plan_inputs(
 ) -> None:
     """Fail closed unless every portable plan blob matches the supplied root."""
 
-    validate_dependency_inputs(plan, root=root)
+    from agents_shipgate.core.verification_input_currency import validate_bound_plan_inputs
 
-    blobs = [
-        plan.inputs.config,
-        *plan.inputs.tool_sources,
-        *plan.inputs.policy_packs,
-        *plan.inputs.changed_files,
-    ]
-    if plan.inputs.baseline is not None:
-        blobs.append(plan.inputs.baseline)
-    if plan.inputs.diff_from is not None:
-        blobs.append(plan.inputs.diff_from)
-    resolved_root = root.resolve()
-    resolved_bundle_root = (bundle_root or resolved_root).resolve()
-    for blob in blobs:
-        candidate_root = (
-            resolved_bundle_root
-            if blob.source in {"external_input", "generated"}
-            else resolved_root
-        )
-        candidate = (candidate_root / blob.path).resolve()
-        if candidate != candidate_root and candidate_root not in candidate.parents:
-            raise ValueError(f"plan input escapes supplied root: {blob.path}")
-        if not candidate.is_file():
-            raise ValueError(f"plan input is missing: {blob.path}")
-        if sha256_file(candidate) != blob.sha256:
-            raise ValueError(f"plan input hash does not match: {blob.path}")
-        if candidate.stat().st_size != blob.size_bytes:
-            raise ValueError(f"plan input size does not match: {blob.path}")
-    resolved_diff = (diff_path or (resolved_root / plan.inputs.diff.path)).resolve()
-    if not resolved_diff.is_file():
-        raise ValueError(f"plan diff input is missing: {plan.inputs.diff.path}")
-    if sha256_file(resolved_diff) != plan.inputs.diff.sha256:
-        raise ValueError("plan diff input hash does not match")
-    if resolved_diff.stat().st_size != plan.inputs.diff.size_bytes:
-        raise ValueError("plan diff input size does not match")
+    validate_bound_plan_inputs(
+        plan, root=root, artifacts_root=bundle_root or root,
+        live_origins=False, diff_path=diff_path or root / plan.inputs.diff.path,
+    )
 
 
 def validate_dependency_inputs(plan: VerificationPlan, *, root: Path, snapshot=None) -> None:

--- a/src/agents_shipgate/core/verification_input_currency.py
+++ b/src/agents_shipgate/core/verification_input_currency.py
@@ -7,6 +7,10 @@ import os
 import re
 from pathlib import Path
 
+from agents_shipgate.core.input_directory_identity import (
+    directory_input_exclusions,
+    validate_directory_inputs,
+)
 from agents_shipgate.core.static_inputs import (
     DEFAULT_STATIC_INPUT_FILES,
     DEFAULT_STATIC_INPUT_TOTAL_BYTES,
@@ -81,7 +85,26 @@ def validate_current_plan_inputs(
     captured artifact graph. This is intentionally separate from worker replay.
     """
 
+    validate_bound_plan_inputs(plan, root=root, artifacts_root=artifacts_root, live_origins=True)
+
+
+def validate_bound_plan_inputs(
+    plan: VerificationPlan, *, root: Path, artifacts_root: Path,
+    live_origins: bool, diff_path: Path | None = None,
+) -> None:
+    """Bind bytes and membership in one observation, for replay or live reads.
+
+    Replay consumes captured auxiliary copies; only a current-authority read
+    also checks their original workspace paths. Neither mode evaluates policy.
+    """
+
     from agents_shipgate.core.verification_identity import validate_dependency_inputs
+
+    root = Path(os.path.abspath(root))
+    artifacts_root = Path(os.path.abspath(artifacts_root))
+    if diff_path is not None:
+        diff_path = Path(os.path.abspath(diff_path))
+    exclusions = directory_input_exclusions(plan)
 
     blobs = [
         plan.inputs.config, *plan.inputs.tool_sources, *plan.inputs.changed_files,
@@ -133,12 +156,15 @@ def validate_current_plan_inputs(
 
     for blob in blobs:
         _portable(blob.path)
+        if blob is plan.inputs.diff and diff_path is not None:
+            bind(expected, diff_path, blob.sha256, blob.size_bytes)
+            continue
         if blob.source in {"worktree", "git_blob"}:
             bind(expected, root / blob.path, blob.sha256, blob.size_bytes)
         elif blob.source in {"generated", "external_input", "artifact"}:
             bind(artifact_inputs, Path(blob.path), blob.sha256, blob.size_bytes)
             origin = origins.get(blob.path)
-            if origin is not None and origin["path"] is not None:
+            if live_origins and origin is not None and origin["path"] is not None:
                 bind(expected, root / origin["path"], blob.sha256, blob.size_bytes)
         else:
             raise ValueError("unknown recorded input source")
@@ -149,7 +175,10 @@ def validate_current_plan_inputs(
         max_entries=DEFAULT_STATIC_INPUT_FILES * 32,
         max_total_bytes=MAX_CURRENCY_TOTAL_BYTES,
     )
-    snapshot = StaticInputSnapshot(root, budget=budget)
+    snapshot = StaticInputSnapshot(
+        root, budget=budget, excluded_paths=[root / path for path in exclusions],
+        external_paths=[diff_path] if diff_path is not None else [],
+    )
     artifacts = IdentityBoundReadSession(artifacts_root, budget=budget)
 
     def check(data: bytes, digest: str, size: int) -> None:
@@ -162,5 +191,6 @@ def validate_current_plan_inputs(
                 raise ValueError("recorded input exceeds the currency read limit")
             check(reader.read_bytes(path, max_bytes=MAX_CURRENCY_INPUT_BYTES), digest, size)
     validate_dependency_inputs(plan, root=root, snapshot=snapshot)
+    validate_directory_inputs(plan, snapshot=snapshot)
     snapshot.finish()
     artifacts.finish()

--- a/src/agents_shipgate/inputs/_python_framework.py
+++ b/src/agents_shipgate/inputs/_python_framework.py
@@ -11,7 +11,7 @@ from agents_shipgate.core.domain import (
     Tool,
 )
 from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.inputs.common import resolve_input_path, stable_tool_id
+from agents_shipgate.inputs.common import list_input_directory, resolve_input_path, stable_tool_id
 from agents_shipgate.inputs.mcp import load_mcp_tools
 from agents_shipgate.inputs.python_static import (
     display_path,
@@ -117,7 +117,7 @@ def _load_framework_source(
     ref = ArtifactPathConfig(path=source.path, optional=source.optional)
     path = resolve_existing_path(ref, base_dir)
     if path.is_dir():
-        python_files = sorted(path.glob("*.py"))
+        python_files = [child for child in list_input_directory(path) if child.match("*.py")]
         if not python_files:
             raise InputParseError(f"{framework_label} source directory has no Python files: {path}")
         loaded: list[LoadedToolSource] = []
@@ -189,7 +189,7 @@ def load_python_path(
 ) -> list[LoadedToolSource]:
     if path.is_dir():
         loaded: list[LoadedToolSource] = []
-        for python_file in sorted(path.glob("*.py")):
+        for python_file in [child for child in list_input_directory(path) if child.match("*.py")]:
             loaded.extend(
                 load_python_path(
                     python_file,

--- a/src/agents_shipgate/inputs/common.py
+++ b/src/agents_shipgate/inputs/common.py
@@ -78,6 +78,7 @@ def resolve_input_path(base_dir: Path, value: str) -> Path:
             try:
                 snapshot.bind_directory(lexical)
             except (OSError, ValueError) as exc:
+                snapshot.mark_unconfirmable_input_directory(lexical)
                 raise InputParseError(
                     f"Input directory {value!r} could not be captured safely: {exc}"
                 ) from exc
@@ -96,6 +97,8 @@ def list_input_directory(directory: Path) -> list[Path]:
 
     lexical = Path(os.path.abspath(os.path.normpath(os.fspath(directory))))
     snapshot = active_static_input_snapshot()
+    if snapshot is not None and snapshot.excludes(lexical):
+        raise InputParseError(f"Input directory overlaps verification output: {lexical}")
     if snapshot is None or (
         lexical != snapshot.root and not snapshot.contains(lexical)
     ):
@@ -106,7 +109,7 @@ def list_input_directory(directory: Path) -> list[Path]:
                 f"Input directory {lexical} could not be inspected safely: {exc}"
             ) from exc
     try:
-        names = snapshot.bind_directory(lexical)
+        names = snapshot.enumerate_input_directory(lexical)
     except (OSError, ValueError) as exc:
         raise InputParseError(
             f"Input directory {lexical} could not be captured safely: {exc}"

--- a/src/agents_shipgate/inputs/conductor.py
+++ b/src/agents_shipgate/inputs/conductor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import os
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -12,8 +11,11 @@ from urllib.parse import urlsplit, urlunsplit
 from agents_shipgate.core.artifact_models import ConductorArtifacts
 from agents_shipgate.core.domain import AuthInfo, LoadedToolSource, Tool
 from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.static_inputs import active_static_input_snapshot
 from agents_shipgate.inputs.common import (
+    MAX_INPUT_FILE_BYTES,
     json_pointer_escape,
+    list_input_directory,
     load_structured_file,
     resolve_input_path,
     stable_tool_id,
@@ -239,11 +241,12 @@ def _conductor_files(path: Path, base_dir: Path) -> list[Path]:
     root = path.resolve()
     discovered: list[tuple[str, Path]] = []
     seen: set[Path] = set()
-    for current, dirnames, filenames in os.walk(path, followlinks=False):
-        current_path = Path(current)
-        traversable_dirs: list[str] = []
-        for name in sorted(dirnames):
-            child_dir = current_path / name
+    pending = [path]
+    while pending:
+        current_path = pending.pop()
+        children = list_input_directory(current_path)
+        directories = {child for child in children if child.is_dir()}
+        for child_dir in sorted(directories):
             if child_dir.is_symlink():
                 resolved_dir = child_dir.resolve()
                 try:
@@ -255,12 +258,22 @@ def _conductor_files(path: Path, base_dir: Path) -> list[Path]:
                         f"{child_dir}"
                     ) from exc
                 continue
-            traversable_dirs.append(name)
-        dirnames[:] = traversable_dirs
-        for filename in sorted(filenames):
-            child = current_path / filename
+            pending.append(child_dir)
+        for child in children:
+            if child in directories:
+                continue
             if child.suffix.lower() != ".json":
                 continue
+            # Capture the selected lexical file before resolution/dedup can
+            # erase an alias, including a second name for an already-seen
+            # target. Parsing below reuses these bytes. The shared session
+            # avoids rescanning every lexical parent separately for each file.
+            snapshot = active_static_input_snapshot()
+            if snapshot is not None and snapshot.contains(child):
+                try:
+                    snapshot.read_bytes(child, max_bytes=MAX_INPUT_FILE_BYTES)
+                except (OSError, ValueError) as exc:
+                    raise InputParseError(f"Unable to read input file {child}: {exc}") from exc
             resolved = child.resolve()
             try:
                 resolved.relative_to(base)
@@ -273,7 +286,7 @@ def _conductor_files(path: Path, base_dir: Path) -> list[Path]:
                 continue
             seen.add(resolved)
             relative = resolved.relative_to(base).as_posix()
-            discovered.append((relative, resolved))
+            discovered.append((relative, child))
     return [item[1] for item in sorted(discovered, key=lambda item: item[0])]
 
 

--- a/src/agents_shipgate/inputs/mcp_manifest.py
+++ b/src/agents_shipgate/inputs/mcp_manifest.py
@@ -19,6 +19,7 @@ from agents_shipgate.core.source_warnings import (
     duplicate_mcp_server_declaration_warning,
 )
 from agents_shipgate.inputs.common import (
+    list_input_directory,
     load_structured_file_with_positions,
     load_text_file,
     manifest_relative_path,
@@ -1042,10 +1043,7 @@ def _iter_mcp_candidate_files(root: Path) -> list[Path]:
     stack = [root]
     while stack:
         current = stack.pop()
-        try:
-            children = sorted(current.iterdir(), key=lambda item: item.name)
-        except OSError:
-            continue
+        children = list_input_directory(current)
         for child in children:
             if child.is_symlink() and child.is_dir():
                 continue

--- a/src/agents_shipgate/inputs/openai_sdk_static.py
+++ b/src/agents_shipgate/inputs/openai_sdk_static.py
@@ -12,7 +12,12 @@ from agents_shipgate.core.domain import (
     ToolkitScopeBound,
 )
 from agents_shipgate.core.errors import InputParseError
-from agents_shipgate.inputs.common import load_text_file, resolve_input_path, stable_tool_id
+from agents_shipgate.inputs.common import (
+    list_input_directory,
+    load_text_file,
+    resolve_input_path,
+    stable_tool_id,
+)
 from agents_shipgate.inputs.config_trace import trace_config_binding
 from agents_shipgate.inputs.coverage import BoundaryCell, SourceCoverage
 from agents_shipgate.inputs.protocol import LoadedAdapterResult
@@ -65,7 +70,7 @@ def load_openai_sdk_static_tools(
             )],
         )
     if path.is_dir():
-        python_files = sorted(path.glob("*.py"))
+        python_files = [child for child in list_input_directory(path) if child.match("*.py")]
         if not python_files:
             raise InputParseError(f"OpenAI Agents SDK source directory has no Python files: {path}")
         tools: list[Tool] = []

--- a/tests/test_conductor.py
+++ b/tests/test_conductor.py
@@ -429,3 +429,83 @@ tool_sources:
 def _write_text(path, text):
     path.write_text(text, encoding="utf-8")
     return path
+
+
+@pytest.mark.parametrize("duplicate_target", [False, True])
+def test_selected_conductor_json_alias_refuses_under_input_capture(tmp_path, duplicate_target):
+    from agents_shipgate.core.static_inputs import (
+        StaticInputSnapshot,
+        activate_static_input_snapshot,
+        reset_static_input_snapshot,
+    )
+
+    workflows = tmp_path / 'workflows'
+    workflows.mkdir()
+    target = 'a.json' if duplicate_target else 'original.txt'
+    _write_workflow(workflows / target, [_task('discover', 'LIST_MCP_TOOLS')])
+    (workflows / 'z.json').symlink_to(target)
+    _write_manifest(tmp_path, 'workflows')
+    # Existing standalone discovery accepts in-root aliases. Verification must
+    # retain the lexical selected entry so changing its target cannot disappear
+    # behind unchanged resolved file bytes and unchanged member kinds.
+    assert inspect_sources(config_path=tmp_path / 'shipgate.yaml')['frameworks']['conductor']['workflow_file_count'] == 1
+    snapshot = StaticInputSnapshot(tmp_path)
+    token = activate_static_input_snapshot(snapshot)
+    try:
+        with pytest.raises(InputParseError, match='symlink'):
+            inspect_sources(config_path=tmp_path / 'shipgate.yaml')
+    finally:
+        reset_static_input_snapshot(token)
+
+
+def test_captured_conductor_directory_scans_grow_linearly(tmp_path, monkeypatch):
+    from agents_shipgate.core import trust_roots
+    from agents_shipgate.core.static_inputs import (
+        StaticInputSnapshot,
+        activate_static_input_snapshot,
+        reset_static_input_snapshot,
+    )
+    from agents_shipgate.inputs.conductor import _load_source
+    from agents_shipgate.schemas.manifest import ToolSourceConfig
+
+    real_scandir = os.scandir
+    entries = []
+
+    class CountedScan:
+        def __init__(self, path):
+            self.scan = real_scandir(path)
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            self.scan.close()
+        def __iter__(self):
+            return self
+        def __next__(self):
+            entry = next(self.scan)
+            entries.append(1)
+            return entry
+
+    counts = []
+    for size in (40, 80):
+        root = tmp_path / str(size)
+        workflows = root / 'workflows'
+        workflows.mkdir(parents=True)
+        for index in range(size):
+            _write_workflow(workflows / f'{index:03}.json', [_task('discover', 'LIST_MCP_TOOLS')])
+        snapshot = StaticInputSnapshot(root)
+        token = activate_static_input_snapshot(snapshot)
+        try:
+            with monkeypatch.context() as patch:
+                patch.setattr(trust_roots.os, 'scandir', CountedScan)
+                entries.clear()
+                records, paths = _load_source(
+                    ToolSourceConfig(id='conductor', type='conductor', path='workflows'), root,
+                )
+                snapshot.finish()
+                counts.append(len(entries))
+            assert len(records) == len(paths) == size
+        finally:
+            reset_static_input_snapshot(token)
+    # Counts actual entries visited through scandir, including unbudgeted
+    # lexical checks: per-file rescans could evade the snapshot's own budget.
+    assert counts[1] <= 2 * counts[0] + 10, counts

--- a/tests/test_current_control_directory_currency.py
+++ b/tests/test_current_control_directory_currency.py
@@ -1,0 +1,303 @@
+"""A recorded file set cannot stand in for a directory input's membership."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+from test_current_control import _git, _live, _verify
+from test_current_control import repo as repo  # noqa: F401
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+
+LOOKUP = '''export class LookupTool extends MongoDBToolBase {
+  static toolName = "docs.lookup";
+  public description = "Look up existing documentation metadata";
+  static operationType: OperationType = "read";
+}
+'''
+ADDED = '''export class DropDatabaseTool extends MongoDBToolBase {
+  static toolName = "drop-database";
+  public description = "Removes the specified database";
+  static operationType: OperationType = "delete";
+}
+'''
+
+
+def directory_source(repo):
+    path = repo / "shipgate.yaml"
+    manifest = yaml.safe_load(path.read_text())
+    manifest["tool_sources"][0].update(type="mcp_server_source", path="server")
+    path.write_text(yaml.safe_dump(manifest, sort_keys=False))
+    source = repo / "server"
+    source.mkdir()
+    (source / "lookup.ts").write_text(LOOKUP)
+    with (repo / ".gitignore").open("a") as handle:
+        handle.write("/server/added.ts\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic directory source")
+    return source
+
+
+@pytest.mark.parametrize("committed", [False, True])
+@pytest.mark.parametrize("observation", [0, 1, 2])
+def test_ignored_directory_member_invalidates_both_current_observations(repo, committed, observation):
+    source = directory_source(repo)
+    _verify(repo, archive_head=committed)
+    reports = repo / "agents-shipgate-reports"
+    before = read_current_control(reports, live=lambda: _live(repo)).pointer
+    assert before.control.permissions.update_pr
+    calls = []
+
+    def insert():
+        (source / "added.ts").write_text(ADDED)
+
+    if observation == 0:
+        insert()
+
+    def live():
+        calls.append(1)
+        state = _live(repo)
+        if len(calls) == observation:
+            insert()
+        return state
+
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=live)
+    assert _live(repo).changed_paths == ()
+    result = CliRunner().invoke(app, [
+        "agent", "control", "--workspace", str(repo), "--reports-dir", str(reports),
+    ], env={"AGENTS_SHIPGATE_AGENT_MODE": "1"})
+    assert result.exit_code == 4, result.output
+    assert result.stdout == ""
+    assert "verify" in json.loads(result.stderr.splitlines()[-1])["next_action"]
+
+
+@pytest.mark.parametrize('mutation', ['remove', 'rename', 'file_to_directory', 'empty_directory', 'nested_file'])
+def test_directory_membership_changes_are_bound_even_without_a_new_blob(repo, mutation):
+    source = directory_source(repo)
+    empty = source / 'empty'
+    empty.mkdir()
+    ignored = source / 'unread.txt'
+    ignored.write_text('unparsed')
+    _git(repo, 'add', '.')
+    _git(repo, 'commit', '-m', 'Synthetic non-tool member')
+    _verify(repo, archive_head=False)
+    reports = repo / 'agents-shipgate-reports'
+    read_current_control(reports, live=lambda: _live(repo))
+    if mutation == 'remove':
+        ignored.unlink()
+    elif mutation == 'rename':
+        ignored.rename(source / 'renamed.txt')
+    elif mutation == 'file_to_directory':
+        ignored.unlink()
+        ignored.mkdir()
+    elif mutation == 'empty_directory':
+        (source / 'another').mkdir()
+    else:
+        (empty / 'added.ts').write_text(ADDED)
+    from test_current_control_input_origins import plan_at
+
+    from agents_shipgate.core.verification_input_currency import validate_current_plan_inputs
+    # Bypass Git drift detection to isolate the input membership obligation.
+    with pytest.raises(ValueError, match='directory membership'):
+        validate_current_plan_inputs(plan_at(reports), root=repo, artifacts_root=reports)
+
+
+@pytest.mark.parametrize('committed', [False, True])
+@pytest.mark.parametrize('nested', [False, True])
+def test_root_source_has_current_authority_with_generated_output_scaffolding(repo, committed, nested):
+    directory_source(repo)
+    path = repo / 'shipgate.yaml'
+    manifest = yaml.safe_load(path.read_text())
+    manifest['tool_sources'][0]['path'] = '.'
+    path.write_text(yaml.safe_dump(manifest, sort_keys=False))
+    with (repo / '.gitignore').open('a') as handle:
+        handle.write('/build/\n')
+    _git(repo, 'add', '.')
+    _git(repo, 'commit', '-m', 'Synthetic root source')
+    reports = repo / ('build/artifacts/reports' if nested else 'agents-shipgate-reports')
+    _verify(repo, archive_head=committed, out=reports)
+    before = read_current_control(reports, live=lambda: _live(repo)).pointer
+    assert before.control.permissions.update_pr
+    if nested:
+        (repo / 'build' / 'added.ts').write_text(ADDED)
+        with pytest.raises(CurrentControlUnavailable):
+            read_current_control(reports, live=lambda: _live(repo))
+
+
+@pytest.mark.parametrize('committed', [False, True])
+def test_prepare_and_worker_bind_the_directory_census(repo, committed):
+    from test_current_control_input_origins import plan_at
+
+    from agents_shipgate.core.verification_identity import validate_plan_inputs
+
+    source = directory_source(repo)
+    reports = repo / 'agents-shipgate-reports'
+    result = CliRunner().invoke(app, [
+        'verification', 'prepare', '--workspace', str(repo), '--no-plugins',
+        '--out', str(reports / 'verification-plan.json'),
+        *(['--base', 'HEAD', '--head', 'HEAD'] if committed else []),
+    ])
+    assert result.exit_code == 0, result.output
+    plan = plan_at(reports)
+    kwargs = dict(root=repo, bundle_root=reports, diff_path=reports / 'verification-input.diff')
+    validate_plan_inputs(plan, **kwargs)
+    (source / 'added.ts').write_text(ADDED)
+    with pytest.raises(ValueError, match='directory membership'):
+        validate_plan_inputs(plan, **kwargs)
+    result = CliRunner().invoke(app, [
+        'verification', 'worker', '--plan', str(reports / 'verification-plan.json'),
+        '--workspace', str(repo), '--diff', str(reports / 'verification-input.diff'),
+        '--out', str(reports / 'replayed-unit.json'),
+    ])
+    assert result.exit_code != 0
+    assert not (reports / 'replayed-unit.json').exists()
+    assert 'directory membership' in str(result.exception)
+
+
+def test_file_source_ignores_an_unrelated_ignored_sibling(repo):
+    with (repo / '.gitignore').open('a') as handle:
+        handle.write('/unrelated.txt\n')
+    _git(repo, 'add', '.')
+    _git(repo, 'commit', '-m', 'Synthetic ignored sibling')
+    _verify(repo, archive_head=True)
+    reports = repo / 'agents-shipgate-reports'
+    first = read_current_control(reports, live=lambda: _live(repo)).pointer
+    (repo / 'unrelated.txt').write_text('not a selected input')
+    second = read_current_control(reports, live=lambda: _live(repo)).pointer
+    assert first.current_control_id == second.current_control_id
+
+
+def test_legacy_census_is_unknown_instead_of_a_complete_empty_list(repo):
+    from test_current_control_input_origins import plan_at
+
+    from agents_shipgate.core.verification_input_currency import validate_current_plan_inputs
+
+    _verify(repo, archive_head=False)
+    reports = repo / 'agents-shipgate-reports'
+    plan = plan_at(reports)
+    assert plan.inputs.options['input_directories']['directories'] == []
+    del plan.inputs.options['input_directories']
+    with pytest.raises(ValueError, match='capture is unavailable; re-run'):
+        validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+
+
+def test_worker_accepts_relative_workspace_and_bundle_paths(repo, monkeypatch):
+    directory_source(repo)
+    _verify(repo, archive_head=True)
+    monkeypatch.chdir(repo.parent)
+    reports = 'repo/agents-shipgate-reports'
+    result = CliRunner().invoke(app, [
+        'verification', 'worker', '--plan', f'{reports}/verification-plan.json',
+        '--workspace', 'repo', '--diff', f'{reports}/verification-input.diff',
+        '--out', f'{reports}/relative-unit.json',
+    ])
+    assert result.exit_code == 0, str(result.exception)
+    assert (repo / 'agents-shipgate-reports/relative-unit.json').is_file()
+
+
+@pytest.mark.parametrize('mutation', ['version', 'source', 'absolute', 'traversal', 'duplicate', 'kind', 'name', 'unconfirmable', 'missing_exclusion'])
+def test_malformed_census_refuses_before_filesystem_access(repo, monkeypatch, mutation):
+    from test_current_control_input_origins import plan_at
+
+    from agents_shipgate.core import verification_input_currency as currency
+
+    directory_source(repo)
+    _verify(repo, archive_head=False)
+    reports = repo / 'agents-shipgate-reports'
+    plan = plan_at(reports)
+    raw = plan.inputs.options['input_directories']
+    if mutation == 'version':
+        raw['version'] = True
+    elif mutation == 'source':
+        raw['source'] = 'git_blob'
+    elif mutation == 'absolute':
+        raw['directories'][0]['path'] = str(repo / 'server')
+    elif mutation == 'traversal':
+        raw['excluded_paths'] = ['../server']
+    elif mutation == 'duplicate':
+        raw['directories'].append(raw['directories'][0])
+    elif mutation == 'kind':
+        raw['directories'][0]['members'][0]['kind'] = 'trusted'
+    elif mutation == 'name':
+        raw['directories'][0]['members'][0]['name'] = 'another/path.ts'
+    elif mutation == 'unconfirmable':
+        raw['unconfirmable_paths'] = ['server']
+    else:
+        raw['excluded_paths'] = []
+
+    def forbidden(*args, **kwargs):
+        pytest.fail('malformed metadata must refuse before input filesystem I/O')
+
+    monkeypatch.setattr(currency, 'StaticInputSnapshot', forbidden)
+    with pytest.raises(ValueError):
+        currency.validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+
+
+def test_empty_new_directory_moves_input_identity_without_changing_file_blobs(repo):
+    from test_current_control_input_origins import plan_at
+
+    source = directory_source(repo)
+    reports = repo / 'agents-shipgate-reports'
+    _verify(repo, archive_head=False)
+    before = plan_at(reports)
+    (source / 'empty-new-input-directory').mkdir()
+    assert _live(repo).changed_paths == ()
+    _verify(repo, archive_head=False)
+    after = plan_at(reports)
+    assert before.inputs.tool_sources == after.inputs.tool_sources
+    assert before.inputs.changed_files == after.inputs.changed_files
+    assert before.inputs.input_set_id != after.inputs.input_set_id
+
+
+def test_assembled_pointer_rechecks_directory_membership(repo):
+    from agents_shipgate.cli.verification import assemble, worker
+
+    source = directory_source(repo)
+    _verify(repo, archive_head=True)
+    reports = repo / 'agents-shipgate-reports'
+    unit = reports / 'replayed-unit.json'
+    worker(plan_path=reports / 'verification-plan.json', workspace=repo,
+           diff_path=reports / 'verification-input.diff', out=unit)
+    assemble(plan_path=reports / 'verification-plan.json', unit_paths=[unit],
+             verifier_path=reports / 'verifier.json', artifacts_root=reports,
+             out=reports / 'verification-receipt.json')
+    read_current_control(reports, live=lambda: _live(repo))
+    (source / 'added.ts').write_text(ADDED)
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=lambda: _live(repo))
+
+
+@pytest.mark.parametrize('committed', [False, True])
+def test_prepare_root_source_maps_nested_output_exclusions(repo, committed):
+    from test_current_control_input_origins import plan_at
+
+    from agents_shipgate.core.verification_identity import validate_plan_inputs
+
+    directory_source(repo)
+    path = repo / 'shipgate.yaml'
+    manifest = yaml.safe_load(path.read_text())
+    manifest['tool_sources'][0]['path'] = '.'
+    path.write_text(yaml.safe_dump(manifest, sort_keys=False))
+    with (repo / '.gitignore').open('a') as handle:
+        handle.write('/build/\n')
+    _git(repo, 'add', '.')
+    _git(repo, 'commit', '-m', 'Synthetic root preparation')
+    reports = repo / 'build/artifacts/reports'
+    result = CliRunner().invoke(app, [
+        'verification', 'prepare', '--workspace', str(repo), '--no-plugins',
+        '--out', str(reports / 'verification-plan.json'),
+        *(['--base', 'HEAD', '--head', 'HEAD'] if committed else []),
+    ])
+    assert result.exit_code == 0, str(result.exception)
+    plan = plan_at(reports)
+    validate_plan_inputs(plan, root=repo, bundle_root=reports,
+                         diff_path=reports / 'verification-input.diff')
+    (repo / 'build' / 'unrelated-empty-directory').mkdir()
+    with pytest.raises(ValueError, match='directory membership'):
+        validate_plan_inputs(plan, root=repo, bundle_root=reports,
+                             diff_path=reports / 'verification-input.diff')

--- a/tests/test_declared_manifest_input_identity.py
+++ b/tests/test_declared_manifest_input_identity.py
@@ -985,3 +985,31 @@ def test_derived_blocks_cover_every_framework_that_names_paths() -> None:
     assert "prompt_files" in DECLARED_INPUT_PATH_BLOCKS["anthropic"]
     # openai_api.model_config is aliased; both spellings load, so both resolve.
     assert {"model_config", "api_model_config"} <= DECLARED_INPUT_PATH_BLOCKS["openai_api"]
+
+
+@pytest.mark.parametrize('context', ['none', 'matching', 'outer'])
+def test_direct_builder_cannot_assert_a_complete_census_without_reader_capture(tmp_path, context):
+    from agents_shipgate.core.static_inputs import (
+        activate_static_input_snapshot,
+        reset_static_input_snapshot,
+    )
+
+    repo = _sample_repo(tmp_path, 'clean_read_only_agent')
+    snapshot = StaticInputSnapshot(repo if context == 'matching' else tmp_path)
+    token = activate_static_input_snapshot(snapshot) if context != 'none' else None
+    try:
+        plan = build_verification_plan(
+            git_root=repo, input_root=repo, config_path=repo / 'shipgate.yaml',
+            config_logical_path='shipgate.yaml', base_ref=None, head_ref='HEAD',
+            archived_head=True, repository_id='local:synthetic',
+            base_commit_sha=None, base_tree_sha=None, head_commit_sha='a' * 40,
+            head_tree_sha='b' * 40, merge_base_sha=None, changed_files=[], diff_text='',
+            baseline_path=None, diff_from_path=None, policy_pack_paths=[],
+            evaluation_date='2026-09-10', plugins_enabled=False,
+            options={'input_directories': {'version': 1, 'directories': []}},
+            captured_input_paths=None,
+        )
+        assert 'input_directories' not in plan.inputs.options
+    finally:
+        if token is not None:
+            reset_static_input_snapshot(token)

--- a/tests/test_directory_reader_identity.py
+++ b/tests/test_directory_reader_identity.py
@@ -1,0 +1,68 @@
+"""Actual adapter discovery selects directories; lexical parents alone do not."""
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+from test_codex_plugin import _write_skill_only_codex_plugin
+from test_conductor import _task, _write_workflow
+from test_current_control import repo as repo  # noqa: F401
+from test_n8n import _write_workflow as write_n8n_workflow
+
+from agents_shipgate.cli.scan import inspect_sources
+from agents_shipgate.core.static_inputs import (
+    StaticInputSnapshot,
+    activate_static_input_snapshot,
+    reset_static_input_snapshot,
+)
+
+
+@pytest.mark.parametrize('adapter', ['openai_agents_sdk', 'langchain', 'conductor', 'codex_plugin', 'codex_config', 'n8n'])
+def test_readers_bind_the_directories_they_actually_enumerate(repo, adapter):
+    source = repo / 'sources'
+    source.mkdir()
+    manifest_path = repo / 'shipgate.yaml'
+    manifest = yaml.safe_load(manifest_path.read_text())
+    manifest['tool_sources'] = [{'id': 'source', 'type': adapter, 'path': 'sources'}]
+    expected = {'sources'}
+    if adapter in {'openai_agents_sdk', 'langchain'}:
+        decorator = 'function_tool' if adapter == 'openai_agents_sdk' else 'tool'
+        module = 'agents' if adapter == 'openai_agents_sdk' else 'langchain_core.tools'
+        (source / 'agent.py').write_text(
+            f'from {module} import {decorator}\n@{decorator}\n'
+            'def lookup(query: str) -> str:\n    """Read docs."""\n    return query\n'
+        )
+        # Their directory mode remains top-level, rather than scanning every
+        # Python package merely because it is reachable below the directory.
+        (source / 'unselected').mkdir()
+        (source / 'unselected' / 'another.py').write_text('raise RuntimeError("never execute")')
+    elif adapter == 'conductor':
+        _write_workflow(source / 'agent.json', [_task('discover', 'LIST_MCP_TOOLS')])
+        (source / 'nested').mkdir()
+        expected.add('sources/nested')
+    elif adapter == 'codex_plugin':
+        _write_skill_only_codex_plugin(source)
+        expected = {'sources/skills', 'sources/skills/review'}
+    elif adapter == 'codex_config':
+        (source / '.mcp.json').write_text(json.dumps({'mcpServers': {'docs': {'url': 'https://example.test/mcp'}}}))
+        (source / 'nested').mkdir()
+        expected.add('sources/nested')
+    else:
+        manifest['tool_sources'] = []
+        manifest['n8n'] = {'workflows': [{'path': 'sources'}]}
+        write_n8n_workflow(source / 'agent.json', tool_node_id='lookup', tool_name='Lookup')
+        (source / 'nested').mkdir()
+        expected.add('sources/nested')
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False))
+    snapshot = StaticInputSnapshot(repo)
+    token = activate_static_input_snapshot(snapshot)
+    try:
+        inspect_sources(config_path=manifest_path)
+        snapshot.finish()
+    finally:
+        reset_static_input_snapshot(token)
+    rows = snapshot.input_directory_identity(source='worktree')['directories']
+    assert {row['path'] for row in rows} == expected
+    assert snapshot.input_directory_identity(source='worktree')['unconfirmable_paths'] == []
+    assert 'sources/unselected' not in expected

--- a/tests/test_static_inputs.py
+++ b/tests/test_static_inputs.py
@@ -41,3 +41,86 @@ def test_outer_snapshot_does_not_capture_immutable_archive_directory(
         assert resolve_input_path(archive, "plugins") == source.resolve()
     finally:
         reset_static_input_snapshot(token)
+
+
+def test_directory_limit_is_enforced_after_an_incidental_file_read(tmp_path):
+    from agents_shipgate.core.trust_roots import IdentityBoundReadSession
+
+    (tmp_path / 'a.txt').write_text('a')
+    (tmp_path / 'b.txt').write_text('b')
+    session = IdentityBoundReadSession(tmp_path, max_entries=100, max_total_bytes=100)
+    session.read_bytes(Path('a.txt'), max_bytes=10)
+    with pytest.raises(ValueError, match='entry bound'):
+        session.directory_entries(max_entries=1)
+
+
+@pytest.mark.parametrize('mutation', ['directory', 'symlink', 'special'])
+def test_unread_member_kind_is_rechecked_when_the_read_session_finishes(tmp_path, mutation):
+    import os
+
+    source = tmp_path / 'source'
+    source.mkdir()
+    member = source / 'unread'
+    member.write_text('not an input blob')
+    snapshot = StaticInputSnapshot(tmp_path)
+    assert snapshot.enumerate_input_directory(source) == ('unread',)
+    member.unlink()
+    if mutation == 'directory':
+        member.mkdir()
+    elif mutation == 'symlink':
+        member.symlink_to(tmp_path, target_is_directory=True)
+    elif hasattr(os, 'mkfifo'):
+        os.mkfifo(member)
+    else:
+        pytest.skip('FIFO creation unavailable')
+    with pytest.raises(ValueError, match='(?:kind changed|changed identity)'):
+        snapshot.finish()
+
+
+def test_member_kinds_do_not_make_unread_sibling_bytes_an_input(tmp_path):
+    (tmp_path / 'unused.txt').write_text('before')
+    snapshot = StaticInputSnapshot(tmp_path)
+    snapshot.enumerate_input_directory(tmp_path)
+    (tmp_path / 'unused.txt').write_text('after')
+    snapshot.finish()
+
+
+@pytest.mark.parametrize('extra', ['none', 'file', 'empty_directory', 'symlink'])
+def test_output_projection_excludes_only_scaffolding_on_its_exact_prefix(tmp_path, extra):
+    output = tmp_path / 'build' / 'artifacts' / 'reports'
+    output.mkdir(parents=True)
+    (output / 'report.json').write_text('{}')
+    if extra == 'file':
+        (tmp_path / 'build' / 'agent.ts').write_text('new tool')
+    elif extra == 'empty_directory':
+        (tmp_path / 'build' / 'empty').mkdir()
+    elif extra == 'symlink':
+        import shutil
+        shutil.rmtree(tmp_path / 'build' / 'artifacts')
+        (tmp_path / 'build' / 'artifacts').symlink_to(tmp_path, target_is_directory=True)
+    snapshot = StaticInputSnapshot(tmp_path, excluded_paths=[output])
+    assert snapshot.enumerate_input_directory(tmp_path) == (() if extra == 'none' else ('build',))
+    snapshot.finish()
+    identity = snapshot.input_directory_identity(source='worktree')
+    # Projection probes are session obligations, never selected source rows.
+    assert [row['path'] for row in identity['directories']] == ['.']
+
+
+def test_named_negative_lookup_and_file_parent_are_not_directory_sources(tmp_path):
+    source = tmp_path / 'source'
+    source.mkdir()
+    (source / 'entry.py').write_text('entry')
+    snapshot = StaticInputSnapshot(tmp_path)
+    snapshot.read_bytes(source / 'entry.py')
+    assert snapshot.bind_dependency_absence(source / 'guard.py')
+    snapshot.finish()
+    assert snapshot.input_directory_identity(source='worktree')['directories'] == []
+
+
+def test_caught_directory_cap_retains_an_unconfirmable_obligation(tmp_path):
+    for name in ('a', 'b'):
+        (tmp_path / name).write_text(name)
+    snapshot = StaticInputSnapshot(tmp_path, max_files=1)
+    with pytest.raises(ValueError):
+        snapshot.enumerate_input_directory(tmp_path)
+    assert snapshot.input_directory_identity(source='worktree')['unconfirmable_paths'] == ['.']


### PR DESCRIPTION
Closes #630. Refs #627, #567, #299, #597, #572. The separately reproduced Codex plugin lexical-lookup loss is deferred under #633.

## Problem and resulting behavior

Adding a Git-ignored source file to a directory-valued MCP server source could change the next tool catalog while every previously recorded blob still matched. Both current-control reads could then return the old review-publishable identity. The reproduced fixture never had merge or completion permission; this repair addresses stale input-set evidence without claiming a demonstrated gate bypass.

The plan now records the names and no-follow kinds of directories that input readers actually enumerate. File bytes and directory membership are captured and reconfirmed in the same bounded session, including both current observations, committed and worktree inputs, prepare, and worker replay. A recorded empty directory remains an input; incidental file parents and named negative-lookup parents do not become broad directory dependencies.

## Scope and compatibility

- Keep each adapter's existing discovery depth and skip boundaries. Convert the remaining raw SDK/framework, Conductor and MCP configuration enumerations to captured listings.
- Reconfirm names and kinds, enforce cached and aggregate census bounds, and retain explicit refused-enumeration obligations when an adapter recovers.
- Exclude Git metadata and the exact output subtree with the same projection in archived and live trees. Output-only ancestors do not become archived inputs; new source siblings and unrelated empty directories remain visible.
- Preserve frozen auxiliary inputs during worker replay and validate live originals only for current authority. Normalize relative CLI paths lexically; selected Conductor JSON aliases are refused before resolving away their original identity, including aliases that would otherwise be skipped by resolved-target deduplication.
- Treat a missing census as unknown. Older plans and a direct builder fallback without reader capture need fresh verification/preparation, not an invented empty inventory. Existing receipt integrity, static coverage limits, and the remaining v1.0 qualification obligations are unchanged.

The independent implementation audit also reproduced a plugin component alias
being resolved away before capture. Its old resolved directory census remains
accurate even after a new lookup selects a different target. That distinct
lookup obligation is P1 #633, explicitly retained before final qualification;
this PR does not claim it is repaired.

## Validation

Conductor captures each selected JSON file through the shared snapshot before resolution and reuses its cached bytes for parsing. Independent 40/80-file probes retained the same records, provenance and byte totals while reducing directory entries visited from 943/3,483 to 83/163; a regression counts actual directory visits to prevent per-file lexical scans from bypassing the shared budget.

The final full local suite completed with **9,701 passed, 5 skipped**. Ruff and schema checks passed, and all 24 sample goldens matched. Focused coverage exercises the real current-control CLI, both observations, ignored additions, member removal/rename/kind changes, empty directories, capture caps and malformed/legacy metadata, root/archive/output-prefix cases, relative worker paths, prepare/worker/assemble, six actual adapter discovery paths, and the distinction between reader-selected directories and incidental parents.

Independent GitHub review/address round 1 on `c17a6482b0097f5db052740d9597bf513e5d366d`: [review 5166311511](https://github.com/ThreeMoonsLab/agents-shipgate/pull/634#pullrequestreview-5166311511), [address 5617713611](https://github.com/ThreeMoonsLab/agents-shipgate/pull/634#issuecomment-5617713611). All 20 published blobs matched the isolated review archive; 146 focused tests independently passed with no failures/errors/skips. No actionable findings remain in the selected #630 scope, and no source amendment was needed after this formal review. This is one coding-agent review/address loop, not human qualification. #633 remains the separately recorded P1 obligation.
