### PR TITLE
Preserve Codex plugin component lookup identity before resolution

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,10 +163,23 @@ The #630 implementation review separately reproduced
 component alias is resolved before capture, so retargeting it changes the next
 skill surface while the previously resolved files and directory rows remain
 valid. This is a lost lexical lookup, not missing membership of an already
-recorded directory. Keep its P1 repair after #630 and before final input-set
-qualification/#569 freeze; it is deferred from this census PR. The reproduction
-uses the actual loader and input-currency validator, not a demonstrated merge
-permission bypass.
+recorded directory. The selected #633 repair retains the lexical component
+lookup, uses shared no-follow file/directory capture, and records caught
+failures as unconfirmable inputs. Worktree verification, current-control CLI,
+committed missing-component capture and prepare/worker replay exercise the
+refusal; committed symlinks keep their earlier archive rejection. Repairing a
+component needs a fresh run. This does not establish a demonstrated merge
+permission bypass or runtime behavior.
+
+The #633 implementation pass separately reproduced
+[#635](https://github.com/ThreeMoonsLab/agents-shipgate/issues/635): an implicit
+`.app.json` can appear and change the next app surface while old full input
+currency still passes. Its absent default was never selected for capture.
+Keep this P1 named default-selection obligation after #633 and before final
+input-set qualification/#569 freeze, deferred from the selected-component PR.
+It must preserve unrelated sibling independence rather than census the whole
+plugin root. The reproduction is loader/currency evidence, not a Git authority
+or merge-bypass demonstration.
 
 The following sequence and approved release bars still apply. Contract
 convergence, historical catch results, report freeze, actual human ownership,

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -117,7 +117,9 @@ records an unconfirmable dependency (or an unconfirmable directory for a refused
 root/containment lookup), so repairing the path requires a fresh verification.
 Apps, MCP and hooks require regular files; a directory at one of those paths
 is a captured refusal even when the plugin source is optional. Skills retain
-their directory and direct `SKILL.md` forms.
+their directory and direct `SKILL.md` forms. A selected path named `SKILL.md`
+is always the direct-file form; a directory at that name is a captured refusal,
+including when `.` selects a plugin root with that name.
 Committed archives already reject tracked symlinks before component loading;
 their failure record grants no permissions. Standalone loading retains its
 existing in-root resolution behavior.

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -108,9 +108,23 @@ existing recursive/skip boundaries. This is a census of those selected
 directories, not proof that every repository file or dynamic tool was analyzed.
 File parsing caps and coverage limitations still apply independently.
 A component lookup resolved away before capture cannot be recovered from the
-resulting directory rows: the reproduced Codex plugin alias-retarget case is
-still a separate P1 obligation in [#633](https://github.com/ThreeMoonsLab/agents-shipgate/issues/633).
-This census does not claim that every reader retains such lexical lookups.
+resulting directory rows. Codex plugin component capture now retains its
+declared lexical path before resolution (#633): selected files use the shared
+cached byte reader, and selected directories bind identity before actual skill
+enumeration selects membership. Aliases, parent traversal, unreadable paths and
+non-file/directory kinds refuse capture. A caught component diagnostic also
+records an unconfirmable dependency (or an unconfirmable directory for a refused
+root/containment lookup), so repairing the path requires a fresh verification.
+Committed archives already reject tracked symlinks before component loading;
+their failure record grants no permissions. Standalone loading retains its
+existing in-root resolution behavior.
+
+This does not claim that every reader retains every lookup. The separately
+reproduced implicit default-selection gap — adding a previously absent
+`.app.json` without changing the plugin manifest — remains deferred in
+[#635](https://github.com/ThreeMoonsLab/agents-shipgate/issues/635). A named
+default's absence must be bound where selection happens; broad plugin-root
+membership is not a substitute.
 
 `excluded_paths` records Git metadata and the exact generated report subtree,
 mapped into the archive for committed capture. A live output-only parent such

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -115,6 +115,9 @@ enumeration selects membership. Aliases, parent traversal, unreadable paths and
 non-file/directory kinds refuse capture. A caught component diagnostic also
 records an unconfirmable dependency (or an unconfirmable directory for a refused
 root/containment lookup), so repairing the path requires a fresh verification.
+Apps, MCP and hooks require regular files; a directory at one of those paths
+is a captured refusal even when the plugin source is optional. Skills retain
+their directory and direct `SKILL.md` forms.
 Committed archives already reject tracked symlinks before component loading;
 their failure record grants no permissions. Standalone loading retains its
 existing in-root resolution behavior.

--- a/src/agents_shipgate/core/static_inputs.py
+++ b/src/agents_shipgate/core/static_inputs.py
@@ -196,23 +196,30 @@ class StaticInputSnapshot:
 
     def capture_selected_path(
         self, path: Path, *, max_bytes: int = DEFAULT_STATIC_INPUT_FILE_BYTES,
+        allow_directory: bool = True,
     ) -> None:
         """Bind a selected lookup before its caller can resolve away an alias.
 
         Files use the same cached bytes their parser will consume. Directories
         are bound for this read session only; actual discovery must still call
         enumerate_input_directory to select a persistent membership obligation.
+        File-only readers reject directories here, before adapter recovery can
+        discard a later parser failure without a captured refusal.
         """
 
         if self._finished or ".." in path.parts:
             raise ValueError("invalid selected input lookup")
         if path == self.root:
+            if not allow_directory:
+                raise ValueError("selected input is a directory, expected a regular file")
             self.bind_directory(path)
             return
         key, _relative = self._key(path)
         session, relative = self._session_for(key)
         kind = session.directory_entry_kind(relative)
         if kind == "directory":
+            if not allow_directory:
+                raise ValueError("selected input is a directory, expected a regular file")
             self.bind_directory(key)
         elif kind == "file":
             self.read_bytes(key, max_bytes=max_bytes)

--- a/src/agents_shipgate/core/static_inputs.py
+++ b/src/agents_shipgate/core/static_inputs.py
@@ -194,6 +194,31 @@ class StaticInputSnapshot:
         session, relative = self._session_for(key)
         return session.directory_entries(relative, max_entries=self.max_files)
 
+    def capture_selected_path(
+        self, path: Path, *, max_bytes: int = DEFAULT_STATIC_INPUT_FILE_BYTES,
+    ) -> None:
+        """Bind a selected lookup before its caller can resolve away an alias.
+
+        Files use the same cached bytes their parser will consume. Directories
+        are bound for this read session only; actual discovery must still call
+        enumerate_input_directory to select a persistent membership obligation.
+        """
+
+        if self._finished or ".." in path.parts:
+            raise ValueError("invalid selected input lookup")
+        if path == self.root:
+            self.bind_directory(path)
+            return
+        key, _relative = self._key(path)
+        session, relative = self._session_for(key)
+        kind = session.directory_entry_kind(relative)
+        if kind == "directory":
+            self.bind_directory(key)
+        elif kind == "file":
+            self.read_bytes(key, max_bytes=max_bytes)
+        else:
+            raise ValueError(f"selected input is {kind}, not a regular file or directory")
+
     def mark_unconfirmable_input_directory(self, path: Path) -> None:
         """Keep a refused directory lookup visible even if an adapter recovers."""
 

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -987,8 +987,9 @@ def validate_dependency_inputs(plan: VerificationPlan, *, root: Path, snapshot=N
         raise ValueError("dependency input is both present and absent")
     if unconfirmable:
         raise ValueError(
-            "A guard dependency could not be captured. Inspect "
-            "tool_surface_facts.guard_dependencies, repair unreadable paths "
+            "An input dependency could not be captured. Inspect "
+            "dependency_inputs.unconfirmable_paths and the component/guard diagnostics, "
+            "repair unreadable paths "
             "and re-run verification before using current authority."
         )
     owns_snapshot = snapshot is None

--- a/src/agents_shipgate/inputs/codex_plugin.py
+++ b/src/agents_shipgate/inputs/codex_plugin.py
@@ -845,7 +845,7 @@ def _resolve_component_path(
     artifacts: CodexPluginArtifacts,
 ) -> Path | None:
     try:
-        resolved = _resolve_plugin_path(root, raw_path)
+        resolved = _resolve_plugin_path(root, raw_path, allow_directory=component == "skills")
     except InputParseError as exc:
         artifacts.component_path_issues.append(
             CodexPluginComponentPathIssue(
@@ -881,7 +881,7 @@ def _resolve_component_path(
     return resolved
 
 
-def _resolve_plugin_path(root: Path, raw_path: str) -> Path:
+def _resolve_plugin_path(root: Path, raw_path: str, *, allow_directory: bool) -> Path:
     raw = Path(raw_path)
     candidate = raw if raw.is_absolute() else root / raw_path
     snapshot = active_static_input_snapshot()
@@ -895,7 +895,9 @@ def _resolve_plugin_path(root: Path, raw_path: str) -> Path:
                 raise ValueError("component path is outside plugin root")
             if snapshot.excludes(candidate):
                 raise ValueError("component path overlaps excluded verification output")
-            snapshot.capture_selected_path(candidate, max_bytes=MAX_INPUT_FILE_BYTES)
+            snapshot.capture_selected_path(
+                candidate, max_bytes=MAX_INPUT_FILE_BYTES, allow_directory=allow_directory,
+            )
         except (OSError, ValueError) as exc:
             # The caller turns InputParseError into a component diagnostic.
             # Keep the failed lookup visible to currency validation as well:

--- a/src/agents_shipgate/inputs/codex_plugin.py
+++ b/src/agents_shipgate/inputs/codex_plugin.py
@@ -895,8 +895,12 @@ def _resolve_plugin_path(root: Path, raw_path: str, *, allow_directory: bool) ->
                 raise ValueError("component path is outside plugin root")
             if snapshot.excludes(candidate):
                 raise ValueError("component path overlaps excluded verification output")
+            # _skill_files treats this basename as a direct file before any
+            # directory walk. Match that selection, including './' when the
+            # plugin root itself is named SKILL.md, before parser recovery.
             snapshot.capture_selected_path(
-                candidate, max_bytes=MAX_INPUT_FILE_BYTES, allow_directory=allow_directory,
+                candidate, max_bytes=MAX_INPUT_FILE_BYTES,
+                allow_directory=allow_directory and candidate.name != "SKILL.md",
             )
         except (OSError, ValueError) as exc:
             # The caller turns InputParseError into a component diagnostic.

--- a/src/agents_shipgate/inputs/codex_plugin.py
+++ b/src/agents_shipgate/inputs/codex_plugin.py
@@ -10,7 +10,9 @@ from agents_shipgate.core.domain import (
     Tool,
 )
 from agents_shipgate.core.errors import InputParseError
+from agents_shipgate.core.static_inputs import active_static_input_snapshot
 from agents_shipgate.inputs.common import (
+    MAX_INPUT_FILE_BYTES,
     PositionIndex,
     json_pointer_escape,
     list_input_directory,
@@ -882,6 +884,30 @@ def _resolve_component_path(
 def _resolve_plugin_path(root: Path, raw_path: str) -> Path:
     raw = Path(raw_path)
     candidate = raw if raw.is_absolute() else root / raw_path
+    snapshot = active_static_input_snapshot()
+    if snapshot is not None and (root == snapshot.root or snapshot.contains(root)):
+        # Preserve the declared lookup. Resolving first would erase an in-root
+        # alias, leaving only its old target in the verification input set.
+        try:
+            if ".." in raw.parts:
+                raise ValueError("parent traversal is not a confirmable component lookup")
+            if candidate != root and root not in candidate.parents:
+                raise ValueError("component path is outside plugin root")
+            if snapshot.excludes(candidate):
+                raise ValueError("component path overlaps excluded verification output")
+            snapshot.capture_selected_path(candidate, max_bytes=MAX_INPUT_FILE_BYTES)
+        except (OSError, ValueError) as exc:
+            # The caller turns InputParseError into a component diagnostic.
+            # Keep the failed lookup visible to currency validation as well:
+            # repairing an alias must never reconfirm an old empty capture.
+            if ".." in raw.parts or candidate == root or root not in candidate.parents:
+                snapshot.mark_unconfirmable_input_directory(root)
+            else:
+                snapshot.mark_unconfirmable_dependency(candidate)
+            raise InputParseError(
+                f"Codex plugin component path {raw_path!r} could not be captured: {exc}"
+            ) from exc
+        return candidate
     resolved = candidate.resolve()
     try:
         resolved.relative_to(root.resolve())

--- a/tests/test_codex_plugin_input_identity.py
+++ b/tests/test_codex_plugin_input_identity.py
@@ -246,3 +246,46 @@ def test_prepare_and_worker_preserve_a_caught_missing_component(repo, committed,
     assert result.exit_code != 0
     assert not (reports / "replayed-unit.json").exists()
     assert "dependency could not be captured" in str(result.exception)
+
+
+@pytest.mark.parametrize("form", ["apps", "mcpServers", "hooks"])
+@pytest.mark.parametrize("committed", [False, True])
+def test_optional_file_component_directory_cannot_reconfirm_after_repair(repo, form, committed):
+    root, target, _ = plugin_source(repo, form)
+    data = target.read_bytes()
+    target.unlink()
+    target.mkdir()
+    # Git does not retain empty directories. Keep this wrong-kind selected
+    # path present in committed capture without making it a discovered source.
+    (target / "unread.txt").write_text("not a component")
+    manifest_path = repo / "shipgate.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text())
+    manifest["tool_sources"][0]["optional"] = True
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False))
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic optional file component is a directory")
+    _verify(repo, archive_head=committed)
+    reports = repo / "agents-shipgate-reports"
+    plan = plan_at(reports)
+    assert plan.inputs.options["dependency_inputs"]["unconfirmable_paths"] == [
+        target.relative_to(repo).as_posix()
+    ]
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=lambda: _live(repo))
+    result = CliRunner().invoke(app, [
+        "agent", "control", "--workspace", str(repo), "--reports-dir", str(reports),
+    ], env={"AGENTS_SHIPGATE_AGENT_MODE": "1"})
+    assert result.exit_code == 4, result.output
+    assert result.stdout == ""
+    shutil.rmtree(target)
+    target.write_bytes(data)
+    with pytest.raises(ValueError, match="dependency.*could not be captured"):
+        validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic optional component repair")
+    _verify(repo, archive_head=committed)
+    read_current_control(reports, live=lambda: _live(repo))
+    surface = json.loads((reports / "report.json").read_text())["codex_plugin_surface"]
+    count = {"apps": "app_count", "mcpServers": "mcp_server_stub_count", "hooks": "hook_stub_count"}[form]
+    assert surface[count] == 1
+    assert not (root / "never-execute").exists()

--- a/tests/test_codex_plugin_input_identity.py
+++ b/tests/test_codex_plugin_input_identity.py
@@ -248,7 +248,7 @@ def test_prepare_and_worker_preserve_a_caught_missing_component(repo, committed,
     assert "dependency could not be captured" in str(result.exception)
 
 
-@pytest.mark.parametrize("form", ["apps", "mcpServers", "hooks"])
+@pytest.mark.parametrize("form", ["skills_file", "apps", "mcpServers", "hooks"])
 @pytest.mark.parametrize("committed", [False, True])
 def test_optional_file_component_directory_cannot_reconfirm_after_repair(repo, form, committed):
     root, target, _ = plugin_source(repo, form)
@@ -286,6 +286,40 @@ def test_optional_file_component_directory_cannot_reconfirm_after_repair(repo, f
     _verify(repo, archive_head=committed)
     read_current_control(reports, live=lambda: _live(repo))
     surface = json.loads((reports / "report.json").read_text())["codex_plugin_surface"]
-    count = {"apps": "app_count", "mcpServers": "mcp_server_stub_count", "hooks": "hook_stub_count"}[form]
+    count = {
+        "skills_file": "skill_count", "apps": "app_count",
+        "mcpServers": "mcp_server_stub_count", "hooks": "hook_stub_count",
+    }[form]
     assert surface[count] == 1
     assert not (root / "never-execute").exists()
+
+
+@pytest.mark.parametrize("suffix", ["", "/", "/."])
+def test_direct_skill_directory_refusal_uses_the_selected_basename(repo, suffix):
+    root, target, key = plugin_source(repo, "skills_file")
+    target.unlink()
+    target.mkdir()
+    select_component(root, key, "./" + target.relative_to(root).as_posix() + suffix)
+    snapshot, artifacts = capture(repo)
+    assert not artifacts.skills
+    assert len(artifacts.component_path_issues) == 1
+    assert "directory, expected a regular file" in artifacts.component_path_issues[0].reason
+    assert snapshot.unconfirmable_dependency_paths() == [target]
+
+
+def test_root_named_skill_md_is_still_a_direct_file_selection(repo):
+    old_root, _, key = plugin_source(repo)
+    root = old_root.with_name("SKILL.md")
+    old_root.rename(root)
+    select_component(root, key, ".")
+    manifest_path = repo / "shipgate.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text())
+    manifest["tool_sources"][0]["path"] = root.relative_to(repo).as_posix()
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False))
+    snapshot, artifacts = capture(repo)
+    assert not artifacts.skills
+    assert len(artifacts.component_path_issues) == 1
+    assert "directory, expected a regular file" in artifacts.component_path_issues[0].reason
+    assert snapshot.input_directory_identity(source="worktree")["unconfirmable_paths"] == [
+        root.relative_to(repo).as_posix()
+    ]

--- a/tests/test_codex_plugin_input_identity.py
+++ b/tests/test_codex_plugin_input_identity.py
@@ -1,0 +1,248 @@
+"""A selected component's spelling must survive before its target is read."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+from test_codex_plugin import _write_skill_only_codex_plugin
+from test_current_control import _git, _live, _verify
+from test_current_control import repo as repo  # noqa: F401
+from test_current_control_input_origins import plan_at
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+from agents_shipgate.core.errors import ConfigError
+from agents_shipgate.core.static_inputs import (
+    StaticInputSnapshot,
+    activate_static_input_snapshot,
+    reset_static_input_snapshot,
+)
+from agents_shipgate.core.verification_input_currency import validate_current_plan_inputs
+from agents_shipgate.inputs.codex_plugin import load_codex_plugin_artifacts
+
+
+def plugin_source(repo: Path, form: str = "skills_directory") -> tuple[Path, Path, str]:
+    root = repo / "plugins" / "reviewer"
+    _write_skill_only_codex_plugin(root)
+    key = "skills" if form.startswith("skills_") else form
+    if form == "skills_directory":
+        target = root / "skills"
+    elif form == "skills_file":
+        target = root / "skills" / "review" / "SKILL.md"
+    else:
+        target = root / f"{form}.json"
+        payload = {
+            "apps": {"apps": {"example": {"id": "connector_example"}}},
+            "mcpServers": {"mcpServers": {"docs": {"command": "never-execute"}}},
+            "hooks": {"preRun": {"command": "never-execute"}},
+        }[form]
+        target.write_text(json.dumps(payload), encoding="utf-8")
+    select_component(root, key, target.relative_to(root).as_posix())
+    path = repo / "shipgate.yaml"
+    manifest = yaml.safe_load(path.read_text())
+    manifest["tool_sources"] = [{
+        "id": "plugin", "type": "codex_plugin", "mode": "package",
+        "path": "plugins/reviewer",
+    }]
+    path.write_text(yaml.safe_dump(manifest, sort_keys=False))
+    return root, target, key
+
+
+def select_component(root: Path, key: str, path: str) -> None:
+    manifest = root / ".codex-plugin" / "plugin.json"
+    data = json.loads(manifest.read_text())
+    data[key] = path
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+
+
+def capture(repo: Path):
+    snapshot = StaticInputSnapshot(repo)
+    token = activate_static_input_snapshot(snapshot)
+    try:
+        manifest = load_manifest(repo / "shipgate.yaml")
+        _, artifacts = load_codex_plugin_artifacts(manifest, repo)
+        snapshot.finish()
+    finally:
+        reset_static_input_snapshot(token)
+    assert artifacts is not None
+    return snapshot, artifacts
+
+
+def symlink(link: Path, target: Path, *, directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+
+@pytest.mark.parametrize("committed", [False, True])
+@pytest.mark.parametrize("fault", ["alias", "missing"])
+def test_caught_component_lookup_never_publishes_current_authority(repo, committed, fault):
+    root, target, key = plugin_source(repo)
+    alias = root / "skills-alias"
+    if fault == "alias":
+        symlink(alias, Path("skills"), directory=True)
+    select_component(root, key, "./skills-alias")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic aliased component")
+    reports = repo / "agents-shipgate-reports"
+    plan = None
+    if committed and fault == "alias":
+        # Committed archives already reject tracked symlinks before adapters
+        # run. Preserve that stronger boundary: its current failure record
+        # carries no permissions, rather than a successful component capture.
+        with pytest.raises(ConfigError, match="unsupported external binding"):
+            _verify(repo, archive_head=True)
+    else:
+        _verify(repo, archive_head=committed)
+        plan = plan_at(reports)
+        assert plan.inputs.options["dependency_inputs"]["unconfirmable_paths"] == [
+            "plugins/reviewer/skills-alias"
+        ]
+    if plan is None:
+        refused = read_current_control(reports, live=lambda: _live(repo)).pointer
+        assert refused.control.state == "human_review_required"
+        assert not any(refused.control.permissions.model_dump().values())
+    else:
+        with pytest.raises(CurrentControlUnavailable):
+            read_current_control(reports, live=lambda: _live(repo))
+    result = CliRunner().invoke(app, [
+        "agent", "control", "--workspace", str(repo), "--reports-dir", str(reports),
+    ], env={"AGENTS_SHIPGATE_AGENT_MODE": "1"})
+    if plan is None:
+        assert result.exit_code == 0, result.output
+        assert not any(json.loads(result.stdout)["permissions"].values())
+    else:
+        assert result.exit_code == 4, result.output
+        assert result.stdout == ""
+        assert "verify" in json.loads(result.stderr.splitlines()[-1])["next_action"]
+
+    # Isolate the captured refusal from Git's independent drift check: even a
+    # now ordinary directory cannot reconfirm an old refused/empty capture.
+    if fault == "alias":
+        alias.unlink()
+    shutil.copytree(target, alias)
+    if plan is not None:
+        with pytest.raises(ValueError, match="dependency.*could not be captured"):
+            validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic component repair")
+    _verify(repo, archive_head=committed)
+    refreshed = read_current_control(reports, live=lambda: _live(repo)).pointer
+    assert refreshed.control.permissions.update_pr
+
+
+@pytest.mark.parametrize("form", ["skills_directory", "skills_file", "apps", "mcpServers", "hooks"])
+def test_selected_component_alias_is_captured_before_resolution(repo, form):
+    root, target, key = plugin_source(repo, form)
+    alias = root / ("SKILL.md" if form == "skills_file" else "component-alias")
+    symlink(alias, target.relative_to(root), directory=target.is_dir())
+    select_component(root, key, "./" + alias.name)
+    snapshot, artifacts = capture(repo)
+    assert len(artifacts.component_path_issues) == 1
+    assert artifacts.component_path_issues[0].path == "./" + alias.name
+    assert snapshot.unconfirmable_dependency_paths() == [alias]
+    assert not snapshot.paths_under(target)
+
+
+@pytest.mark.parametrize("form", ["skills_directory", "skills_file", "apps", "mcpServers", "hooks"])
+@pytest.mark.parametrize("committed", [False, True])
+def test_ordinary_components_remain_current(repo, form, committed):
+    plugin_source(repo, form)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic ordinary component")
+    _verify(repo, archive_head=committed)
+    reports = repo / "agents-shipgate-reports"
+    read_current_control(reports, live=lambda: _live(repo))
+    assert not plan_at(reports).inputs.options.get("dependency_inputs", {}).get("unconfirmable_paths")
+
+
+@pytest.mark.parametrize("fault", ["parent_alias", "canceled_parent_alias", "missing_parent", "outside", "dangling", "cycle", "special"])
+def test_failed_lexical_lookups_keep_bounded_diagnostics(repo, fault):
+    import os
+
+    root, target, key = plugin_source(repo)
+    selected = root / "lookup"
+    if fault in {"parent_alias", "canceled_parent_alias"}:
+        symlink(selected, Path("skills"), directory=True)
+        raw = "lookup/review/SKILL.md" if fault == "parent_alias" else "lookup/../skills"
+    elif fault == "missing_parent":
+        raw = "missing/nested/SKILL.md"
+    elif fault == "outside":
+        raw = str(repo / "tools.json")
+    elif fault in {"dangling", "cycle"}:
+        symlink(selected, Path("not-present" if fault == "dangling" else "lookup"))
+        raw = "lookup"
+    else:
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO creation unavailable")
+        os.mkfifo(selected)
+        raw = "lookup"
+    select_component(root, key, raw)
+    snapshot, artifacts = capture(repo)
+    assert len(artifacts.component_path_issues) == 1
+    issue = artifacts.component_path_issues[0]
+    assert issue.component == "skills"
+    assert issue.path == raw
+    assert "could not be captured" in issue.reason
+    assert len(issue.reason) < 1200
+    assert not artifacts.skills
+    assert not snapshot.paths_under(target)
+    assert snapshot.unconfirmable_dependency_paths() or snapshot.input_directory_identity(
+        source="worktree"
+    )["unconfirmable_paths"]
+
+
+def test_standalone_in_root_alias_behavior_is_unchanged(repo):
+    root, _, key = plugin_source(repo)
+    symlink(root / "alias", Path("skills"), directory=True)
+    select_component(root, key, "./alias")
+    _, artifacts = load_codex_plugin_artifacts(load_manifest(repo / "shipgate.yaml"), repo)
+    assert artifacts is not None
+    assert [skill.name for skill in artifacts.skills] == ["review"]
+    assert not artifacts.component_path_issues
+
+
+@pytest.mark.parametrize("form", ["skills_directory", "skills_file", "apps", "mcpServers", "hooks"])
+def test_component_file_bytes_are_cached_and_incidental_parent_is_not_a_source(repo, form):
+    root, target, _ = plugin_source(repo, form)
+    snapshot, artifacts = capture(repo)
+    assert not artifacts.component_path_issues
+    if target.is_file():
+        assert snapshot.has(target)
+    directories = snapshot.input_directory_identity(source="worktree")["directories"]
+    assert root.relative_to(repo).as_posix() not in {row["path"] for row in directories}
+
+
+@pytest.mark.parametrize("committed", [False, True])
+@pytest.mark.parametrize("form", ["skills_directory", "apps"])
+def test_prepare_and_worker_preserve_a_caught_missing_component(repo, committed, form):
+    root, _, key = plugin_source(repo, form)
+    select_component(root, key, "./missing-component")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic missing component")
+    reports = repo / "agents-shipgate-reports"
+    result = CliRunner().invoke(app, [
+        "verification", "prepare", "--workspace", str(repo), "--no-plugins",
+        "--out", str(reports / "verification-plan.json"),
+        *(["--base", "HEAD", "--head", "HEAD"] if committed else []),
+    ])
+    assert result.exit_code == 0, str(result.exception)
+    plan = plan_at(reports)
+    assert "plugins/reviewer/missing-component" in plan.inputs.options[
+        "dependency_inputs"
+    ]["unconfirmable_paths"]
+    result = CliRunner().invoke(app, [
+        "verification", "worker", "--plan", str(reports / "verification-plan.json"),
+        "--workspace", str(repo), "--diff", str(reports / "verification-input.diff"),
+        "--out", str(reports / "replayed-unit.json"),
+    ])
+    assert result.exit_code != 0
+    assert not (reports / "replayed-unit.json").exists()
+    assert "dependency could not be captured" in str(result.exception)

--- a/tests/test_static_inputs.py
+++ b/tests/test_static_inputs.py
@@ -128,6 +128,8 @@ def test_caught_directory_cap_retains_an_unconfirmable_obligation(tmp_path):
 
 def test_selected_root_is_bound_without_selecting_a_directory_census(tmp_path):
     snapshot = StaticInputSnapshot(tmp_path)
+    with pytest.raises(ValueError, match="directory, expected a regular file"):
+        snapshot.capture_selected_path(tmp_path, allow_directory=False)
     snapshot.capture_selected_path(tmp_path)
     snapshot.finish()
     assert snapshot.input_directory_identity(source="worktree")["directories"] == []

--- a/tests/test_static_inputs.py
+++ b/tests/test_static_inputs.py
@@ -124,3 +124,23 @@ def test_caught_directory_cap_retains_an_unconfirmable_obligation(tmp_path):
     with pytest.raises(ValueError):
         snapshot.enumerate_input_directory(tmp_path)
     assert snapshot.input_directory_identity(source='worktree')['unconfirmable_paths'] == ['.']
+
+
+def test_selected_root_is_bound_without_selecting_a_directory_census(tmp_path):
+    snapshot = StaticInputSnapshot(tmp_path)
+    snapshot.capture_selected_path(tmp_path)
+    snapshot.finish()
+    assert snapshot.input_directory_identity(source="worktree")["directories"] == []
+    with pytest.raises(ValueError, match="invalid selected input lookup"):
+        snapshot.capture_selected_path(tmp_path)
+
+
+def test_selected_file_obeys_the_parser_byte_bound_even_when_cached(tmp_path):
+    path = tmp_path / "selected.json"
+    path.write_bytes(b"12345")
+    snapshot = StaticInputSnapshot(tmp_path)
+    snapshot.read_bytes(path)
+    with pytest.raises(ValueError, match="4-byte read limit"):
+        snapshot.capture_selected_path(path, max_bytes=4)
+    with pytest.raises(ValueError, match="invalid selected input lookup"):
+        snapshot.capture_selected_path(tmp_path / "alias" / ".." / path.name)


### PR DESCRIPTION
A declared Codex plugin component such as `skills: ./skills-alias` could be resolved before verification captured its lexical lookup. Retargeting the alias changed the next static skill surface while the old resolved files and directory census still validated. Caught lookup errors also needed to remain visible instead of becoming an apparently complete empty capture.

The plugin reader now validates the selected path before resolution during capture. Ordinary files share the parser's cached, bounded byte read; directories bind identity before actual discovery selects membership. Aliases, parent traversal, missing/unreadable paths and unsupported kinds leave an unconfirmable obligation before the existing component diagnostic catches the error. Apps/MCP/hooks require regular files; a directory is rejected before optional-source recovery can swallow its parser failure. Skills retain ordinary directory and direct `SKILL.md` forms; a selected path named `SKILL.md` must be a regular file, matching the actual reader shortcut even for trailing-path or plugin-root spellings. Repairing the path requires a fresh verification. The dependency refusal message now covers component and guard inputs accurately.

Standalone in-root resolution and the earlier committed-archive symlink rejection remain intact. No component is executed, no permission/declaration is supplied, and incidental plugin-root siblings do not become directory inputs. ROADMAP and reproducibility documentation distinguish this repair from the separately reproduced implicit-default gap in #635, deferred until after this PR and before final input-set qualification/#569 freeze.

Validation:

- Real worktree-verifier red regression failed on the old implementation because the rejected lookup was absent from `dependency_inputs`.
- Final review-fix full suite: **9,751 passed, 5 skipped** (423.71 s). Focused plugin/current-control/directory set: 112 passed, including all four file forms and restored real surface counts after fresh verification.
- Actual verifier/current-control CLI and prepare/worker tests cover ordinary and missing component forms in worktree/committed modes, aliases and repair, direct `SKILL.md`, apps/MCP/hooks, parent/canceled-parent aliases, dangling/cyclic links and special files.
- Committed symlinks fail at the existing archive boundary; their current failure record has every permission false. This does not claim a demonstrated committed merge bypass.
- Ruff, schema drift and all 24 sample artifacts pass; no generated artifact changed.

Independent coding-agent [round 1](https://github.com/ThreeMoonsLab/agents-shipgate/pull/636#pullrequestreview-5166751895) found the optional file-component directory gap (124 isolated tests passed on the original head). The review fix adds component-specific kind constraints and six real committed/worktree verifier/CLI regressions, including refusal after repair and the restored app/MCP/hook counts after a fresh run. Independent [round 2](https://github.com/ThreeMoonsLab/agents-shipgate/pull/636#pullrequestreview-5166911639) confirmed that repair and found the direct `SKILL.md` directory variant (130 isolated tests passed). The final fix binds that direct-file kind too, with actual verifier/CLI and path-spelling regressions. Independent [round 3](https://github.com/ThreeMoonsLab/agents-shipgate/pull/636#pullrequestreview-5167090807) confirmed both findings fixed and no remaining actionable findings; 136 isolated tests passed, with all seven published file blobs checked. [Round 1 address](https://github.com/ThreeMoonsLab/agents-shipgate/pull/636#issuecomment-5618438175) and [round 2 address](https://github.com/ThreeMoonsLab/agents-shipgate/pull/636#issuecomment-5618672545) bind the two fixes. The [round 3 address](https://github.com/ThreeMoonsLab/agents-shipgate/pull/636#issuecomment-5618754540) completes three formal review/address loops; both finding threads are resolved. All nine required native GitHub Actions checks on final head `d670456fc9f3e018fb22116110bd0d5e4d897124` passed, including combined coverage ([CI run](https://github.com/ThreeMoonsLab/agents-shipgate/actions/runs/34476905023)). The non-required release-tag-consistency check was skipped for this non-release PR. Fresh current-control permission is still required at merge. This is a bounded implementation of #633, not v1.0 qualification or human release approval.

Closes #633. Refs #630, #627, #597, #572. Deferred: #635.
