### PR TITLE
Attribute each finding to the bound this change moved (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- Name what a change did to the bound each finding depends on.
+  `tool_surface_diff.finding_attributions[]` projects the shipped
+  `openapi_delete/v1` and `sdk_boolean_guard/v1` comparisons onto active
+  findings and separates a standing weakness, an improvement that leaves the
+  finding standing, and a newly widened capability — three cases the identity
+  bucket reports as one. Only evidence naming a finding's own fingerprint
+  classifies; same-capability evidence can withdraw a negative claim but never
+  establish one, a display name is never a join, two active findings sharing one
+  fingerprint are unresolvable, and findings no profile can compare are counted
+  in the diff notes. A run with no base asks no diff
+  question and emits no rows. Dependency coverage remains
+  incomplete, exclusion eligibility remains false, and no finding, fingerprint,
+  severity, baseline, exit code or release decision changes. No `--scope`
+  option and no receipt question are added (#515).
+
 - Bind reader-selected input directory names and no-follow entry kinds in the
   verification plan. Both current-control observations and worker replay now
   reject changed membership, including ignored additions with unchanged file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
   bucket reports as one. Only evidence naming a finding's own fingerprint
   classifies; same-capability evidence can withdraw a negative claim but never
   establish one, a display name is never a join, two active findings sharing one
-  fingerprint are unresolvable, and findings no profile can compare are counted
-  in the diff notes. A run with no base asks no diff
+  fingerprint are unresolvable, and findings no profile can compare — including
+  any carrying neither a fingerprint nor an id — are counted in
+  `tool_surface_diff.unattributed_findings` and printed beside the rows. A run with no base asks no diff
   question and emits no rows. Dependency coverage remains
   incomplete, exclusion eligibility remains false, and no finding, fingerprint,
   severity, baseline, exit code or release decision changes. No `--scope`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
   bucket reports as one. Only evidence naming a finding's own fingerprint
   classifies; same-capability evidence can withdraw a negative claim but never
   establish one, a display name is never a join, two active findings sharing one
-  fingerprint are unresolvable, and findings no profile can compare — including
-  any carrying neither a fingerprint nor an id — are counted in
-  `tool_surface_diff.unattributed_findings` and printed beside the rows. A run with no base asks no diff
+  fingerprint are unresolvable, and findings that could not be joined to any
+  profile — including any carrying neither a fingerprint nor an id — are counted
+  in `tool_surface_diff.unattributed_findings` and printed beside the rows. A run with no base asks no diff
   question and emits no rows. Dependency coverage remains
   incomplete, exclusion eligibility remains false, and no finding, fingerprint,
   severity, baseline, exit code or release decision changes. No `--scope`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -196,6 +196,22 @@ default insertion, including both control observations and committed/worktree
 plans. This follows #633 and precedes final input-set qualification/#569 freeze;
 it does not qualify all reader discovery or establish a merge-permission bypass.
 
+The subsequent #515 pass projects the two shipped comparison profiles onto the
+findings they support. `tool_surface_diff.finding_attributions[]` names, per
+active finding, whether this change widened a bound, added or narrowed one
+without resolving the finding, or left every modeled bound unchanged — the
+three cases the existing `unchanged_findings` identity bucket reports
+identically. Paired committed repositories pin all three plus a removed
+approval declaration. [The projection contract](docs/finding-attribution.md)
+records its refusals: only evidence naming a finding's own fingerprint
+classifies, same-capability evidence can withdraw a negative claim but never
+establish one, and unattributed findings are counted rather than dropped.
+Dependency coverage stays `incomplete` and finding-exclusion eligibility stays
+false, so no finding is excluded and no verdict changes. This is #515's
+attribution step only: `--scope diff`/`--scope tree`, the receipt question,
+decision consumption, #557's dependency closure and the TypeScript MongoDB
+`cal-1` case all remain open, and no historical safety bar is satisfied.
+
 The following sequence and approved release bars still apply. Contract
 convergence, historical catch results, report freeze, actual human ownership,
 blind labels, independent signing, rehearsals and external product evidence

--- a/docs/finding-attribution.md
+++ b/docs/finding-attribution.md
@@ -66,12 +66,20 @@ not joined at all. And because a profile row names a *fingerprint*, two active
 findings answering to one fingerprint make every row about them `unresolved`:
 no comparison can say which of them it names.
 
-**Capability-linked evidence can withdraw a claim, never establish one.**
-`standing_weakness` and `improved_not_resolved` are claims about what did not
-get worse. Any capability-linked movement — a widened guard predicate, a
-literal true-return domain that grew, an axis the profile could not compare —
-retracts them to `unresolved`. It can never promote a finding to a direction of
-its own.
+**Capability-linked evidence can withdraw a claim, never establish one.** It
+never promotes a finding to a direction of its own, and the two negative claims
+are withdrawn by different things, because they claim different amounts.
+
+`standing_weakness` says nothing anywhere on the capability got worse, so *any*
+same-capability row that is not `unchanged` defeats it — a widened guard
+predicate, a literal true-return domain that grew, or an axis the profile could
+not compare at all.
+
+`improved_not_resolved` is narrower: a specific bound this finding depends on
+demonstrably narrowed. An axis elsewhere on the capability that could not be
+compared does not refute that, so it is withdrawn only by a demonstrated
+`widening` — where calling the change an improvement would misstate the net
+direction.
 
 **Absence is not agreement.** A finding no profile can compare draws no row.
 The number of them is published as `tool_surface_diff.unattributed_findings`,

--- a/docs/finding-attribution.md
+++ b/docs/finding-attribution.md
@@ -1,0 +1,99 @@
+# Finding attribution
+
+`tool_surface_diff.finding_deltas` answers a question about identity: is this
+fingerprint in the base report? Three very different changes give it the same
+answer. A repository weakness the pull request never touched, a change that
+bounds the capability without perfecting it, and a change that widens the
+capability all land in one `unchanged_findings` row.
+
+`tool_surface_diff.finding_attributions[]` (#515) answers the other question —
+what did *this change* do to the bound this finding depends on — for the
+findings the shipped comparison profiles can actually speak about. It is an
+optional diagnostic. It changes no finding, fingerprint, support
+classification, severity, baseline, exit code or release decision, it
+introduces no check ID, and `finding_exclusion_eligible` is `false` on every
+row. There is no scope flag: `--scope diff` / `--scope tree` and the receipt
+question they imply are still #515's open work.
+
+## What a row is, and is not
+
+Each row names one active finding and one class:
+
+| Class | Means |
+|---|---|
+| `widened_by_change` | A bound this finding depends on was removed, or the compared domain of the capability it names grew. |
+| `improved_not_resolved` | A bound was added or narrowed and the finding still stands — an improvement, not the finding's cause. |
+| `standing_weakness` | The finding matched the base and every *modeled* bound it depends on is unchanged. |
+| `unresolved` | No comparable evidence, a refused direction, or a contradiction on the same capability. |
+
+`standing_weakness` is the class most easily misread. It says no modeled bound
+changed. It does not say the capability is unchanged, because
+`dependency_coverage` is still `incomplete`: no profile has yet proved a
+complete shared-helper, import and configuration closure for a capability
+(#557). A finding is not droppable because it carries this class.
+
+## Where the direction comes from
+
+The projection reads no source, reconstructs no tree and runs no second diff.
+Every direction it reports is copied verbatim out of a comparison row that
+`compare_operations` (`openapi_delete/v1`,
+[contract](operation-attribution.md)) or `compare_guard_dependencies`
+(`sdk_boolean_guard/v1`) already published, and the row carries that profile's
+own spelling in `evidence[].direction` so it can be joined back to the
+comparison it came from.
+
+`evidence[].effect` is the one place the two vocabularies are reconciled. A
+compared domain that is neither equal to nor a subset of the base contains at
+least one member the base did not declare, so `changed` and `predicate_changed`
+are recorded as `widening` — a proved statement about the compared sets, not a
+risk judgement.
+
+## The three refusals
+
+**Only predicate-linked evidence classifies.** A profile row earns
+`link: "predicate"` by naming the finding's own fingerprint, which today only
+`openapi_delete/v1` does. A row joined by canonical tool id is `link:
+"capability"`: evidence about the same capability whose relation to *this*
+finding's predicate is unproved. A tool's display name is never a join;
+a guard comparison without a canonical tool id, or a finding without one, is
+not joined at all. And because a profile row names a *fingerprint*, two active
+findings answering to one fingerprint make every row about them `unresolved`:
+no comparison can say which of them it names.
+
+**Capability-linked evidence can withdraw a claim, never establish one.**
+`standing_weakness` and `improved_not_resolved` are claims about what did not
+get worse. Any capability-linked movement — a widened guard predicate, a
+literal true-return domain that grew, an axis the profile could not compare —
+retracts them to `unresolved`. It can never promote a finding to a direction of
+its own.
+
+**Absence is not agreement.** A finding no profile can compare draws no row,
+and the count of those findings is published in `tool_surface_diff.notes` so an
+empty attribution can never be read as a clean one.
+
+A run that asks no diff question answers none: where neither profile is active,
+or where there is no base — no `--diff-from` report, no baseline snapshot and no
+reconstructed Git operation base — the block is absent entirely rather than
+filled with `unresolved` rows against every finding of every plain `scan`. The
+missing base is already explicit in `tool_surface_diff.notes`. Where a base
+exists but the identity buckets do not name a fingerprint, `identity` is
+`unresolved`; it is never reported as `new`.
+
+## Boundary
+
+Rows are ordered most-consequential first and then by finding identity, so a
+rerun on an unchanged repository prints an unchanged block and the Markdown
+section's eight-row limit cannot hide a widening behind a documentation
+finding. `report.json` carries every row; `report.md` spells the rows that
+reached a direction and counts the rest, because one `unresolved` sentence per
+finding on a shared capability buries the decided rows printed beside it.
+Neither surface can disagree with the other about a class: both read the same
+rows, and only this projection produces them.
+
+The regression inputs are isolated synthetic fixtures and paired committed
+repositories, not deployed wiring, human qualification labels or runtime
+observations. #557 owns the dependency closure this projection reports as
+incomplete; #515 owns the scope flag, the receipt question, decision
+consumption and its TypeScript MongoDB `cal-1` case; #563/#312 still require
+independently reviewed historical evidence. This projection satisfies none of
+those bars and does not freeze report 1.0 (#569).

--- a/docs/finding-attribution.md
+++ b/docs/finding-attribution.md
@@ -48,6 +48,12 @@ least one member the base did not declare, so `changed` and `predicate_changed`
 are recorded as `widening` — a proved statement about the compared sets, not a
 risk judgement.
 
+`evidence[].base_pointer` / `head_pointer` name the compared bound on each
+side: the declaring OpenAPI document plus its JSON pointer, or the guard
+module and line. A pointer printed under a `guard_predicate` axis has to name
+the guard, so an observation whose guard location is unknown publishes no
+pointer for that side rather than substituting the tool declaration.
+
 ## The three refusals
 
 **Only predicate-linked evidence classifies.** A profile row earns
@@ -67,9 +73,13 @@ literal true-return domain that grew, an axis the profile could not compare —
 retracts them to `unresolved`. It can never promote a finding to a direction of
 its own.
 
-**Absence is not agreement.** A finding no profile can compare draws no row,
-and the count of those findings is published in `tool_surface_diff.notes` so an
-empty attribution can never be read as a clean one.
+**Absence is not agreement.** A finding no profile can compare draws no row.
+The number of them is published as `tool_surface_diff.unattributed_findings`,
+not only as prose, because `report.md` renders three diff notes and a fourth is
+dropped — the one statement that stops an empty attribution reading as a clean
+one cannot live where it can be truncated. A finding carrying neither a
+fingerprint nor an id has no identity to join on at all, which is the strongest
+form of "not compared", so it is counted rather than skipped.
 
 A run that asks no diff question answers none: where neither profile is active,
 or where there is no base — no `--diff-from` report, no baseline snapshot and no
@@ -85,8 +95,10 @@ Rows are ordered most-consequential first and then by finding identity, so a
 rerun on an unchanged repository prints an unchanged block and the Markdown
 section's eight-row limit cannot hide a widening behind a documentation
 finding. `report.json` carries every row; `report.md` spells the rows that
-reached a direction and counts the rest, because one `unresolved` sentence per
-finding on a shared capability buries the decided rows printed beside it.
+reached a direction and counts the rest — both the rows that stayed
+`unresolved` and the findings that drew no row at all — because one
+`unresolved` sentence per finding on a shared capability buries the decided
+rows printed beside it.
 Neither surface can disagree with the other about a class: both read the same
 rows, and only this projection produces them.
 

--- a/docs/finding-attribution.md
+++ b/docs/finding-attribution.md
@@ -58,13 +58,16 @@ pointer for that side rather than substituting the tool declaration.
 
 **Only predicate-linked evidence classifies.** A profile row earns
 `link: "predicate"` by naming the finding's own fingerprint, which today only
-`openapi_delete/v1` does. A row joined by canonical tool id is `link:
-"capability"`: evidence about the same capability whose relation to *this*
-finding's predicate is unproved. A tool's display name is never a join;
-a guard comparison without a canonical tool id, or a finding without one, is
-not joined at all. And because a profile row names a *fingerprint*, two active
-findings answering to one fingerprint make every row about them `unresolved`:
-no comparison can say which of them it names.
+`openapi_delete/v1` does. Everything else joins by canonical identity — a
+shared tool id, or a capability id the finding cites in `capability_refs` — and
+is `link: "capability"`: evidence about the same capability whose relation to
+*this* finding's predicate is unproved.
+
+A display name is never a join. A guard comparison carries no canonical tool
+id of its own beyond its observation, so a guard row without one, or a finding
+without one, is not joined at all. And because a profile row names a
+*fingerprint*, two active findings answering to one fingerprint make every row
+about them `unresolved`: no comparison can say which of them it names.
 
 **Capability-linked evidence can withdraw a claim, never establish one.** It
 never promotes a finding to a direction of its own, and the two negative claims

--- a/docs/finding-attribution.md
+++ b/docs/finding-attribution.md
@@ -110,6 +110,13 @@ rows printed beside it.
 Neither surface can disagree with the other about a class: both read the same
 rows, and only this projection produces them.
 
+The projection is published on `report.json` and `report.md` only, like the two
+profile comparisons it reads. `packet.json` and the PR comment carry the diff
+notes, and both truncate them, so neither restates a class — a surface that
+does not answer is preferable to one that answers differently. The packet's
+"Finding identities" line remains an identity statement, and `report.json` is
+where its attribution lives.
+
 The regression inputs are isolated synthetic fixtures and paired committed
 repositories, not deployed wiring, human qualification labels or runtime
 observations. #557 owns the dependency closure this projection reports as

--- a/docs/report-schema.v0.43.json
+++ b/docs/report-schema.v0.43.json
@@ -8010,6 +8010,12 @@
           },
           "title": "Tools",
           "type": "array"
+        },
+        "unattributed_findings": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Unattributed Findings",
+          "type": "integer"
         }
       },
       "required": [

--- a/docs/report-schema.v0.43.json
+++ b/docs/report-schema.v0.43.json
@@ -5006,6 +5006,179 @@
       "title": "Finding",
       "type": "object"
     },
+    "FindingAttribution": {
+      "additionalProperties": false,
+      "properties": {
+        "attribution": {
+          "enum": [
+            "widened_by_change",
+            "improved_not_resolved",
+            "standing_weakness",
+            "unresolved"
+          ],
+          "title": "Attribution",
+          "type": "string"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "dependency_coverage": {
+          "const": "incomplete",
+          "default": "incomplete",
+          "title": "Dependency Coverage",
+          "type": "string"
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/FindingAttributionEvidence"
+          },
+          "title": "Evidence",
+          "type": "array"
+        },
+        "finding_exclusion_eligible": {
+          "const": false,
+          "default": false,
+          "title": "Finding Exclusion Eligible",
+          "type": "boolean"
+        },
+        "fingerprint": {
+          "title": "Fingerprint",
+          "type": "string"
+        },
+        "identity": {
+          "enum": [
+            "new",
+            "matched",
+            "accepted_debt",
+            "unresolved"
+          ],
+          "title": "Identity",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Id"
+        },
+        "tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Name"
+        }
+      },
+      "required": [
+        "fingerprint",
+        "check_id",
+        "identity",
+        "attribution",
+        "reason"
+      ],
+      "title": "FindingAttribution",
+      "type": "object"
+    },
+    "FindingAttributionEvidence": {
+      "additionalProperties": false,
+      "description": "One compared axis of one profile row, and where to read both sides.",
+      "properties": {
+        "axis": {
+          "enum": [
+            "approval_predicate",
+            "declared_target_domain",
+            "guard_predicate",
+            "bound_true_domain"
+          ],
+          "title": "Axis",
+          "type": "string"
+        },
+        "base_pointer": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Pointer"
+        },
+        "direction": {
+          "title": "Direction",
+          "type": "string"
+        },
+        "effect": {
+          "enum": [
+            "widening",
+            "narrowing",
+            "unchanged",
+            "unresolved"
+          ],
+          "title": "Effect",
+          "type": "string"
+        },
+        "head_pointer": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Head Pointer"
+        },
+        "link": {
+          "enum": [
+            "predicate",
+            "capability"
+          ],
+          "title": "Link",
+          "type": "string"
+        },
+        "observation_id": {
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "profile": {
+          "enum": [
+            "openapi_delete/v1",
+            "sdk_boolean_guard/v1"
+          ],
+          "title": "Profile",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile",
+        "observation_id",
+        "link",
+        "axis",
+        "direction",
+        "effect"
+      ],
+      "title": "FindingAttributionEvidence",
+      "type": "object"
+    },
     "FindingSupport": {
       "additionalProperties": false,
       "description": "Authoritative support for finding confidence and release contribution.\n\nRule metadata may request a severity or block, but it cannot upgrade the\nunderlying evidence. ``support_hash`` binds baselines and audit surfaces\nto the predicate evidence that actually made the finding eligible.",
@@ -7768,6 +7941,13 @@
           "default": false,
           "title": "Enabled",
           "type": "boolean"
+        },
+        "finding_attributions": {
+          "items": {
+            "$ref": "#/$defs/FindingAttribution"
+          },
+          "title": "Finding Attributions",
+          "type": "array"
         },
         "finding_deltas": {
           "$ref": "#/$defs/ToolSurfaceFindingDeltas"

--- a/src/agents_shipgate/cli/scan/sanitization.py
+++ b/src/agents_shipgate/cli/scan/sanitization.py
@@ -30,6 +30,7 @@ from agents_shipgate.core.lenses.declaration_surface import (
     build_public_action_declaration_facts,
 )
 from agents_shipgate.core.lenses.effective_policy import accepted_debt_fingerprints
+from agents_shipgate.core.lenses.finding_attribution import attribute_findings
 from agents_shipgate.core.lenses.tool_surface import (
     build_tool_surface_facts,
     compute_tool_surface_diff,
@@ -683,6 +684,13 @@ def _public_tool_surfaces(
             reference=public_diff_reference,
         )
     public_tool_surface_diff.operation_comparisons = compare_operations(public_operations, operation_base)
+    # One canonical per-finding statement over both comparison lists, built
+    # here because ``operation_comparisons`` is only complete after the line
+    # above. Both inputs are already sanitized, so the projection carries no
+    # value the redaction pass has not seen.
+    attributions, attribution_notes = attribute_findings(public_tool_surface_diff, public_findings)
+    public_tool_surface_diff.finding_attributions = attributions
+    public_tool_surface_diff.notes.extend(attribution_notes)
     # v0.19 reviewer-grade provenance: enrich tool-surface diff
     # controls (and any other reason-bearing rows) with the public
     # tool path:line citation so the rendered report.json and packet

--- a/src/agents_shipgate/cli/scan/sanitization.py
+++ b/src/agents_shipgate/cli/scan/sanitization.py
@@ -688,9 +688,10 @@ def _public_tool_surfaces(
     # here because ``operation_comparisons`` is only complete after the line
     # above. Both inputs are already sanitized, so the projection carries no
     # value the redaction pass has not seen.
-    attributions, attribution_notes = attribute_findings(public_tool_surface_diff, public_findings)
-    public_tool_surface_diff.finding_attributions = attributions
-    public_tool_surface_diff.notes.extend(attribution_notes)
+    attribution = attribute_findings(public_tool_surface_diff, public_findings)
+    public_tool_surface_diff.finding_attributions = attribution.rows
+    public_tool_surface_diff.unattributed_findings = attribution.unattributed
+    public_tool_surface_diff.notes.extend(attribution.notes)
     # v0.19 reviewer-grade provenance: enrich tool-surface diff
     # controls (and any other reason-bearing rows) with the public
     # tool path:line citation so the rendered report.json and packet

--- a/src/agents_shipgate/core/lenses/finding_attribution.py
+++ b/src/agents_shipgate/core/lenses/finding_attribution.py
@@ -1,0 +1,385 @@
+"""Join the shipped comparison profiles onto the findings they support.
+
+``finding_deltas`` answers a question about *identity*: is this fingerprint in
+the base report?  #515 needs a different answer — did *this change* widen,
+bound, or leave alone the capability the finding is about — and the evidence
+for it already exists, split across two profile surfaces with two private
+vocabularies and no join to the findings that gate.
+
+This module is that join and nothing else.  It reads no source, reconstructs no
+tree and computes no second diff: every direction it reports is copied verbatim
+out of a comparison row that ``compare_operations`` or
+``compare_guard_dependencies`` already published.  What it adds is one canonical
+statement per finding, and the refusals that statement is allowed to make.
+
+Three rules keep it from overclaiming, and each is the reason a whole class of
+row lands on ``unresolved``:
+
+1. Only **predicate-linked** evidence classifies.  A profile row earns that link
+   by naming the finding's own fingerprint.  A row joined by canonical tool id
+   is evidence about the same capability whose relation to this finding's
+   predicate is unproved.
+2. Capability-linked evidence may **withdraw** a claim, never establish one.
+   ``standing_weakness`` and ``improved_not_resolved`` are negative claims about
+   what did not get worse, so any capability-linked movement retracts them.
+3. Absence is never agreement.  A finding no profile can compare gets no row at
+   all and is counted in a note, and a matched finding whose modeled bounds are
+   all unchanged is only ``standing_weakness`` while its dependency coverage is
+   still published as ``incomplete``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from agents_shipgate.schemas.finding_attribution import (
+    AttributionEffect,
+    AttributionLink,
+    FindingAttribution,
+    FindingAttributionClass,
+    FindingAttributionEvidence,
+    FindingIdentity,
+)
+from agents_shipgate.schemas.guard_dependencies import GuardDependencyComparison
+from agents_shipgate.schemas.operation_attribution import OperationComparison
+from agents_shipgate.schemas.report import Finding
+from agents_shipgate.schemas.surfaces import ToolSurfaceDiff
+
+_LIMIT = (
+    "Finding attribution names the modeled bound this change moved. Dependency "
+    "coverage is incomplete, so an unchanged bound is not proof that the "
+    "capability is unchanged and no finding is excluded from the release "
+    "decision."
+)
+
+# A domain that is neither equal to nor a subset of the base contains at least
+# one member the base did not declare, so `changed` is a proved widening.
+_DOMAIN_EFFECTS: dict[str, AttributionEffect] = {
+    "unchanged": "unchanged",
+    "narrowed": "narrowing",
+    "widened": "widening",
+    "changed": "widening",
+    "unresolved": "unresolved",
+}
+_APPROVAL_EFFECTS: dict[str, AttributionEffect] = {
+    "standing_weakness": "unchanged",
+    "still_declared": "unchanged",
+    "resolved_by_declaration": "narrowing",
+    "newly_missing": "widening",
+    "unresolved": "unresolved",
+}
+_ORDER = {
+    "widened_by_change": 0,
+    "improved_not_resolved": 1,
+    "standing_weakness": 2,
+    "unresolved": 3,
+}
+_GUARD_EFFECTS: dict[str, AttributionEffect] = {
+    "predicate_unchanged": "unchanged",
+    "predicate_narrowed": "narrowing",
+    "predicate_widened": "widening",
+    "predicate_changed": "widening",
+    "unresolved": "unresolved",
+}
+
+
+def _operation_pointer(row) -> str | None:
+    """``<document>#<json pointer>`` — a file a reviewer can actually open.
+
+    A bare JSON pointer names a location in a document nobody has been told
+    the name of, so the declaring document is carried with it whenever the
+    profile recorded one.
+    """
+    if row is None:
+        return None
+    document = next(
+        (item.path for item in row.operation.inputs if item.role == "openapi_document"),
+        None,
+    )
+    pointer = row.operation.source_pointer
+    return f"{document}#{pointer}" if document else pointer
+
+
+def _guard_pointer(row) -> str | None:
+    if row is None:
+        return None
+    if row.guard_path and row.guard_line:
+        return f"{row.guard_path}:{row.guard_line}"
+    return f"{row.tool_path}:{row.tool_line}"
+
+
+def _operation_evidence(
+    comparison: OperationComparison, link: AttributionLink
+) -> list[FindingAttributionEvidence]:
+    base, head = _operation_pointer(comparison.before), _operation_pointer(comparison.after)
+    return [
+        FindingAttributionEvidence(
+            profile="openapi_delete/v1",
+            observation_id=comparison.observation_id,
+            link=link,
+            axis=axis,
+            direction=direction,
+            effect=table[direction],
+            base_pointer=base,
+            head_pointer=head,
+        )
+        for axis, direction, table in (
+            ("approval_predicate", comparison.approval_predicate, _APPROVAL_EFFECTS),
+            ("declared_target_domain", comparison.declared_target_domain, _DOMAIN_EFFECTS),
+        )
+    ]
+
+
+def _guard_evidence(
+    comparison: GuardDependencyComparison, link: AttributionLink
+) -> list[FindingAttributionEvidence]:
+    base, head = _guard_pointer(comparison.before), _guard_pointer(comparison.after)
+    rows = [
+        FindingAttributionEvidence(
+            profile="sdk_boolean_guard/v1",
+            observation_id=comparison.observation_id,
+            link=link,
+            axis="guard_predicate",
+            direction=comparison.direction,
+            effect=_GUARD_EFFECTS[comparison.direction],
+            base_pointer=base,
+            head_pointer=head,
+        )
+    ]
+    if comparison.source_behavior is not None:
+        direction = comparison.source_behavior.bound_true_domain
+        rows.append(
+            FindingAttributionEvidence(
+                profile="sdk_boolean_guard/v1",
+                observation_id=comparison.observation_id,
+                link=link,
+                axis="bound_true_domain",
+                direction=direction,
+                effect=_DOMAIN_EFFECTS[direction],
+                base_pointer=base,
+                head_pointer=head,
+            )
+        )
+    return rows
+
+
+def _operation_fingerprints(comparison: OperationComparison) -> set[str]:
+    return {
+        fingerprint
+        for side in (comparison.before, comparison.after)
+        if side is not None
+        for fingerprint in side.finding_fingerprints
+    }
+
+
+def _operation_tool_ids(comparison: OperationComparison) -> set[str]:
+    return {
+        side.tool_id
+        for side in (comparison.before, comparison.after)
+        if side is not None and side.tool_id
+    }
+
+
+def _operation_capability_ids(comparison: OperationComparison) -> set[str]:
+    return {
+        side.capability_id
+        for side in (comparison.before, comparison.after)
+        if side is not None and side.capability_id
+    }
+
+
+def _guard_tool_ids(comparison: GuardDependencyComparison) -> set[str]:
+    ids = {row.tool_id for row in (comparison.before, comparison.after) if row is not None}
+    ids.add(comparison.tool_id)
+    return {value for value in ids if value}
+
+
+def _asks_the_question(diff: ToolSurfaceDiff) -> bool:
+    """Whether this run compared a head against a base at all.
+
+    Read off the diff itself rather than a caller flag: a reconstructed Git
+    operation base is provenance the public report cannot set, and it can carry
+    a comparison even where no report or baseline reference was supplied.
+    """
+    if not diff.operation_comparisons and not diff.guard_comparisons:
+        return False
+    return diff.base.kind != "none" or any(
+        row.evidence_source == "reconstructed_git_base" for row in diff.operation_comparisons
+    )
+
+
+def _identity(diff: ToolSurfaceDiff) -> dict[str, FindingIdentity]:
+    deltas = diff.finding_deltas
+    identity: dict[str, FindingIdentity] = {}
+    for bucket, label in (
+        (deltas.new_findings, "new"),
+        (deltas.unchanged_findings, "matched"),
+        (deltas.accepted_debt, "accepted_debt"),
+    ):
+        for row in bucket:
+            identity[row.fingerprint] = label
+    return identity
+
+
+def _classify(
+    identity: FindingIdentity,
+    predicate: list[FindingAttributionEvidence],
+    capability: list[FindingAttributionEvidence],
+    *,
+    ambiguous: bool,
+) -> tuple[FindingAttributionClass, str]:
+    if ambiguous:
+        # A profile row names a fingerprint. Where two active findings answer
+        # to that fingerprint, no row can say which of them it attributes.
+        return "unresolved", (
+            "Two or more active findings share this identity, so no comparison "
+            "row can say which of them it names."
+        )
+    if not predicate:
+        return "unresolved", (
+            "No comparison profile names this finding's fingerprint, so the bound "
+            "that made it eligible was not compared."
+            + (
+                " Evidence on the same capability is carried in this row and "
+                "does not attribute this finding."
+                if capability
+                else ""
+            )
+        )
+    effects = {row.effect for row in predicate}
+    capability_effects = {row.effect for row in capability}
+    if "unresolved" in effects:
+        return "unresolved", (
+            "A compared axis of this finding's own bound is unresolved; the "
+            "profile refused to state a direction."
+        )
+    if "widening" in effects:
+        return "widened_by_change", (
+            "This change removed a bound this finding depends on, or grew the "
+            "compared domain of the capability it names."
+        )
+    if "narrowing" in effects:
+        if "widening" in capability_effects:
+            return "unresolved", (
+                "This finding's own bound was narrowed, but another modeled bound "
+                "on the same capability widened; the net direction is unresolved."
+            )
+        return "improved_not_resolved", (
+            "This change added or narrowed a bound this finding depends on and the "
+            "finding still stands. It is an improvement, not the finding's cause."
+        )
+    if identity != "matched":
+        # `accepted_debt` is not proof of absence from the base either: the
+        # baseline bucket is filled before the identity buckets are, so a row
+        # there says nothing about whether the base carried the fingerprint.
+        return "unresolved", (
+            "Every compared bound is unchanged, but this finding is not an "
+            f"unchanged base identity ({identity}); what moved its identity was "
+            "not modeled."
+        )
+    if capability_effects - {"unchanged"}:
+        return "unresolved", (
+            "Every compared bound of this finding is unchanged, but another "
+            "modeled bound on the same capability moved or could not be compared."
+        )
+    return "standing_weakness", (
+        "The finding matched the base and every modeled bound it depends on is "
+        "unchanged. Dependency coverage is incomplete, so this is not proof the "
+        "capability is unchanged."
+    )
+
+
+def attribute_findings(
+    diff: ToolSurfaceDiff, findings: list[Finding]
+) -> tuple[list[FindingAttribution], list[str]]:
+    """Return one attribution row per comparable finding, plus its limit notes.
+
+    A finding no profile can join gets no row: an empty attribution is the
+    absence of evidence, and the returned note counts those findings so absence
+    is never read as agreement.
+    """
+    if not _asks_the_question(diff):
+        # Either no profile is active, or the run has no base and is therefore
+        # not asking what a change did. Attributing findings to a change that
+        # was never described would print "unresolved" against every finding of
+        # every plain `scan`, and the diff notes already say a base is missing.
+        return [], []
+    identity = _identity(diff)
+    # Built once, not once per (finding, comparison) pair: the evidence rows
+    # differ between the two links only by that word, and the join keys are
+    # properties of the comparison alone.
+    operations = [
+        (
+            _operation_fingerprints(comparison),
+            _operation_tool_ids(comparison),
+            _operation_capability_ids(comparison),
+            _operation_evidence(comparison, "predicate"),
+            _operation_evidence(comparison, "capability"),
+        )
+        for comparison in diff.operation_comparisons
+    ]
+    guards = [
+        (_guard_tool_ids(comparison), _guard_evidence(comparison, "capability"))
+        for comparison in diff.guard_comparisons
+    ]
+    active = [finding for finding in findings if not finding.suppressed]
+    shared = Counter(
+        fingerprint
+        for finding in active
+        if (fingerprint := finding.fingerprint or finding.id)
+    )
+    rows: list[FindingAttribution] = []
+    unattributed = 0
+    for finding in active:
+        fingerprint = finding.fingerprint or finding.id
+        if not fingerprint:
+            continue
+        refs = set(finding.capability_refs)
+        predicate: list[FindingAttributionEvidence] = []
+        capability: list[FindingAttributionEvidence] = []
+        for fingerprints, tool_ids, capability_ids, named, same_capability in operations:
+            # Copied, so each attribution row owns the evidence it publishes
+            # rather than sharing one mutable model with every other finding on
+            # the same capability.
+            if fingerprint in fingerprints:
+                predicate.extend(row.model_copy() for row in named)
+            elif (finding.tool_id and finding.tool_id in tool_ids) or (capability_ids & refs):
+                capability.extend(row.model_copy() for row in same_capability)
+        for tool_ids, evidence in guards:
+            # Guard evidence carries no fingerprint, so it is only ever
+            # capability-linked, and only through a canonical tool id — a
+            # display name is not an identity.
+            if finding.tool_id and finding.tool_id in tool_ids:
+                capability.extend(row.model_copy() for row in evidence)
+        if not predicate and not capability:
+            unattributed += 1
+            continue
+        bucket = identity.get(fingerprint, "unresolved")
+        attribution, reason = _classify(
+            bucket, predicate, capability, ambiguous=shared[fingerprint] > 1
+        )
+        rows.append(
+            FindingAttribution(
+                fingerprint=fingerprint,
+                check_id=finding.check_id,
+                tool_id=finding.tool_id,
+                tool_name=finding.tool_name,
+                identity=bucket,
+                attribution=attribution,
+                reason=reason,
+                evidence=[*predicate, *capability],
+            )
+        )
+    # Most-consequential first, then a stable identity tie-break, so a rerun on
+    # an unchanged repository prints an unchanged block and the Markdown
+    # truncation never hides a widening behind a documentation finding.
+    rows.sort(key=lambda row: (_ORDER[row.attribution], row.check_id, row.fingerprint))
+    if not rows and not unattributed:
+        return [], []
+    notes = [_LIMIT]
+    if unattributed:
+        notes.append(
+            f"{unattributed} active finding(s) have no comparison profile evidence "
+            "and are not attributed to this change in either direction."
+        )
+    return rows, notes

--- a/src/agents_shipgate/core/lenses/finding_attribution.py
+++ b/src/agents_shipgate/core/lenses/finding_attribution.py
@@ -31,6 +31,7 @@ row lands on ``unresolved``:
 from __future__ import annotations
 
 from collections import Counter
+from typing import NamedTuple
 
 from agents_shipgate.schemas.finding_attribution import (
     AttributionEffect,
@@ -101,11 +102,16 @@ def _operation_pointer(row) -> str | None:
 
 
 def _guard_pointer(row) -> str | None:
-    if row is None:
+    """The guard's own location, or nothing.
+
+    An unresolved observation can carry a ``guard_path`` with no line, and can
+    carry neither. The tool declaration is not a substitute: a pointer printed
+    under a ``guard_predicate`` axis has to name the guard, so an unknown
+    location stays absent rather than sending a reviewer to the wrong file.
+    """
+    if row is None or not row.guard_path:
         return None
-    if row.guard_path and row.guard_line:
-        return f"{row.guard_path}:{row.guard_line}"
-    return f"{row.tool_path}:{row.tool_line}"
+    return f"{row.guard_path}:{row.guard_line}" if row.guard_line else row.guard_path
 
 
 def _operation_evidence(
@@ -264,9 +270,14 @@ def _classify(
                 "This finding's own bound was narrowed, but another modeled bound "
                 "on the same capability widened; the net direction is unresolved."
             )
+        standing = (
+            "the finding still stands"
+            if identity == "matched"
+            else f"a finding of this shape is present at head (identity {identity})"
+        )
         return "improved_not_resolved", (
-            "This change added or narrowed a bound this finding depends on and the "
-            "finding still stands. It is an improvement, not the finding's cause."
+            f"This change added or narrowed a bound this finding depends on and "
+            f"{standing}. It is an improvement, not the finding's cause."
         )
     if identity != "matched":
         # `accepted_debt` is not proof of absence from the base either: the
@@ -289,13 +300,27 @@ def _classify(
     )
 
 
+class FindingAttributionResult(NamedTuple):
+    """Rows, the findings no profile could compare, and the limit notes.
+
+    ``unattributed`` is returned as a value rather than only as prose because
+    the prose is a diff note, and ``report.md`` renders the first three notes
+    only. The one statement that keeps an empty attribution from reading as a
+    clean one cannot live where a fourth note is dropped.
+    """
+
+    rows: list[FindingAttribution]
+    unattributed: int
+    notes: list[str]
+
+
 def attribute_findings(
     diff: ToolSurfaceDiff, findings: list[Finding]
-) -> tuple[list[FindingAttribution], list[str]]:
-    """Return one attribution row per comparable finding, plus its limit notes.
+) -> FindingAttributionResult:
+    """Return one attribution row per comparable finding, and what was skipped.
 
     A finding no profile can join gets no row: an empty attribution is the
-    absence of evidence, and the returned note counts those findings so absence
+    absence of evidence, and ``unattributed`` counts those findings so absence
     is never read as agreement.
     """
     if not _asks_the_question(diff):
@@ -303,7 +328,7 @@ def attribute_findings(
         # not asking what a change did. Attributing findings to a change that
         # was never described would print "unresolved" against every finding of
         # every plain `scan`, and the diff notes already say a base is missing.
-        return [], []
+        return FindingAttributionResult([], 0, [])
     identity = _identity(diff)
     # Built once, not once per (finding, comparison) pair: the evidence rows
     # differ between the two links only by that word, and the join keys are
@@ -328,11 +353,15 @@ def attribute_findings(
         for finding in active
         if (fingerprint := finding.fingerprint or finding.id)
     )
-    rows: list[FindingAttribution] = []
     unattributed = 0
+    rows: list[FindingAttribution] = []
     for finding in active:
         fingerprint = finding.fingerprint or finding.id
         if not fingerprint:
+            # No identity to join on is the strongest form of "not compared",
+            # so it is counted rather than skipped. Both fields are optional
+            # and a plugin check can supply neither.
+            unattributed += 1
             continue
         refs = set(finding.capability_refs)
         predicate: list[FindingAttributionEvidence] = []
@@ -375,11 +404,16 @@ def attribute_findings(
     # truncation never hides a widening behind a documentation finding.
     rows.sort(key=lambda row: (_ORDER[row.attribution], row.check_id, row.fingerprint))
     if not rows and not unattributed:
-        return [], []
+        return FindingAttributionResult([], 0, [])
     notes = [_LIMIT]
     if unattributed:
-        notes.append(
-            f"{unattributed} active finding(s) have no comparison profile evidence "
-            "and are not attributed to this change in either direction."
-        )
-    return rows, notes
+        notes.append(unattributed_sentence(unattributed))
+    return FindingAttributionResult(rows, unattributed, notes)
+
+
+def unattributed_sentence(count: int) -> str:
+    """The one spelling of the count, for every surface that prints it."""
+    return (
+        f"{count} active finding(s) have no comparison profile evidence and are "
+        "not attributed to this change in either direction."
+    )

--- a/src/agents_shipgate/core/lenses/finding_attribution.py
+++ b/src/agents_shipgate/core/lenses/finding_attribution.py
@@ -412,8 +412,14 @@ def attribute_findings(
 
 
 def unattributed_sentence(count: int) -> str:
-    """The one spelling of the count, for every surface that prints it."""
+    """The one spelling of the count, for every surface that prints it.
+
+    The wording covers both causes: a finding no active profile could speak
+    about, and a finding that published no identity for one to join on. Naming
+    only the first would send a reader to look at profile coverage for a
+    finding no coverage could have reached.
+    """
     return (
-        f"{count} active finding(s) have no comparison profile evidence and are "
-        "not attributed to this change in either direction."
+        f"{count} active finding(s) could not be joined to any comparison "
+        "profile and are not attributed to this change in either direction."
     )

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -26,6 +26,7 @@ from agents_shipgate.core.findings.subject_rollup import (
     rollup_headline,
     top_findings_block,
 )
+from agents_shipgate.core.lenses.finding_attribution import unattributed_sentence
 from agents_shipgate.core.privacy import sanitize_report
 from agents_shipgate.core.source_warnings import group_source_warnings
 from agents_shipgate.core.surface_exclusions import agent_label_index
@@ -836,7 +837,7 @@ def _append_finding_attributions(lines: list[str], diff: ToolSurfaceDiff) -> Non
     ``core.lenses.finding_attribution`` and this only spells it, so Markdown
     can never disagree with ``report.json`` about which bound moved.
     """
-    if not diff.finding_attributions:
+    if not diff.finding_attributions and not diff.unattributed_findings:
         return
     # Only the rows that reached a direction are spelled here. An `unresolved`
     # row repeats one sentence per finding on a shared capability, which buries
@@ -870,13 +871,24 @@ def _append_finding_attributions(lines: list[str], diff: ToolSurfaceDiff) -> Non
                 f"{evidence.direction.replace('_', ' ')} ({evidence.effect}, "
                 f"{evidence.link}-linked){_attribution_pointers(evidence)}"
             )
+    # A trailing line that is not separated from the bullets above becomes a
+    # lazy continuation of the last one, so the counts would render inside a
+    # row instead of under the section.
+    trailing: list[str] = []
     if len(decided) > 8:
-        lines.append(f"{len(decided) - 8} more attributed findings in report.json.")
+        trailing.append(f"{len(decided) - 8} more attributed findings in report.json.")
     if undecided:
-        lines.append(
-            f"{undecided} finding(s) could not be attributed in either direction; "
-            "their evidence and the reason are in report.json."
+        trailing.append(
+            f"{undecided} finding(s) have evidence on their capability but could not "
+            "be attributed in either direction; the reason is in report.json."
         )
+    if diff.unattributed_findings:
+        # Printed here rather than left to the diff notes, which this report
+        # truncates to three: absence of evidence has to be visible next to the
+        # rows that have it.
+        trailing.append(unattributed_sentence(diff.unattributed_findings))
+    if trailing:
+        lines.extend(["", *trailing])
     lines.append("")
 
 

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -44,6 +44,7 @@ from agents_shipgate.schemas.report import (
     Misalignment,
     ReadinessReport,
 )
+from agents_shipgate.schemas.surfaces import ToolSurfaceDiff
 
 DISCLAIMER = (
     "Agents Shipgate is an advisory tool: the deterministic merge gate for "
@@ -802,6 +803,83 @@ def _append_tool_surface(lines: list[str], report: ReadinessReport) -> None:
     )
 
 
+_ATTRIBUTION_LABELS = {
+    "widened_by_change": "widened by this change",
+    "improved_not_resolved": "improved by this change, not resolved",
+    "standing_weakness": "standing weakness, no modeled bound changed",
+    "unresolved": "unresolved",
+}
+
+
+def _attribution_pointers(evidence) -> str:
+    """Where to read the compared bound, naming each side only when they differ.
+
+    Escaped plain text rather than a code span: these pointers carry `#`, `{`
+    and `}`, and a backslash escape inside backticks reaches the reader as a
+    backslash.
+    """
+    base, head = evidence.base_pointer, evidence.head_pointer
+    if base and head:
+        if base == head:
+            return f"; {_safe_markdown_text(base)}."
+        return f"; base {_safe_markdown_text(base)}, head {_safe_markdown_text(head)}."
+    if base or head:
+        side = "base" if base else "head"
+        return f"; {side} only, {_safe_markdown_text(base or head)}."
+    return "."
+
+
+def _append_finding_attributions(lines: list[str], diff: ToolSurfaceDiff) -> None:
+    """Render the per-finding attribution rows the JSON block also carries.
+
+    One renderer for both profiles: the value-join lives in
+    ``core.lenses.finding_attribution`` and this only spells it, so Markdown
+    can never disagree with ``report.json`` about which bound moved.
+    """
+    if not diff.finding_attributions:
+        return
+    # Only the rows that reached a direction are spelled here. An `unresolved`
+    # row repeats one sentence per finding on a shared capability, which buries
+    # the decided rows it is printed next to; `report.json` keeps all of them.
+    decided = [row for row in diff.finding_attributions if row.attribution != "unresolved"]
+    undecided = len(diff.finding_attributions) - len(decided)
+    lines.extend(
+        [
+            "### Finding attribution",
+            "",
+            "What this change did to the bound each finding depends on. "
+            "Dependency coverage is incomplete and no finding is excluded.",
+            "",
+        ]
+    )
+    for row in decided[:8]:
+        # A tool a reader can open, or the check ID alone. A fingerprint is
+        # identity vocabulary for `report.json`, never a subject line.
+        subject = (
+            f"{_safe_markdown_text(row.tool_name)} ({_safe_markdown_text(row.check_id)})"
+            if row.tool_name
+            else _safe_markdown_text(row.check_id)
+        )
+        lines.append(
+            f"- {subject}: {_ATTRIBUTION_LABELS[row.attribution]}. "
+            f"{_safe_markdown_text(row.reason)}"
+        )
+        for evidence in row.evidence:
+            lines.append(
+                f"  - {evidence.axis.replace('_', ' ')}: "
+                f"{evidence.direction.replace('_', ' ')} ({evidence.effect}, "
+                f"{evidence.link}-linked){_attribution_pointers(evidence)}"
+            )
+    if len(decided) > 8:
+        lines.append(f"{len(decided) - 8} more attributed findings in report.json.")
+    if undecided:
+        lines.append(
+            f"{undecided} finding(s) could not be attributed in either direction; "
+            "their evidence and the reason are in report.json."
+        )
+    lines.append("")
+
+
 def _append_tool_surface_diff(lines: list[str], report: ReadinessReport) -> None:
     diff = report.tool_surface_diff
     lines.extend(["## Tool Surface Diff", ""])
@@ -836,6 +914,7 @@ def _append_tool_surface_diff(lines: list[str], report: ReadinessReport) -> None
         if len(diff.operation_comparisons) > 8:
             lines.append(f"{len(diff.operation_comparisons) - 8} more operation comparisons in report.json.")
         lines.append("")
+    _append_finding_attributions(lines, diff)
     if not diff.enabled:
         note = diff.notes[0] if diff.notes else "No comparison source was available."
         lines.extend(

--- a/src/agents_shipgate/report/markdown.py
+++ b/src/agents_shipgate/report/markdown.py
@@ -844,15 +844,23 @@ def _append_finding_attributions(lines: list[str], diff: ToolSurfaceDiff) -> Non
     # the decided rows it is printed next to; `report.json` keeps all of them.
     decided = [row for row in diff.finding_attributions if row.attribution != "unresolved"]
     undecided = len(diff.finding_attributions) - len(decided)
+    # The lead must not promise per-finding statements the section then does
+    # not make. A repository whose only profile publishes no fingerprint can
+    # never reach a direction, so that is the normal shape there, not an edge.
+    lead = (
+        "What this change did to the bound each finding depends on."
+        if decided
+        else "No finding could be attributed to this change in either direction."
+    )
     lines.extend(
         [
             "### Finding attribution",
             "",
-            "What this change did to the bound each finding depends on. "
-            "Dependency coverage is incomplete and no finding is excluded.",
-            "",
+            f"{lead} Dependency coverage is incomplete and no finding is excluded.",
         ]
     )
+    if decided:
+        lines.append("")
     for row in decided[:8]:
         # A tool a reader can open, or the check ID alone. A fingerprint is
         # identity vocabulary for `report.json`, never a subject line.

--- a/src/agents_shipgate/schemas/finding_attribution.py
+++ b/src/agents_shipgate/schemas/finding_attribution.py
@@ -1,0 +1,95 @@
+"""Attribution of one finding to a modeled capability bound the change moved.
+
+This is a *projection* over the comparison rows the source profiles already
+publish (``tool_surface_diff.operation_comparisons`` and
+``tool_surface_diff.guard_comparisons``); it reads no source and computes no
+second diff.  It answers "did this change widen, bound or leave alone the
+capability this finding is about?" and nothing else.
+
+It is not a release decision, not a severity, and not permission to drop a
+finding: ``dependency_coverage`` stays ``incomplete`` and
+``finding_exclusion_eligible`` stays ``False`` on every row, because no
+profile has yet proved a complete shared-helper/import/configuration closure
+for a capability (#557).  A ``standing_weakness`` row means *no modeled bound
+changed*, never *nothing changed*.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+#: How one compared axis moved the capability the finding is about.
+#:
+#: ``widening`` is a proved statement, not a guess: a compared domain that is
+#: neither equal nor a subset of the base declares at least one member the base
+#: did not, so ``changed`` maps here rather than to ``unresolved``.
+AttributionEffect = Literal["widening", "narrowing", "unchanged", "unresolved"]
+
+#: ``predicate`` — the profile row names this finding's own fingerprint, so the
+#: compared bound is the one that made the finding eligible.
+#: ``capability`` — the row was joined only by canonical tool id, so it is a
+#: bound on the same capability whose relation to *this* finding's predicate is
+#: unproved.  Capability-linked evidence is recorded and can withdraw a
+#: negative claim; it can never establish one.
+AttributionLink = Literal["predicate", "capability"]
+
+FindingAttributionClass = Literal[
+    # A bound the finding depends on was removed, or the capability's compared
+    # domain grew.  Under a diff-scoped question this is the change's finding.
+    "widened_by_change",
+    # A bound was added or narrowed and the finding still stands — a strict
+    # improvement that did not perfect the surface (#515's `cal-1` shape).
+    "improved_not_resolved",
+    # Finding identity matched the base and every joined comparison says the
+    # modeled bounds are unchanged.  Dependency coverage is still incomplete.
+    "standing_weakness",
+    # No comparable predicate evidence, an unresolved or ambiguous comparison,
+    # or a capability-linked contradiction.  Never read as safe.
+    "unresolved",
+]
+
+#: Which fingerprint bucket of ``finding_deltas`` this finding is in.
+#: ``matched`` is ``unchanged_findings`` — an identity match, not a safety claim.
+#: ``unresolved`` is a finding no bucket named, which happens when there is no
+#: base to compare identity against; it is never reported as ``new``.
+FindingIdentity = Literal["new", "matched", "accepted_debt", "unresolved"]
+
+
+class FindingAttributionEvidence(BaseModel):
+    """One compared axis of one profile row, and where to read both sides."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile: Literal["openapi_delete/v1", "sdk_boolean_guard/v1"]
+    observation_id: str
+    link: AttributionLink
+    axis: Literal[
+        "approval_predicate",
+        "declared_target_domain",
+        "guard_predicate",
+        "bound_true_domain",
+    ]
+    # The profile's own vocabulary, verbatim, so the row can be joined back to
+    # the comparison it came from without a second spelling of the direction.
+    direction: str
+    effect: AttributionEffect
+    # The named thing to open on each side; absent when that side has no row.
+    base_pointer: str | None = None
+    head_pointer: str | None = None
+
+
+class FindingAttribution(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    fingerprint: str
+    check_id: str
+    tool_id: str | None = None
+    tool_name: str | None = None
+    identity: FindingIdentity
+    attribution: FindingAttributionClass
+    reason: str
+    evidence: list[FindingAttributionEvidence] = Field(default_factory=list)
+    dependency_coverage: Literal["incomplete"] = "incomplete"
+    finding_exclusion_eligible: Literal[False] = False

--- a/src/agents_shipgate/schemas/finding_attribution.py
+++ b/src/agents_shipgate/schemas/finding_attribution.py
@@ -29,31 +29,37 @@ AttributionEffect = Literal["widening", "narrowing", "unchanged", "unresolved"]
 
 #: ``predicate`` — the profile row names this finding's own fingerprint, so the
 #: compared bound is the one that made the finding eligible.
-#: ``capability`` — the row was joined only by canonical tool id, so it is a
-#: bound on the same capability whose relation to *this* finding's predicate is
-#: unproved.  Capability-linked evidence is recorded and can withdraw a
-#: negative claim; it can never establish one.
+#: ``capability`` — the row was joined by canonical identity instead: a shared
+#: tool id, or a capability id the finding cites in ``capability_refs``.  It is
+#: a bound on the same capability whose relation to *this* finding's predicate
+#: is unproved.  Capability-linked evidence is recorded and can withdraw a
+#: negative claim; it can never establish one.  A display name is never a join.
 AttributionLink = Literal["predicate", "capability"]
 
 FindingAttributionClass = Literal[
     # A bound the finding depends on was removed, or the capability's compared
     # domain grew.  Under a diff-scoped question this is the change's finding.
     "widened_by_change",
-    # A bound was added or narrowed and the finding still stands — a strict
-    # improvement that did not perfect the surface (#515's `cal-1` shape).
+    # A bound was added or narrowed and a finding of this shape is still
+    # present at head — a strict improvement that did not perfect the surface
+    # (#515's `cal-1` shape).  Whether that finding is the base's own is the
+    # separate ``identity`` axis, which the row's reason states.
     "improved_not_resolved",
     # Finding identity matched the base and every joined comparison says the
     # modeled bounds are unchanged.  Dependency coverage is still incomplete.
     "standing_weakness",
-    # No comparable predicate evidence, an unresolved or ambiguous comparison,
-    # or a capability-linked contradiction.  Never read as safe.
+    # No comparable predicate evidence, a comparison the profile refused or
+    # could not disambiguate, a shared finding identity, a same-capability
+    # contradiction, or unchanged bounds under an identity that is not a base
+    # match.  Never read as safe.
     "unresolved",
 ]
 
 #: Which fingerprint bucket of ``finding_deltas`` this finding is in.
 #: ``matched`` is ``unchanged_findings`` — an identity match, not a safety claim.
-#: ``unresolved`` is a finding no bucket named, which happens when there is no
-#: base to compare identity against; it is never reported as ``new``.
+#: ``unresolved`` is a finding no bucket named: the buckets are empty when the
+#: run's only base is a reconstructed Git operation base and no report or
+#: baseline reference supplied identities.  It is never reported as ``new``.
 FindingIdentity = Literal["new", "matched", "accepted_debt", "unresolved"]
 
 

--- a/src/agents_shipgate/schemas/surfaces.py
+++ b/src/agents_shipgate/schemas/surfaces.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agents_shipgate.schemas.common import BaselineStatus, Confidence, Severity
+from agents_shipgate.schemas.finding_attribution import FindingAttribution
 from agents_shipgate.schemas.guard_dependencies import (
     GuardDependencyComparison,
     GuardDependencyEvidence,
@@ -260,6 +261,11 @@ class ToolSurfaceDiff(BaseModel):
     notes: list[str] = Field(default_factory=list)
     guard_comparisons: list[GuardDependencyComparison] = Field(default_factory=list, exclude_if=lambda value: not value)
     operation_comparisons: list[OperationComparison] = Field(default_factory=list, exclude_if=lambda value: not value)
+    # The canonical per-finding projection over the two comparison lists above.
+    # ``finding_deltas`` stays an identity comparison; this answers what the
+    # change did to the bound each finding depends on (#515), and never
+    # excludes a finding from the release decision.
+    finding_attributions: list[FindingAttribution] = Field(default_factory=list, exclude_if=lambda value: not value)
 
 
 ActionEffect = Literal[

--- a/src/agents_shipgate/schemas/surfaces.py
+++ b/src/agents_shipgate/schemas/surfaces.py
@@ -266,6 +266,11 @@ class ToolSurfaceDiff(BaseModel):
     # change did to the bound each finding depends on (#515), and never
     # excludes a finding from the release decision.
     finding_attributions: list[FindingAttribution] = Field(default_factory=list, exclude_if=lambda value: not value)
+    # Active findings no comparison profile could speak about at all. Carried
+    # as a value, not only as a diff note, because renderers truncate notes and
+    # this is the statement that stops an empty attribution reading as a clean
+    # one. It is a count of what was *not* compared, never a pass.
+    unattributed_findings: int = Field(default=0, ge=0, exclude_if=lambda value: not value)
 
 
 ActionEffect = Literal[

--- a/tests/test_finding_attribution.py
+++ b/tests/test_finding_attribution.py
@@ -8,6 +8,7 @@ fixtures pin the difference, and pin that naming it still excludes nothing.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import get_args
 
 import pytest
@@ -22,8 +23,9 @@ from agents_shipgate.core.lenses.finding_attribution import (
     _GUARD_EFFECTS,
     _ORDER,
     attribute_findings,
+    unattributed_sentence,
 )
-from agents_shipgate.report.markdown import _ATTRIBUTION_LABELS
+from agents_shipgate.report.markdown import _ATTRIBUTION_LABELS, render_markdown_report
 from agents_shipgate.schemas.finding_attribution import FindingAttributionClass
 from agents_shipgate.schemas.guard_dependencies import (
     BooleanDomainDirection,
@@ -38,7 +40,7 @@ from agents_shipgate.schemas.operation_attribution import (
     OperationComparison,
     OperationInput,
 )
-from agents_shipgate.schemas.report import Finding
+from agents_shipgate.schemas.report import Finding, ReadinessReport
 from agents_shipgate.schemas.surfaces import (
     ToolSurfaceDiff,
     ToolSurfaceFindingDeltaItem,
@@ -302,7 +304,10 @@ def test_markdown_spells_exactly_what_the_json_block_says(tmp_path):
     # The three same-capability-only rows here are all unresolved, so Markdown
     # counts them instead of repeating one sentence and two axes each. Their
     # evidence stays in report.json.
-    assert "3 finding(s) could not be attributed in either direction" in text
+    assert (
+        "3 finding(s) have evidence on their capability but could not be "
+        "attributed in either direction" in text
+    )
     assert len([row for row in rows if row["attribution"] == "unresolved"]) == 3
     assert "capability-linked" not in text
 
@@ -326,11 +331,11 @@ def test_a_reconstructed_git_base_asks_the_question_without_a_reference():
     assert diff.base.kind == "none"
     assert attribute_findings(diff, [_finding()])[0][0].attribution == "standing_weakness"
     comparison.evidence_source = "unavailable"
-    assert attribute_findings(diff, [_finding()]) == ([], [])
+    assert attribute_findings(diff, [_finding()]) == ([], 0, [])
 
 
 def test_a_run_with_no_comparison_profile_adds_no_rows_and_no_notes():
-    rows, notes = attribute_findings(ToolSurfaceDiff(), [])
+    rows, _, notes = attribute_findings(ToolSurfaceDiff(), [])
     assert (rows, notes) == ([], [])
 
 
@@ -424,7 +429,7 @@ def test_capability_evidence_withdraws_a_standing_weakness_it_cannot_confirm(dir
         observation_id="obs", tool_id="tool_v2_a", tool_name="refund",
         direction=direction, reason="compared", before=_guard(), after=_guard(allowed=(1, 2)),
     )
-    rows, _ = attribute_findings(
+    rows, _, _ = attribute_findings(
         _diff(operations=[_unchanged_operation()], guards=[guard], matched=["fp1"]),
         [_finding()],
     )
@@ -432,7 +437,7 @@ def test_capability_evidence_withdraws_a_standing_weakness_it_cannot_confirm(dir
     assert row.attribution == "unresolved"
     assert "another modeled bound on the same capability" in row.reason
     # Without the guard row the very same inputs are a standing weakness.
-    rows, _ = attribute_findings(
+    rows, _, _ = attribute_findings(
         _diff(operations=[_unchanged_operation()], matched=["fp1"]), [_finding()]
     )
     assert rows[0].attribution == "standing_weakness"
@@ -446,12 +451,12 @@ def test_capability_widening_withdraws_an_improvement_claim():
         direction="predicate_widened", reason="compared",
         before=_guard(), after=_guard(allowed=(1, 2)),
     )
-    rows, _ = attribute_findings(
+    rows, _, _ = attribute_findings(
         _diff(operations=[improvement], guards=[guard], matched=["fp1"]), [_finding()]
     )
     assert rows[0].attribution == "unresolved"
     assert "net direction is unresolved" in rows[0].reason
-    rows, _ = attribute_findings(
+    rows, _, _ = attribute_findings(
         _diff(operations=[improvement], matched=["fp1"]), [_finding()]
     )
     assert rows[0].attribution == "improved_not_resolved"
@@ -465,12 +470,12 @@ def test_a_guard_comparison_never_joins_a_finding_by_display_name():
         before=_guard(tool_id=None), after=_guard(tool_id=None, allowed=(1, 2)),
     )
     diff = _diff(operations=[_unchanged_operation()], guards=[guard], matched=["fp1"])
-    rows, _ = attribute_findings(diff, [_finding()])
+    rows, _, _ = attribute_findings(diff, [_finding()])
     assert rows[0].attribution == "standing_weakness"
     assert not [item for item in rows[0].evidence if item.profile == "sdk_boolean_guard/v1"]
     # A finding carrying no canonical id is not joined to a guard either, so
     # it draws no row at all rather than one built on a name match.
-    rows, _ = attribute_findings(diff, [_finding("fp2", tool_id=None, refs=())])
+    rows, _, _ = attribute_findings(diff, [_finding("fp2", tool_id=None, refs=())])
     assert not rows
 
 
@@ -487,7 +492,7 @@ def test_the_whole_function_domain_is_carried_as_its_own_axis():
             bound_true_domain="widened", reason="compared",
         ),
     )
-    rows, _ = attribute_findings(
+    rows, _, _ = attribute_findings(
         _diff(operations=[_unchanged_operation()], guards=[guard], matched=["fp1"]), [_finding()]
     )
     bound = next(item for item in rows[0].evidence if item.axis == "bound_true_domain")
@@ -501,11 +506,11 @@ def test_two_findings_sharing_one_identity_are_never_attributed():
     """A profile row names a fingerprint, not a finding; a tie is unresolvable."""
     diff = _diff(operations=[_unchanged_operation()], matched=["fp1"])
     twin = _finding().model_copy(update={"check_id": "ORG-OTHER"})
-    rows, _ = attribute_findings(diff, [_finding(), twin])
+    rows, _, _ = attribute_findings(diff, [_finding(), twin])
     assert [row.attribution for row in rows] == ["unresolved", "unresolved"]
     assert all("share this identity" in row.reason for row in rows)
     # A suppressed twin is not an active finding and does not create the tie.
-    rows, _ = attribute_findings(
+    rows, _, _ = attribute_findings(
         diff, [_finding(), twin.model_copy(update={"suppressed": True})]
     )
     assert [row.attribution for row in rows] == ["standing_weakness"]
@@ -535,7 +540,7 @@ def test_accepted_debt_keeps_its_bucket_and_is_never_a_standing_weakness():
 
 
 def test_an_unattributed_finding_is_counted_rather_than_dropped_silently():
-    rows, notes = attribute_findings(
+    rows, _, notes = attribute_findings(
         _diff(operations=[_unchanged_operation()], matched=["fp1"]),
         [_finding(), _finding("fp2", tool_id="tool_v2_other", refs=())],
     )
@@ -546,8 +551,80 @@ def test_an_unattributed_finding_is_counted_rather_than_dropped_silently():
 
 def test_a_suppressed_finding_is_not_attributed():
     finding = _finding().model_copy(update={"suppressed": True})
-    rows, notes = attribute_findings(
+    rows, _, notes = attribute_findings(
         _diff(operations=[_unchanged_operation()], matched=["fp1"]), [finding]
     )
     assert rows == []
     assert not [note for note in notes if "active finding" in note]
+
+
+# --- The statements that must survive every truncation on the way out ---
+
+
+def test_the_uncompared_count_survives_the_three_note_report_limit():
+    """`report.md` prints three diff notes. The absence statement is not one."""
+    diff = _diff(operations=[_unchanged_operation()], matched=["fp1"])
+    rows, unattributed, notes = attribute_findings(
+        diff, [_finding(), _finding("fp2", tool_id="tool_v2_other", refs=())]
+    )
+    assert (unattributed, [row.fingerprint for row in rows]) == (1, ["fp1"])
+    diff.finding_attributions = rows
+    diff.unattributed_findings = unattributed
+    # Four notes ahead of it, exactly as an enabled diff produces.
+    diff.notes = ["first", "second", "third", *notes]
+    diff.enabled = True
+    report = ReadinessReport.model_validate(
+        json.loads(Path("samples/support_refund_agent/expected/report.json").read_text())
+    )
+    report.tool_surface_diff = diff
+    text = render_markdown_report(report, sanitize_output=False)
+    # The note carrying the same statement is truncated away, as it is today.
+    assert "more comparison notes in report.json" in text
+    assert notes[-1] not in text.split("Notes:", 1)[1].split("##", 1)[0]
+    # The section states it anyway.
+    section = text.split("### Finding attribution", 1)[1].split("- Base:", 1)[0]
+    assert unattributed_sentence(1) in section
+
+
+def test_a_finding_with_no_identity_at_all_is_counted_not_dropped():
+    """Both identity fields are optional; a plugin check can supply neither."""
+    diff = _diff(operations=[_unchanged_operation()], matched=["fp1"])
+    nameless = _finding().model_copy(update={"fingerprint": None, "id": None})
+    rows, unattributed, notes = attribute_findings(diff, [_finding(), nameless])
+    assert [row.fingerprint for row in rows] == ["fp1"]
+    assert unattributed == 1
+    assert unattributed_sentence(1) in notes
+
+
+def test_an_improvement_does_not_claim_a_continuity_its_identity_denies():
+    improvement = _unchanged_operation()
+    improvement.declared_target_domain = "narrowed"
+    matched, *_ = attribute_findings(
+        _diff(operations=[improvement], matched=["fp1"]), [_finding()]
+    )
+    assert matched[0].attribution == "improved_not_resolved"
+    assert "the finding still stands" in matched[0].reason
+    # The same direction against a fingerprint the base never matched must not
+    # be described as a finding that survived the change.
+    fresh, *_ = attribute_findings(_diff(operations=[improvement]), [_finding()])
+    assert (fresh[0].attribution, fresh[0].identity) == ("improved_not_resolved", "unresolved")
+    assert "still stands" not in fresh[0].reason
+    assert "present at head (identity unresolved)" in fresh[0].reason
+
+
+def test_an_unlocated_guard_publishes_no_pointer_rather_than_the_tool_s():
+    """A pointer under a guard axis names the guard or nothing at all."""
+    unlocated = _guard().model_copy(update={"guard_path": None, "guard_line": None})
+    comparison = GuardDependencyComparison(
+        observation_id="obs", tool_id="tool_v2_a", tool_name="refund",
+        direction="unresolved", reason="predicate_or_dependency_evidence_unresolved",
+        before=unlocated, after=_guard(),
+    )
+    rows, *_ = attribute_findings(
+        _diff(operations=[_unchanged_operation()], guards=[comparison], matched=["fp1"]),
+        [_finding()],
+    )
+    guard = next(item for item in rows[0].evidence if item.profile == "sdk_boolean_guard/v1")
+    assert guard.base_pointer is None
+    assert guard.head_pointer == "shared/guard.py:2"
+    assert "tools/refund.py" not in rows[0].model_dump_json()

--- a/tests/test_finding_attribution.py
+++ b/tests/test_finding_attribution.py
@@ -65,6 +65,15 @@ def _attributions(root):
     return report, diff, diff.get("finding_attributions", [])
 
 
+def _render_with(diff):
+    """Render one diff through the real report renderer and sample scaffolding."""
+    report = ReadinessReport.model_validate(
+        json.loads(Path("samples/support_refund_agent/expected/report.json").read_text())
+    )
+    report.tool_surface_diff = diff
+    return render_markdown_report(report, sanitize_output=False)
+
+
 def _predicate_row(rows):
     """The one row whose own bound the profile named by fingerprint."""
     (row,) = [
@@ -573,11 +582,7 @@ def test_the_uncompared_count_survives_the_three_note_report_limit():
     # Four notes ahead of it, exactly as an enabled diff produces.
     diff.notes = ["first", "second", "third", *notes]
     diff.enabled = True
-    report = ReadinessReport.model_validate(
-        json.loads(Path("samples/support_refund_agent/expected/report.json").read_text())
-    )
-    report.tool_surface_diff = diff
-    text = render_markdown_report(report, sanitize_output=False)
+    text = _render_with(diff)
     # The note carrying the same statement is truncated away, as it is today.
     assert "more comparison notes in report.json" in text
     assert notes[-1] not in text.split("Notes:", 1)[1].split("##", 1)[0]
@@ -628,3 +633,57 @@ def test_an_unlocated_guard_publishes_no_pointer_rather_than_the_tool_s():
     assert guard.base_pointer is None
     assert guard.head_pointer == "shared/guard.py:2"
     assert "tools/refund.py" not in rows[0].model_dump_json()
+
+
+def test_a_section_with_no_direction_says_so_instead_of_promising_rows():
+    """A profile that publishes no fingerprint can never reach a direction."""
+    diff = _diff(operations=[_unchanged_operation(("nomatch",))], matched=["fp1"])
+    rows, unattributed, _ = attribute_findings(
+        diff, [_finding(), _finding("fp2", tool_id="tool_v2_other", refs=())]
+    )
+    assert [row.attribution for row in rows] == ["unresolved"]
+    diff.finding_attributions, diff.unattributed_findings = rows, unattributed
+    section = _render_with(diff).split("### Finding attribution", 1)[1].split("- Base:", 1)[0]
+    assert "No finding could be attributed to this change in either direction." in section
+    assert "What this change did to the bound" not in section
+    assert "\n\n\n" not in section
+    assert unattributed_sentence(1) in section
+    # The decided lead comes back as soon as a row reaches a direction.
+    widened = _unchanged_operation()
+    widened.declared_target_domain = "widened"
+    diff = _diff(operations=[widened], matched=["fp1"])
+    diff.finding_attributions = attribute_findings(diff, [_finding()]).rows
+    section = _render_with(diff).split("### Finding attribution", 1)[1].split("- Base:", 1)[0]
+    assert "What this change did to the bound each finding depends on." in section
+    assert "\n\n\n" not in section
+
+
+def test_an_uncomparable_bound_elsewhere_does_not_withdraw_an_improvement():
+    """The two negative claims claim different amounts, so they withdraw
+    differently: `standing_weakness` needs every same-capability axis
+    unchanged, while a demonstrated narrowing survives an axis nobody could
+    compare and is withdrawn only by a demonstrated widening."""
+    improvement = _unchanged_operation()
+    improvement.declared_target_domain = "narrowed"
+    unresolved_guard = GuardDependencyComparison(
+        observation_id="obs", tool_id="tool_v2_a", tool_name="refund",
+        direction="unresolved", reason="base_or_head_guard_evidence_unavailable",
+        after=_guard(),
+    )
+    rows, *_ = attribute_findings(
+        _diff(operations=[improvement], guards=[unresolved_guard], matched=["fp1"]),
+        [_finding()],
+    )
+    assert rows[0].attribution == "improved_not_resolved"
+    assert {item.effect for item in rows[0].evidence if item.link == "capability"} == {
+        "unresolved"
+    }
+    # The same unresolved axis does defeat the wider claim.
+    rows, *_ = attribute_findings(
+        _diff(
+            operations=[_unchanged_operation()], guards=[unresolved_guard], matched=["fp1"]
+        ),
+        [_finding()],
+    )
+    assert rows[0].attribution == "unresolved"
+    assert "could not be compared" in rows[0].reason

--- a/tests/test_finding_attribution.py
+++ b/tests/test_finding_attribution.py
@@ -488,6 +488,21 @@ def test_a_guard_comparison_never_joins_a_finding_by_display_name():
     assert not rows
 
 
+def test_a_cited_capability_id_joins_a_finding_that_carries_no_tool_id():
+    """The same-capability join is canonical identity, not the tool id alone."""
+    widened = _unchanged_operation(("other",))
+    widened.declared_target_domain = "widened"
+    diff = _diff(operations=[widened], matched=["fp1"])
+    # No tool id at all, and the operation's fingerprint names another finding.
+    cited = _finding(tool_id=None, refs=("cap_a",))
+    (row,) = attribute_findings(diff, [cited]).rows
+    assert [item.link for item in row.evidence] == ["capability", "capability"]
+    assert row.attribution == "unresolved"
+    # Citing nothing leaves the same finding unjoined entirely.
+    result = attribute_findings(diff, [_finding(tool_id=None, refs=())])
+    assert (result.rows, result.unattributed) == ([], 1)
+
+
 def test_the_whole_function_domain_is_carried_as_its_own_axis():
     behavior = BooleanSourceBehavior(
         status="observed", reason="observed", parameters=["dry_run"], returns=["false", "true"],

--- a/tests/test_finding_attribution.py
+++ b/tests/test_finding_attribution.py
@@ -554,7 +554,7 @@ def test_an_unattributed_finding_is_counted_rather_than_dropped_silently():
         [_finding(), _finding("fp2", tool_id="tool_v2_other", refs=())],
     )
     assert [row.fingerprint for row in rows] == ["fp1"]
-    assert any("1 active finding(s) have no comparison profile evidence" in note for note in notes)
+    assert unattributed_sentence(1) in notes
     assert any("no finding is excluded" in note for note in notes)
 
 
@@ -599,6 +599,10 @@ def test_a_finding_with_no_identity_at_all_is_counted_not_dropped():
     assert [row.fingerprint for row in rows] == ["fp1"]
     assert unattributed == 1
     assert unattributed_sentence(1) in notes
+    # One sentence for both causes: an unjoinable finding is not a statement
+    # about how much the active profiles cover.
+    assert "could not be joined to any comparison profile" in unattributed_sentence(1)
+    assert "no comparison profile evidence" not in unattributed_sentence(1)
 
 
 def test_an_improvement_does_not_claim_a_continuity_its_identity_denies():

--- a/tests/test_finding_attribution.py
+++ b/tests/test_finding_attribution.py
@@ -1,0 +1,553 @@
+"""Paired base/head repositories for the three classes #515 must distinguish.
+
+A standing weakness, a strict improvement and a newly widened capability all
+look identical in ``finding_deltas``: one row in ``unchanged_findings``. These
+fixtures pin the difference, and pin that naming it still excludes nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import get_args
+
+import pytest
+import yaml
+from test_current_control import _live, _verify
+from test_openapi_operation_attribution import scan, spec, workspace
+from test_operation_attribution_verification import git, repository
+
+from agents_shipgate.core.lenses.finding_attribution import (
+    _APPROVAL_EFFECTS,
+    _DOMAIN_EFFECTS,
+    _GUARD_EFFECTS,
+    _ORDER,
+    attribute_findings,
+)
+from agents_shipgate.report.markdown import _ATTRIBUTION_LABELS
+from agents_shipgate.schemas.finding_attribution import FindingAttributionClass
+from agents_shipgate.schemas.guard_dependencies import (
+    BooleanDomainDirection,
+    BooleanSourceBehavior,
+    BooleanSourceComparison,
+    GuardDependencyComparison,
+    GuardDependencyEvidence,
+)
+from agents_shipgate.schemas.operation_attribution import (
+    DeclaredOperation,
+    OperationAttribution,
+    OperationComparison,
+    OperationInput,
+)
+from agents_shipgate.schemas.report import Finding
+from agents_shipgate.schemas.surfaces import (
+    ToolSurfaceDiff,
+    ToolSurfaceFindingDeltaItem,
+    ToolSurfaceFindingDeltas,
+)
+
+
+def _head(root, *, document=None, approval=False, extra=None):
+    """Commit a head revision and return the base commit it is compared to."""
+    base = git(root, "rev-parse", "HEAD")
+    workspace(root, document, approval=approval)
+    if extra:
+        (root / extra).write_text("unrelated\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "head")
+    return base
+
+
+def _attributions(root):
+    report = json.loads((root / "agents-shipgate-reports/report.json").read_text())
+    diff = report["tool_surface_diff"]
+    return report, diff, diff.get("finding_attributions", [])
+
+
+def _predicate_row(rows):
+    """The one row whose own bound the profile named by fingerprint."""
+    (row,) = [
+        item
+        for item in rows
+        if any(evidence["link"] == "predicate" for evidence in item["evidence"])
+    ]
+    return row
+
+
+@pytest.mark.parametrize(
+    "head,expected,direction",
+    [
+        # Nothing about the declared capability moved: the weakness stands, and
+        # it is the repository's, not this change's.
+        (
+            {"extra": "NOTES.md"},
+            "standing_weakness",
+            "unchanged",
+        ),
+        # `cal-1`'s shape: the change bounds the capability without perfecting
+        # it, so the finding survives and must not be read as its cause.
+        (
+            {"document": spec(("alpha",))},
+            "improved_not_resolved",
+            "narrowed",
+        ),
+        # The same identity bucket, the opposite direction.
+        (
+            {"document": spec(("alpha", "beta", "gamma"))},
+            "widened_by_change",
+            "widened",
+        ),
+    ],
+)
+def test_paired_repositories_separate_the_three_classes(tmp_path, head, expected, direction):
+    root = repository(tmp_path)
+    base = _head(root, **head)
+    _verify(root, base=base)
+    report, diff, rows = _attributions(root)
+    row = _predicate_row(rows)
+    # The identity comparison cannot tell these three apart; that is the point:
+    # all four findings sit in one bucket in all three fixtures.
+    assert [item["check_id"] for item in diff["finding_deltas"]["unchanged_findings"]] == [
+        "SHIP-ACTION-DESTRUCTIVE-ROLLBACK-MISSING",
+        "SHIP-DOC-MISSING-DESCRIPTION",
+        "SHIP-POLICY-CONFIRMATION-MISSING",
+        "SHIP-POLICY-APPROVAL-MISSING",
+    ]
+    assert diff["finding_deltas"]["new_findings"] == []
+    assert row["identity"] == "matched"
+    assert row["attribution"] == expected, row
+    assert row["check_id"] == "SHIP-POLICY-APPROVAL-MISSING"
+    targets = next(
+        item for item in row["evidence"] if item["axis"] == "declared_target_domain"
+    )
+    assert (targets["direction"], targets["link"]) == (direction, "predicate")
+    assert targets["base_pointer"] == targets["head_pointer"] == (
+        "api.json#/paths/~1documents~1{id}/delete"
+    )
+    # Attribution is evidence for a later decision, never a decision.
+    for item in rows:
+        assert item["dependency_coverage"] == "incomplete"
+        assert item["finding_exclusion_eligible"] is False
+    # Bounds on the same capability are recorded, but a finding whose own
+    # predicate the profile never named stays unattributed in either direction.
+    for item in rows:
+        if item is not row:
+            assert item["attribution"] == "unresolved"
+            assert {evidence["link"] for evidence in item["evidence"]} == {"capability"}
+    assert _live(root) is not None
+
+
+def test_opposite_attributions_leave_one_identical_verdict(tmp_path):
+    """The projection explains; it does not gate. Narrowing and widening the
+    same declared capability produce opposite classes, the same finding
+    identities and the same release decision."""
+    seen = {}
+    for label, document in (
+        ("improved", spec(("alpha",))),
+        ("widened", spec(("alpha", "beta", "gamma"))),
+    ):
+        (tmp_path / label).mkdir()
+        root = repository(tmp_path / label)
+        base = _head(root, document=document)
+        _verify(root, base=base)
+        report, diff, rows = _attributions(root)
+        seen[label] = (
+            _predicate_row(rows)["attribution"],
+            report["release_decision"]["decision"],
+            sorted(item["fingerprint"] for item in diff["finding_deltas"]["unchanged_findings"]),
+            sorted(item["check_id"] for item in report["findings"] if not item["suppressed"]),
+        )
+    improved, widened = seen["improved"], seen["widened"]
+    assert (improved[0], widened[0]) == ("improved_not_resolved", "widened_by_change")
+    assert improved[1:] == widened[1:]
+
+
+def test_naming_the_class_changes_no_verdict_and_drops_no_finding(tmp_path):
+    """The improvement is still reported; only the explanation is new."""
+    root = repository(tmp_path)
+    base = _head(root, document=spec(("alpha",)))
+    _verify(root, base=base)
+    report, diff, rows = _attributions(root)
+    row = _predicate_row(rows)
+    assert row["attribution"] == "improved_not_resolved"
+    finding = next(
+        item for item in report["findings"] if item["fingerprint"] == row["fingerprint"]
+    )
+    assert finding["suppressed"] is False
+    assert report["release_decision"]["decision"] != "passed"
+    assert any(
+        item["fingerprint"] == row["fingerprint"]
+        for item in diff["finding_deltas"]["unchanged_findings"]
+    )
+
+
+def test_removing_the_approval_declaration_is_attributed_to_the_change(tmp_path):
+    """A bound the base declared and the head does not is this change's finding."""
+    root = tmp_path / "repo"
+    workspace(root, approval=True)
+    (root / ".gitignore").write_text("agents-shipgate-reports/\n")
+    git(root, "init", "-q", "-b", "main")
+    git(root, "config", "user.name", "Test User")
+    git(root, "config", "user.email", "test@example.test")
+    git(root, "add", ".")
+    git(root, "commit", "-qm", "base declares approval")
+    base = _head(root, approval=False)
+    _verify(root, base=base)
+    _, diff, rows = _attributions(root)
+    row = _predicate_row(rows)
+    # New fingerprint, and a bound that demonstrably went away.
+    assert row["identity"] == "new"
+    assert row["attribution"] == "widened_by_change"
+    approval = next(
+        item for item in row["evidence"] if item["axis"] == "approval_predicate"
+    )
+    assert (approval["direction"], approval["effect"]) == ("newly_missing", "widening")
+
+
+_SDK_AGENT = '''from agents import Agent, function_tool
+from .guards import permitted as allowed
+
+@function_tool
+def delete_refund(approved: bool, within_limit: bool) -> bool:
+    if not allowed(approved, within_limit):
+        return False
+    return True
+
+agent = Agent(name="Refund", tools=[delete_refund])
+'''
+
+
+def _sdk_workspace(root, predicate="approved and within_limit"):
+    """An SDK tool whose only guard lives in a separate imported module."""
+    package = root / "refund_agent"
+    package.mkdir(parents=True, exist_ok=True)
+    (package / "__init__.py").write_text("")
+    (package / "agent.py").write_text(_SDK_AGENT)
+    (package / "guards.py").write_text(
+        f"def permitted(approved: bool, within_limit: bool) -> bool:\n    return {predicate}\n"
+    )
+    (root / "shipgate.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": "0.1",
+                "project": {"name": "guard-attribution-fixture"},
+                "agent": {"name": "Refund", "declared_purpose": ["compare an imported guard"]},
+                "environment": {"target": "local"},
+                "tool_sources": [
+                    {"id": "sdk", "type": "openai_agents_sdk", "path": "refund_agent/agent.py"}
+                ],
+                "output": {"directory": "agents-shipgate-reports", "formats": ["markdown", "json"]},
+            }
+        )
+    )
+
+
+def test_a_weakened_shared_guard_reaches_the_findings_of_an_unchanged_tool(tmp_path):
+    """#515's shared-helper case, as far as the shipped profiles prove it.
+
+    Only `refund_agent/guards.py` changes; the tool declaration file does not,
+    and the finding's own fingerprint is unchanged. The finding still carries
+    the widened predicate and its base/head location, and it may not be called
+    a standing weakness.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    _sdk_workspace(root)
+    (root / ".gitignore").write_text("agents-shipgate-reports/\n")
+    git(root, "init", "-q", "-b", "main")
+    git(root, "config", "user.name", "Test User")
+    git(root, "config", "user.email", "test@example.test")
+    git(root, "add", ".")
+    git(root, "commit", "-qm", "base")
+    base = git(root, "rev-parse", "HEAD")
+    declaration = (root / "refund_agent/agent.py").read_bytes()
+    _sdk_workspace(root, "approved")
+    git(root, "add", "refund_agent/guards.py")
+    git(root, "commit", "-qm", "weaken the shared predicate")
+    _verify(root, base=base)
+    assert (root / "refund_agent/agent.py").read_bytes() == declaration
+    _, diff, rows = _attributions(root)
+    (row,) = rows
+    assert row["identity"] == "matched"
+    assert [item["axis"] for item in row["evidence"]] == [
+        "guard_predicate",
+        "bound_true_domain",
+    ]
+    for item in row["evidence"]:
+        # A bound that moved on this capability, carried by the guard module
+        # rather than by anything the tool's own declaration says.
+        assert (item["profile"], item["effect"], item["link"]) == (
+            "sdk_boolean_guard/v1",
+            "widening",
+            "capability",
+        )
+        assert item["base_pointer"] == item["head_pointer"] == "refund_agent/guards.py:1"
+    # Same-capability evidence explains; it never attributes on its own.
+    assert row["attribution"] == "unresolved"
+    assert row["finding_exclusion_eligible"] is False
+
+
+def test_markdown_spells_exactly_what_the_json_block_says(tmp_path):
+    root = repository(tmp_path)
+    base = _head(root, document=spec(("alpha", "beta", "gamma")))
+    _verify(root, base=base)
+    _, _, rows = _attributions(root)
+    text = (root / "agents-shipgate-reports/report.md").read_text()
+    assert "### Finding attribution" in text
+    assert "widened by this change" in text
+    assert "declared target domain: widened (widening, predicate-linked)" in text
+    assert "no finding is excluded" in text
+    # The most consequential row is rendered first, and names the document.
+    assert _predicate_row(rows) is rows[0]
+    assert "api.json\\#/paths/~1documents~1\\{id\\}/delete" in text
+    # The three same-capability-only rows here are all unresolved, so Markdown
+    # counts them instead of repeating one sentence and two axes each. Their
+    # evidence stays in report.json.
+    assert "3 finding(s) could not be attributed in either direction" in text
+    assert len([row for row in rows if row["attribution"] == "unresolved"]) == 3
+    assert "capability-linked" not in text
+
+
+def test_a_scan_with_no_base_asks_no_question_and_attributes_nothing(tmp_path):
+    """A run with nothing to compare against must not answer a diff question."""
+    root = tmp_path / "repo"
+    workspace(root)
+    report = scan(root, tmp_path / "reports")
+    diff = report.tool_surface_diff
+    assert diff.operation_comparisons and diff.base.kind == "none"
+    assert diff.finding_attributions == []
+    # The missing base stays explicit where it already was.
+    assert any("No --diff-from report" in note for note in diff.notes)
+
+
+def test_a_reconstructed_git_base_asks_the_question_without_a_reference():
+    """Verifier provenance a public report cannot set still earns attribution."""
+    comparison = _unchanged_operation()
+    diff = _diff(operations=[comparison], matched=["fp1"])
+    assert diff.base.kind == "none"
+    assert attribute_findings(diff, [_finding()])[0][0].attribution == "standing_weakness"
+    comparison.evidence_source = "unavailable"
+    assert attribute_findings(diff, [_finding()]) == ([], [])
+
+
+def test_a_run_with_no_comparison_profile_adds_no_rows_and_no_notes():
+    rows, notes = attribute_findings(ToolSurfaceDiff(), [])
+    assert (rows, notes) == ([], [])
+
+
+@pytest.mark.parametrize(
+    "table,literals",
+    [
+        (_APPROVAL_EFFECTS, get_args(OperationComparison.model_fields["approval_predicate"].annotation)),
+        (
+            _DOMAIN_EFFECTS,
+            get_args(OperationComparison.model_fields["declared_target_domain"].annotation),
+        ),
+        (_GUARD_EFFECTS, get_args(GuardDependencyComparison.model_fields["direction"].annotation)),
+        (_DOMAIN_EFFECTS, get_args(BooleanDomainDirection)),
+    ],
+)
+def test_every_shipped_direction_has_an_effect(table, literals):
+    """A profile that grows a direction must not fall through to a KeyError."""
+    assert literals and set(literals) <= set(table)
+
+
+def test_every_class_has_an_order_and_a_rendered_label():
+    """A new class must not silently sort last or crash the Markdown renderer."""
+    classes = set(get_args(FindingAttributionClass))
+    assert classes == set(_ORDER) == set(_ATTRIBUTION_LABELS)
+    assert len(set(_ORDER.values())) == len(classes)
+
+
+# --- Classification rules the paired repositories cannot reach on their own ---
+
+
+def _guard(observation="obs", *, tool_id="tool_v2_a", allowed=(1,), behavior=None):
+    return GuardDependencyEvidence(
+        source_id="sdk", observation_id=observation, tool_id=tool_id,
+        tool_name="refund", tool_path="tools/refund.py", tool_symbol="refund", tool_line=4,
+        guard_symbol="allowed", guard_path="shared/guard.py", guard_line=2,
+        status="observed", reason="observed", parameters=["dry_run"],
+        allowed_inputs=list(allowed), source_behavior=behavior,
+    )
+
+
+def _operation(fingerprints, *, tool_id="tool_v2_a", approval=True, targets=("a",)):
+    return OperationAttribution(
+        operation=DeclaredOperation(
+            source_id="api", observation_id="op", tool_name="remove_document",
+            method="delete", path_template="/documents/{id}",
+            source_pointer="/paths/~1documents~1{id}/delete",
+            status="observed", reason="observed", declared_targets=list(targets),
+            inputs=[OperationInput(path="api.json", sha256="0" * 64, role="openapi_document")],
+        ),
+        tool_id=tool_id, capability_id="cap_a", finding_fingerprints=list(fingerprints),
+        status="observed", reason="observed", missing_approval=approval,
+    )
+
+
+def _diff(*, operations=(), guards=(), matched=()):
+    return ToolSurfaceDiff(
+        operation_comparisons=list(operations),
+        guard_comparisons=list(guards),
+        finding_deltas=ToolSurfaceFindingDeltas(
+            unchanged_findings=[
+                ToolSurfaceFindingDeltaItem(
+                    fingerprint=value, check_id="ORG-CHECK", severity="high", title="t"
+                )
+                for value in matched
+            ]
+        ),
+    )
+
+
+def _finding(fingerprint="fp1", *, tool_id="tool_v2_a", refs=("cap_a",)):
+    return Finding(
+        fingerprint=fingerprint, check_id="ORG-CHECK", title="t", severity="high",
+        category="policy", tool_id=tool_id, tool_name="remove_document",
+        capability_refs=list(refs), recommendation="Review it.",
+    )
+
+
+def _unchanged_operation(fingerprints=("fp1",)):
+    row = _operation(fingerprints)
+    return OperationComparison(
+        observation_id="op", before=row, after=row, evidence_source="reconstructed_git_base",
+        base_tree="t" * 40, declared_target_domain="unchanged",
+        approval_predicate="standing_weakness", reason="compared",
+    )
+
+
+@pytest.mark.parametrize("direction", ["predicate_widened", "predicate_changed"])
+def test_capability_evidence_withdraws_a_standing_weakness_it_cannot_confirm(direction):
+    """A bound moved on this capability, so "nothing changed" is not available."""
+    guard = GuardDependencyComparison(
+        observation_id="obs", tool_id="tool_v2_a", tool_name="refund",
+        direction=direction, reason="compared", before=_guard(), after=_guard(allowed=(1, 2)),
+    )
+    rows, _ = attribute_findings(
+        _diff(operations=[_unchanged_operation()], guards=[guard], matched=["fp1"]),
+        [_finding()],
+    )
+    (row,) = rows
+    assert row.attribution == "unresolved"
+    assert "another modeled bound on the same capability" in row.reason
+    # Without the guard row the very same inputs are a standing weakness.
+    rows, _ = attribute_findings(
+        _diff(operations=[_unchanged_operation()], matched=["fp1"]), [_finding()]
+    )
+    assert rows[0].attribution == "standing_weakness"
+
+
+def test_capability_widening_withdraws_an_improvement_claim():
+    improvement = _unchanged_operation()
+    improvement.declared_target_domain = "narrowed"
+    guard = GuardDependencyComparison(
+        observation_id="obs", tool_id="tool_v2_a", tool_name="refund",
+        direction="predicate_widened", reason="compared",
+        before=_guard(), after=_guard(allowed=(1, 2)),
+    )
+    rows, _ = attribute_findings(
+        _diff(operations=[improvement], guards=[guard], matched=["fp1"]), [_finding()]
+    )
+    assert rows[0].attribution == "unresolved"
+    assert "net direction is unresolved" in rows[0].reason
+    rows, _ = attribute_findings(
+        _diff(operations=[improvement], matched=["fp1"]), [_finding()]
+    )
+    assert rows[0].attribution == "improved_not_resolved"
+
+
+def test_a_guard_comparison_never_joins_a_finding_by_display_name():
+    """A tool name is a label; only a canonical id is an identity."""
+    guard = GuardDependencyComparison(
+        observation_id="obs", tool_id=None, tool_name="remove_document",
+        direction="predicate_widened", reason="compared",
+        before=_guard(tool_id=None), after=_guard(tool_id=None, allowed=(1, 2)),
+    )
+    diff = _diff(operations=[_unchanged_operation()], guards=[guard], matched=["fp1"])
+    rows, _ = attribute_findings(diff, [_finding()])
+    assert rows[0].attribution == "standing_weakness"
+    assert not [item for item in rows[0].evidence if item.profile == "sdk_boolean_guard/v1"]
+    # A finding carrying no canonical id is not joined to a guard either, so
+    # it draws no row at all rather than one built on a name match.
+    rows, _ = attribute_findings(diff, [_finding("fp2", tool_id=None, refs=())])
+    assert not rows
+
+
+def test_the_whole_function_domain_is_carried_as_its_own_axis():
+    behavior = BooleanSourceBehavior(
+        status="observed", reason="observed", parameters=["dry_run"], returns=["false", "true"],
+    )
+    guard = GuardDependencyComparison(
+        observation_id="obs", tool_id="tool_v2_a", tool_name="refund",
+        direction="predicate_unchanged", reason="compared",
+        before=_guard(behavior=behavior), after=_guard(behavior=behavior),
+        source_behavior=BooleanSourceComparison(
+            returns="unchanged", true_domain="unchanged", binding="unchanged",
+            bound_true_domain="widened", reason="compared",
+        ),
+    )
+    rows, _ = attribute_findings(
+        _diff(operations=[_unchanged_operation()], guards=[guard], matched=["fp1"]), [_finding()]
+    )
+    bound = next(item for item in rows[0].evidence if item.axis == "bound_true_domain")
+    assert (bound.effect, bound.link) == ("widening", "capability")
+    assert bound.base_pointer == bound.head_pointer == "shared/guard.py:2"
+    # The literal true-domain widening is what withdraws the negative claim.
+    assert rows[0].attribution == "unresolved"
+
+
+def test_two_findings_sharing_one_identity_are_never_attributed():
+    """A profile row names a fingerprint, not a finding; a tie is unresolvable."""
+    diff = _diff(operations=[_unchanged_operation()], matched=["fp1"])
+    twin = _finding().model_copy(update={"check_id": "ORG-OTHER"})
+    rows, _ = attribute_findings(diff, [_finding(), twin])
+    assert [row.attribution for row in rows] == ["unresolved", "unresolved"]
+    assert all("share this identity" in row.reason for row in rows)
+    # A suppressed twin is not an active finding and does not create the tie.
+    rows, _ = attribute_findings(
+        diff, [_finding(), twin.model_copy(update={"suppressed": True})]
+    )
+    assert [row.attribution for row in rows] == ["standing_weakness"]
+
+
+def test_a_fingerprint_no_identity_bucket_names_is_never_reported_as_new():
+    """Without identity buckets there is no base match, and no claim of one."""
+    diff = _diff(operations=[_unchanged_operation()])
+    assert diff.finding_deltas.new_findings == []
+    (row,) = attribute_findings(diff, [_finding()])[0]
+    assert row.identity == "unresolved"
+    assert row.attribution == "unresolved"
+    assert "not an unchanged base identity (unresolved)" in row.reason
+
+
+def test_accepted_debt_keeps_its_bucket_and_is_never_a_standing_weakness():
+    diff = _diff(operations=[_unchanged_operation()])
+    diff.finding_deltas.accepted_debt = [
+        ToolSurfaceFindingDeltaItem(
+            fingerprint="fp1", check_id="ORG-CHECK", severity="high", title="t",
+            baseline_status="matched",
+        )
+    ]
+    (row,) = attribute_findings(diff, [_finding()])[0]
+    assert row.identity == "accepted_debt"
+    assert row.attribution == "unresolved"
+
+
+def test_an_unattributed_finding_is_counted_rather_than_dropped_silently():
+    rows, notes = attribute_findings(
+        _diff(operations=[_unchanged_operation()], matched=["fp1"]),
+        [_finding(), _finding("fp2", tool_id="tool_v2_other", refs=())],
+    )
+    assert [row.fingerprint for row in rows] == ["fp1"]
+    assert any("1 active finding(s) have no comparison profile evidence" in note for note in notes)
+    assert any("no finding is excluded" in note for note in notes)
+
+
+def test_a_suppressed_finding_is_not_attributed():
+    finding = _finding().model_copy(update={"suppressed": True})
+    rows, notes = attribute_findings(
+        _diff(operations=[_unchanged_operation()], matched=["fp1"]), [finding]
+    )
+    assert rows == []
+    assert not [note for note in notes if "active finding" in note]


### PR DESCRIPTION
Refs #515. This is the attribution step of #515's stated implementation order,
not its scope switch.

## The gap

`tool_surface_diff.finding_deltas` answers a question about identity: is this
fingerprint in the base report? Three different changes get the same answer.
A weakness the pull request never touched, a change that bounds the capability
without perfecting it, and a change that widens the capability all land in one
`unchanged_findings` row. That is the ambiguity #515 was opened for, and the
evidence needed to separate them already exists — split across
`operation_comparisons` (#628) and `guard_comparisons` (#599/#606), in two
private vocabularies, with no join to the findings that gate.

## What this adds

`tool_surface_diff.finding_attributions[]`: one canonical statement per active
finding, projected over the comparison rows those profiles already publish.

| Class | Means |
|---|---|
| `widened_by_change` | A bound this finding depends on was removed, or the compared domain of the capability grew. |
| `improved_not_resolved` | A bound was added or narrowed and the finding still stands — `cal-1`'s shape. |
| `standing_weakness` | Matched the base and every *modeled* bound is unchanged. |
| `unresolved` | No comparable evidence, a refused direction, or a contradiction. |

It reads no source, reconstructs no tree and runs no second diff: every
direction is copied verbatim out of an existing comparison row, and
`evidence[].direction` keeps the profile's own spelling so a row joins back to
the comparison it came from. `evidence[].effect` is the single place the two
vocabularies are reconciled; a domain that is neither equal to nor a subset of
the base contains at least one member the base did not declare, so `changed`
is recorded as `widening` — a statement about the compared sets, not a risk
judgement.

Three refusals, each of which is why a whole class of row is `unresolved`:

- **Only predicate-linked evidence classifies.** A row earns that link by
  naming the finding's own fingerprint. A row joined by canonical tool id is
  `capability`-linked evidence whose relation to *this* finding's predicate is
  unproved. A display name is never a join, and two active findings sharing one
  fingerprint make every row about them unresolved.
- **Capability-linked evidence can withdraw a claim, never establish one.**
  `standing_weakness` and `improved_not_resolved` are claims about what did not
  get worse, so any same-capability movement retracts them.
- **Absence is not agreement.** Findings no profile can compare are counted in
  `tool_surface_diff.notes`, never silently dropped. A run with no base asks no
  diff question and emits no rows at all, rather than printing `unresolved`
  against every finding of every plain `scan`; the missing base is already
  explicit in those notes.

`docs/finding-attribution.md` is the contract.

## What this does not do

No `--scope diff` / `--scope tree`, no receipt question, no decision
consumption. `dependency_coverage` stays `incomplete` and
`finding_exclusion_eligible` stays `false` on every row, because #557's
shared-helper/import/configuration closure is still unproved: `standing_weakness`
says *no modeled bound changed*, never *nothing changed*. No finding,
fingerprint, support classification, severity, baseline, exit code or release
decision changes; no check ID is added; no report schema version is bumped.
#515's TypeScript MongoDB `cal-1` case needs a TypeScript profile and stays
open, as do #563/#312's historical bars.

## Surface discipline

`finding_attributions` is a field on the existing `tool_surface_diff` block,
added exactly as `guard_comparisons` and `operation_comparisons` were, so it is
not one of the five kinds of new surface the gate names. Answering it anyway:

1. **Metric.** Noise rate. #515 names whole-tree judging as a false-positive
   generator — a strictly-improving PR carrying the repository's standing
   weakness. This is the attribution that a later gate change needs in order to
   stop counting an untouched weakness as this PR's finding. On its own it
   moves no metric, by design.
2. **Existing surface.** Yes. It extends the one projection and consumes the
   one decision engine's existing comparison rows. No second diff engine, no
   parallel verdict, no new check id, no schema version.
3. **Non-goals.** No second verdict — `test_opposite_attributions_leave_one_identical_verdict`
   pins that narrowing and widening the same capability produce opposite
   classes, the same finding identities and one identical release decision. No
   new adapter, no execution, no LLM, no network.

## Validation

Paired committed repositories cover the three classes, a removed approval
declaration, and #515's shared-helper case: a repository where only
`refund_agent/guards.py` changes, the tool declaration file and the finding's
fingerprint do not, and the finding still carries the widened predicate with
its base/head location — and is not called a standing weakness. Unit fixtures
cover the withdrawal rules, the display-name and shared-identity refusals, the
whole-function true-domain axis, accepted debt, suppressed findings, the
no-base and no-profile gates, and exhaustiveness of both direction tables and
the class tables. Full local suite and `ruff` pass;
`scripts/generate_schemas.py` regenerated `docs/report-schema.v0.43.json`
additively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
