### PR TITLE
fix(scan): one availability contract for required tool sources (#585)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,7 +495,8 @@ When a required `tool_sources[].path` does not resolve under the manifest direct
 
 - `agents-shipgate doctor --json` exits **0** with a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic and an `unresolved_sources: [{id, declared_path, line, reason}]` field in the payload, so an agent can route to a fix without parsing the error message. `reason` is `"missing"` or `"outside_manifest_dir"`.
 - `agents-shipgate doctor` (no `--json`) prints the same `unresolved_sources` + diagnostic block in human-readable form and **exits 3**, preserving the pre-feature loud failure for interactive users.
-- `agents-shipgate scan` is unchanged — it still raises `InputParseError(3)` regardless of `--json`. Once you're past doctor, missing sources are real scan failures.
+- `agents-shipgate scan` is unchanged — it still raises `InputParseError(3)` regardless of `--json`. Once you're past doctor, missing sources are real scan failures. One precondition enforces this for every source type before any adapter runs, off the resolver doctor uses, so the answer does not depend on which reader the source would have gone to. `optional: true` sources are not covered: they keep their source warning and recovery evidence, and the scan completes.
+- `verify` applies the same precondition to each tree it scans. A base commit whose manifest declares a path that tree does not contain yields `base_status: "scan_failed"` with the reason in `base_notes` and no capability delta; the head gate is unchanged.
 
 ### Missing vs invalid manifests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   absent entrypoint finish as an advisory exit-0 scan; an integration using
   execution status to tell bad input from a completed scan got a different
   answer per reader. The error names each offending source id, its declared
-  path, and whether it is missing or escapes the manifest directory.
+  path, and whether it was not found or escapes the manifest directory.
   `optional: true` sources are unchanged, keeping their warning and
   `coverage_recovery` evidence. `verify` applies the same precondition per
   tree: a base commit declaring a path absent from that tree reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- Refuse a required tool source whose declared path is unavailable, once,
+  for every reader. `scan` applies one availability precondition before any
+  adapter runs, reading the same resolver `doctor` renders as
+  `SHIP-DIAG-MISSING-SOURCE-FILE`, so the two agree by construction. The
+  contract `docs/diagnostics.md` already published — a required
+  `tool_sources[].path` that does not resolve is `InputParseError(3)` — was
+  true of the shared loaders and `mcp_server_source` and false of
+  `openai_agents_sdk`, which returned a source warning and let a required,
+  absent entrypoint finish as an advisory exit-0 scan; an integration using
+  execution status to tell bad input from a completed scan got a different
+  answer per reader. The error names each offending source id, its declared
+  path, and whether it is missing or escapes the manifest directory.
+  `optional: true` sources are unchanged, keeping their warning and
+  `coverage_recovery` evidence. `verify` applies the same precondition per
+  tree: a base commit declaring a path absent from that tree reports
+  `base_status: "scan_failed"` with the reason in `base_notes` and no
+  capability delta, and does not move the head gate. Missing input is named,
+  never repaired by an invented declaration (#585).
+
 - Read every counted hunk row, so header-shaped content stops being lost.
   Hunk state and the header's declared row counts, not a line's spelling,
   decide what the shared unified-diff parser treats as content: a removed

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -268,6 +268,22 @@ interactive users.
 or escaped required sources regardless of `--json`, because once an
 agent moves past doctor, those are real scan failures.
 
+That refusal is **one precondition applied before any adapter runs**,
+reading the same resolver this diagnostic uses, so scan and doctor agree
+by construction rather than by each reader deciding for itself. Before
+#585 they did decide for themselves: the shared loaders and
+`mcp_server_source` raised, while `openai_agents_sdk` returned a source
+warning and let a required, absent entrypoint finish as an advisory
+exit-0 scan. The message names each offending source id, its declared
+path and whether it is missing or escapes the manifest directory.
+
+`optional: true` sources are outside this rule by design — they keep
+their source warning and `coverage_recovery` evidence, and the scan
+completes. `verify` applies the precondition to every tree it scans; a
+base commit whose manifest declares a path absent from that tree gives
+`base_status: "scan_failed"` with the reason in `base_notes`, no
+capability delta, and an unchanged head gate.
+
 ## Adoption rung
 
 Every `doctor --json` payload also carries `adoption`, a projection of where

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -520,7 +520,8 @@ When a required `tool_sources[].path` does not resolve under the manifest direct
 
 - `agents-shipgate doctor --json` exits **0** with a `SHIP-DIAG-MISSING-SOURCE-FILE` diagnostic and an `unresolved_sources: [{id, declared_path, line, reason}]` field in the payload, so an agent can route to a fix without parsing the error message. `reason` is `"missing"` or `"outside_manifest_dir"`.
 - `agents-shipgate doctor` (no `--json`) prints the same `unresolved_sources` + diagnostic block in human-readable form and **exits 3**, preserving the pre-feature loud failure for interactive users.
-- `agents-shipgate scan` is unchanged — it still raises `InputParseError(3)` regardless of `--json`. Once you're past doctor, missing sources are real scan failures.
+- `agents-shipgate scan` is unchanged — it still raises `InputParseError(3)` regardless of `--json`. Once you're past doctor, missing sources are real scan failures. One precondition enforces this for every source type before any adapter runs, off the resolver doctor uses, so the answer does not depend on which reader the source would have gone to. `optional: true` sources are not covered: they keep their source warning and recovery evidence, and the scan completes.
+- `verify` applies the same precondition to each tree it scans. A base commit whose manifest declares a path that tree does not contain yields `base_status: "scan_failed"` with the reason in `base_notes` and no capability delta; the head gate is unchanged.
 
 ### Missing vs invalid manifests
 

--- a/src/agents_shipgate/cli/scan/inspect.py
+++ b/src/agents_shipgate/cli/scan/inspect.py
@@ -29,7 +29,7 @@ from .source_loading import (
     _load_sources,
 )
 from .surface_redaction import _frameworks_surface
-from .validation import _resolve_source_paths
+from .validation import unresolved_required_sources
 
 # Out-of-band key carrying the manifest bytes this inspection read. Popped by
 # the caller before the payload is published; it is not part of the doctor JSON.
@@ -98,7 +98,7 @@ def inspect_sources(
     # plainly held a rung-2 answer.
     declared_manifest = manifest
     base_dir = config_path.resolve().parent
-    unresolved_sources = _resolve_source_paths(manifest, base_dir, config_path)
+    unresolved_sources = unresolved_required_sources(manifest, base_dir, config_path)
     if unresolved_sources:
         # Drop unresolved-required sources from the manifest before loading
         # so doctor returns a structured payload with `unresolved_sources`

--- a/src/agents_shipgate/cli/scan/source_loading.py
+++ b/src/agents_shipgate/cli/scan/source_loading.py
@@ -16,7 +16,57 @@ from agents_shipgate.schemas.manifest import (
     ToolSourceConfig,
 )
 
+from .validation import unresolved_required_sources
+
 logger = logging.getLogger(__name__)
+
+_UNRESOLVED_SOURCE_REASONS = {
+    "missing": "does not exist",
+    "outside_manifest_dir": "resolves outside the manifest directory",
+}
+
+
+def raise_for_unresolved_required_sources(
+    manifest: AgentsShipgateManifest,
+    base_dir: Path,
+    *,
+    config_path: Path | None = None,
+) -> None:
+    """Refuse a scan whose required ``tool_sources[].path`` is unusable.
+
+    One precondition for every source type, applied before any adapter
+    runs. Readers used to decide for themselves and disagreed: the shared
+    loaders and `mcp_server_source` raised `InputParseError`, matching the
+    contract `docs/diagnostics.md` publishes, while `openai_agents_sdk`
+    returned a warning and let the scan finish advisory exit 0 on a
+    required entrypoint that was not there (#585). An integration reading
+    execution status to tell bad input from a completed scan got a
+    different answer per reader.
+
+    Optional sources keep their warning-and-recovery route untouched — the
+    resolver never reports them — and this refusal invents nothing: a
+    missing input is named, not replaced by a declaration.
+    """
+
+    unresolved = unresolved_required_sources(manifest, base_dir, config_path)
+    if not unresolved:
+        return
+    details = "; ".join(
+        "{id!r} at {path!r} {reason}".format(
+            id=entry["id"],
+            path=entry["declared_path"],
+            reason=_UNRESOLVED_SOURCE_REASONS.get(
+                str(entry["reason"]), str(entry["reason"])
+            ),
+        )
+        for entry in unresolved
+    )
+    plural = "s" if len(unresolved) > 1 else ""
+    raise InputParseError(
+        f"Required tool source{plural} unavailable: {details}. "
+        "Restore the declared file, correct tool_sources[].path, or remove "
+        "the source entry."
+    )
 
 
 def _load_sources(
@@ -80,6 +130,9 @@ def _load_sources(
         registry = REGISTRY
     if third_party_records is None:
         third_party_records = {}
+    # One availability precondition for every source type, before any
+    # adapter sees the manifest (#585).
+    raise_for_unresolved_required_sources(manifest, base_dir)
     per_source_loaded: list[LoadedToolSource] = []
     per_scan_loaded: list[LoadedToolSource] = []
     bag = ArtifactBag()

--- a/src/agents_shipgate/cli/scan/source_loading.py
+++ b/src/agents_shipgate/cli/scan/source_loading.py
@@ -20,8 +20,12 @@ from .validation import unresolved_required_sources
 
 logger = logging.getLogger(__name__)
 
+# "not found" is the repository's shared vocabulary for an *absent* input,
+# pinned across manifest, policy-pack and baseline messages by
+# `tests/test_absent_input_messages.py`. An absent input must never be
+# described in the words used for a malformed one.
 _UNRESOLVED_SOURCE_REASONS = {
-    "missing": "does not exist",
+    "missing": "was not found",
     "outside_manifest_dir": "resolves outside the manifest directory",
 }
 

--- a/src/agents_shipgate/cli/scan/validation.py
+++ b/src/agents_shipgate/cli/scan/validation.py
@@ -7,10 +7,22 @@ from agents_shipgate.core.errors import InputParseError
 from agents_shipgate.inputs.common import load_text_file
 
 
-def _resolve_source_paths(
-    manifest, base_dir: Path, config_path: Path
+def unresolved_required_sources(
+    manifest, base_dir: Path, config_path: Path | None = None
 ) -> list[dict[str, object]]:
     """Return required tool_sources whose declared path is unusable.
+
+    One rule, two readers: ``doctor`` renders these as a
+    ``SHIP-DIAG-MISSING-SOURCE-FILE`` diagnostic and ``scan`` refuses on
+    them before adapter dispatch (see
+    ``cli.scan.source_loading.raise_for_unresolved_required_sources``).
+    Sharing the resolver is what makes the two agree; when each decided
+    for itself, a required ``openai_agents_sdk`` entrypoint that does not
+    exist produced a doctor diagnostic *and* a successful advisory scan
+    (#585).
+
+    ``config_path`` is optional and only supplies manifest line numbers;
+    callers past the manifest read do not have to re-thread it.
 
     Two failure modes are flagged so doctor can surface them as a
     ``SHIP-DIAG-MISSING-SOURCE-FILE`` diagnostic instead of crashing in
@@ -28,10 +40,12 @@ def _resolve_source_paths(
     and the failure reason.
     """
     unresolved: list[dict[str, object]] = []
-    try:
-        manifest_text = load_text_file(config_path)
-    except InputParseError:
-        manifest_text = ""
+    manifest_text = ""
+    if config_path is not None:
+        try:
+            manifest_text = load_text_file(config_path)
+        except InputParseError:
+            manifest_text = ""
     text_lines = manifest_text.splitlines()
     base_resolved = base_dir.resolve()
     for source in manifest.tool_sources:

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -296,12 +296,16 @@ def test_per_scan_framework_adapter_invoked_once_with_multiple_tool_sources(monk
             return LoadedAdapterResult(artifact=LangChainArtifacts())
 
     monkeypatch.setitem(REGISTRY._adapters, "langchain", _RecordingLangChain())
+    # These rows exist to exercise dispatch order, not to be read: their
+    # paths are placeholders that do not exist. They are `optional` so the
+    # shared required-source availability precondition (#585) does not
+    # refuse the manifest before the dispatcher runs.
     manifest = load_manifest(REFUND_SAMPLE)
     duplicated = manifest.model_copy(
         update={
             "tool_sources": [
-                ToolSourceConfig(id="lc1", type="langchain", path="a.py"),
-                ToolSourceConfig(id="lc2", type="langchain", path="b.py"),
+                ToolSourceConfig(id="lc1", type="langchain", path="a.py", optional=True),
+                ToolSourceConfig(id="lc2", type="langchain", path="b.py", optional=True),
             ]
         }
     )
@@ -332,7 +336,7 @@ def test_dispatcher_validates_adapter_artifact_class(monkeypatch):
     triggered = manifest.model_copy(
         update={
             "tool_sources": [
-                ToolSourceConfig(id="lc", type="langchain", path="a.py"),
+                ToolSourceConfig(id="lc", type="langchain", path="a.py", optional=True),
             ]
         }
     )
@@ -392,8 +396,8 @@ def test_per_scan_order_is_canonical_not_tool_sources(monkeypatch):
     swapped = manifest.model_copy(
         update={
             "tool_sources": [
-                ToolSourceConfig(id="lc", type="langchain", path="a.py"),
-                ToolSourceConfig(id="adk", type="google_adk", path="b.py"),
+                ToolSourceConfig(id="lc", type="langchain", path="a.py", optional=True),
+                ToolSourceConfig(id="adk", type="google_adk", path="b.py", optional=True),
             ]
         }
     )

--- a/tests/test_coverage_recovery.py
+++ b/tests/test_coverage_recovery.py
@@ -250,19 +250,26 @@ def test_supported_syntax_does_not_manufacture_a_recovery(tmp_path, expression):
     assert all(gap.recovery is None for gap in report.release_decision.evidence_coverage.evidence_gaps)
 
 
-def test_required_sdk_source_keeps_existing_advisory_execution_result(tmp_path, monkeypatch):
+def test_required_sdk_source_uses_the_shared_input_error_contract(tmp_path, monkeypatch):
+    """Recovery metadata must not change the execution contract — the
+    invariant this test was written for — and #585 decided what that
+    contract is: a required source whose path is absent is an input error
+    before any adapter runs, not an advisory scan that finished.
+
+    Optional sources keep the warning-and-recovery route; every other case
+    in this module covers it.
+    """
+
     project = _project(tmp_path / "project", None)
     manifest = project / "shipgate.yaml"
     manifest.write_text(manifest.read_text().replace("optional: true", "optional: false"))
     monkeypatch.chdir(project)
     result = CliRunner().invoke(app, ["scan", "--config", str(manifest)])
-    # #585 records the existing required-SDK input-error contract mismatch.
-    # Recovery metadata must not change that execution contract as a side effect.
     _without_recovery(monkeypatch)
     original = CliRunner().invoke(app, ["scan", "--config", str(manifest)])
-    assert result.exit_code == original.exit_code == 0
-    assert "Decision: insufficient_evidence" in result.output
-    assert "Decision: insufficient_evidence" in original.output
+    assert result.exit_code == original.exit_code == 3
+    assert "Required tool source unavailable" in result.output
+    assert "Required tool source unavailable" in original.output
 
 
 def test_recovery_does_not_rewrite_space_bearing_source_locations(tmp_path, capsys):

--- a/tests/test_required_source_availability.py
+++ b/tests/test_required_source_availability.py
@@ -75,7 +75,7 @@ def test_a_required_missing_path_is_an_input_error_for_every_reader(
     assert "Required tool source unavailable" in result.output
     # The exact declared path, so the reader knows which line to fix.
     assert "'src'" in result.output
-    assert "'agent.py'" in result.output
+    assert "'agent.py' was not found" in result.output
 
 
 @pytest.mark.parametrize("source_type", PATH_SOURCE_TYPES)

--- a/tests/test_required_source_availability.py
+++ b/tests/test_required_source_availability.py
@@ -1,0 +1,253 @@
+"""One availability contract for required tool sources (#585).
+
+`docs/diagnostics.md` publishes it: a required `tool_sources[].path` that
+does not resolve is `InputParseError(3)` from `scan`. Readers used to
+decide for themselves — the shared loaders and `mcp_server_source` raised,
+`openai_agents_sdk` returned a warning and let the scan finish advisory
+exit 0 — so the answer depended on which reader you happened to declare.
+
+The precondition now runs once, before any adapter, off the same resolver
+`doctor` uses. Optional sources are untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.cli.scan.source_loading import _load_sources
+from agents_shipgate.config.loader import load_manifest
+from agents_shipgate.core.errors import InputParseError
+
+runner = CliRunner()
+
+# Every per-source type that takes a path. The point of the parametrization
+# is that the answer no longer depends on which reader would have run.
+PATH_SOURCE_TYPES = ["openai_agents_sdk", "mcp", "openapi", "mcp_server_source"]
+
+
+def _manifest(
+    project: Path,
+    *,
+    source_type: str = "openai_agents_sdk",
+    path: str = "agent.py",
+    optional: bool = False,
+) -> Path:
+    project.mkdir(parents=True, exist_ok=True)
+    config = project / "shipgate.yaml"
+    config.write_text(
+        "version: '0.1'\n"
+        "project: {name: availability}\n"
+        "agent: {name: availability, declared_purpose: [read local data]}\n"
+        "environment: {target: local}\n"
+        "tool_sources:\n"
+        f"  - {{id: src, type: {source_type}, path: {path}, "
+        f"optional: {str(optional).lower()}}}\n",
+        encoding="utf-8",
+    )
+    return config
+
+
+def _scan_cli(config: Path, out: Path, *extra: str):
+    return runner.invoke(
+        app,
+        ["scan", "--config", str(config), "--out", str(out), *extra],
+    )
+
+
+# --- the contract ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("source_type", PATH_SOURCE_TYPES)
+def test_a_required_missing_path_is_an_input_error_for_every_reader(
+    tmp_path: Path, source_type: str
+) -> None:
+    config = _manifest(tmp_path / "p", source_type=source_type)
+
+    result = _scan_cli(config, tmp_path / "out")
+
+    assert result.exit_code == 3
+    assert "Required tool source unavailable" in result.output
+    # The exact declared path, so the reader knows which line to fix.
+    assert "'src'" in result.output
+    assert "'agent.py'" in result.output
+
+
+@pytest.mark.parametrize("source_type", PATH_SOURCE_TYPES)
+def test_an_optional_missing_path_still_warns_and_completes(
+    tmp_path: Path, source_type: str
+) -> None:
+    config = _manifest(tmp_path / "p", source_type=source_type, optional=True)
+
+    result = _scan_cli(config, tmp_path / "out")
+
+    assert result.exit_code == 0
+    assert "Required tool source unavailable" not in result.output
+    report = json.loads((tmp_path / "out" / "report.json").read_text())
+    assert report["source_warnings"], "an optional miss must still be reported"
+
+
+def test_the_sdk_reader_no_longer_disagrees_with_the_published_contract(
+    tmp_path: Path,
+) -> None:
+    """#585's exact reproduction: this combination completed advisory
+    exit 0 with only a source warning."""
+
+    config = _manifest(tmp_path / "p", source_type="openai_agents_sdk")
+
+    result = _scan_cli(config, tmp_path / "out")
+
+    assert result.exit_code == 3
+    assert not (tmp_path / "out" / "report.json").exists()
+
+
+def test_a_required_path_outside_the_manifest_directory_is_refused(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    config = _manifest(tmp_path / "p", source_type="mcp", path="../outside.json")
+
+    result = _scan_cli(config, tmp_path / "out")
+
+    assert result.exit_code == 3
+    assert "resolves outside the manifest directory" in result.output
+
+
+def test_the_refusal_precedes_adapter_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The point of #585 is one precondition, not another reader that
+    happens to raise. No adapter may run at all."""
+
+    from agents_shipgate.inputs import protocol
+
+    def explode(*args: object, **kwargs: object):  # pragma: no cover - must not run
+        raise AssertionError("an adapter ran before the availability check")
+
+    monkeypatch.setattr(protocol.REGISTRY, "require", explode)
+    config = _manifest(tmp_path / "p")
+    manifest = load_manifest(config)
+
+    with pytest.raises(InputParseError, match="Required tool source unavailable"):
+        _load_sources(manifest, config.parent, verbose=False)
+
+
+def test_strict_mode_reports_the_same_input_error(tmp_path: Path) -> None:
+    """Exit 3 is an input failure, not the strict gate's exit 20."""
+
+    config = _manifest(tmp_path / "p")
+
+    result = _scan_cli(config, tmp_path / "out", "--ci-mode", "strict")
+
+    assert result.exit_code == 3
+
+
+def test_module_invocation_agrees_with_the_cli(tmp_path: Path) -> None:
+    config = _manifest(tmp_path / "p")
+
+    completed = subprocess.run(
+        [
+            "python",
+            "-m",
+            "agents_shipgate",
+            "scan",
+            "--config",
+            str(config),
+            "--out",
+            str(tmp_path / "out"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+
+    assert completed.returncode == 3
+    assert "Required tool source unavailable" in completed.stdout + completed.stderr
+
+
+# --- the other two surfaces must say the same thing ------------------------
+
+
+def test_doctor_json_reports_the_same_source_without_raising(tmp_path: Path) -> None:
+    """doctor's documented behaviour is a diagnostic, not an exception —
+    but it must be about the same source, from the same resolver."""
+
+    config = _manifest(tmp_path / "p")
+
+    result = runner.invoke(app, ["doctor", "--config", str(config), "--json"])
+
+    payload = json.loads(result.output)
+    payload = payload[0] if isinstance(payload, list) else payload
+    assert payload["unresolved_sources"] == [
+        {"declared_path": "agent.py", "id": "src", "line": 6, "reason": "missing"}
+    ]
+    assert any(
+        entry.get("id") == "SHIP-DIAG-MISSING-SOURCE-FILE"
+        for entry in payload["diagnostics"]
+    )
+
+
+def test_verify_reports_a_typed_base_failure_and_leaves_the_head_gate(
+    tmp_path: Path,
+) -> None:
+    """A base commit whose manifest declares a file that tree does not
+    contain: the base scan is refused, named, and explicitly does not move
+    the head gate."""
+
+    repo = tmp_path / "repo"
+    config = _manifest(repo)
+    (repo / ".gitignore").write_text("agents-shipgate-reports/\n", encoding="utf-8")
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "test@example.invalid")
+    git("config", "user.name", "Test")
+    git("add", "-A")
+    git("commit", "-qm", "manifest without its entrypoint")
+    git("checkout", "-q", "-b", "feat")
+    (repo / "agent.py").write_text(
+        "from agents import Agent, function_tool\n"
+        "@function_tool\n"
+        "def read_tool() -> str:\n"
+        '    return "a"\n'
+        'agent = Agent(name="availability", tools=[read_tool])\n',
+        encoding="utf-8",
+    )
+    git("add", "-A")
+    git("commit", "-qm", "add the entrypoint")
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "--workspace",
+            str(repo),
+            "--config",
+            str(config),
+            "--base",
+            "main",
+            "--head",
+            "HEAD",
+            "--ci-mode",
+            "advisory",
+        ],
+    )
+
+    assert result.exit_code == 0
+    verifier = json.loads(
+        (repo / "agents-shipgate-reports" / "verifier.json").read_text()
+    )
+    assert verifier["base_status"] == "scan_failed"
+    notes = " ".join(verifier["base_notes"])
+    assert "Required tool source unavailable" in notes
+    assert "without changing the head gate" in notes
+    # The head scan itself is unaffected: it read its own tree fine.
+    assert verifier["merge_verdict"] != "unknown"


### PR DESCRIPTION
Closes #585.

## The mismatch

`docs/diagnostics.md:267` and `AGENTS.md` both publish the same contract: a required `tool_sources[].path` that does not resolve is `InputParseError(3)` from `scan`. Measured on `main`, the answer depended on the reader:

| required source, path absent | `main` | this PR |
| --- | --- | --- |
| `mcp`, `openapi`, `mcp_server_source` | exit 3, `Input file not found: …` | exit 3, names the source id |
| `openai_agents_sdk` | **exit 0**, source warning, `insufficient_evidence` | exit 3 |

`tests/test_adapter_registry.py::test_dispatch_required_source_raises` already asserted the dispatcher raises for a required missing source. It passed only because its fixture used `mcp`.

## The decision

The issue allowed two outcomes: enforce the published contract, or document an SDK exception. Enforcing it is the right one — the docs already promise it, the majority of readers already do it, and exit 3 naming one fixable thing is more useful to a first-time user than exit 0 with a buried warning and an abstaining verdict.

So: **one availability precondition, before any adapter runs**, reading the same resolver `doctor` uses for `SHIP-DIAG-MISSING-SOURCE-FILE`. Scan and doctor now agree by construction rather than by each reader deciding for itself.

```
Input parsing error: Required tool source unavailable: 'sdk' at 'agent.py' does not exist.
Restore the declared file, correct tool_sources[].path, or remove the source entry.
```

The message deliberately does not suggest `optional: true`. Telling someone to downgrade their own required declaration to silence the error is the weakening this issue warns against.

## Deliberately unchanged

- **Optional sources.** They keep the warning and the `coverage_recovery` evidence; the resolver never reports them. Covered for all four path-taking source types.
- **doctor.** `--json` still exits 0 with the diagnostic, human form still exits 3.

## The one behaviour change worth reviewing

`verify` applies the precondition per tree, so a **base** commit whose manifest declares a path absent from that tree changes:

| | `main` | this PR |
| --- | --- | --- |
| `base_status` | `succeeded` | `scan_failed` |
| `capability_review` | `added: 2` | `added: 0` |
| `merge_verdict` | `insufficient_evidence` | `insufficient_evidence` |

Measured on the same fixture, not asserted. The verdict does not move. What changes is the claim: `main` reported the base as successfully scanned with zero tools and a `+2` delta, having never read the source the base manifest declared. The new `base_notes` entry is explicit and actionable, and says the head gate is untouched:

> Base scan failed without changing the head gate: Required tool source unavailable: 'sdk' at 'agent.py' does not exist. …

## Two existing tests moved with the decision

- `test_required_sdk_source_keeps_existing_advisory_execution_result` was #561's pin that *recovery metadata must not alter the execution contract*, and its own comment named #585 as the owner of the contract. It keeps that invariant — both paths equal — and now asserts exit 3.
- Four dispatch-order fixtures in `test_adapter_registry.py` declared placeholder paths (`a.py`, `b.py`) that never existed. They are marked `optional`, which is what they always were; the ordering assertions are untouched.

## Acceptance

- [x] Public scan, doctor JSON/human and verify agree on the required/optional boundary — by sharing the resolver.
- [x] A missing required SDK entrypoint has a tested structured result naming the exact path; optional behaviour is explicit.
- [x] CLI, `python -m` invocation, advisory and strict mode covered; other adapters regression-covered.
- [x] Error catalog, `docs/diagnostics.md`, `AGENTS.md` and `llms-full.txt` agree with the implementation.

15 cases in `tests/test_required_source_availability.py`, one of which fails if any adapter runs before the check. **Negative control:** replayed against pre-fix `main`, 10 fail; the 5 that pass are the optional-source and doctor cases that must not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
