### PR TITLE
fix: bind base-scan cache to effective engine identity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,6 +83,17 @@ Git base, and report declared target changes separately from missing approval.
 unknown deployed reachability and false exclusion eligibility. #557 and #515 remain open; these source models do not satisfy
 the TypeScript MongoDB acceptance case or historical safety bars.
 
+The subsequent #515 prerequisite pass selects existing [#596](https://github.com/ThreeMoonsLab/agents-shipgate/issues/596)
+for v1.0: a real same-version engine replay exposed reuse of a base report made
+by an older reader. Base-cache keys now bind the effective engine requirement,
+shared once per invocation with the verification plan. Source-checkout and
+installed-wheel regressions exercise actual reader changes, old version-only
+keys, warm reuse and corrupt-record recovery. This is a cache compatibility
+repair before further #515 attribution/default work and #569 freeze. It does
+not supply the TypeScript dependency/frame proof, finding-exclusion eligibility
+or reviewed deployment declarations; OpenAPI operation attribution still
+reconstructs its base from Git independently of cached report claims.
+
 [#612](https://github.com/ThreeMoonsLab/agents-shipgate/pull/612) closes #545 and #516. It separates
 supported instruction structure from prose across the final/local verifier,
 preflight, host drift and exact edit-hook previews. Its successor schemas retain
@@ -119,7 +130,7 @@ continues to route that concrete plan to a human. The rejected optional PR
 trigger for #570 remains absent, but the existing manual workflow now runs.
 
 Newly discovered issues #575/#577/#580/#581, #584–#586, #588/#590, #592/#593,
-#596–#598/#601, #609–#611, #613/#615/#617/#618/#620 remain separately deferred; they are not silently
+#597/#598/#601, #609–#611, #613/#615/#617/#618/#620 remain separately deferred; they are not silently
 added to this implementation pass or counted as repairs. #609 documents a frozen
 preflight schema URL/discriminator mismatch; the current successor uses a fresh
 version without rewriting historical bytes. #610 owns the distinct compatibility

--- a/docs/verification-reproducibility.md
+++ b/docs/verification-reproducibility.md
@@ -231,8 +231,39 @@ record while the terminal receipt still identifies the complete overlay.
 `attempt_id` is diagnostic and deliberately excluded from `receipt_id`.
 Changing an authoritative input, result, decision, or artifact changes the
 corresponding content ID. Reusing a base-scan cache does not change the public
-verification identity or artifacts, and cached reports are accepted only when
-their sidecar content hash validates.
+verification identity or artifacts.
+
+### Base-scan cache compatibility
+
+A base-cache key binds the effective `engine_requirement_id` in addition to the
+Git tree, manifest, baseline, policy packs, scan options, evaluation date and
+cache-format epoch (#596). The engine requirement covers actual package bytes,
+Python/platform, installed dependency closure, adapters, enabled plugin identity
+and policy catalog. A source edit, editable install or rebuilt wheel at the same
+package version therefore cannot reuse an older engine's entry. The verifier
+captures this descriptor once per invocation for both the cache lookup and
+verification plan; subsequent invocations and engine validation read it afresh.
+
+Existing version-only keys are unreachable and regenerate on demand; no user
+migration command is needed. Equivalent warm runs reuse the current entry.
+Before reuse, bounded no-follow reads validate the report and checksum from one
+identity-bound session: at most 64 directory entries, 64 MiB of report bytes and
+128 checksum bytes. The SHA-256 must match, and the report must parse against the
+current model with an explicit current `report_schema_version`. Missing,
+corrupt or incompatible material triggers a fresh Git base scan and a diagnostic
+explaining the regeneration. Report and checksum files are replaced atomically,
+so repairing a refused file link preserves its external target. This is not a
+cache-directory namespace or concurrent-parent-replacement guarantee.
+If the cache cannot store that report, verification
+reports unavailable base comparison and names the cache location to repair;
+it preserves a conflicting directory and any contents. Missing engine identity
+also refuses cache reuse and routes to `doctor --json`.
+
+These checks establish engine compatibility and byte consistency, not
+authenticated source provenance. A locally writable report plus checksum cannot
+prove what an operation does. The OpenAPI operation-attribution path still
+reconstructs its base from Git, and this cache repair grants neither
+finding-exclusion eligibility nor human release authority.
 
 ## Local verification and portable execution validation
 

--- a/src/agents_shipgate/cli/verify/orchestrator.py
+++ b/src/agents_shipgate/cli/verify/orchestrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import functools
 import hashlib
 import json
 import os
@@ -88,12 +89,14 @@ from agents_shipgate.core.surface_exclusions import (
     nameable_subject,
 )
 from agents_shipgate.core.trust_roots import (
+    IdentityBoundReadSession,
     conditional_instruction_edits,
     inspect_lexical_path_identity,
     is_configured_manifest,
     read_identity_bound_text,
 )
 from agents_shipgate.core.verification_identity import (
+    build_engine_requirement,
     build_executor,
     build_terminal_receipt,
     build_unit_result,
@@ -151,7 +154,11 @@ from agents_shipgate.schemas.report import (
     without_machine_patches,
 )
 from agents_shipgate.schemas.verification import VerificationContext
-from agents_shipgate.schemas.verification_identity import VerificationPlan, content_id
+from agents_shipgate.schemas.verification_identity import (
+    VerificationEngineRequirement,
+    VerificationPlan,
+    content_id,
+)
 from agents_shipgate.schemas.verifier import (
     MergeVerdict,
     VerifierArtifact,
@@ -221,12 +228,10 @@ DEFAULT_OUT_DIR = Path("agents-shipgate-reports")
 BASE_CACHE_KEEP_ENTRIES = 16
 # Cache-key epoch for base-scan reuse.
 #
-# A cached base report is admitted on a content hash alone: that proves the
-# file was not tampered with, never that its CONTENTS still mean what the
-# current CLI expects of them. ``__version__`` is in the key but is not
-# sufficient on its own — a source checkout, an editable install, or any two
-# builds sharing one pre-release version string can change what a field means
-# without moving the version, and the stale entry is then reused verbatim.
+# The effective engine requirement now binds implementation, dependencies,
+# plugins and the policy catalog (#596); same-version reader changes cannot
+# reuse an older engine's entry. The epoch remains a cache-format boundary.
+# A report checksum detects byte corruption, not authenticated source provenance.
 #
 # Bump this whenever the MEANING of anything inside a cached base report
 # changes. Pre-existing entries then land on a key nothing computes and are
@@ -938,6 +943,12 @@ def run_verify(
 
     operation_base = None
 
+    @functools.cache
+    def engine_requirement() -> VerificationEngineRequirement:
+        # One capture per invocation, shared by base cache and final plan.
+        # Never reuse this value across invocations or engine validation reads.
+        return build_engine_requirement(plugins_enabled=plugins_enabled)
+
     def capture_base_operations(tree, rows):
         nonlocal operation_base
         operation_base = ReconstructedOperationBase(tree=tree, rows=tuple(rows))
@@ -968,6 +979,7 @@ def run_verify(
                 verbose=verbose,
                 evaluation_date=verification_date,
                 operation_callback=capture_base_operations,
+                engine_requirement_factory=engine_requirement,
             )
             base_notes.extend(cache_notes)
 
@@ -1312,6 +1324,7 @@ def run_verify(
                     capability_lock_diff=capability_lock_diff,
                     capability_attestation_inputs=capability_attestation_inputs,
                     human_context=head_human_context,
+                    engine_requirement_factory=engine_requirement,
                     input_root=head_input_root,
                     input_snapshot=head_snapshot,
                     config_from_worktree=overlay_worktree_manifest,
@@ -1358,6 +1371,7 @@ def _prepare_base_report(
     verbose: bool,
     evaluation_date: str,
     operation_callback=None,
+    engine_requirement_factory: Callable[[], VerificationEngineRequirement] | None = None,
 ) -> tuple[
     VerifierBaseStatus,
     str | None,
@@ -1371,6 +1385,18 @@ def _prepare_base_report(
     except Exception as exc:  # noqa: BLE001 - optional base enrichment.
         return "archive_failed", None, None, None, [f"Could not resolve base tree: {exc}"]
 
+    try:
+        engine = (
+            engine_requirement_factory()
+            if engine_requirement_factory is not None
+            else build_engine_requirement(plugins_enabled=plugins_enabled)
+        )
+    except (OSError, ValueError):
+        return "scan_failed", base_tree, None, None, [
+            "Base engine identity is unavailable; the base cache was not used. "
+            f"Run {render_command(['doctor', '--json'])} and rerun verification "
+            "after repairing the install."
+        ]
     cache_report = _cache_report_path(
         base_tree=base_tree,
         config_relative=config_relative,
@@ -1380,6 +1406,7 @@ def _prepare_base_report(
         plugins_enabled=plugins_enabled,
         no_heuristics=no_heuristics,
         evaluation_date=evaluation_date,
+        engine_requirement=engine,
     )
     cache_valid = cache_report.exists() and _cache_report_valid(cache_report)
     if cache_valid and operation_callback is None:
@@ -1392,8 +1419,10 @@ def _prepare_base_report(
             [f"Base report resolved for tree {base_tree}.", *lock_notes],
         )
     if cache_report.exists() and not cache_valid:
-        notes.append("Discarded base cache entry whose content hash did not validate.")
-        cache_report.unlink(missing_ok=True)
+        notes.append(
+            "Regenerating cached base report.json from Git: the report or its checksum "
+            "is unreadable, corrupt or incompatible with this engine."
+        )
 
     with tempfile.TemporaryDirectory(prefix="agents-shipgate-verify-") as tmp:
         tmp_root = Path(tmp)
@@ -1545,11 +1574,20 @@ def _prepare_base_report(
             json.dumps(report_json_payload(base_report_model), indent=2),
             encoding="utf-8",
         )
-        _copy_report_to_cache(source_report, cache_report)
-        if base_capability_lock is not None:
-            _write_capability_lock_to_cache(base_capability_lock, cache_report)
-        else:
-            notes.append("Base scan did not produce a capability lock; diff artifact disabled.")
+        try:
+            _copy_report_to_cache(source_report, cache_report)
+            if base_capability_lock is not None:
+                _write_capability_lock_to_cache(base_capability_lock, cache_report)
+            else:
+                notes.append("Base scan did not produce a capability lock; diff artifact disabled.")
+        except OSError:
+            return "scan_failed", base_tree, None, None, [
+                *notes,
+                "Could not store the regenerated base report; diff enrichment is unavailable. "
+                f"Check that {cache_report.parent} is a writable cache directory and that "
+                "report.json, report.sha256 and capabilities.lock.json are regular files, "
+                "then rerun verification.",
+            ]
         _prune_base_scan_cache(cache_report.parents[1], keep=BASE_CACHE_KEEP_ENTRIES)
         notes.append(f"Base report resolved for tree {base_tree}.")
     return "succeeded", base_tree, cache_report, base_capability_lock, notes
@@ -1565,9 +1603,12 @@ def _cache_report_path(
     plugins_enabled: bool | None,
     no_heuristics: bool,
     evaluation_date: str,
+    engine_requirement: VerificationEngineRequirement | None = None,
 ) -> Path:
+    engine = engine_requirement or build_engine_requirement(plugins_enabled=plugins_enabled)
     payload = {
         "version": BASE_CACHE_KEY_EPOCH,
+        "engine_requirement_id": engine.engine_requirement_id,
         "agents_shipgate_version": __version__,
         "base_tree": base_tree,
         "config": config_relative.as_posix(),
@@ -1593,7 +1634,9 @@ def _cache_report_path(
     key = hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()[:24]
-    return git_path(git_root, f"agents-shipgate/base-scans/{key}/report.json")
+    # Resolve Git's metadata root only. Resolving the report path itself would
+    # erase a refused file link before the recovery writer can replace it.
+    return git_path(git_root, "") / "agents-shipgate" / "base-scans" / key / "report.json"
 
 
 def _copy_report_to_cache(source_report: Path, cache_report: Path) -> None:
@@ -1605,26 +1648,49 @@ def _copy_report_to_cache(source_report: Path, cache_report: Path) -> None:
         delete=False,
     ) as handle:
         temp_path = Path(handle.name)
+    digest_temp: Path | None = None
     try:
         shutil.copy2(source_report, temp_path)
+        digest = _sha256_file(temp_path)
+        with tempfile.NamedTemporaryFile(
+            dir=cache_report.parent, prefix="checksum-", suffix=".tmp",
+            delete=False, mode="w", encoding="ascii",
+        ) as handle:
+            digest_temp = Path(handle.name)
+            handle.write(f"{digest}\n")
         temp_path.replace(cache_report)
-        cache_report.with_suffix(".sha256").write_text(
-            f"{_sha256_file(cache_report)}\n",
-            encoding="ascii",
-        )
+        # Recovery must replace a refused checksum alias, never follow it.
+        digest_temp.replace(cache_report.with_suffix(".sha256"))
     finally:
         temp_path.unlink(missing_ok=True)
+        if digest_temp is not None:
+            digest_temp.unlink(missing_ok=True)
 
 
 def _cache_report_valid(cache_report: Path) -> bool:
     digest_path = cache_report.with_suffix(".sha256")
-    if not digest_path.is_file():
-        return False
     try:
-        expected = digest_path.read_text(encoding="ascii").strip()
-    except OSError:
+        session = IdentityBoundReadSession(
+            cache_report.parent, max_entries=64, max_total_bytes=64 * 1024 * 1024 + 128,
+        )
+        data = session.read_bytes(Path(cache_report.name), max_bytes=64 * 1024 * 1024)
+        expected = session.read_bytes(Path(digest_path.name), max_bytes=128).decode("ascii").strip()
+        if re.fullmatch(r"[0-9a-f]{64}", expected) is None:
+            return False
+        if expected != hashlib.sha256(data).hexdigest():
+            return False
+        report = ReadinessReport.model_validate_json(data)
+        if (
+            "report_schema_version" not in report.model_fields_set
+            or report.report_schema_version != ReadinessReport.model_fields[
+                "report_schema_version"
+            ].default
+        ):
+            return False
+        session.finish()
+    except (OSError, ValueError):
         return False
-    return bool(expected and expected == _sha256_file(cache_report))
+    return True
 
 
 def _base_capability_lock_cache_path(cache_report: Path) -> Path:
@@ -4183,6 +4249,7 @@ def _write_artifacts(
     capability_lock_diff: CapabilityLockDiffV1 | None = None,
     capability_attestation_inputs: CapabilityDeltaAttestationInputs | None = None,
     human_context: HumanArtifactContext | None = None,
+    engine_requirement_factory: Callable[[], VerificationEngineRequirement] | None = None,
     input_root: Path | None = None,
     input_snapshot: StaticInputSnapshot | None = None,
     config_from_worktree: bool = False,
@@ -4406,6 +4473,9 @@ def _write_artifacts(
     )
     try:
         plan = build_verification_plan(
+            _engine_requirement=(
+                engine_requirement_factory() if engine_requirement_factory is not None else None
+            ),
             git_root=git_root,
             input_root=resolved_input_root,
             config_path=config_path,

--- a/src/agents_shipgate/core/verification_identity.py
+++ b/src/agents_shipgate/core/verification_identity.py
@@ -191,6 +191,7 @@ def build_verification_plan(
     auxiliary_origins: dict[Path, dict[str, str | None]] | None = None,
     auxiliary_source_paths: dict[Path, Path] | None = None,
     config_from_worktree: bool = False,
+    _engine_requirement: VerificationEngineRequirement | None = None,
 ) -> VerificationPlan:
     effective_plugins_enabled = _plugins_enabled(plugins_enabled)
     normalized_options = dict(options)
@@ -385,7 +386,11 @@ def build_verification_plan(
         ),
         **inputs_payload,
     )
-    engine = build_engine_requirement(plugins_enabled=effective_plugins_enabled)
+    # The verifier may already have captured this invocation's engine for its
+    # base-cache lookup. Serialized options never select an engine identity.
+    engine = _engine_requirement or build_engine_requirement(
+        plugins_enabled=effective_plugins_enabled
+    )
     task_payload = {
         "kind": "evaluate",
         "shard": 0,

--- a/tests/test_base_cache_engine_identity.py
+++ b/tests/test_base_cache_engine_identity.py
@@ -1,0 +1,293 @@
+"""A cached base must have been scanned by the engine answering this run."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from test_packaging import built_wheel, installed_wheel_site  # noqa: F401
+from test_verify_weakening import _weakened_repo
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROBE = r'''
+import json
+import sys
+from pathlib import Path
+from agents_shipgate import __version__
+from agents_shipgate.cli.verify import orchestrator
+from test_verify_weakening import _run_verify
+
+calls = []
+original = orchestrator.run_scan
+def observed_scan(*args, **kwargs):
+    config = kwargs["config_path"]
+    if any(p.name == "base" and p.parent.name.startswith("agents-shipgate-verify-")
+           for p in config.parents):
+        calls.append(str(config))
+    return original(*args, **kwargs)
+orchestrator.run_scan = observed_scan
+repo = Path(sys.argv[1])
+_, report, _ = _run_verify(repo)
+assert report is not None
+plan = json.loads((repo / "agents-shipgate-reports/verification-plan.json").read_text())
+print("CACHE_PROBE " + json.dumps({
+    "version": __version__,
+    "engine": plan["engine"],
+    "request_id": plan["request_id"],
+    "base_scans": len(calls),
+    "policy_kinds": sorted(f.evidence.get("kind", "") for f in report.findings
+                           if f.check_id == "SHIP-VERIFY-POLICY-WEAKENED"),
+}))
+'''
+
+
+def run_engine(python_path: Path, repo: Path) -> dict:
+    env = os.environ.copy()
+    env.update(
+        PYTHONPATH=os.pathsep.join([str(python_path), str(REPO_ROOT / "tests")]),
+        PYTHONNOUSERSITE="1",
+        PYTHONDONTWRITEBYTECODE="1",
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", PROBE, str(repo)],
+        cwd=repo.parent, env=env, capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return json.loads(next(
+        line.removeprefix("CACHE_PROBE ")
+        for line in result.stdout.splitlines() if line.startswith("CACHE_PROBE ")
+    ))
+
+
+@pytest.mark.parametrize("layout", ["source_checkout", "installed_wheel"])
+@pytest.mark.parametrize("change", ["reader_behavior", "legacy_version_key"])
+def test_actual_same_version_engine_change_rescans_base(tmp_path, request, layout, change):
+    engine = tmp_path / "engine"
+    if layout == "installed_wheel":
+        shutil.copytree(request.getfixturevalue("installed_wheel_site"), engine)
+        python_path = engine
+    else:
+        shutil.copytree(REPO_ROOT, engine, ignore=shutil.ignore_patterns(
+            ".git", ".venv", "__pycache__", ".pytest_cache", ".ruff_cache",
+            ".coverage", "agents-shipgate-reports", "build", "dist", "htmlcov",
+        ))
+        python_path = engine / "src"
+    if change == "reader_behavior":
+        reader = python_path / "agents_shipgate/core/lenses/effective_policy.py"
+        before = 'ci_mode=getattr(ci, "mode", None),'
+        after = 'ci_mode="advisory",'
+    else:
+        reader = python_path / "agents_shipgate/cli/verify/orchestrator.py"
+        before = '        "engine_requirement_id": engine.engine_requirement_id,\n'
+        after = ''
+    current_source = reader.read_text()
+    assert before in current_source
+    # Recreate the old producer's actual behavior in an isolated engine. This
+    # is not a forged report or a version/epoch bump: both runs execute code.
+    reader.write_text(current_source.replace(before, after, 1))
+    repo = _weakened_repo(tmp_path, sample_dir=Path("samples/clean_read_only_agent"))
+    old = run_engine(python_path, repo)
+    assert old["base_scans"] == 1
+    assert ("ci_mode_weakened" in old["policy_kinds"]) == (change == "legacy_version_key")
+    repeated_old = run_engine(python_path, repo)
+    assert repeated_old["base_scans"] == 0
+    assert repeated_old["engine"] == old["engine"]
+    assert repeated_old["request_id"] == old["request_id"]
+
+    reader.write_text(current_source)
+    current = run_engine(python_path, repo)
+    assert current["version"] == old["version"]
+    assert current["engine"]["engine_distribution_sha256"] != old["engine"][
+        "engine_distribution_sha256"
+    ]
+    assert current["base_scans"] == 1
+    assert "ci_mode_weakened" in current["policy_kinds"]
+    repeated_current = run_engine(python_path, repo)
+    assert repeated_current["base_scans"] == 0
+    assert repeated_current["engine"] == current["engine"]
+    assert repeated_current["request_id"] == current["request_id"]
+    assert repeated_current["policy_kinds"] == current["policy_kinds"]
+
+
+def _base_scan_observer(monkeypatch):
+    from agents_shipgate.cli.verify import orchestrator
+
+    calls = []
+    original = orchestrator.run_scan
+
+    def observe(*args, **kwargs):
+        config = kwargs['config_path']
+        if any(p.name == 'base' and p.parent.name.startswith('agents-shipgate-verify-')
+               for p in config.parents):
+            calls.append(config)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(orchestrator, 'run_scan', observe)
+    return calls
+
+
+def _cache_entry(repo):
+    (entry,) = (repo / '.git/agents-shipgate/base-scans').glob('*/report.json')
+    return entry
+
+
+@pytest.mark.parametrize('damage', [
+    'missing_checksum', 'non_ascii_checksum', 'oversized_checksum', 'wrong_checksum',
+    'invalid_json', 'invalid_model', 'missing_schema', 'old_schema',
+])
+def test_corrupt_cache_is_regenerated_from_git(tmp_path, monkeypatch, damage):
+    import hashlib
+
+    from test_verify_weakening import _policy_kinds, _run_verify
+
+    from agents_shipgate.cli.verify import orchestrator
+
+    repo = _weakened_repo(tmp_path, sample_dir=Path('samples/clean_read_only_agent'))
+    scans = _base_scan_observer(monkeypatch)
+    _run_verify(repo)
+    entry = _cache_entry(repo)
+    assert orchestrator._cache_report_valid(entry)
+    _run_verify(repo)
+    assert len(scans) == 1  # Positive control: this engine reuses a valid entry.
+    checksum = entry.with_suffix('.sha256')
+    if damage == 'missing_checksum':
+        checksum.unlink()
+    elif damage == 'non_ascii_checksum':
+        checksum.write_bytes(b'\xff')
+    elif damage == 'oversized_checksum':
+        checksum.write_bytes(b'0' * 1024)
+    elif damage == 'wrong_checksum':
+        checksum.write_text('0' * 64)
+    else:
+        payload = json.loads(entry.read_text())
+        if damage == 'invalid_json':
+            entry.write_text('{')
+        elif damage == 'invalid_model':
+            entry.write_text('{}')
+        else:
+            if damage == 'missing_schema':
+                payload.pop('report_schema_version')
+            else:
+                payload['report_schema_version'] = '0.1'
+            entry.write_text(json.dumps(payload))
+        # A matching checksum is insufficient for malformed/incompatible data.
+        checksum.write_text(hashlib.sha256(entry.read_bytes()).hexdigest())
+    assert not orchestrator._cache_report_valid(entry)
+    verifier, report, _ = _run_verify(repo)
+    assert len(scans) == 2
+    assert 'ci_mode_weakened' in _policy_kinds(report)
+    assert 'Regenerating cached base report.json from Git' in verifier.model_dump_json()
+    assert orchestrator._cache_report_valid(entry)
+    _run_verify(repo)
+    assert len(scans) == 2
+
+
+def test_directory_at_cache_report_is_preserved_and_routes_to_repair(tmp_path, monkeypatch):
+    from test_verify_weakening import _run_verify
+
+    repo = _weakened_repo(tmp_path, sample_dir=Path('samples/clean_read_only_agent'))
+    scans = _base_scan_observer(monkeypatch)
+    _run_verify(repo)
+    entry = _cache_entry(repo)
+    entry.unlink()
+    entry.mkdir()
+    marker = entry / 'user-data'
+    marker.write_text('preserve this')
+    verifier, report, _ = _run_verify(repo)
+    assert len(scans) == 2
+    assert verifier.base_status == 'scan_failed'
+    assert report.release_decision.decision == 'review_required'
+    assert not verifier.control.permissions.merge
+    assert not verifier.control.permissions.report_complete
+    assert 'Could not store the regenerated base report' in verifier.model_dump_json()
+    assert 'then rerun verification' in verifier.model_dump_json()
+    assert marker.read_text() == 'preserve this'
+
+
+def test_engine_identity_is_shared_with_plan_but_rebuilt_next_run(tmp_path, monkeypatch):
+    from test_verify_weakening import _run_verify
+
+    from agents_shipgate.cli.verify import orchestrator
+    from agents_shipgate.core import verification_identity
+
+    repo = _weakened_repo(tmp_path, sample_dir=Path('samples/clean_read_only_agent'))
+    original = verification_identity.build_engine_requirement
+    captures = []
+
+    def observe(**kwargs):
+        engine = original(**kwargs)
+        captures.append(engine)
+        return engine
+
+    monkeypatch.setattr(orchestrator, 'build_engine_requirement', observe)
+    monkeypatch.setattr(verification_identity, 'build_engine_requirement', observe)
+    _run_verify(repo)
+    assert len(captures) == 1
+    plan = json.loads((repo / 'agents-shipgate-reports/verification-plan.json').read_text())
+    assert plan['engine'] == captures[-1].model_dump(mode='json')
+    _run_verify(repo)
+    assert len(captures) == 2
+    assert captures[0] == captures[1]
+    assert captures[0] is not captures[1]
+    verification_identity.validate_engine_requirement(captures[0], plugins_enabled=False)
+    assert len(captures) == 3  # Validation independently observes the current engine.
+
+
+def test_missing_engine_identity_refuses_even_a_valid_warm_cache(tmp_path, monkeypatch):
+    from test_verify_weakening import _run_verify
+
+    from agents_shipgate.cli.verify import orchestrator
+
+    repo = _weakened_repo(tmp_path, sample_dir=Path('samples/clean_read_only_agent'))
+    scans = _base_scan_observer(monkeypatch)
+    _run_verify(repo)
+    entry = _cache_entry(repo)
+    original_bytes = entry.read_bytes()
+    assert orchestrator._cache_report_valid(entry)
+
+    def unavailable():
+        raise OSError('private install details must not leak')
+
+    status, _, cached, lock, notes = orchestrator._prepare_base_report(
+        git_root=repo, base='HEAD~1',
+        config_relative=Path('samples/support_refund_agent/shipgate.yaml'),
+        baseline_path=None, policy_packs=[], plugins_enabled=False,
+        no_heuristics=False, verbose=False, evaluation_date='2026-09-10',
+        engine_requirement_factory=unavailable,
+    )
+    assert status == 'scan_failed'
+    assert cached is None and lock is None
+    assert len(scans) == 1
+    assert entry.read_bytes() == original_bytes
+    assert 'doctor --json' in ' '.join(notes)
+    assert 'private install details' not in ' '.join(notes)
+
+
+@pytest.mark.parametrize("linked_file", ["report.json", "report.sha256"])
+def test_cache_repair_replaces_file_link_without_changing_target(tmp_path, monkeypatch, linked_file):
+    from test_verify_weakening import _policy_kinds, _run_verify
+
+    from agents_shipgate.cli.verify import orchestrator
+
+    repo = _weakened_repo(tmp_path, sample_dir=Path("samples/clean_read_only_agent"))
+    scans = _base_scan_observer(monkeypatch)
+    _run_verify(repo)
+    entry = _cache_entry(repo)
+    selected = entry.with_name(linked_file)
+    target = tmp_path / "external-file"
+    original_bytes = selected.read_bytes()
+    target.write_bytes(original_bytes)
+    selected.unlink()
+    selected.symlink_to(target)
+    assert not orchestrator._cache_report_valid(entry)
+    _, report, _ = _run_verify(repo)
+    assert len(scans) == 2
+    assert "ci_mode_weakened" in _policy_kinds(report)
+    assert not selected.is_symlink()
+    assert target.read_bytes() == original_bytes
+    assert orchestrator._cache_report_valid(entry)


### PR DESCRIPTION
When an editable install or rebuilt package changed a reader without changing the version, verification could reuse a base report made by the old engine. Bind the base-cache key to the existing effective engine requirement, and share that descriptor with the final verification plan once per invocation. Equivalent engines still reuse their warm cache; future invocations and explicit engine validation capture identity afresh.

Old version-only keys regenerate on demand. Cache admission uses bounded identity-bound reads, SHA-256 consistency, model validation and an explicit current report schema. Corrupt records regenerate from Git with a repair diagnostic. Report and checksum recovery preserve their lexical file paths and use atomic replacement so a refused file link does not overwrite its target; directory conflicts preserve their contents and return unavailable base evidence with repair guidance. The OpenAPI operation callback still reconstructs source evidence independently of report claims.

Validation: a real red regression ran the old effective-policy producer, warmed its cache, restored the current implementation without changing package version, and observed an incompatible cache hit despite a different engine digest. Source-checkout and installed-wheel coverage now exercises that reader repair and actual legacy version-only keys, deterministic warm request IDs, corrupt/schema-mismatched records, file links, directory conflicts, unavailable engine identity and one capture per invocation. The frozen full suite passed: **9,836 passed, 5 skipped in 376.07s**. Ruff, compilation, schema drift and all 24 sample goldens pass with no generated changes. Independent coding-agent [review round 1](https://github.com/ThreeMoonsLab/agents-shipgate/pull/639#pullrequestreview-5168197999) matched all five published blobs and independently passed 139 isolated tests with zero failures/errors/skips, including the actual source and wheel regressions. No actionable in-scope finding remained; the [address response](https://github.com/ThreeMoonsLab/agents-shipgate/pull/639#issuecomment-5620111739) completes one formal review/address loop without post-review code changes. All nine required native GitHub Actions checks passed on `ec374016e5f21617a2c801738c28fadcb440c350`, including combined coverage ([CI run](https://github.com/ThreeMoonsLab/agents-shipgate/actions/runs/34487131441)). The non-required release-tag-consistency check was skipped for this non-release PR. Fresh current-control permission remains required at merge.

This is the selected cache compatibility prerequisite before further #515 attribution/default work and #569 freeze. It does not authenticate a locally writable cache, prove TypeScript operation dependencies, permit finding exclusion, or provide reviewed deployment declarations.

Independent preparatory review also reproduced a pre-existing parent-cache-directory link write escape. It is tracked separately in #638 (P2, deferred); individual file-link recovery here does not establish cache-directory containment or concurrent-parent-replacement safety.

Closes #596. Refs #515, #557, #569, #572, #638.
