### PR TITLE
fix: bind implicit Codex plugin default selection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -175,11 +175,15 @@ The #633 implementation pass separately reproduced
 [#635](https://github.com/ThreeMoonsLab/agents-shipgate/issues/635): an implicit
 `.app.json` can appear and change the next app surface while old full input
 currency still passes. Its absent default was never selected for capture.
-Keep this P1 named default-selection obligation after #633 and before final
-input-set qualification/#569 freeze, deferred from the selected-component PR.
-It must preserve unrelated sibling independence rather than census the whole
-plugin root. The reproduction is loader/currency evidence, not a Git authority
-or merge-bypass demonstration.
+The #635 repair binds named absence/presence for implicit `skills`, `.app.json`
+and `.mcp.json` before selection. An exact-name miss must also fail a no-follow
+lookup before it counts as absence; a case alias or unreadable lookup remains
+an unconfirmable dependency with a component diagnostic. Explicit paths do not
+bind unused defaults, and unrelated root siblings stay outside the input set.
+Actual verifier/current-control and prepare/worker regressions cover ignored
+default insertion, including both control observations and committed/worktree
+plans. This follows #633 and precedes final input-set qualification/#569 freeze;
+it does not qualify all reader discovery or establish a merge-permission bypass.
 
 The following sequence and approved release bars still apply. Contract
 convergence, historical catch results, report freeze, actual human ownership,

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -124,12 +124,18 @@ Committed archives already reject tracked symlinks before component loading;
 their failure record grants no permissions. Standalone loading retains its
 existing in-root resolution behavior.
 
-This does not claim that every reader retains every lookup. The separately
-reproduced implicit default-selection gap — adding a previously absent
-`.app.json` without changing the plugin manifest — remains deferred in
-[#635](https://github.com/ThreeMoonsLab/agents-shipgate/issues/635). A named
-default's absence must be bound where selection happens; broad plugin-root
-membership is not a substitute.
+Implicit Codex plugin defaults (`skills`, `.app.json`, `.mcp.json`) bind named
+absence or presence before selection (#635). A missing exact directory entry
+counts as absence only when a no-follow probe of that name also reports it
+missing. Case aliases, unreadable lookups and excluded output overlap retain
+an unconfirmable dependency and a component-path diagnostic. A later successful
+retry does not clear a captured failure; repair needs fresh verification.
+Existing defaults use the same component kind and byte capture described above.
+Explicit component paths do not bind unused defaults, hooks gain no default,
+and unrelated plugin-root siblings are not input dependencies. The existing
+`dependency_inputs` obligations are checked in both current-control observations
+and prepare/worker replay. This closes the reproduced default-selection gap;
+it does not claim that every reader retains every lookup.
 
 `excluded_paths` records Git metadata and the exact generated report subtree,
 mapped into the archive for committed capture. A live output-only parent such

--- a/src/agents_shipgate/core/static_inputs.py
+++ b/src/agents_shipgate/core/static_inputs.py
@@ -130,12 +130,25 @@ class StaticInputSnapshot:
         """Capture a named absent lookup candidate, including its parent listing."""
 
         key, _relative = self._key(path)
-        names = self.bind_directory(key.parent)
-        if key.name in names:
-            self._present_dependency_paths.add(key)
-            return False
-        self._absent_dependency_paths.add(key)
-        return True
+        try:
+            names = self.bind_directory(key.parent)
+            if key.name in names:
+                self._present_dependency_paths.add(key)
+                return False
+            # An exact listing miss can still resolve on a case-insensitive
+            # filesystem. Probe only this name, without following its target;
+            # the bound parent is rechecked when the session finishes.
+            try:
+                key.lstat()
+            except FileNotFoundError:
+                self._absent_dependency_paths.add(key)
+                return True
+            raise ValueError("path resolves through a differently spelled filesystem entry")
+        except (OSError, ValueError):
+            # Readers may recover from a lookup failure. Keep its obligation
+            # even when they return a diagnostic instead of parsed evidence.
+            self.mark_unconfirmable_dependency(key)
+            raise
 
     def dependency_paths(self) -> list[Path]:
         return sorted(self._dependency_paths)

--- a/src/agents_shipgate/inputs/codex_plugin.py
+++ b/src/agents_shipgate/inputs/codex_plugin.py
@@ -564,7 +564,7 @@ def _load_skills(
     plugin_name: str,
     artifacts: CodexPluginArtifacts,
 ) -> None:
-    paths = _component_paths(data, root, "skills", default="skills")
+    paths = _component_paths(data, root, "skills", plugin_name, artifacts, default="skills")
     skill_files: list[Path] = []
     for path in paths:
         resolved = _resolve_component_path(
@@ -630,7 +630,7 @@ def _load_apps(
     plugin_name: str,
     artifacts: CodexPluginArtifacts,
 ) -> None:
-    for path in _component_paths(data, root, "apps", default=".app.json"):
+    for path in _component_paths(data, root, "apps", plugin_name, artifacts, default=".app.json"):
         resolved = _resolve_component_path(
             root=root,
             base_dir=base_dir,
@@ -678,7 +678,7 @@ def _load_mcp_servers(
     inventories: dict[tuple[str, str], CodexPluginMcpInventoryConfig],
 ) -> list[LoadedToolSource]:
     loaded_sources: list[LoadedToolSource] = []
-    for path in _component_paths(data, root, "mcpServers", default=".mcp.json"):
+    for path in _component_paths(data, root, "mcpServers", plugin_name, artifacts, default=".mcp.json"):
         resolved = _resolve_component_path(
             root=root,
             base_dir=base_dir,
@@ -788,7 +788,7 @@ def _load_hooks(
     plugin_name: str,
     artifacts: CodexPluginArtifacts,
 ) -> None:
-    for path in _component_paths(data, root, "hooks"):
+    for path in _component_paths(data, root, "hooks", plugin_name, artifacts):
         resolved = _resolve_component_path(
             root=root,
             base_dir=base_dir,
@@ -821,6 +821,8 @@ def _component_paths(
     data: dict[str, Any],
     root: Path,
     key: str,
+    plugin: str,
+    artifacts: CodexPluginArtifacts,
     *,
     default: str | None = None,
 ) -> list[str]:
@@ -830,8 +832,27 @@ def _component_paths(
         paths.append(value)
     elif isinstance(value, list):
         paths.extend(item for item in value if isinstance(item, str) and item.strip())
-    if not paths and default and (root / default).exists():
-        paths.append(default)
+    if not paths and default:
+        candidate = root / default
+        snapshot = active_static_input_snapshot()
+        if snapshot is not None and (root == snapshot.root or snapshot.contains(root)):
+            try:
+                if snapshot.excludes(candidate):
+                    raise ValueError("default component path overlaps excluded verification output")
+                if not snapshot.bind_dependency_absence(candidate):
+                    paths.append(default)
+            except (OSError, ValueError) as exc:
+                snapshot.mark_unconfirmable_dependency(candidate)
+                artifacts.component_path_issues.append(
+                    CodexPluginComponentPathIssue(
+                        plugin=plugin,
+                        component=key,
+                        path=default,
+                        reason=f"Default component lookup could not be captured: {exc}",
+                    )
+                )
+        elif candidate.exists():
+            paths.append(default)
     return paths
 
 

--- a/tests/test_codex_plugin_default_identity.py
+++ b/tests/test_codex_plugin_default_identity.py
@@ -1,0 +1,327 @@
+"""Implicit plugin components bind named selection, including real absence."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from test_codex_plugin_input_identity import capture, plugin_source, select_component, symlink
+from test_current_control import _git, _live, _verify
+from test_current_control import repo as repo  # noqa: F401
+from test_current_control_input_origins import plan_at
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.core.current_control import CurrentControlUnavailable, read_current_control
+from agents_shipgate.core.static_inputs import (
+    StaticInputSnapshot,
+    activate_static_input_snapshot,
+    reset_static_input_snapshot,
+)
+from agents_shipgate.core.verification_input_currency import validate_current_plan_inputs
+from agents_shipgate.inputs.codex_plugin import load_codex_plugin_artifacts
+
+DEFAULTS = {"skills": "skills", "apps": ".app.json", "mcpServers": ".mcp.json"}
+
+
+def missing_default(repo, key):
+    root, _, _ = plugin_source(repo)
+    path = root / ".codex-plugin" / "plugin.json"
+    data = json.loads(path.read_text())
+    data.pop(key, None)
+    path.write_text(json.dumps(data))
+    target = root / DEFAULTS[key]
+    if target.is_dir():
+        shutil.rmtree(target)
+    with (repo / ".gitignore").open("a") as handle:
+        handle.write(f"/{target.relative_to(repo).as_posix()}\n")
+        handle.write("/plugins/reviewer/unrelated.txt\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Synthetic absent default component")
+    return root, target
+
+
+def add_default(target, key):
+    if key == "skills":
+        (target / "added").mkdir(parents=True)
+        (target / "added" / "SKILL.md").write_text(
+            "---\nname: added\ndescription: Review only\n---\nReview.\n"
+        )
+    else:
+        target.write_text(json.dumps({
+            "apps": {"apps": {"example": {"id": "connector_example"}}},
+            "mcpServers": {"mcpServers": {"docs": {"command": "never-execute"}}},
+        }[key]))
+
+
+@pytest.mark.parametrize("key", DEFAULTS)
+@pytest.mark.parametrize("committed", [False, True])
+@pytest.mark.parametrize("observation", [0, 1, 2])
+def test_ignored_default_insertion_invalidates_current_control(repo, key, committed, observation):
+    _, target = missing_default(repo, key)
+    _verify(repo, archive_head=committed)
+    reports = repo / "agents-shipgate-reports"
+    read_current_control(reports, live=lambda: _live(repo))
+    calls = []
+    if observation == 0:
+        add_default(target, key)
+
+    def live():
+        state = _live(repo)
+        calls.append(1)
+        if len(calls) == observation:
+            add_default(target, key)
+        return state
+
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=live)
+    assert _live(repo).changed_paths == ()
+    result = CliRunner().invoke(app, [
+        "agent", "control", "--workspace", str(repo), "--reports-dir", str(reports),
+    ], env={"AGENTS_SHIPGATE_AGENT_MODE": "1"})
+    assert result.exit_code == 4, result.output
+    assert result.stdout == ""
+    assert "verify" in json.loads(result.stderr.splitlines()[-1])["next_action"]
+    _, artifacts = capture(repo)
+    assert getattr(artifacts, {"mcpServers": "mcp_server_stubs"}.get(key, key))
+
+
+@pytest.mark.parametrize("key", DEFAULTS)
+@pytest.mark.parametrize("committed", [False, True])
+def test_prepare_worker_reject_a_new_default(repo, key, committed):
+    _, target = missing_default(repo, key)
+    reports = repo / "agents-shipgate-reports"
+    result = CliRunner().invoke(app, [
+        "verification", "prepare", "--workspace", str(repo), "--no-plugins",
+        "--out", str(reports / "verification-plan.json"),
+        *(["--base", "HEAD", "--head", "HEAD"] if committed else []),
+    ])
+    assert result.exit_code == 0, str(result.exception)
+    plan = plan_at(reports)
+    validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    command = [
+        "verification", "worker", "--plan", str(reports / "verification-plan.json"),
+        "--workspace", str(repo), "--diff", str(reports / "verification-input.diff"),
+        "--out", str(reports / "replayed-unit.json"),
+    ]
+    result = CliRunner().invoke(app, command)
+    assert result.exit_code == 0, str(result.exception)
+    (reports / "replayed-unit.json").unlink()
+    add_default(target, key)
+    with pytest.raises(ValueError, match="lookup candidate appeared"):
+        validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    result = CliRunner().invoke(app, command)
+    assert result.exit_code != 0
+    assert "lookup candidate appeared" in str(result.exception)
+    assert not (reports / "replayed-unit.json").exists()
+
+
+def test_named_absence_rejects_a_case_alias_on_this_filesystem(tmp_path):
+    (tmp_path / ".APP.JSON").write_text("{}")
+    candidate = tmp_path / ".app.json"
+    if not candidate.exists():
+        pytest.skip("filesystem keeps these names distinct")
+    snapshot = StaticInputSnapshot(tmp_path)
+    with pytest.raises(ValueError, match="differently spelled"):
+        snapshot.bind_dependency_absence(candidate)
+    assert snapshot.absent_dependency_paths() == []
+    assert snapshot.unconfirmable_dependency_paths() == [candidate]
+
+
+@pytest.mark.parametrize("key", DEFAULTS)
+@pytest.mark.parametrize("explicit", [False, True])
+def test_only_selected_defaults_bind_named_dependencies(repo, key, explicit):
+    root, target = missing_default(repo, key)
+    if explicit:
+        selected = root / "explicit-component"
+        add_default(selected, key)
+        select_component(root, key, selected.name)
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "Synthetic explicit component")
+    _verify(repo, archive_head=False)
+    reports = repo / "agents-shipgate-reports"
+    plan = plan_at(reports)
+    dependencies = plan.inputs.options["dependency_inputs"]
+    relative = target.relative_to(repo).as_posix()
+    assert (relative in dependencies["absent_paths"]) is not explicit
+    assert relative not in dependencies["present_paths"]
+    assert root.relative_to(repo).as_posix() not in {
+        row["path"] for row in plan.inputs.options["input_directories"]["directories"]
+    }
+    (root / "unrelated.txt").write_text("not read by the plugin")
+    if explicit:
+        add_default(target, key)
+    assert _live(repo).changed_paths == ()
+    read_current_control(reports, live=lambda: _live(repo))
+
+
+@pytest.mark.parametrize("key", DEFAULTS)
+@pytest.mark.parametrize("committed", [False, True])
+def test_present_implicit_component_uses_normal_capture_and_fresh_verification(repo, key, committed):
+    _, target = missing_default(repo, key)
+    add_default(target, key)
+    _git(repo, "add", "-f", str(target.relative_to(repo)))
+    _git(repo, "commit", "-m", "Synthetic present default")
+    _verify(repo, archive_head=committed)
+    reports = repo / "agents-shipgate-reports"
+    read_current_control(reports, live=lambda: _live(repo))
+    plan = plan_at(reports)
+    assert target.relative_to(repo).as_posix() in plan.inputs.options[
+        "dependency_inputs"
+    ]["present_paths"]
+    if target.is_dir():
+        shutil.rmtree(target)
+    else:
+        target.unlink()
+    with pytest.raises((OSError, ValueError)):
+        validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    _git(repo, "add", "-u")
+    _git(repo, "commit", "-m", "Synthetic default removal")
+    _verify(repo, archive_head=committed)
+    read_current_control(reports, live=lambda: _live(repo))
+
+
+@pytest.mark.parametrize("key", DEFAULTS)
+@pytest.mark.parametrize("fault", ["dangling", "cycle", "alias", "special", "wrong_kind"])
+def test_failed_implicit_components_keep_diagnostics_and_obligations(repo, key, fault):
+    import os
+
+    root, target = missing_default(repo, key)
+    if fault in {"dangling", "cycle", "alias"}:
+        destination = Path("missing" if fault == "dangling" else target.name)
+        if fault == "alias":
+            destination = Path("ordinary")
+            add_default(root / destination, key)
+        symlink(target, destination, directory=key == "skills")
+    elif fault == "special":
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO creation unavailable")
+        os.mkfifo(target)
+    elif key == "skills":
+        target.write_text("not a skill directory")
+    else:
+        target.mkdir()
+    snapshot, artifacts = capture(repo)
+    issues = [issue for issue in artifacts.component_path_issues if issue.component == key]
+    assert len(issues) == 1
+    assert issues[0].path == target.name
+    assert len(issues[0].reason) < 1200
+    assert target in snapshot.present_dependency_paths()
+    if fault == "wrong_kind" and key == "skills":
+        # Ordinary bytes remain bound even when skill parsing diagnoses them.
+        assert snapshot.has(target)
+    else:
+        assert target in snapshot.unconfirmable_dependency_paths()
+
+
+@pytest.mark.parametrize("present", [False, True])
+def test_excluded_default_cannot_be_confirmed_absent_or_read(repo, present):
+    _, target = missing_default(repo, "apps")
+    if present:
+        add_default(target, "apps")
+    snapshot = StaticInputSnapshot(repo, excluded_paths=[target])
+    token = activate_static_input_snapshot(snapshot)
+    try:
+        _, artifacts = load_codex_plugin_artifacts(load_manifest(repo / "shipgate.yaml"), repo)
+        snapshot.finish()
+    finally:
+        reset_static_input_snapshot(token)
+    assert target not in snapshot.absent_dependency_paths()
+    assert target in snapshot.unconfirmable_dependency_paths()
+    assert not snapshot.has(target)
+    assert any("excluded verification output" in row.reason for row in artifacts.component_path_issues)
+
+
+@pytest.mark.parametrize("failure", ["permission", "cap"])
+def test_default_lookup_failures_remain_named_even_if_a_later_probe_succeeds(repo, monkeypatch, failure):
+    root, target = missing_default(repo, "apps")
+    original = StaticInputSnapshot.bind_dependency_absence
+    calls = []
+
+    def fail_once(self, path):
+        if path == target and not calls:
+            calls.append(1)
+
+            def fail_parent(path):
+                assert path == root
+                if failure == "permission":
+                    raise PermissionError("synthetic unreadable plugin parent")
+                raise ValueError("synthetic directory entry cap")
+
+            with monkeypatch.context() as scoped:
+                scoped.setattr(self, "bind_directory", fail_parent)
+                return original(self, path)
+        return original(self, path)
+
+    monkeypatch.setattr(StaticInputSnapshot, "bind_dependency_absence", fail_once)
+    snapshot, artifacts = capture(repo)
+    assert calls == [1]
+    assert snapshot.unconfirmable_dependency_paths() == [target]
+    assert target not in snapshot.absent_dependency_paths()
+    assert artifacts.component_path_issues[0].path == ".app.json"
+    assert "Default component lookup could not be captured" in artifacts.component_path_issues[0].reason
+
+
+def test_case_alias_added_after_absence_is_refused_by_full_currency(repo):
+    root, target = missing_default(repo, "apps")
+    with (repo / ".gitignore").open("a") as handle:
+        handle.write("/plugins/reviewer/.APP.JSON\n")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-m", "Synthetic ignored alias")
+    _verify(repo, archive_head=False)
+    reports = repo / "agents-shipgate-reports"
+    (root / ".APP.JSON").write_text("{}")
+    if not target.exists():
+        pytest.skip("filesystem keeps these names distinct")
+    assert _live(repo).changed_paths == ()
+    with pytest.raises(ValueError, match="differently spelled"):
+        validate_current_plan_inputs(plan_at(reports), root=repo, artifacts_root=reports)
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=lambda: _live(repo))
+
+
+@pytest.mark.parametrize("value", [None, "", " ", [], ["", 7], 42])
+def test_empty_or_invalid_explicit_paths_preserve_default_selection(repo, value):
+    root, target = missing_default(repo, "apps")
+    path = root / ".codex-plugin" / "plugin.json"
+    data = json.loads(path.read_text())
+    data["apps"] = value
+    path.write_text(json.dumps(data))
+    snapshot, artifacts = capture(repo)
+    assert target in snapshot.absent_dependency_paths()
+    assert not artifacts.apps
+    add_default(target, "apps")
+    snapshot, artifacts = capture(repo)
+    assert target in snapshot.present_dependency_paths()
+    assert [row.name for row in artifacts.apps] == ["example"]
+
+
+@pytest.mark.parametrize("fault", ["dangling", "case_alias"])
+def test_failed_default_lookup_needs_fresh_verification_after_repair(repo, fault):
+    root, target = missing_default(repo, "apps")
+    alias = root / ".APP.JSON"
+    if fault == "case_alias":
+        alias.write_text("{}")
+        if not target.exists():
+            pytest.skip("filesystem keeps these names distinct")
+    else:
+        symlink(target, Path("missing"))
+    _verify(repo, archive_head=False)
+    reports = repo / "agents-shipgate-reports"
+    plan = plan_at(reports)
+    assert target.relative_to(repo).as_posix() in plan.inputs.options[
+        "dependency_inputs"
+    ]["unconfirmable_paths"]
+    with pytest.raises(CurrentControlUnavailable):
+        read_current_control(reports, live=lambda: _live(repo))
+    (alias if fault == "case_alias" else target).unlink()
+    add_default(target, "apps")
+    with pytest.raises(ValueError, match="dependency.*could not be captured"):
+        validate_current_plan_inputs(plan, root=repo, artifacts_root=reports)
+    _verify(repo, archive_head=False)
+    read_current_control(reports, live=lambda: _live(repo))
+    _, artifacts = capture(repo)
+    assert [row.name for row in artifacts.apps] == ["example"]

--- a/tests/test_static_inputs.py
+++ b/tests/test_static_inputs.py
@@ -117,6 +117,48 @@ def test_named_negative_lookup_and_file_parent_are_not_directory_sources(tmp_pat
     assert snapshot.input_directory_identity(source='worktree')['directories'] == []
 
 
+def test_named_negative_lookup_keeps_a_failed_probe_after_successful_retry(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    candidate = tmp_path / 'missing'
+    snapshot = StaticInputSnapshot(tmp_path)
+    original = Path.lstat
+
+    def unreadable(path):
+        if path == candidate:
+            raise PermissionError('synthetic named lookup failure')
+        return original(path)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(Path, 'lstat', unreadable)
+        with pytest.raises(PermissionError):
+            snapshot.bind_dependency_absence(candidate)
+    assert snapshot.absent_dependency_paths() == []
+    assert snapshot.bind_dependency_absence(candidate)
+    snapshot.finish()
+    assert snapshot.unconfirmable_dependency_paths() == [candidate]
+
+
+def test_named_negative_lookup_parent_cap_is_not_absence(tmp_path):
+    for name in ('a', 'b'):
+        (tmp_path / name).write_text(name)
+    candidate = tmp_path / 'missing'
+    snapshot = StaticInputSnapshot(tmp_path, max_files=1)
+    with pytest.raises(ValueError):
+        snapshot.bind_dependency_absence(candidate)
+    assert snapshot.absent_dependency_paths() == []
+    assert snapshot.unconfirmable_dependency_paths() == [candidate]
+
+
+def test_named_negative_lookup_rechecks_parent_at_finish(tmp_path):
+    snapshot = StaticInputSnapshot(tmp_path)
+    candidate = tmp_path / 'missing'
+    assert snapshot.bind_dependency_absence(candidate)
+    candidate.write_text('appeared during capture')
+    with pytest.raises(ValueError):
+        snapshot.finish()
+
+
 def test_caught_directory_cap_retains_an_unconfirmable_obligation(tmp_path):
     for name in ('a', 'b'):
         (tmp_path / name).write_text(name)


### PR DESCRIPTION
When a Codex plugin omits `skills`, `apps` or `mcpServers`, adding its previously absent default component could change the next static tool surface while the old full input currency check still passed. Bind the named default lookup before selection, so current-control and worker replay reject an appeared default even when Git ignores it.

Reuse the existing `dependency_inputs` absence/presence/refusal contract and #633's lexical component capture. An exact directory-listing miss now needs a no-follow named probe before it counts as absence: case aliases and unreadable lookups remain unconfirmable, including when a reader catches the error or a later probe succeeds. Plugin diagnostics name the default component. Excluded verification output cannot supply selection evidence. Explicit paths do not bind unused defaults, hooks gain no default, and unrelated plugin-root siblings stay outside the input set. Standalone loading retains its existing behavior; no components are executed.

Validation includes an actual red regression where `read_current_control` accepted an ignored default insertion, then committed/worktree verification, both current observations, CLI refusal, prepare/worker replay, repaired-path fresh verification, positive implicit and explicit selection, case aliases, wrong kinds, symlinks, output exclusions and bounded lookup failures. The plugin and guard-dependency regression pass had 184 passing tests; the completed default-component file has 65 passing tests. The full final-source suite passed: **9,819 passed, 5 skipped in 365.66s**. Ruff, diff hygiene, schema drift and all 24 sample goldens pass with no generated changes. Independent coding-agent [review round 1](https://github.com/ThreeMoonsLab/agents-shipgate/pull/637#pullrequestreview-5167562551) found no actionable issues, matched all six published file blobs and independently passed 204 isolated tests (0 failures/errors/skips). The [address response](https://github.com/ThreeMoonsLab/agents-shipgate/pull/637#issuecomment-5619328839) completes one formal review/address loop; no implementation change was needed. All nine required native GitHub Actions checks passed on `16cf82c2c1308eac21c12727a8184943ab3482dd`, including combined coverage ([CI run](https://github.com/ThreeMoonsLab/agents-shipgate/actions/runs/34481174427)). The non-required release-tag-consistency check was skipped for this non-release PR. Fresh current-control permission is still required at merge.

This closes the reproduced #635 selection gap before input-set qualification/#569 freeze. It does not qualify all reader discovery, prove runtime behavior, establish a merge-permission bypass, or supply the missing human release evidence.

Closes #635. Refs #633, #630, #569, #572.
