### PR TITLE
fix(diff): read every counted hunk row, so header-shaped content is not lost (#611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Read every counted hunk row, so header-shaped content stops being lost.
+  Hunk state and the header's declared row counts, not a line's spelling,
+  decide what the shared unified-diff parser treats as content: a removed
+  `---` renders as `----` and a removed `-- note` renders as `--- note`,
+  and matching those against the file-header prefixes dropped the row and,
+  in the second case, replaced the file's identity with the invalid-path
+  sentinel. A plain Markdown horizontal-rule removal now reaches a complete
+  structural comparison instead of an unnecessary `human_review_required`.
+  Truncated and over-declared hunks still end at the first line that cannot
+  be hunk data, keep their short row list, and are still refused by the
+  declared-count comparison; path, rename, no-newline and malformed-header
+  contracts are unchanged (#611).
+
 - Name what a change did to the bound each finding depends on.
   `tool_surface_diff.finding_attributions[]` projects the shipped
   `openapi_delete/v1` and `sdk_boolean_guard/v1` comparisons onto active

--- a/src/agents_shipgate/core/boundary_diff.py
+++ b/src/agents_shipgate/core/boundary_diff.py
@@ -105,17 +105,38 @@ def git_diff_path_token(prefix: str, path: str) -> str:
 
 
 def parse_unified_diff(diff_text: str) -> list[DiffFile]:
+    """Parse unified diff text into per-file added/removed lines and hunks.
+
+    Hunk state, not line spelling, decides what is content.  A removed
+    ``---`` renders as ``----`` and a removed ``-- note`` renders as
+    ``--- note``; matching those against the file-header prefixes drops a
+    counted row, and in the second case rewrites the file's own identity
+    from its content.  While a hunk still owes rows, any line opening with
+    a unified-diff marker (space, ``+``, ``-``, ``\\``) is that hunk's data
+    and is dispatched on its first character alone.
+
+    The row budget comes from the hunk header, so a truncated or
+    over-declared hunk ends as soon as a line cannot be hunk data.  The
+    short hunk is kept, and the declared-count comparison in
+    ``core.instruction_structure`` still refuses it — repairing the parser
+    must not turn an incomplete comparison into a successful one.
+    """
+
     files_out: list[DiffFile] = []
     current: dict[str, Any] | None = None
     current_hunk: DiffHunk | None = None
+    old_remaining = 0
+    new_remaining = 0
 
     def finish() -> None:
-        nonlocal current, current_hunk
+        nonlocal current, current_hunk, old_remaining, new_remaining
         if current is None:
             return
         if current_hunk is not None:
             current.setdefault("hunks", []).append(current_hunk)
             current_hunk = None
+        old_remaining = 0
+        new_remaining = 0
         files_out.append(
             DiffFile(
                 old_path=current.get("old_path"),
@@ -162,6 +183,35 @@ def parse_unified_diff(diff_text: str) -> list[DiffFile]:
             continue
         if current is None:
             continue
+        if (old_remaining > 0 or new_remaining > 0) and raw_line[:1] in {
+            " ",
+            "+",
+            "-",
+            "\\",
+        }:
+            # Inside a hunk that still owes rows: this is content, whatever
+            # it is spelled like. "\ No newline at end of file" is a marker
+            # rather than a row, so it consumes no budget.
+            if raw_line.startswith("\\"):
+                continue
+            marker, text = raw_line[0], raw_line[1:]
+            if marker == "+":
+                current["added_lines"].append(text)
+                new_remaining -= 1
+            elif marker == "-":
+                current["removed_lines"].append(text)
+                old_remaining -= 1
+            else:
+                old_remaining -= 1
+                new_remaining -= 1
+            if current_hunk is not None:
+                current_hunk.lines.append((marker, text))
+            continue
+        # Any other line ends the hunk, however many rows it still owed.
+        # The short hunk is retained so the declared-count comparison can
+        # refuse it.
+        old_remaining = 0
+        new_remaining = 0
         if raw_line.startswith(("old mode ", "new mode ", "copy from ", "copy to ")):
             current["metadata_changed"] = True
         elif raw_line.startswith("deleted file mode"):
@@ -218,6 +268,8 @@ def parse_unified_diff(diff_text: str) -> list[DiffFile]:
             if current_hunk is not None:
                 current.setdefault("hunks", []).append(current_hunk)
             current_hunk = _parse_hunk_header(raw_line)
+            old_remaining = current_hunk.old_count
+            new_remaining = current_hunk.new_count
         elif raw_line.startswith("+") and not raw_line.startswith("+++"):
             current["added_lines"].append(raw_line[1:])
             if current_hunk is not None:

--- a/tests/test_boundary_diff_hunks.py
+++ b/tests/test_boundary_diff_hunks.py
@@ -1,0 +1,293 @@
+"""Hunk-row retention in the shared unified-diff parser (#611).
+
+The parser used to decide what a line *was* from how it was spelled, so a
+removed ``---`` (rendered ``----``) and a removed ``-- note`` (rendered
+``--- note``) matched the file-header prefixes.  The first dropped a
+counted row; the second rewrote the file's identity from its own content.
+
+These cases run against real ``git diff`` output wherever the defect is
+about what Git actually emits, and against handwritten text where the
+point is a malformed input Git would never produce.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.core.boundary_diff import (
+    ResolvedFileText,
+    parse_unified_diff,
+)
+from agents_shipgate.core.instruction_structure import (
+    instruction_pair_is_complete,
+    unchanged_instruction_structure,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _git(workspace, "init", "-q", "-b", "main")
+    _git(workspace, "config", "user.email", "test@example.invalid")
+    _git(workspace, "config", "user.name", "Test")
+    return workspace
+
+
+def _commit(repo: Path, name: str, text: str) -> None:
+    (repo / name).write_text(text, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", f"write {name}")
+
+
+def _rows_are_counted(diff) -> bool:
+    """Every hunk retains exactly the rows its header declared."""
+
+    return all(
+        hunk.old_count == sum(kind in {" ", "-"} for kind, _ in hunk.lines)
+        and hunk.new_count == sum(kind in {" ", "+"} for kind, _ in hunk.lines)
+        for hunk in diff.hunks
+    )
+
+
+# --- what Git really emits -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "before,after,removed,added",
+    [
+        # The reported case: a Markdown horizontal rule, rendered "----".
+        (
+            "Explain results.\n---\nKeep examples concise.\n",
+            "Explain results.\nKeep examples concise.\n",
+            ["---"],
+            [],
+        ),
+        # The mirror: adding one, and adding a "+++" lookalike.
+        (
+            "Explain results.\nKeep examples concise.\n",
+            "Explain results.\n+++\nKeep examples concise.\n",
+            [],
+            ["+++"],
+        ),
+        # Header-shaped content *with a space*, which reached the file-header
+        # branch rather than being dropped.
+        (
+            "Explain results.\n-- note\nKeep examples concise.\n",
+            "Explain results.\nKeep examples concise.\n",
+            ["-- note"],
+            [],
+        ),
+        (
+            "Explain results.\nKeep examples concise.\n",
+            "Explain results.\n++ note\nKeep examples concise.\n",
+            [],
+            ["++ note"],
+        ),
+        # A line that is only dashes, longer than the header prefix.
+        (
+            "Explain results.\n-------\nKeep examples concise.\n",
+            "Explain results.\nKeep examples concise.\n",
+            ["-------"],
+            [],
+        ),
+    ],
+)
+def test_header_shaped_content_is_retained_as_hunk_data(
+    repo: Path, before: str, after: str, removed: list[str], added: list[str]
+) -> None:
+    _commit(repo, "AGENTS.md", before)
+    (repo / "AGENTS.md").write_text(after, encoding="utf-8")
+
+    diff = parse_unified_diff(_git(repo, "diff"))[0]
+
+    assert diff.removed_lines == removed
+    assert diff.added_lines == added
+    assert _rows_are_counted(diff)
+    # Identity comes from the header, never from a content row that looks
+    # like one.
+    assert diff.old_path == "AGENTS.md"
+    assert diff.new_path == "AGENTS.md"
+
+
+def test_the_reported_rule_removal_reaches_a_complete_comparison(repo: Path) -> None:
+    """#611's acceptance: plain guidance either side, so the structural
+    comparison must complete rather than refuse an incomplete input."""
+
+    before = "Explain results.\n---\nKeep examples concise.\n"
+    after = "Explain results.\nKeep examples concise.\n"
+    _commit(repo, "AGENTS.md", before)
+    (repo / "AGENTS.md").write_text(after, encoding="utf-8")
+
+    diff = parse_unified_diff(_git(repo, "diff"))[0]
+    resolved = ResolvedFileText(before, after, "fixture", None, None)
+
+    assert instruction_pair_is_complete(diff, resolved)
+    assert unchanged_instruction_structure(diff, resolved)
+
+
+def test_multi_file_rows_stay_with_their_own_file(repo: Path) -> None:
+    _commit(repo, "AGENTS.md", "One.\n---\nTwo.\n")
+    _commit(repo, "CLAUDE.md", "Three.\n-- four\nFive.\n")
+    (repo / "AGENTS.md").write_text("One.\nTwo.\n", encoding="utf-8")
+    (repo / "CLAUDE.md").write_text("Three.\nFive.\n", encoding="utf-8")
+
+    files = {f.path: f for f in parse_unified_diff(_git(repo, "diff"))}
+
+    assert set(files) == {"AGENTS.md", "CLAUDE.md"}
+    assert files["AGENTS.md"].removed_lines == ["---"]
+    assert files["CLAUDE.md"].removed_lines == ["-- four"]
+    assert all(_rows_are_counted(f) for f in files.values())
+
+
+def test_multiple_hunks_in_one_file_each_keep_their_rows(repo: Path) -> None:
+    body = "\n".join(["---"] + [f"line {n}" for n in range(1, 30)] + ["---", ""])
+    _commit(repo, "AGENTS.md", body)
+    (repo / "AGENTS.md").write_text(
+        "\n".join([f"line {n}" for n in range(1, 30)] + [""]), encoding="utf-8"
+    )
+
+    diff = parse_unified_diff(_git(repo, "diff"))[0]
+
+    assert len(diff.hunks) == 2
+    assert diff.removed_lines == ["---", "---"]
+    assert _rows_are_counted(diff)
+
+
+def test_rename_contract_is_unchanged(repo: Path) -> None:
+    _commit(repo, "AGENTS.md", "One.\n---\nTwo.\n")
+    _git(repo, "mv", "AGENTS.md", "CLAUDE.md")
+    (repo / "CLAUDE.md").write_text("One.\nTwo.\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+
+    diff = parse_unified_diff(_git(repo, "diff", "--cached", "-M"))[0]
+
+    assert diff.is_rename
+    assert (diff.old_path, diff.new_path) == ("AGENTS.md", "CLAUDE.md")
+    assert diff.removed_lines == ["---"]
+    assert _rows_are_counted(diff)
+
+
+def test_no_newline_marker_consumes_no_row_budget(repo: Path) -> None:
+    _commit(repo, "AGENTS.md", "One.\n---")
+    (repo / "AGENTS.md").write_text("One.\n----", encoding="utf-8")
+
+    raw = _git(repo, "diff")
+    diff = parse_unified_diff(raw)[0]
+
+    assert "\\ No newline at end of file" in raw
+    assert diff.removed_lines == ["---"]
+    assert diff.added_lines == ["----"]
+    assert _rows_are_counted(diff)
+    assert all(kind in {" ", "+", "-"} for kind, _ in diff.hunks[0].lines)
+
+
+def test_new_and_deleted_files_keep_their_whole_side(repo: Path) -> None:
+    _commit(repo, "keep.md", "anchor\n")
+    (repo / "AGENTS.md").write_text("---\nprose\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    added = parse_unified_diff(_git(repo, "diff", "--cached"))
+    added_file = next(f for f in added if f.path == "AGENTS.md")
+
+    assert added_file.is_new
+    assert added_file.added_lines == ["---", "prose"]
+    assert _rows_are_counted(added_file)
+
+    _git(repo, "commit", "-qm", "add agents")
+    _git(repo, "rm", "-q", "AGENTS.md")
+    deleted = parse_unified_diff(_git(repo, "diff", "--cached"))[0]
+
+    assert deleted.is_deleted
+    assert deleted.removed_lines == ["---", "prose"]
+    assert _rows_are_counted(deleted)
+
+
+# --- malformed input Git would not produce ---------------------------------
+
+
+def _handwritten(hunk_header: str, *rows: str, path: str = "AGENTS.md") -> str:
+    head = (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"{hunk_header}\n"
+    )
+    return head + "".join(row + "\n" for row in rows)
+
+
+def test_a_truncated_hunk_is_still_incomplete() -> None:
+    """Under-supplied rows must not become a successful comparison."""
+
+    diff = parse_unified_diff(
+        _handwritten("@@ -1,3 +1,2 @@", " One.", " Two.")
+    )[0]
+
+    assert not _rows_are_counted(diff)
+    assert not instruction_pair_is_complete(
+        diff, ResolvedFileText("One.\n---\nTwo.\n", "One.\nTwo.\n", "fixture", None, None)
+    )
+
+
+def test_an_over_declared_hunk_does_not_swallow_the_next_file() -> None:
+    """A hunk that owes rows still ends at the next file header, so the
+    second file is parsed and the short hunk stays refusable."""
+
+    text = _handwritten("@@ -1,9 +1,9 @@", " One.") + _handwritten(
+        "@@ -1,1 +1,1 @@", "-Two.", "+Three.", path="CLAUDE.md"
+    )
+
+    files = {f.path: f for f in parse_unified_diff(text)}
+
+    assert set(files) == {"AGENTS.md", "CLAUDE.md"}
+    assert not _rows_are_counted(files["AGENTS.md"])
+    assert files["CLAUDE.md"].removed_lines == ["Two."]
+    assert files["CLAUDE.md"].added_lines == ["Three."]
+    assert _rows_are_counted(files["CLAUDE.md"])
+
+
+def test_an_over_declared_hunk_does_not_swallow_the_next_hunk_header() -> None:
+    text = _handwritten("@@ -1,9 +1,9 @@", " One.", "@@ -5,1 +5,1 @@", "-Two.", "+Three.")
+
+    diff = parse_unified_diff(text)[0]
+
+    assert len(diff.hunks) == 2
+    assert [h.old_start for h in diff.hunks] == [1, 5]
+    assert not _rows_are_counted(diff)
+
+
+def test_a_header_path_that_disagrees_with_the_diff_line_still_refuses() -> None:
+    text = (
+        "diff --git a/AGENTS.md b/AGENTS.md\n"
+        "--- a/OTHER.md\n"
+        "+++ b/AGENTS.md\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-One.\n"
+        "+Two.\n"
+    )
+
+    diff = parse_unified_diff(text)[0]
+
+    assert diff.old_path == "\0invalid-diff-path"
+
+
+def test_a_file_header_after_an_exhausted_hunk_is_still_a_header() -> None:
+    """Once the budget is spent the parser is outside the hunk again, so a
+    second file's headers are read as headers."""
+
+    text = _handwritten("@@ -1,1 +1,1 @@", "-One.", "+Two.") + _handwritten(
+        "@@ -1,1 +1,1 @@", "-Three.", "+Four.", path="CLAUDE.md"
+    )
+
+    files = {f.path: f for f in parse_unified_diff(text)}
+
+    assert set(files) == {"AGENTS.md", "CLAUDE.md"}
+    assert all(_rows_are_counted(f) for f in files.values())


### PR DESCRIPTION
Closes #611.

## The defect

The shared unified-diff parser decided what a line *was* from how it was spelled. Two shapes Git really emits collide with the file-header prefixes:

| file content | rendered in the diff | old behaviour |
| --- | --- | --- |
| removed `---` (Markdown rule) | `----` | row dropped; `old_count` 3 vs 2 retained rows |
| removed `-- note` | `--- note` | matched the `--- ` **file header** branch: `old_path` became `\0invalid-diff-path` |

The first cost an unnecessary `human_review_required` on a plain-guidance edit, which is what #611 reports. The second is worse and was not in the report's title: a file's own content rewrote the file's identity.

Reproduced with real `git diff` before touching anything:

```
old_path='\x00invalid-diff-path' new_path='AGENTS.md'
removed []
```

## The fix

Hunk state and the header's declared row counts decide, not spelling. While a hunk still owes rows, any line opening with a unified-diff marker (space, `+`, `-`, `\`) is that hunk's data and is dispatched on its first character alone. `\ No newline at end of file` is a marker, so it consumes no row budget.

**Nothing is loosened.** A truncated or over-declared hunk ends at the first line that cannot be hunk data, keeps its short row list, and is still refused by the declared-count comparison in `core.instruction_structure`; the next file's header is still read as a header. Path identity, rename, new/deleted and malformed-header contracts are unchanged. Lines outside a hunk keep their existing branches, so callers that synthesise headerless diffs are untouched.

## Acceptance

- [x] Real Git diffs removing `---` and adding `+++` retain every counted hunk row.
- [x] Header-looking lines inside hunks cannot overwrite the file's identity.
- [x] Multi-file/multi-hunk, rename and no-newline cases retain their existing contracts.
- [x] The same plain-guidance horizontal-rule removal reaches a complete structural comparison (`instruction_pair_is_complete` and `unchanged_instruction_structure` both hold).
- [x] Malformed counts and genuine path/header mismatches still refuse.

## Evidence

16 cases in `tests/test_boundary_diff_hunks.py` — real `git diff` output where the defect is about what Git emits, handwritten text where the point is input Git would never produce.

**Negative control** (the part that matters): replayed against pre-fix `main`, the 11 defect cases fail and the 5 contract-preservation cases pass in both states. A guard that passes before the fix is not a guard.

Locally green: every test matching `boundary|instruction|diff|host|codex|hook`, plus `ruff check`. The file is not `ruff format` clean on `main` either and CI runs only `ruff check`, so it is left unreformatted rather than adding unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
