### PR TITLE
fix(control): make every emitted next action lead somewhere (#650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- Make every emitted next action lead somewhere, and prove it. Following
+  `control.next_action` on a repository with recognized host configuration
+  and no manifest went round three commands forever: `verify --preview`
+  named `init --write`, `init` refused because a host-only repository needs
+  no manifest and named `audit --host`, and `audit --host` named
+  `verify --preview` again. The host-audit footer is now conditional — the
+  baseline comparison where there is no manifest, `verify` where there is,
+  `--drift` once a baseline exists — and it says to record the baseline on
+  the base ref, never on the changed checkout, which would accept the change
+  instead of comparing it. That footer also emitted its command without
+  `--workspace`, so following it ran the next step against the caller's
+  current directory rather than the repository just audited; every emitted
+  command now carries the workspace it was produced for. A preview that
+  evaluated no gate reports `Agents Shipgate verify: not evaluated` instead
+  of `failed`, matching the `not_run` its machine fields already carried.
+  `tests/test_next_action_chains_terminate.py` walks every entry command on
+  two repository shapes and fails on a repeat, a lost workspace, or a step
+  this CLI cannot run (#650).
+
 - Read every counted hunk row, so header-shaped content stops being lost.
   Hunk state and the header's declared row counts, not a line's spelling,
   decide what the shared unified-diff parser treats as content: a removed

--- a/docs/agent-contract-current.md
+++ b/docs/agent-contract-current.md
@@ -94,6 +94,32 @@ well. In verifier, verify-run, and preview output, follow
 only `control.next_action` and `control.allowed_next_commands`. See the
 [embedded-trigger migration note](../STABILITY.md#migration-note-unreleased-embedded-trigger-routing).
 
+### Emitted next actions terminate
+
+Following `control.next_action.command` — or the human `Next:` line, which is
+the same routing rendered for a person — reaches a terminal. Three properties
+hold, and `tests/test_next_action_chains_terminate.py` walks every entry
+command on a host-only and a manifest repository to keep them holding:
+
+- **No cycle.** No chain returns to a question it already asked. Output
+  format is not part of a step's identity: `audit --host` and
+  `audit --host --json` ask the same thing, and treating them as different
+  steps is what once hid a three-command loop
+  (`verify --preview` → `init --write` → `audit --host` → `verify --preview`).
+- **No workspace loss.** Every emitted command names the same `--workspace`
+  it was produced for. A step that drops it does not continue the walk; it
+  starts a different one against the caller's current directory, which is
+  the silent retargeting the [invocation policy](diagnostics.md#invocation-policy)
+  exists to prevent.
+- **Every step is runnable.** An emitted command names a Shipgate command
+  that accepts it. Prose that names no command is a terminal: it hands the
+  reader a decision, not another lap.
+
+A run that evaluated no gate says so. `verify --preview` on a repository with
+nothing to gate reports `execution: "not_run"` and
+`applicability: "not_evaluated"`, and the human line reads
+`Agents Shipgate verify: not evaluated` rather than `failed`.
+
 Runtime contract v28 publishes the capability delta as a **standalone
 attestation**. `verify` writes
 `agents-shipgate-reports/capability-delta-attestation.json`: an

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1634,6 +1634,32 @@ well. In verifier, verify-run, and preview output, follow
 only `control.next_action` and `control.allowed_next_commands`. See the
 [embedded-trigger migration note](../STABILITY.md#migration-note-unreleased-embedded-trigger-routing).
 
+### Emitted next actions terminate
+
+Following `control.next_action.command` — or the human `Next:` line, which is
+the same routing rendered for a person — reaches a terminal. Three properties
+hold, and `tests/test_next_action_chains_terminate.py` walks every entry
+command on a host-only and a manifest repository to keep them holding:
+
+- **No cycle.** No chain returns to a question it already asked. Output
+  format is not part of a step's identity: `audit --host` and
+  `audit --host --json` ask the same thing, and treating them as different
+  steps is what once hid a three-command loop
+  (`verify --preview` → `init --write` → `audit --host` → `verify --preview`).
+- **No workspace loss.** Every emitted command names the same `--workspace`
+  it was produced for. A step that drops it does not continue the walk; it
+  starts a different one against the caller's current directory, which is
+  the silent retargeting the [invocation policy](diagnostics.md#invocation-policy)
+  exists to prevent.
+- **Every step is runnable.** An emitted command names a Shipgate command
+  that accepts it. Prose that names no command is a terminal: it hands the
+  reader a decision, not another lap.
+
+A run that evaluated no gate says so. `verify --preview` on a repository with
+nothing to gate reports `execution: "not_run"` and
+`applicability: "not_evaluated"`, and the human line reads
+`Agents Shipgate verify: not evaluated` rather than `failed`.
+
 Runtime contract v28 publishes the capability delta as a **standalone
 attestation**. `verify` writes
 `agents-shipgate-reports/capability-delta-attestation.json`: an

--- a/src/agents_shipgate/cli/host_audit.py
+++ b/src/agents_shipgate/cli/host_audit.py
@@ -14,6 +14,7 @@ import typer
 
 from agents_shipgate.cli.agent_mode import emit_agent_mode_error_action
 from agents_shipgate.cli.workspace_guard import require_workspace
+from agents_shipgate.core.agent_controls import _cwd_anchored
 from agents_shipgate.core.host_grants import (
     DEFAULT_BASELINE_FILE,
     HOST_GRANTS_INVENTORY_SCHEMA_VERSION,
@@ -399,7 +400,58 @@ def audit(
         typer.echo(json.dumps(inventory, indent=2, sort_keys=True))
         return
     _write_json_out(out, inventory)
-    typer.echo(render_host_audit_markdown(inventory), nl=False)
+    typer.echo(
+        render_host_audit_markdown(
+            inventory,
+            next_step=_audit_next_step(
+                workspace=workspace, baseline_file=baseline_file
+            ),
+        ),
+        nl=False,
+    )
+
+
+def _audit_next_step(*, workspace: Path, baseline_file: Path) -> str:
+    """The step that actually advances from a finished host audit.
+
+    The footer always named `verify --preview`. On a repository with no
+    manifest that is a cycle: preview routes to `init`, `init` refuses
+    because a host-only repository needs no manifest and routes back here,
+    and here pointed at preview again. A reader following the tool's own
+    advice went round three commands forever (#650).
+
+    Every emitted command carries `--workspace`. The old footer did not,
+    so following it ran the next step against the caller's current
+    directory rather than the repository just audited — the invocation
+    policy's "silently retarget the authorized operation", emitted by the
+    tool itself.
+
+    `verify` is still the answer where a manifest exists. Where one does
+    not, the baseline comparison is — and it is named on the *base* ref
+    deliberately: recording a baseline from the changed checkout would
+    acknowledge the very change under review.
+    """
+
+    recorded = _baseline_write_target(workspace=workspace, baseline_file=baseline_file)
+    anchored = _cwd_anchored(workspace)
+    if recorded.exists():
+        return (
+            f"Next: `agents-shipgate audit --host --workspace {anchored} --drift` "
+            "to compare this inventory with the recorded baseline."
+        )
+    if (workspace / "shipgate.yaml").exists():
+        return (
+            f"Next: `agents-shipgate verify --preview --workspace {anchored} --json` "
+            "for release gating."
+        )
+    return (
+        "Next: this inventory is the whole answer for a repository with no "
+        "`shipgate.yaml`. To see what a change alters, record a baseline on "
+        "the base ref — switch to it, run `agents-shipgate audit --host "
+        "--save-baseline`, then return here and rerun with `--drift`. Record "
+        "it on the base, never on the changed checkout, which would accept "
+        "the change instead of comparing it."
+    )
 
 
 def _incomplete_inventory_review(inventory: dict[str, object]) -> str:

--- a/src/agents_shipgate/cli/verify/command.py
+++ b/src/agents_shipgate/cli/verify/command.py
@@ -473,6 +473,24 @@ def verify(
     raise typer.Exit(exit_code)
 
 
+def _unevaluated_verdict_word(verifier) -> str:
+    """The human word for a run that produced no release decision.
+
+    "failed" was the catch-all, so a preview that simply did not evaluate a
+    gate — no manifest, nothing to gate — printed "Agents Shipgate verify:
+    failed" directly above "Exit code: 0". Nothing had failed; the machine
+    fields said so already (`execution: "not_run"`,
+    `applicability: "not_evaluated"`), and only the human line disagreed
+    with them (#650).
+    """
+
+    if verifier.head_status == "skipped":
+        return "skipped"
+    if (getattr(verifier, "execution", None) or verifier.head_status) == "not_run":
+        return "not evaluated"
+    return "failed"
+
+
 def _emit_verify_stdout(
     verifier: VerifierArtifact,
     *,
@@ -495,7 +513,7 @@ def _emit_verify_stdout(
         verdict = (
             verifier.release_decision.decision
             if verifier.release_decision is not None
-            else ("skipped" if verifier.head_status == "skipped" else "failed")
+            else _unevaluated_verdict_word(verifier)
         )
         # Lead with the operational answer. The release verdict below is the
         # gate's word on the change; these lines are the reader's word on what

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -1828,7 +1828,9 @@ def build_host_drift_payload(
     return HostGrantsDriftV3.model_validate(payload).model_dump(mode="json")
 
 
-def render_host_audit_markdown(inventory: dict[str, Any]) -> str:
+def render_host_audit_markdown(
+    inventory: dict[str, Any], *, next_step: str | None = None
+) -> str:
     lines = ["# Host Capability Audit", ""]
     lines.append(
         f"Static `{inventory['scope']}` inventory. Runtime session behavior was not verified."
@@ -1874,7 +1876,12 @@ def render_host_audit_markdown(inventory: dict[str, Any]) -> str:
     lines.append("")
     for item in inventory["excluded_scopes"]:
         lines.append(f"- {item}")
-    lines.extend(["", "---", "Next: `agents-shipgate verify --preview --json` for release gating."])
+    lines.extend([
+        "",
+        "---",
+        next_step
+        or "Next: `agents-shipgate verify --preview --json` for release gating.",
+    ])
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_next_action_chains_terminate.py
+++ b/tests/test_next_action_chains_terminate.py
@@ -1,0 +1,276 @@
+"""#650: an emitted next action must lead somewhere.
+
+`control.next_action` is what a coding agent follows, so a next action that
+points at a command which refuses — or back at the command that emitted it —
+is worse than none at all. On a repository with recognized host
+configuration and no manifest, the tool sent a reader round three commands
+forever:
+
+    verify --preview  ->  "Next: init --write"
+    init --write      ->  refuses (host-only needs no manifest), "Next: audit --host"
+    audit --host      ->  "Next: verify --preview"          <- back to the start
+
+These cases follow every emitted chain to a terminal and fail on a repeat.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+
+runner = CliRunner()
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SAMPLE = REPO_ROOT / "samples" / "ai_generated_refund_pr"
+
+#: A chain longer than this is not a chain, it is a maze.
+MAX_STEPS = 6
+
+#: Commands a chain may name. An emitted step outside this set is itself a
+#: finding: the contract promises a Shipgate command the caller can run.
+RUNNABLE = {
+    "check", "verify", "init", "audit", "scan", "detect", "preflight", "doctor",
+}
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def host_only_repo(tmp_path: Path) -> Path:
+    """Recognized host configuration, no manifest — the reported shape."""
+
+    repo = tmp_path / "host-only"
+    (repo / ".claude").mkdir(parents=True)
+    (repo / ".claude" / "settings.json").write_text(
+        '{"permissions": {"allow": ["Bash(pytest *)"]}}', encoding="utf-8"
+    )
+    (repo / ".mcp.json").write_text(
+        '{"mcpServers": {"fs": {"command": "npx", "args": ["server-filesystem"]}}}',
+        encoding="utf-8",
+    )
+    (repo / ".gitignore").write_text("agents-shipgate-reports/\n", encoding="utf-8")
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return repo
+
+
+@pytest.fixture
+def manifest_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "manifest"
+    repo.mkdir()
+    for name in ("shipgate.yaml", "tools.json"):
+        (repo / name).write_text((SAMPLE / name).read_text(encoding="utf-8"), encoding="utf-8")
+    (repo / ".gitignore").write_text("agents-shipgate-reports/\n", encoding="utf-8")
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return repo
+
+
+def _emitted_next_command(output: str) -> str | None:
+    """The one command this output tells the caller to run next.
+
+    Both surfaces count, because both produced the reported cycle: the
+    control envelope an agent reads, and the `Next:` line a person reads.
+    Prose advice that names no command is a terminal — it hands the reader
+    a decision rather than another lap.
+    """
+
+    try:
+        payload = json.loads(output)
+    except ValueError:
+        payload = None
+    if isinstance(payload, dict):
+        command = ((payload.get("control") or {}).get("next_action") or {}).get("command")
+        if command:
+            return str(command)
+    for line in output.splitlines():
+        if line.startswith("Next command: "):
+            return line[len("Next command: ") :].strip()
+        # Not anchored to end-of-line: the host-audit footer reads
+        # "Next: `... --json` for release gating.", and requiring the line to
+        # end at the backtick made this reader miss the exact cycle it exists
+        # to catch. Verified by replaying against pre-fix `main`.
+        matched = re.match(r"Next: `([^`]+)`", line.strip())
+        if matched:
+            return matched.group(1)
+    return None
+
+
+def _argv(command: str) -> list[str]:
+    """The Shipgate argv inside an emitted command string."""
+
+    tokens = shlex.split(command)
+    while tokens and tokens[0] not in RUNNABLE:
+        tokens = tokens[1:]
+    return tokens
+
+
+#: Flags that change how a result is printed, not which question is asked.
+#: The cycle they hid: `audit --host` emitted `verify --preview --json`,
+#: which emitted `init --write --json`, which emitted `audit --host --json`.
+#: Keyed on raw argv those are four distinct nodes and the walk looks
+#: finite; keyed on the question asked it is the reported three-command
+#: loop. Verified by replaying against pre-fix `main`.
+_PRESENTATION_FLAGS = {"--json", "--format", "--out"}
+
+
+def _identity(argv: list[str]) -> tuple[str, ...]:
+    """What this step *asks*, with presentation stripped."""
+
+    kept: list[str] = []
+    skip_value = False
+    for token in argv:
+        if skip_value:
+            skip_value = False
+            continue
+        if token in _PRESENTATION_FLAGS:
+            skip_value = token != "--json"
+            continue
+        kept.append(token)
+    return tuple(kept)
+
+
+def _workspace_of(argv: list[str]) -> str | None:
+    for index, token in enumerate(argv):
+        if token == "--workspace" and index + 1 < len(argv):
+            return str(Path(argv[index + 1]).resolve())
+    return None
+
+
+def _follow(entry: list[str]) -> list[tuple[str, ...]]:
+    """Run ``entry``, then whatever it names, until a terminal.
+
+    Returns the chain actually walked. Raises on a repeat, because a repeat
+    is the defect: following the tool's own advice must not return you to a
+    command you already ran.
+    """
+
+    chain: list[tuple[str, ...]] = []
+    argv = entry
+    expected_workspace = _workspace_of(entry)
+    for _ in range(MAX_STEPS):
+        key = _identity(argv)
+        assert key not in chain, (
+            "emitted next actions cycle: "
+            + " -> ".join(" ".join(step) for step in [*chain, _identity(argv)])
+        )
+        chain.append(key)
+        result = runner.invoke(app, argv)
+        command = _emitted_next_command(result.output or "")
+        if command is None:
+            return chain
+        argv = _argv(command)
+        assert argv, f"emitted a next command this CLI cannot run: {command!r}"
+        assert argv[0] in RUNNABLE, (
+            f"emitted next command {argv[0]!r} is not a Shipgate command: {command!r}"
+        )
+        # A step that drops the workspace does not continue this walk — it
+        # starts a different one, against whatever directory the caller
+        # happens to be in. That is the invocation policy's "silently
+        # retarget the authorized operation", emitted by the tool itself,
+        # and it is how the reported cycle stayed invisible: the chain
+        # wandered into another repository and terminated there.
+        if expected_workspace is not None:
+            assert _workspace_of(argv) == expected_workspace, (
+                f"emitted next command left the audited workspace: {command!r}"
+            )
+    raise AssertionError(
+        f"chain did not terminate within {MAX_STEPS} steps: "
+        + " -> ".join(" ".join(step) for step in chain)
+    )
+
+
+ENTRY_POINTS = [
+    ["check", "--agent", "claude-code", "--format", "agent-boundary-json"],
+    ["verify", "--preview"],
+    ["verify", "--preview", "--format", "text"],
+    ["init"],
+    ["audit", "--host"],
+    ["audit", "--host", "--json"],
+    ["scan"],
+]
+
+
+@pytest.mark.parametrize(
+    "entry", ENTRY_POINTS, ids=lambda entry: "-".join(entry).replace("--", "")
+)
+def test_every_chain_terminates_on_a_host_only_repository(
+    host_only_repo: Path, entry: list[str]
+) -> None:
+    _follow([*entry, "--workspace", str(host_only_repo)])
+
+
+@pytest.mark.parametrize(
+    "entry", ENTRY_POINTS, ids=lambda entry: "-".join(entry).replace("--", "")
+)
+def test_every_chain_terminates_on_a_manifest_repository(
+    manifest_repo: Path, entry: list[str]
+) -> None:
+    entry = [*entry, "--workspace", str(manifest_repo)]
+    if entry[0] == "scan":
+        entry = ["scan", "--config", str(manifest_repo / "shipgate.yaml")]
+    _follow(entry)
+
+
+def test_the_reported_cycle_specifically(host_only_repo: Path) -> None:
+    """preview -> init -> audit -> preview, named so a regression is
+    recognizable rather than just 'the property test went red'."""
+
+    chain = _follow(["verify", "--preview", "--workspace", str(host_only_repo)])
+    commands = [step[0] for step in chain]
+
+    assert commands[0] == "verify"
+    assert commands.count("verify") == 1, f"returned to verify: {commands}"
+    assert "audit" in commands, f"never reached the host route: {commands}"
+
+
+def test_the_host_route_is_reached_within_two_steps(host_only_repo: Path) -> None:
+    chain = _follow(["verify", "--preview", "--workspace", str(host_only_repo)])
+
+    assert [step[0] for step in chain][:3] == ["verify", "init", "audit"]
+
+
+def test_a_preview_that_evaluated_nothing_does_not_say_it_failed(
+    host_only_repo: Path,
+) -> None:
+    """"failed" beside "Exit code: 0" was the catch-all word for a run with
+    no release decision; the machine fields said `not_run` all along."""
+
+    result = runner.invoke(
+        app,
+        ["verify", "--preview", "--workspace", str(host_only_repo), "--format", "text"],
+    )
+
+    assert "Agents Shipgate verify: failed" not in result.output
+    assert "Agents Shipgate verify: not evaluated" in result.output
+
+
+def test_a_real_failure_is_still_called_a_failure() -> None:
+    """The word only moves for runs that did not evaluate."""
+
+    from agents_shipgate.cli.verify.command import _unevaluated_verdict_word
+
+    class _Verifier:
+        def __init__(self, head_status: str, execution: str | None = None) -> None:
+            self.head_status = head_status
+            self.execution = execution
+
+    assert _unevaluated_verdict_word(_Verifier("failed", "failed")) == "failed"
+    assert _unevaluated_verdict_word(_Verifier("skipped")) == "skipped"
+    assert _unevaluated_verdict_word(_Verifier("not_run", "not_run")) == "not evaluated"


### PR DESCRIPTION
Closes #650.

## The reported cycle

On a repository with recognized host configuration and no manifest, following the tool's own advice never ends:

```
verify --preview  ->  "Next: init --write"
init --write      ->  refuses; a host-only repo needs no manifest, "Next: audit --host"
audit --host      ->  "Next: verify --preview"            <- back to the start
```

`control.next_action` is what a coding agent follows. A next action that points at a command which refuses, or back at the command that emitted it, is worse than none.

## The second defect, found by writing the test

The host-audit footer emitted `agents-shipgate verify --preview --json` **with no `--workspace`**. Walking the chain therefore did not loop — it *left*:

```
1. audit --host --workspace <repo>   ->  verify --preview --json        (no workspace!)
2. verify --preview --json           ->  ... mainwt/shipgate.yaml       (a different repository)
3. terminal
```

That is the invocation policy's own prohibition — *"Control commands are commonly executed after a tool/cwd transition; retaining a relative spelling would silently retarget the authorized operation"* — emitted by the tool itself. Every emitted command now carries the workspace it was produced for.

## The fixes

- **Conditional footer.** The baseline comparison where there is no manifest, `verify` where there is, `--drift` once a baseline exists. It names the **base ref** deliberately: recording a baseline from the changed checkout acknowledges the change under review rather than comparing it — the trap recorded in the 2026-09-04 pilot notes.
- **Workspace carried** on every emitted command.
- **`not evaluated`, not `failed`.** "failed" was the catch-all whenever no release decision existed, so a preview with nothing to gate printed `Agents Shipgate verify: failed` directly above `Exit code: 0` while its own fields said `execution: "not_run"` and `applicability: "not_evaluated"`. Only the human line disagreed.

## The guard, and three passes to stop it being vacuous

`tests/test_next_action_chains_terminate.py` walks every entry command on a host-only and a manifest repository, failing on a repeat, a lost workspace, or a step this CLI cannot run. Getting it to actually detect the defect took three corrections, each now recorded in its comments:

1. **Anchored the `Next:` reader to end-of-line.** The footer reads ``Next: `… --json` for release gating.`` — the text continues past the backtick, so the reader saw no command and called it a terminal.
2. **Keyed a step on raw argv.** `audit --host` and `audit --host --json` became different nodes, so a loop through both looked finite. The key is now the question asked, with presentation flags stripped.
3. **Only asserted termination.** The real chain terminated legitimately — in the wrong repository. The workspace assertion is what finally reproduced it.

**Negative control:** replayed against pre-fix `main`, both `audit --host` chain cases fail, plus the two verdict-word cases. Before correction 3 the chain cases passed on `main`, which is the definition of a guard that is not one.

## Acceptance

- [x] The termination property test exists, runs in CI, and is green.
- [x] From `verify --preview`, the chain reaches the host route in 2 steps (`verify` → `init` → `audit`), pinned separately.
- [x] `verify --preview` never prints "failed" on exit 0.
- [x] Documented in `docs/agent-contract-current.md` as a guarantee of the control envelope: no cycle, no workspace loss, every step runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
