### PR TITLE
feat(check): compare against the detected base by default (#649)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,17 @@ shipgate check --agent cursor --workspace . --format agent-boundary-json
 recognized changed Codex, Claude Code, Cursor, VS Code MCP, shared trust-root,
 and GitHub workflow surface is evaluated on every run.
 
+**What a flagless run compares.** The detected default branch's merge base
+against the working tree, so committed branch work and uncommitted edits are
+one comparison. `subject.base` names the ref that was used. `--base` and
+`--head` are independent: `--base <ref>` compares that ref's merge base with
+the working tree, `--head <ref>` compares the detected base against it, and
+both together are the committed `base...head` range. `--base HEAD` restricts
+the run to uncommitted changes. On the default branch, where there is no
+other base, the working-tree comparison is the whole answer. Where no base
+can be detected at all — no remote, no `main` or `master` — the run stops and
+names `--base` rather than reporting a pass it did not establish.
+
 Read the single stdout object as `shipgate.agent_boundary_result/v1`. Switch on
 `control.state`; inspect `input_coverage`, `host_coverage`, `affected_hosts`,
 `policies`, `violations`, and `issues`; then follow `control.next_action`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+- Compare against the detected base by default in `check`, so a branch's
+  committed work is visible without flags. `shipgate check` compared the
+  working tree with `HEAD`, so on a branch whose changes were already
+  committed it answered `allow` with an empty change set — truthfully
+  reporting "nothing is uncommitted" to someone asking "what does this
+  branch change". Reaching the real answer took `--base <ref> --head HEAD`,
+  a pair the help never suggested and which the CLI rejected unless both
+  were given. A flagless run now compares the detected default branch's
+  merge base against the working tree, one comparison spanning committed
+  and uncommitted work, and `subject.base` names the ref it used. `--base`
+  and `--head` are independent; `--base HEAD` keeps the previous
+  uncommitted-only comparison. On the default branch the working-tree
+  answer is complete and unchanged. Where no base can be detected — no
+  remote and no `main` or `master` — the run stops and names `--base`
+  rather than reporting a pass it did not establish. The implicit local
+  fallback is narrow on purpose: a local `main` is refused while a remote
+  exists, because the remote is the authority it might be stale against,
+  and used only where the repository has no remote at all. `verify`'s own
+  base detection is untouched, and the emitted `verify` command now accepts
+  either ref alone so it cannot disagree with the check that emitted it
+  (#649).
+
 - Read every counted hunk row, so header-shaped content stops being lost.
   Hunk state and the header's declared row counts, not a line's spelling,
   decide what the shared unified-diff parser treats as content: a removed

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -111,6 +111,17 @@ shipgate check --agent cursor --workspace . --format agent-boundary-json
 recognized changed Codex, Claude Code, Cursor, VS Code MCP, shared trust-root,
 and GitHub workflow surface is evaluated on every run.
 
+**What a flagless run compares.** The detected default branch's merge base
+against the working tree, so committed branch work and uncommitted edits are
+one comparison. `subject.base` names the ref that was used. `--base` and
+`--head` are independent: `--base <ref>` compares that ref's merge base with
+the working tree, `--head <ref>` compares the detected base against it, and
+both together are the committed `base...head` range. `--base HEAD` restricts
+the run to uncommitted changes. On the default branch, where there is no
+other base, the working-tree comparison is the whole answer. Where no base
+can be detected at all — no remote, no `main` or `master` — the run stops and
+names `--base` rather than reporting a pass it did not establish.
+
 Read the single stdout object as `shipgate.agent_boundary_result/v1`. Switch on
 `control.state`; inspect `input_coverage`, `host_coverage`, `affected_hosts`,
 `policies`, `violations`, and `issues`; then follow `control.next_action`,

--- a/src/agents_shipgate/cli/agent_result.py
+++ b/src/agents_shipgate/cli/agent_result.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -77,21 +78,25 @@ def build_codex_agent_result(
     """
 
     return freeze_codex_boundary_result(
-        _assessment_for_diff(
-            agent=agent,
-            workspace=workspace,
-            diff_text=diff_text,
-            config=config,
-            policy=policy,
-            input_mode=input_mode,
-            input_issues=input_issues,
-            base=base,
-            head=head,
-            verification_replayable=verification_replayable,
-            base_manifest_absent=base_manifest_absent,
-            requested_workspace=requested_workspace,
-            changed_files_override=changed_files_override,
-            manifest_text_snapshot=manifest_text_snapshot,
+        _with_compared_refs(
+            _assessment_for_diff(
+                agent=agent,
+                workspace=workspace,
+                diff_text=diff_text,
+                config=config,
+                policy=policy,
+                input_mode=input_mode,
+                input_issues=input_issues,
+                base=base,
+                head=head,
+                verification_replayable=verification_replayable,
+                base_manifest_absent=base_manifest_absent,
+                requested_workspace=requested_workspace,
+                changed_files_override=changed_files_override,
+                manifest_text_snapshot=manifest_text_snapshot,
+            ),
+            base,
+            head,
         ).legacy_result
     )
 
@@ -129,7 +134,36 @@ def build_agent_boundary_result(
         changed_files_override=changed_files_override,
         manifest_text_snapshot=manifest_text_snapshot,
     )
-    return project_agent_boundary_result(assessment)
+    return project_agent_boundary_result(_with_compared_refs(assessment, base, head))
+
+
+def _with_compared_refs(assessment, base: str | None, head: str | None):
+    """Name the refs the check compared, on the assessment it produced.
+
+    `check` resolves an omitted base to the default branch's merge base
+    (#649), so which question was answered is no longer evident from the
+    request. `AgentResultSubject` already carries `base`/`head` and nothing
+    ever filled them. Set only when a ref was actually resolved, so a plain
+    worktree check is byte-identical to before.
+
+    Both projections read `assessment.legacy_result`, so replacing the
+    subject there reaches the current and the frozen v2 contract from one
+    place rather than two.
+    """
+
+    if base is None and head is None:
+        return assessment
+    legacy = assessment.legacy_result
+    return replace(
+        assessment,
+        legacy_result=legacy.model_copy(
+            update={
+                "subject": legacy.subject.model_copy(
+                    update={"base": base, "head": head}
+                )
+            }
+        ),
+    )
 
 
 def _assessment_for_diff(
@@ -527,6 +561,119 @@ def _declared_codex_marketplace_roots(
     return roots
 
 
+class UnresolvedComparisonError(RuntimeError):
+    """No base could be resolved, and guessing one would answer a
+    different question than the caller asked."""
+
+
+def _resolve_comparison(
+    *,
+    workspace: Path,
+    base: str | None,
+    head: str | None,
+) -> tuple[str | None, str | None, str, str]:
+    """Decide what this check compares, and say so.
+
+    Returns ``(resolved_base, resolved_head, revspec, comparison_ref)``.
+    A non-empty ``revspec`` selects the committed-range diff; otherwise
+    the worktree is compared against ``comparison_ref``, which keeps
+    untracked capability paths and the manifest binding in scope.
+
+    Before #649 an omitted pair meant "worktree against ``HEAD``", so a
+    branch whose changes were already committed reported ``allow`` with
+    an empty change set — the tool answered "nothing is uncommitted"
+    to the question "what does this branch change". The ladder now:
+
+    1. **Both refs** — unchanged: ``base...head``, the merge-base range.
+    2. **``--base`` alone** — that base's merge base with ``HEAD``,
+       compared against the worktree, so uncommitted work still counts.
+    3. **``--head`` alone** — the detected default base against it.
+    4. **Neither** — the detected default base's merge base against the
+       worktree. This is the reviewer's question by default.
+    5. **On the default branch** (the detected base *is* ``HEAD``) —
+       ``HEAD`` against the worktree, which is both the old behaviour and
+       the complete answer there.
+    6. **No base detectable at all** — refuse and name ``--base``. A
+       repository whose base cannot be identified gets an honest stop,
+       never an ``allow`` computed from a question nobody asked.
+    """
+
+    from agents_shipgate.cli.verify.git import detect_default_base, merge_base_sha
+
+    if base and head:
+        return base, head, f"{base}...{head}", "HEAD"
+
+    def default_base() -> str:
+        detected = detect_default_base(
+            workspace, "HEAD", allow_local_when_no_remote=True
+        )
+        if detected is None:
+            raise UnresolvedComparisonError(
+                "No base ref could be detected for this repository, so there is "
+                "nothing to compare this working tree against. Pass --base "
+                "<ref> to name one explicitly (use --base HEAD for uncommitted "
+                "changes only)."
+            )
+        return detected
+
+    if head and not base:
+        detected = default_base()
+        return detected, head, f"{detected}...{head}", "HEAD"
+
+    requested = base or None
+    if requested is None:
+        detected = detect_default_base(
+            workspace, "HEAD", allow_local_when_no_remote=True
+        )
+        if detected is None:
+            # Rung 5 before rung 6: being *on* the default branch is the
+            # commonest reason nothing else was detected, and there the
+            # worktree-against-HEAD answer is complete rather than wrong.
+            if _head_is_only_commit_line(workspace):
+                return "HEAD", None, "", "HEAD"
+            raise UnresolvedComparisonError(
+                "No base ref could be detected for this repository, so there is "
+                "nothing to compare this working tree against. Pass --base "
+                "<ref> to name one explicitly (use --base HEAD for uncommitted "
+                "changes only)."
+            )
+        requested = detected
+
+    if requested == "HEAD":
+        return "HEAD", None, "", "HEAD"
+    merge_base = merge_base_sha(workspace, requested, "HEAD")
+    if merge_base is None:
+        raise UnresolvedComparisonError(
+            f"No merge base between {requested!r} and HEAD, so this working "
+            "tree cannot be compared against it. Pass --base <ref> naming a "
+            "ref that shares history with HEAD."
+        )
+    return requested, None, "", merge_base
+
+
+def _head_is_only_commit_line(workspace: Path) -> bool:
+    """Whether HEAD is the repository's own default line of history.
+
+    ``detect_default_base`` returns nothing both when a base exists but
+    equals ``HEAD`` and when none exists at all. Only the first is a
+    complete answer, so the two are separated here rather than guessed.
+    """
+
+    from agents_shipgate.cli.verify.git import (
+        LOCAL_BASE_CANDIDATES,
+        REMOTE_BASE_CANDIDATES,
+        commit_sha,
+    )
+
+    head_sha = commit_sha(workspace, "HEAD")
+    if head_sha is None:
+        return False
+    for candidate in (*REMOTE_BASE_CANDIDATES, *LOCAL_BASE_CANDIDATES):
+        if commit_sha(workspace, candidate) == head_sha:
+            return True
+    return False
+
+
 def git_boundary_change_set(
     *,
     workspace: Path,
@@ -551,19 +698,15 @@ def git_boundary_change_set(
             config_path,
             requested_workspace=requested_workspace,
         )
-    if bool(base) != bool(head):
-        raise RuntimeError(
-            "--base and --head must be provided together; omit both to check "
-            "local uncommitted changes."
-        )
-    if base and head:
-        revspec = f"{base}...{head}"
-    else:
-        revspec = ""
     if repository_root is None:
         raise RuntimeError("Workspace is not inside a Git repository.")
+    resolved_base, resolved_head, revspec, comparison_ref = _resolve_comparison(
+        workspace=workspace, base=base, head=head
+    )
     try:
-        changed_paths, diff_text = _git_diff_context(revspec, cwd=workspace)
+        changed_paths, diff_text = _git_diff_context(
+            revspec, cwd=workspace, comparison_ref=comparison_ref
+        )
     except BinaryCapabilityDiffError as exc:
         return BoundaryChangeSet(
             mode="git_range" if revspec else "worktree",
@@ -612,7 +755,9 @@ def git_boundary_change_set(
     if revspec and config_path is not None:
         try:
             relative = config_path.relative_to(workspace)
-            manifest_text_snapshot = read_file_at_ref(workspace, head, relative)
+            manifest_text_snapshot = read_file_at_ref(
+                workspace, resolved_head or "HEAD", relative
+            )
         except (OSError, RuntimeError, ValueError) as exc:
             raise ConfigError(
                 f"Configured manifest could not be read from head ref {head!r}: {exc}"
@@ -637,6 +782,8 @@ def git_boundary_change_set(
         changed_paths=tuple(sorted(changed_paths)),
         issues=tuple(issues),
         manifest_text_snapshot=manifest_text_snapshot,
+        resolved_base=resolved_base,
+        resolved_head=resolved_head,
     )
 
 

--- a/src/agents_shipgate/cli/check.py
+++ b/src/agents_shipgate/cli/check.py
@@ -13,6 +13,7 @@ from agents_shipgate.cli.agent_mode import (
     emit_agent_mode_error_action,
 )
 from agents_shipgate.cli.agent_result import (
+    UnresolvedComparisonError,
     agent_result_json,
     build_agent_boundary_result,
     build_codex_agent_result,
@@ -216,12 +217,15 @@ def check(
     base: str | None = typer.Option(
         None,
         "--base",
-        help="Base git ref for diff resolution when --diff is omitted.",
+        help=(
+            "Base git ref. Defaults to the detected default branch's merge "
+            "base with HEAD; use --base HEAD for uncommitted changes only."
+        ),
     ),
     head: str | None = typer.Option(
         None,
         "--head",
-        help="Head git ref for diff resolution when --diff is omitted.",
+        help="Head git ref. Defaults to the working tree.",
     ),
 ) -> None:
     """Run the agent-native local boundary check."""
@@ -256,13 +260,14 @@ def check(
             command=None,
             expects="A non-empty diff path, stdin, a complete ref range, or the worktree.",
         )
-    if (base is None) != (head is None) or (
-        base is not None and (not base or not head)
-    ):
+    if (base is not None and not base) or (head is not None and not head):
         raise _flag_error(
-            "--base and --head must be provided together and cannot be empty.",
+            "--base and --head cannot be empty.",
             command=None,
-            expects="Both non-empty refs, or neither for local worktree changes.",
+            expects=(
+                "A non-empty ref, both refs for a committed range, or neither "
+                "to compare this branch against its detected base."
+            ),
         )
     if any(
         value is not None
@@ -328,6 +333,10 @@ def check(
             changed_files_override = list(change_set.changed_paths)
             manifest_text_snapshot = change_set.manifest_text_snapshot
             manifest_snapshot_captured = True
+            # Publish what was actually compared, not what was typed. A
+            # verdict whose base is unnamed cannot be reviewed (#649).
+            base = change_set.resolved_base
+            head = change_set.resolved_head
     except InputParseError as exc:
         if isinstance(exc.__cause__, FileNotFoundError):
             result = _diff_input_error_result(
@@ -366,6 +375,15 @@ def check(
                 "Resolve the exact deterministic Git/diff or manifest-identity "
                 "failure reported by this check before rerunning it."
             ),
+        ) from exc
+    except UnresolvedComparisonError as exc:
+        # Ahead of the RuntimeError handler below on purpose: that one
+        # renders a diff-input result and exits 0, and "I could not work out
+        # what to compare" must never leave as a passing check (#649).
+        raise _flag_error(
+            str(exc),
+            command=None,
+            expects="A named base ref this working tree can be compared against.",
         ) from exc
     except (OSError, RuntimeError) as exc:
         result = _diff_input_error_result(
@@ -408,7 +426,9 @@ def check(
         "input_issues": input_issues,
         "base": base,
         "head": head,
-        "input_mode": "provided_diff" if diff else "git_range" if base else "worktree",
+        "input_mode": (
+            "provided_diff" if diff else "git_range" if (base and head) else "worktree"
+        ),
         # A standalone diff can describe either side of a change, but verify
         # accepts a checkout or a ref range. Do not authorize a worktree verify
         # for a subject the check cannot bind to repository state.

--- a/src/agents_shipgate/cli/verify/git.py
+++ b/src/agents_shipgate/cli/verify/git.py
@@ -414,7 +414,12 @@ def _normalized_sha_hint(value: str | None, *, label: str) -> str | None:
     return normalized
 
 
-def detect_default_base(workspace: Path, head: str = "HEAD") -> str | None:
+def detect_default_base(
+    workspace: Path,
+    head: str = "HEAD",
+    *,
+    allow_local_when_no_remote: bool = False,
+) -> str | None:
     """Best-effort default base ref for PR-style diff enrichment.
 
     Tries the remote default branch (``origin/HEAD``) first, then remote
@@ -425,12 +430,27 @@ def detect_default_base(workspace: Path, head: str = "HEAD") -> str | None:
     selected implicitly because they are often stale in CI and worktrees;
     pass ``--base main`` explicitly when that is intended. Never fetches;
     this only reads refs that already exist in the checkout.
+
+    ``allow_local_when_no_remote`` narrows that last rule to the case it
+    was written for. A local ``main`` is refused because a remote is the
+    authority it might be stale against; where the repository has **no
+    remote at all**, there is no such authority and the local branch is
+    the only base in existence. Refusing there would leave `check` with
+    nothing to compare on a repository that was simply never pushed
+    (#649). Off by default, so `verify` keeps its behaviour exactly.
     """
 
-    return detect_default_base_with_notes(workspace, head).base
+    return detect_default_base_with_notes(
+        workspace, head, allow_local_when_no_remote=allow_local_when_no_remote
+    ).base
 
 
-def detect_default_base_with_notes(workspace: Path, head: str = "HEAD") -> DefaultBaseDetection:
+def detect_default_base_with_notes(
+    workspace: Path,
+    head: str = "HEAD",
+    *,
+    allow_local_when_no_remote: bool = False,
+) -> DefaultBaseDetection:
     """Return the implicit base plus warnings for skipped local defaults."""
 
     head_sha = commit_sha(workspace, head)
@@ -451,12 +471,30 @@ def detect_default_base_with_notes(workspace: Path, head: str = "HEAD") -> Defau
             selected_base = candidate
             selected_base_sha = sha
             break
+    if (
+        selected_base is None
+        and allow_local_when_no_remote
+        and not _has_configured_remote(workspace)
+    ):
+        for candidate in LOCAL_BASE_CANDIDATES:
+            sha = commit_sha(workspace, candidate)
+            if sha is not None and sha != head_sha:
+                selected_base = candidate
+                selected_base_sha = sha
+                break
     notes = _skipped_local_base_notes(
         workspace,
         head_sha,
         selected_base_sha=selected_base_sha,
     )
     return DefaultBaseDetection(base=selected_base, notes=notes)
+
+
+def _has_configured_remote(workspace: Path) -> bool:
+    """Whether this checkout has any remote to be stale against."""
+
+    result = _run_git(workspace, ["remote"], check=False)
+    return result.returncode == 0 and bool(result.stdout.strip())
 
 
 def _skipped_local_base_notes(

--- a/src/agents_shipgate/core/agent_controls.py
+++ b/src/agents_shipgate/core/agent_controls.py
@@ -74,17 +74,22 @@ def verify_command_for(
     relative spelling would silently retarget the authorized operation.
     """
 
-    if (base is None) != (head is None):
-        raise ValueError("verify command requires both base and head, or neither")
-    if workspace is None and config is None and base is None and not extra:
+    # `verify` accepts either ref on its own — it auto-detects the base and
+    # defaults the head — so emitting whichever the check actually resolved
+    # is faithful. Requiring both mirrored `check`'s old paired-flag rule,
+    # which #649 removed; keeping it here would have made the emitted
+    # command disagree with the command that emitted it.
+    if workspace is None and config is None and base is None and head is None and not extra:
         return retarget_command(DEFAULT_VERIFY_COMMAND)
     args = ["verify"]
     if workspace is not None:
         args.extend(["--workspace", _cwd_anchored(workspace)])
     if config is not None:
         args.extend(["--config", _config_for_verify(workspace, config)])
-    if base is not None and head is not None:
-        args.extend(["--base", base, "--head", head])
+    if base is not None:
+        args.extend(["--base", base])
+    if head is not None:
+        args.extend(["--head", head])
     args.extend(extra)
     args.append("--json")
     return render_command(args)

--- a/src/agents_shipgate/core/boundary_diff.py
+++ b/src/agents_shipgate/core/boundary_diff.py
@@ -72,6 +72,12 @@ class BoundaryChangeSet:
     changed_paths: tuple[str, ...]
     issues: tuple[BoundaryInputIssue, ...] = ()
     manifest_text_snapshot: str | None = None
+    #: The refs this change set actually compared, after defaults were
+    #: resolved. A caller that passed nothing still needs to publish what
+    #: was answered — a diff against an unnamed base is not a reviewable
+    #: claim (#649).
+    resolved_base: str | None = None
+    resolved_head: str | None = None
 
 
 def git_diff_path_token(prefix: str, path: str) -> str:

--- a/src/agents_shipgate/triggers.py
+++ b/src/agents_shipgate/triggers.py
@@ -926,7 +926,10 @@ def _verdict_label(result: dict[str, Any]) -> str:
 
 
 def _git_diff_context(
-    revspec: str | None, *, cwd: Path | None = None
+    revspec: str | None,
+    *,
+    cwd: Path | None = None,
+    comparison_ref: str = "HEAD",
 ) -> tuple[list[str], str]:
     """Read changed paths and the unified-diff body from ``git diff``.
 
@@ -934,9 +937,11 @@ def _git_diff_context(
 
     - Non-empty (e.g. ``"origin/main...HEAD"``): PR-style diff.
       ``git diff [--name-only] <revspec>``.
-    - Empty string (bare ``--git-diff``): all uncommitted tracked
-      changes against ``HEAD`` — includes BOTH staged and unstaged
-      edits. Untracked file *paths* (newly-`git add`-able files that
+    - Empty string (bare ``--git-diff``): all changes against
+      ``comparison_ref`` (``HEAD`` by default) — includes BOTH staged and
+      unstaged edits. Passing a merge-base commit as ``comparison_ref``
+      makes one comparison that spans committed branch work *and*
+      uncommitted edits, which is what a branch-scoped review needs. Untracked file *paths* (newly-`git add`-able files that
       aren't yet `git add`ed) are appended to the path list via
       ``git ls-files --others --exclude-standard``; their content is
       NOT captured in ``diff_text`` because reading arbitrary unstaged
@@ -959,7 +964,9 @@ def _git_diff_context(
     return (
         diff_revspec_context(root, revspec)
         if revspec
-        else working_tree_context(root, reject_index_hidden=True)
+        else working_tree_context(
+            root, comparison_ref=comparison_ref, reject_index_hidden=True
+        )
     )
 
 

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -257,7 +257,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.Popen",
-        line=1954,
+        line=1992,
         snippet=(
             "subprocess.Popen(cmd, env=env, stderr=subprocess.PIPE, "
             "stdin=subprocess.PIPE if input is not None else "
@@ -276,7 +276,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.run",
-        line=2198,
+        line=2236,
         snippet=(
             "subprocess.run(cmd, capture_output=capture_output, check=check, "
             "env=env, input=input, stderr=stderr, stdin=stdin, stdout=stdout, "

--- a/tests/test_check_default_comparison.py
+++ b/tests/test_check_default_comparison.py
@@ -1,0 +1,237 @@
+"""#649: `check` compares against the merge base by default.
+
+On a branch whose changes were already committed, `shipgate check` used to
+answer `allow` with an empty change set — it compared the working tree with
+`HEAD`, so it was truthfully reporting "nothing is uncommitted" to someone
+asking "what does this branch change". Reaching the real answer took
+`--base main --head HEAD`, a pair the help never suggested and which the
+CLI rejected unless both were given.
+
+The ladder these cases pin, in order: both refs, `--base` alone, `--head`
+alone, neither, being on the default branch, and no detectable base at all.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+
+runner = CliRunner()
+
+BASE_SETTINGS = '{"permissions": {"allow": ["Bash(pytest *)", "Read(**)"]}}'
+WIDENED_SETTINGS = '{"permissions": {"allow": ["Bash(*)", "Read(**)", "WebFetch(*)"]}}'
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _repo(tmp_path: Path, *, default_branch: str = "main") -> Path:
+    repo = tmp_path / "repo"
+    (repo / ".claude").mkdir(parents=True)
+    (repo / ".claude" / "settings.json").write_text(BASE_SETTINGS, encoding="utf-8")
+    _git(repo, "init", "-q", "-b", default_branch)
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return repo
+
+
+def _widen_on_a_branch(repo: Path) -> None:
+    _git(repo, "checkout", "-q", "-b", "feat/widen")
+    (repo / ".claude" / "settings.json").write_text(WIDENED_SETTINGS, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "widen the allow list")
+
+
+def _check(repo: Path, *extra: str) -> dict:
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            "--workspace",
+            str(repo),
+            "--agent",
+            "claude-code",
+            "--format",
+            "agent-boundary-json",
+            *extra,
+        ],
+    )
+    assert result.output, result
+    return json.loads(result.output)
+
+
+# --- the reported defect ---------------------------------------------------
+
+
+def test_a_committed_branch_change_is_visible_without_any_flags(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _widen_on_a_branch(repo)
+
+    payload = _check(repo)
+
+    assert payload["decision"] == "block"
+    assert payload["changed_files"] == [".claude/settings.json"]
+    assert payload["violations"], "the widened allow rule must be named"
+
+
+def test_the_compared_base_is_published_on_the_result(tmp_path: Path) -> None:
+    """A verdict whose base is unnamed cannot be reviewed."""
+
+    repo = _repo(tmp_path)
+    _widen_on_a_branch(repo)
+
+    payload = _check(repo)
+
+    assert payload["subject"]["base"] == "main"
+
+
+def test_uncommitted_work_on_the_branch_is_included(tmp_path: Path) -> None:
+    """One comparison spanning committed and uncommitted work, not two."""
+
+    repo = _repo(tmp_path)
+    _widen_on_a_branch(repo)
+    (repo / ".mcp.json").write_text(
+        '{"mcpServers": {"pg": {"command": "npx", "args": ["server-postgres"]}}}',
+        encoding="utf-8",
+    )
+
+    payload = _check(repo)
+
+    assert set(payload["changed_files"]) == {".claude/settings.json", ".mcp.json"}
+
+
+# --- the rest of the ladder ------------------------------------------------
+
+
+def test_base_alone_is_accepted_and_compares_against_the_working_tree(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _widen_on_a_branch(repo)
+
+    payload = _check(repo, "--base", "main")
+
+    assert payload["decision"] == "block"
+    assert payload["subject"]["base"] == "main"
+
+
+def test_head_alone_is_accepted(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _widen_on_a_branch(repo)
+
+    payload = _check(repo, "--head", "HEAD")
+
+    assert payload["subject"]["base"] == "main"
+    assert payload["subject"]["head"] == "HEAD"
+    assert payload["decision"] == "block"
+
+
+def test_base_head_keeps_the_old_uncommitted_only_comparison(tmp_path: Path) -> None:
+    """The previous default stays reachable, by name."""
+
+    repo = _repo(tmp_path)
+    _widen_on_a_branch(repo)
+
+    payload = _check(repo, "--base", "HEAD")
+
+    assert payload["changed_files"] == []
+    assert payload["decision"] == "allow"
+
+
+def test_on_the_default_branch_the_answer_is_the_working_tree(tmp_path: Path) -> None:
+    """Being on the default branch is the commonest reason no other base is
+    detected, and there worktree-against-HEAD is complete, not wrong."""
+
+    repo = _repo(tmp_path)
+    payload = _check(repo)
+
+    assert payload["decision"] == "allow"
+    assert payload["changed_files"] == []
+
+    (repo / ".claude" / "settings.json").write_text(WIDENED_SETTINGS, encoding="utf-8")
+    widened = _check(repo)
+
+    assert widened["decision"] == "block"
+    assert widened["changed_files"] == [".claude/settings.json"]
+
+
+def test_an_undetectable_base_stops_instead_of_allowing(tmp_path: Path) -> None:
+    """No remote, no main/master: the honest answer is "tell me", never a
+    pass computed from a question nobody asked."""
+
+    repo = _repo(tmp_path, default_branch="trunk")
+    _git(repo, "checkout", "-q", "-b", "work")
+    (repo / ".claude" / "settings.json").write_text(WIDENED_SETTINGS, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "widen")
+
+    result = runner.invoke(
+        app,
+        ["check", "--workspace", str(repo), "--agent", "claude-code"],
+    )
+
+    assert result.exit_code == 2
+    assert "No base ref could be detected" in result.output
+    assert "--base" in result.output
+    assert "allow" not in result.output
+
+
+# --- the reason the local fallback is narrow -------------------------------
+
+
+def test_a_stale_local_default_never_beats_a_remote_one(tmp_path: Path) -> None:
+    """The local fallback exists only for repositories with no remote. Where
+    a remote exists it remains the authority, because a local `main` is
+    exactly the ref that goes stale."""
+
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "--bare", "-b", "main")
+
+    repo = _repo(tmp_path)
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "-q", "origin", "main")
+    # The local default now moves ahead; the remote is what a PR is against.
+    (repo / "README.md").write_text("local only\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "local drift")
+    _widen_on_a_branch(repo)
+
+    payload = _check(repo)
+
+    assert payload["subject"]["base"] == "origin/main"
+
+
+def test_empty_refs_are_still_refused(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    result = runner.invoke(
+        app, ["check", "--workspace", str(repo), "--base", "", "--head", "HEAD"]
+    )
+
+    assert result.exit_code == 2
+    assert "cannot be empty" in result.output
+
+
+@pytest.mark.parametrize("flag", ["--base", "--head"])
+def test_a_ref_cannot_smuggle_an_option(tmp_path: Path, flag: str) -> None:
+    repo = _repo(tmp_path)
+
+    result = runner.invoke(
+        app, ["check", "--workspace", str(repo), flag, "--upload-pack=evil"]
+    )
+
+    assert result.exit_code == 2

--- a/tests/test_codex_boundary_check.py
+++ b/tests/test_codex_boundary_check.py
@@ -1152,7 +1152,12 @@ def test_codex_check_reads_diff_from_stdin(tmp_path: Path) -> None:
     assert json.loads(result.output)["decision"] == "allow"
 
 
-def test_codex_check_rejects_one_sided_git_refs(tmp_path: Path) -> None:
+def test_codex_check_accepts_a_one_sided_git_ref(tmp_path: Path) -> None:
+    """#649 removed the paired-flag rule: `--base` alone means "that base
+    against the working tree" and `--head` alone means "the detected base
+    against that head". A workspace that is not a repository still fails
+    closed, exactly as it does with no refs at all."""
+
     result = runner.invoke(
         app,
         [
@@ -1166,8 +1171,27 @@ def test_codex_check_rejects_one_sided_git_refs(tmp_path: Path) -> None:
         ],
     )
 
+    assert "--base and --head must be provided together" not in result.output
+    payload = json.loads(result.output)
+    assert payload["decision"] == "block"
+
+
+def test_codex_check_still_rejects_an_empty_git_ref(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            "--workspace",
+            str(tmp_path),
+            "--base",
+            "",
+            "--format",
+            "codex-boundary-json",
+        ],
+    )
+
     assert result.exit_code == 2
-    assert "--base and --head must be provided together" in result.output
+    assert "cannot be empty" in result.output
 
 
 def test_codex_check_malformed_toml_returns_schema_valid_json(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #649.

## The defect

`shipgate check` compared the working tree with `HEAD`. On a branch whose changes were already committed it answered:

```
decision: allow    changed_files: []    "No recognized coding-agent boundary change"
```

It was truthfully reporting *"nothing is uncommitted"* to someone asking *"what does this branch change"*. The real answer needed `--base main --head HEAD` — a pair nothing in `--help` suggested, and which the CLI rejected unless **both** were given.

Measured on a repository that widens `.claude/settings.json` to `Bash(*)`, adds an MCP server, and gives its workflow `contents: write` + `pull_request_target`, all committed:

| | before | after |
| --- | --- | --- |
| `shipgate check` (no flags) | `allow`, 0 changed files | `block`/`critical`, 3 changed files, **5 violations** |

## The ladder

| invocation | compares |
| --- | --- |
| *(no flags)* | detected base's merge base → working tree |
| `--base <ref>` | that ref's merge base → working tree |
| `--head <ref>` | detected base → that ref |
| `--base A --head B` | `A...B`, unchanged |
| `--base HEAD` | uncommitted only — the previous default, by name |
| on the default branch | working tree, unchanged and complete |
| no base detectable | **exit 2** naming `--base`, never `allow` |

`subject.base` now names the ref actually compared. A verdict whose base is unnamed cannot be reviewed.

## Two places the issue's sketch was wrong

**It proposed falling back to local `main`/`master`.** `detect_default_base` refuses those *on purpose* — a remote is the authority a local branch might be stale against. Rather than override that reasoning, I narrowed the fallback to the case it does not cover: a repository with **no remote at all**, where the local branch is the only base in existence. Opt-in, so `verify` is untouched. A test pins that a remote still wins over a locally-ahead `main`.

**It assumed "no base detected" means "cannot be determined".** That detector also returns nothing when HEAD *is* the default branch — the commonest situation there is — which would have turned an ordinary `check` on `main` into an error. The two are now separated: on the default branch the working-tree answer is complete; only a genuinely undetectable base stops.

## A behaviour change worth reviewing

The issue assumed hook and skill callers pass explicit refs. **They do not** — `adoption-kits/*/SKILL.md`, `docs/agents/*.md` and the plugin all invoke `shipgate check --agent … --workspace . --format agent-boundary-json` with no refs. Those calls now get branch scope instead of session scope.

I believe that is right, and it is the fix for a known complaint: the 2026-07-26 in-loop review recorded that *"`git commit` silently clears check (worktree-vs-HEAD diff)"*. An agent that commits mid-session no longer loses the finding. But it is a real change to the in-session loop's noise profile, so it should be a conscious call rather than a side effect — if you would rather the local guard keep session scope, the fix is `--base HEAD` in the rendered hook, and I will make that change.

## Also touched, for consistency

`verify_command_for` required both refs or neither — a mirror of the CLI rule this removes. It now emits whichever ref was resolved, since `verify` accepts either alone. Leaving it would have made the emitted command disagree with the check that emitted it, which is this repository's recurring second-implementation defect.

## Evidence

12 cases in `tests/test_check_default_comparison.py`. **Negative control:** against pre-fix `main`, 8 fail; the 4 that pass are the default-branch, empty-ref and option-smuggling cases that must not change.

`test_codex_check_rejects_one_sided_git_refs` pinned the removed rule. It now pins the new one and, separately, the empty-ref refusal it was also covering. Two line-pinned entries in the static-only allowlist moved with the code they point at.

Locally green: everything matching `check|boundary|agent_mode|agent_result|trigger|control|invocation|verify|hook|static_only`, plus the surface-contract and parity suites and `ruff check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
