### PR TITLE
Tell a widened permission rule from a narrowed one (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## Unreleased
 
+- Tell a widened permission rule from a narrowed one, and stop rating
+  reading files as critical. Host grants are keyed by rule text, so
+  replacing `Bash(npm *)` with `Bash(npm test:*)` arrived as one removal
+  plus one addition — byte-for-byte the same shape as replacing it with
+  `Bash(*)`. Set arithmetic cannot separate those, so drift reported a
+  tightening as an expansion, and a reviewer who tightens a rule and gets
+  warned for it learns to stop reading the warnings. A new
+  `core/permission_lattice.py` decides which of two rules is wider for the
+  patterns hosts actually use — whole-tool grants, trailing-star prefixes,
+  literals, and the bare `mcp__server__*` spelling — and answers `None`
+  for anything else, including character classes and interior stars, where
+  a guess would be the same wrong direction in a new place. A narrowing no
+  longer contributes to `expansion_signals`; it stays visible in `changes`
+  as the removal and addition it is. A widening is now named
+  (`permission_widened: <host>:<before> -> <after>`) rather than only
+  counted.
+
+  The same lattice sets severity, replacing a model where every wildcard
+  allow was `admin`/`critical`. `Read(**)` sat beside `Bash(*)` at the top
+  of the table. On a carefully written host config — wildcard reads,
+  scoped `Bash` and `Edit`, two deny rules, one MCP server, a
+  least-privilege workflow — `audit --host` rated 7 of 10 grants `high` or
+  `critical`, three of them `critical`/`admin` for reading files. The same
+  config now rates 1 of 10 above `medium`: the MCP server, which is the
+  one row there that can reach anything new. Severity follows what the
+  grant reaches:
+  execution and `*` stay `critical`, network and write are `high`, an
+  unrecognised whole-tool grant is `high` because nothing establishes
+  otherwise, and reading a workspace the agent already has checked out is
+  `low`.
+
+  This narrows a blocking check. `SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW`
+  blocked the release on any wildcard allow, so adding `Read(**)` — the
+  ordinary configuration for a coding agent — was a `critical` release
+  blocker, and a gate that stops a release over reading files is one a team
+  turns off. Read-only whole-tool grants now raise
+  `SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED` (`require_review`, `high`)
+  instead. Nothing else moves: execution, network, write, `*` and unknown
+  tools still block, and the check ID is unchanged for them. The gate had
+  classified wildcards a second time in `core/host_boundary.py`; both
+  readers now share the one lattice, and a test pins that they agree.
+
+  `policies/host-boundary.shipgate.yaml` records why each severity is what
+  it is, one `why:` line per rule — nine of the ten sat at `high` or above
+  with nothing written down. `tests/test_permission_lattice.py`
+  carries twenty widen/narrow/unchanged pairs replayed through the real
+  reader for both hosts with a rule vocabulary, and marks the two pairs
+  this lattice declines so the boundary moves visibly rather than
+  silently. Replayed against pre-fix `main`, 51 of its 78 cases fail
+  (#657).
+
 - Lead the Cursor instruction surface with `shipgate diff`. It opened with
   the control envelope, so an agent following it reported "a human must
   review" without naming what changed, while `AGENTS.md` had led with the

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -116,8 +116,8 @@ baseline summary and do not fail CI.
 | `SHIP-HOST-BOUNDARY-CONFIG-PARSE-FAILED` | medium | A coding-agent host configuration file could not be parsed. |
 | `SHIP-HOST-BOUNDARY-MCP-SERVER-ADDED` | high | A new MCP server was declared for the coding-agent host. |
 | `SHIP-HOST-BOUNDARY-MCP-SERVER-CHANGED` | high | An existing MCP server declaration changed its command, URL, args, or env keys. |
-| `SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW` | critical | A Claude Code allow rule grants a wildcard tool surface. |
-| `SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED` | high | The Claude Code permission allowlist expanded. |
+| `SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW` | critical | A Claude Code allow rule grants a wildcard surface over a tool that can execute, reach the network, or write. |
+| `SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED` | high | The Claude Code permission allowlist expanded, by a scoped rule or a read-only wildcard. |
 | `SHIP-HOST-BOUNDARY-PERMISSION-DENY-REMOVED` | high | A Claude Code permission deny rule was removed. |
 | `SHIP-HOST-BOUNDARY-HOOK-CHANGED` | high | Claude Code hooks changed. |
 | `SHIP-HOST-BOUNDARY-WORKFLOW-WRITE-ALL` | critical | A GitHub workflow grants write-all permissions. |
@@ -662,13 +662,23 @@ names only.
 
 A changed `.claude/settings.json` or `.claude/settings.local.json` adds an
 allow rule that is `*`, a bare tool name, or a wildcard-shaped rule such as
-`Bash(*)`. Do not allow wildcard tool permissions; scope the rule to specific
-commands.
+`Bash(*)`, **and** the tool it grants can reach beyond reading. Do not allow
+wildcard tool permissions over execution, network access or writes; scope the
+rule to specific commands.
+
+A wildcard grant over a read tool — `Read(**)`, `Glob`, `Grep(**)` — raises
+`SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED` instead. It is still an
+expansion and still reviewed, but it is not a release blocker: the agent
+already has the workspace checked out, and turning that read into an
+exfiltration needs a network or write grant, which is its own finding. Before
+v0.17 every wildcard shape reached this check, so the ordinary coding-agent
+configuration blocked the release at `critical` (#657).
 
 ### SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED
 
-A changed Claude Code settings file adds a non-wildcard `permissions.allow`
-entry. Have a human approve the new permission allow rule.
+A changed Claude Code settings file adds a `permissions.allow` entry that is
+either scoped (`Bash(npm test:*)`) or a wildcard over a read-only tool
+(`Read(**)`). Have a human approve the new permission allow rule.
 
 ### SHIP-HOST-BOUNDARY-PERMISSION-DENY-REMOVED
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3169,8 +3169,8 @@ baseline summary and do not fail CI.
 | `SHIP-HOST-BOUNDARY-CONFIG-PARSE-FAILED` | medium | A coding-agent host configuration file could not be parsed. |
 | `SHIP-HOST-BOUNDARY-MCP-SERVER-ADDED` | high | A new MCP server was declared for the coding-agent host. |
 | `SHIP-HOST-BOUNDARY-MCP-SERVER-CHANGED` | high | An existing MCP server declaration changed its command, URL, args, or env keys. |
-| `SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW` | critical | A Claude Code allow rule grants a wildcard tool surface. |
-| `SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED` | high | The Claude Code permission allowlist expanded. |
+| `SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW` | critical | A Claude Code allow rule grants a wildcard surface over a tool that can execute, reach the network, or write. |
+| `SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED` | high | The Claude Code permission allowlist expanded, by a scoped rule or a read-only wildcard. |
 | `SHIP-HOST-BOUNDARY-PERMISSION-DENY-REMOVED` | high | A Claude Code permission deny rule was removed. |
 | `SHIP-HOST-BOUNDARY-HOOK-CHANGED` | high | Claude Code hooks changed. |
 | `SHIP-HOST-BOUNDARY-WORKFLOW-WRITE-ALL` | critical | A GitHub workflow grants write-all permissions. |
@@ -3715,13 +3715,23 @@ names only.
 
 A changed `.claude/settings.json` or `.claude/settings.local.json` adds an
 allow rule that is `*`, a bare tool name, or a wildcard-shaped rule such as
-`Bash(*)`. Do not allow wildcard tool permissions; scope the rule to specific
-commands.
+`Bash(*)`, **and** the tool it grants can reach beyond reading. Do not allow
+wildcard tool permissions over execution, network access or writes; scope the
+rule to specific commands.
+
+A wildcard grant over a read tool — `Read(**)`, `Glob`, `Grep(**)` — raises
+`SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED` instead. It is still an
+expansion and still reviewed, but it is not a release blocker: the agent
+already has the workspace checked out, and turning that read into an
+exfiltration needs a network or write grant, which is its own finding. Before
+v0.17 every wildcard shape reached this check, so the ordinary coding-agent
+configuration blocked the release at `critical` (#657).
 
 ### SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED
 
-A changed Claude Code settings file adds a non-wildcard `permissions.allow`
-entry. Have a human approve the new permission allow rule.
+A changed Claude Code settings file adds a `permissions.allow` entry that is
+either scoped (`Bash(npm test:*)`) or a wildcard over a read-only tool
+(`Read(**)`). Have a human approve the new permission allow rule.
 
 ### SHIP-HOST-BOUNDARY-PERMISSION-DENY-REMOVED
 

--- a/policies/host-boundary.shipgate.yaml
+++ b/policies/host-boundary.shipgate.yaml
@@ -1,3 +1,18 @@
+# Host boundary policy — what a change to the host's own configuration costs.
+#
+# Every rule below carries a `why:` line. The severities were flat before
+# #657 — nine of the ten sat at `high` or above with nothing recorded
+# about why — and a column where almost everything is severe carries no
+# information: a reviewer skims it, and the one row that mattered is
+# skimmed with the rest. A severity no one can defend in a sentence is a
+# severity that should move, so each one now has to earn its line.
+#
+# This file cannot lower a severity. `DEFAULT_RULES` in
+# `core/host_boundary.py` is a safety floor; an edit here that sits below
+# it is refused with `policy_safety_floor_downgrade` and the floor is
+# used instead. Raising is allowed. `why:` is documentation — the loader
+# reads `action`, `risk_level`, `check_id`, `title` and `recommendation`
+# and ignores everything else.
 id: host-boundary
 name: Host Boundary Local Policy
 version: "1"
@@ -7,58 +22,92 @@ rules:
     title: Host configuration could not be parsed
     action: require_review
     risk_level: medium
+    # why: an unreadable config is an unknown, not a finding. It cannot be
+    # called safe, so it is not `low`; nothing about it is established, so
+    # it is not `high` either. A human reads the file.
     recommendation: Fix the malformed host config or have a human review the change.
   - id: HOST-MCP-SERVER-ADDED
     check_id: SHIP-HOST-BOUNDARY-MCP-SERVER-ADDED
     title: New MCP server declared for the coding-agent host
     action: require_review
     risk_level: high
+    # why: a new server is new code the agent may call, with tools this
+    # engine has not seen and cannot bound statically. The authority is
+    # whatever the server implements.
     recommendation: Have a human review the new MCP server before the agent can use it.
   - id: HOST-MCP-SERVER-CHANGED
     check_id: SHIP-HOST-BOUNDARY-MCP-SERVER-CHANGED
     title: Existing MCP server declaration changed
     action: require_review
     risk_level: high
+    # why: same authority as adding one. A changed command, URL or env key
+    # can repoint an approved name at something else entirely, and the
+    # name is all a reviewer sees.
     recommendation: Review the changed MCP server command, URL, args, or env keys.
   - id: HOST-PERMISSION-WILDCARD-ALLOW
     check_id: SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW
     title: Coding-agent allow rule grants a wildcard tool surface
     action: block
     risk_level: critical
+    # why: a whole-tool grant over execution, network or writes is
+    # unbounded by construction — `Bash(*)` is every command there is.
+    # Read-only whole-tool grants no longer reach this rule at all: they
+    # are routed to ALLOW-EXPANDED, because blocking the release over
+    # `Read(**)` on a repository the agent already has checked out is how
+    # a team learns to turn the gate off (#657).
     recommendation: Do not allow wildcard tool permissions; scope the rule to specific commands.
   - id: HOST-PERMISSION-ALLOW-EXPANDED
     check_id: SHIP-HOST-BOUNDARY-PERMISSION-ALLOW-EXPANDED
     title: Coding-agent permission allowlist expanded
     action: require_review
     risk_level: high
+    # why: a scoped new rule is bounded by its own text, so it is
+    # reviewable rather than refusable — a human can read `Bash(npm *)`
+    # and decide. This is also where read-only wildcards land.
     recommendation: Have a human approve the new permission allow rule.
   - id: HOST-PERMISSION-DENY-REMOVED
     check_id: SHIP-HOST-BOUNDARY-PERMISSION-DENY-REMOVED
     title: Coding-agent permission deny rule removed
     action: require_review
     risk_level: high
+    # why: a deny rule is the only thing in this file someone wrote to
+    # stop something specific. Removing it restores whatever it stopped,
+    # and the reason it existed is rarely written down anywhere.
     recommendation: Have a human confirm the removed deny rule is no longer needed.
   - id: HOST-HOOK-CHANGED
     check_id: SHIP-HOST-BOUNDARY-HOOK-CHANGED
     title: Coding-agent executable hooks changed
     action: require_review
     risk_level: high
+    # why: a hook runs on the developer's machine on the host's schedule,
+    # not the agent's. It is code execution that no permission rule
+    # governs and no prompt asks about.
     recommendation: Review executable hook changes before the agent relies on them.
   - id: HOST-WORKFLOW-WRITE-ALL
     check_id: SHIP-HOST-BOUNDARY-WORKFLOW-WRITE-ALL
     title: GitHub workflow grants write-all permissions
     action: block
     risk_level: critical
+    # why: `write-all` includes `contents: write`, so a job holding it can
+    # rewrite the very guardrails being reviewed, this file among them.
+    # There is no narrower reading of it to review.
     recommendation: Replace write-all with the minimal explicit permission scopes.
   - id: HOST-WORKFLOW-PERMISSIONS-EXPANDED
     check_id: SHIP-HOST-BOUNDARY-WORKFLOW-PERMISSIONS-EXPANDED
     title: GitHub workflow permissions expanded
     action: require_review
     risk_level: high
+    # why: named scopes are bounded and legible, so a human can weigh the
+    # one that was added. `packages: write` is not `contents: write`, and
+    # the difference is exactly what review is for.
     recommendation: Have a human approve the expanded workflow write permission.
   - id: HOST-WORKFLOW-PULL-REQUEST-TARGET-ADDED
     check_id: SHIP-HOST-BOUNDARY-PULL-REQUEST-TARGET-ADDED
     title: GitHub workflow gained a pull_request_target trigger
     action: require_review
     risk_level: critical
+    # why: `critical` while still only `require_review` — the trigger runs
+    # with repository secrets against a fork's code, which is the shape of
+    # the standard exfiltration, but it is also the only supported way to
+    # do a few legitimate things. Rated to be unmissable, not refused.
     recommendation: Review the pull_request_target trigger; it runs with secrets on fork PRs.

--- a/src/agents_shipgate/core/host_boundary.py
+++ b/src/agents_shipgate/core/host_boundary.py
@@ -47,6 +47,7 @@ from agents_shipgate.core.codex_boundary import (
     _dedupe_violations,
     _display_path,
 )
+from agents_shipgate.core.permission_lattice import whole_tool_risk
 from agents_shipgate.core.trust_roots import read_absolute_identity_bound_text
 from agents_shipgate.schemas.agent_result_v1 import (
     AgentResultDiagnostic,
@@ -479,18 +480,19 @@ def _evaluate_claude_settings(diff_file, resolved, add) -> None:
     _evaluate_permission_mode(old_permissions, permissions, path, add)
     old_allow = set(_string_entries(old_permissions.get("allow")))
     for rule in sorted(set(_string_entries(permissions.get("allow"))) - old_allow):
-        if _is_wildcard_allow(rule):
-            add(
-                "HOST-PERMISSION-WILDCARD-ALLOW",
-                path=path,
-                evidence={"kind": "permission_wildcard_allow", "rule": _safe_rule(rule)},
-            )
-        else:
-            add(
-                "HOST-PERMISSION-ALLOW-EXPANDED",
-                path=path,
-                evidence={"kind": "permission_allow_expanded", "rule": _safe_rule(rule)},
-            )
+        rule_id = _allow_rule_id(rule)
+        add(
+            rule_id,
+            path=path,
+            evidence={
+                "kind": (
+                    "permission_wildcard_allow"
+                    if rule_id == "HOST-PERMISSION-WILDCARD-ALLOW"
+                    else "permission_allow_expanded"
+                ),
+                "rule": _safe_rule(rule),
+            },
+        )
     new_deny = set(_string_entries(permissions.get("deny")))
     for rule in sorted(set(_string_entries(old_permissions.get("deny"))) - new_deny):
         add(
@@ -561,9 +563,7 @@ def _evaluate_cursor_settings(diff_file, resolved, add) -> None:
         if key == "allow":
             for rule in sorted(set(values) - set(old_values)):
                 add(
-                    "HOST-PERMISSION-WILDCARD-ALLOW"
-                    if _is_wildcard_allow(rule)
-                    else "HOST-PERMISSION-ALLOW-EXPANDED",
+                    _allow_rule_id(rule),
                     path=path,
                     evidence={
                         "kind": "cursor_permission_allow_expanded",
@@ -664,6 +664,32 @@ def _is_wildcard_allow(rule: str) -> bool:
         return True
     argument = stripped[open_paren + 1 :].lstrip()
     return argument.startswith("*")
+
+
+def _allow_rule_id(rule: str) -> str:
+    """Which finding a newly-added allow rule earns.
+
+    `_is_wildcard_allow` answers *whether* a rule grants a whole tool, not
+    *what that tool reaches*, and the blocking rule was wired straight to
+    it. So adding `Read(**)` — the ordinary configuration for a coding
+    agent that already has the workspace checked out — blocked the
+    release at `critical`, exactly as `Bash(*)` does. A gate that stops
+    the release over reading files is one a team turns off, and a gate
+    that is off catches no `Bash(*)` either.
+
+    The tool class is the discriminator, taken from the same lattice the
+    audit table uses so the gate and the table cannot drift apart (#657).
+    """
+
+    if not _is_wildcard_allow(rule):
+        return "HOST-PERMISSION-ALLOW-EXPANDED"
+    _, risk = whole_tool_risk(rule)
+    # Still an expansion, still reviewed — just not a release blocker.
+    return (
+        "HOST-PERMISSION-ALLOW-EXPANDED"
+        if risk == "low"
+        else "HOST-PERMISSION-WILDCARD-ALLOW"
+    )
 
 
 def _safe_rule(rule: str) -> str:

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -40,6 +40,11 @@ from agents_shipgate.core.host_input_failure import (
     safe_failure_text,
 )
 from agents_shipgate.core.instruction_structure import classify_instruction, instruction_profile
+from agents_shipgate.core.permission_lattice import (
+    scoped_risk,
+    subsumes,
+    whole_tool_risk,
+)
 from agents_shipgate.core.privacy import SENSITIVE_VALUE_KEYS
 from agents_shipgate.core.trust_roots import (
     IdentityBoundReadSession,
@@ -559,8 +564,17 @@ def _permission_rule_grants(
         for raw_rule in sorted(_string_entries(permissions.get(disposition))):
             rule = _sanitize_sensitive_string(raw_rule)
             wildcard = disposition == "allow" and _is_wildcard_allow(raw_rule)
-            access = "admin" if wildcard else ("execute" if disposition == "allow" else "none")
-            risk = "critical" if wildcard else ("high" if disposition == "allow" else "low")
+            if wildcard:
+                # Not every whole-tool grant reaches the same thing. Rating
+                # `Read(**)` beside `Bash(*)` put four of eight grants at
+                # `critical` on an ordinary repository, and a severity
+                # column that cries critical at reading files is one a
+                # reviewer stops reading (#657).
+                access, risk = whole_tool_risk(raw_rule)
+            elif disposition == "allow":
+                access, risk = scoped_risk(raw_rule)
+            else:
+                access, risk = "none", "low"
             grants.append({
                 **_grant_base(
                     host=host, scope=scope, source=source, kind="permission_rule",
@@ -1809,7 +1823,8 @@ def _diff_host_coverage(
 
 
 def host_grant_expansion_signals(changes: list[dict[str, Any]]) -> list[str]:
-    signals: list[str] = []
+    widened, narrowed_rules = _permission_direction_signals(changes)
+    signals: list[str] = list(widened)
     for change in changes:
         before = change.get("baseline")
         after = change.get("current")
@@ -1822,6 +1837,15 @@ def host_grant_expansion_signals(changes: list[dict[str, Any]]) -> list[str]:
         if kind == "mcp_server":
             signals.append(f"mcp_server_{prefix}: {after['host']}:{after['server']}")
         elif kind == "permission_rule" and after.get("disposition") == "allow":
+            if (after["host"], str(after["rule"])) in narrowed_rules:
+                # The narrower half of a replacement. This list is an
+                # expansion channel — `preflight` prefixes it with
+                # "Expansion signals:" and the drift markdown prints every
+                # entry under "## Expansion signals" with a ⚠ — so an
+                # `allow_rule_added` here puts the warning on the change
+                # that *removed* authority. The narrowing is still visible:
+                # it is in `changes` as a removal and an addition (#657).
+                continue
             marker = "wildcard_allow" if after.get("wildcard") else "allow_rule"
             signals.append(f"{marker}_{prefix}: {after['host']}:{after['rule']}")
         elif kind in {"permission_mode", "sandbox", "additional_path", "plugin_or_app", "hook"}:
@@ -1851,6 +1875,59 @@ def host_grant_expansion_signals(changes: list[dict[str, Any]]) -> list[str]:
             if inherited_calls(after) - inherited_calls(previous):
                 signals.append(f"workflow_secrets_inherited_{prefix}: {after['source']}")
     return sorted(set(signals))
+
+
+def _permission_direction_signals(
+    changes: list[dict[str, Any]],
+) -> tuple[list[str], set[tuple[str, str]]]:
+    """Name a replaced allow rule as widened or narrowed.
+
+    Grants are keyed by their rule text, so replacing `Bash(npm *)` with
+    `Bash(npm test:*)` arrives as one removal and one addition — the same
+    shape as replacing it with `Bash(*)`. Set arithmetic cannot tell those
+    apart; the lattice can, for the patterns it decides (#657).
+
+    Only pairs within one host, source and disposition are considered, and
+    only where exactly one rule left and one arrived: with several on each
+    side there is no evidence about which replaced which, and inventing a
+    pairing would be inventing the direction too. A pair the lattice cannot
+    decide produces nothing, which leaves the existing add/remove signals
+    as the whole answer.
+    """
+
+    removed: dict[tuple[str, str, str], list[str]] = {}
+    added: dict[tuple[str, str, str], list[str]] = {}
+    for change in changes:
+        before, after = change.get("baseline"), change.get("current")
+        for grant, sink in ((before, removed), (after, added)):
+            if (
+                grant
+                and grant.get("kind") == "permission_rule"
+                and grant.get("disposition") == "allow"
+            ):
+                key = (grant["host"], grant.get("source", ""), grant["disposition"])
+                sink.setdefault(key, []).append(str(grant["rule"]))
+    # A rule present on both sides is unchanged and pairs with nothing.
+    signals: list[str] = []
+    narrowed: set[tuple[str, str]] = set()
+    for key, gone in removed.items():
+        arrived = added.get(key, [])
+        only_gone = [rule for rule in gone if rule not in arrived]
+        only_arrived = [rule for rule in arrived if rule not in gone]
+        if len(only_gone) != 1 or len(only_arrived) != 1:
+            continue
+        before_rule, after_rule = only_gone[0], only_arrived[0]
+        host = key[0]
+        if subsumes(after_rule, before_rule) is True:
+            # Named as well as counted: `allow_rule_changed` says a rule
+            # moved, this says which way and by how much. The add signal
+            # stays too — it is not wrong, and readers already depend on it.
+            signals.append(f"permission_widened: {host}:{before_rule} -> {after_rule}")
+        elif subsumes(before_rule, after_rule) is True:
+            # A narrowing earns no entry in an expansion list. What it earns
+            # is silence there, which is what the caller uses this set for.
+            narrowed.add((host, after_rule))
+    return signals, narrowed
 
 
 def _incomparable_payload(
@@ -1960,11 +2037,23 @@ def render_host_audit_markdown(
             for grant in by_kind.get("permission_rule", [])
             if grant.get("disposition") == "allow" and grant.get("wildcard")
         ]
-        if wildcard_rules:
+        # A `⚠` on `Read(**)` spends the reader's attention on the grant
+        # least worth it, and teaches them the marker means nothing. The
+        # warning names the wildcards whose tool class earned a severity;
+        # the low-risk ones are still listed above, just not shouted (#657).
+        notable = [grant for grant in wildcard_rules if grant.get("risk") != "low"]
+        if notable:
             lines.append("")
+            quiet = len(wildcard_rules) - len(notable)
             lines.append(
-                f"⚠ {len(wildcard_rules)} wildcard allow rule(s); verification "
-                "reports `SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW`."
+                f"⚠ {len(notable)} wildcard allow rule(s) above low risk; "
+                "verification reports "
+                "`SHIP-HOST-BOUNDARY-PERMISSION-WILDCARD-ALLOW`."
+                + (
+                    f" {quiet} further wildcard rule(s) are read-only and listed above."
+                    if quiet
+                    else ""
+                )
             )
     lines.append("")
     if inventory["issues"]:

--- a/src/agents_shipgate/core/permission_lattice.py
+++ b/src/agents_shipgate/core/permission_lattice.py
@@ -1,0 +1,238 @@
+"""How wide a host permission rule is, and how two of them compare (#657).
+
+Two questions were previously answered by string shape alone, and both
+answers were wrong often enough to cost a reviewer's trust:
+
+*Which is wider?* Drift compared rule strings for equality, so replacing
+``Bash(npm *)`` with ``Bash(npm test:*)`` — a narrowing — was reported the
+same way as replacing it with ``Bash(*)``. The reviewer saw "expanded"
+either way.
+
+*How severe?* Every wildcard allow was ``critical`` and ``admin``, so
+``Read(**)`` sat beside ``Bash(*)`` at the top of the table. On the
+three-widening scenario, four of eight grants were noise of this kind, and
+a severity column that cries critical at reading files is one a reviewer
+stops reading.
+
+Both answers here are deliberately partial. ``subsumes`` returns ``None``
+for any pair it cannot decide soundly, and an undecided pair produces no
+direction signal at all — the same silence as before, never a guess. The
+pattern language hosts actually use is richer than this lattice; being
+quiet about the rest is what makes the part it does answer worth trusting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: What a tool lets an agent reach, which is what decides how much a
+#: whole-tool grant matters. Reading files the agent already has checked
+#: out is not the same event as running arbitrary commands, and a severity
+#: model that cannot tell them apart is noise.
+EXECUTION_TOOLS = frozenset({"bash", "shell", "run", "terminal", "execute"})
+NETWORK_TOOLS = frozenset({"webfetch", "websearch", "fetch", "browser"})
+WRITE_TOOLS = frozenset({"write", "edit", "notebookedit", "multiedit", "patch"})
+READ_TOOLS = frozenset({"read", "glob", "grep", "ls", "search", "notebookread"})
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One host permission rule, split into the tool and its argument."""
+
+    tool: str
+    argument: str | None
+    raw: str
+
+    @property
+    def whole_tool(self) -> bool:
+        """True when the rule grants the tool without narrowing it."""
+
+        return self.argument is None or self.argument.strip() in {"*", "**"}
+
+    @property
+    def everything(self) -> bool:
+        return self.raw.strip() == "*"
+
+
+def parse_rule(raw: str) -> Rule:
+    """Split ``Tool(argument)`` without interpreting the argument."""
+
+    text = raw.strip()
+    if text == "*":
+        return Rule(tool="*", argument="*", raw=text)
+    open_paren = text.find("(")
+    if open_paren == -1:
+        return Rule(tool=text, argument=None, raw=text)
+    close_paren = text.rfind(")")
+    argument = text[open_paren + 1 : close_paren if close_paren > open_paren else len(text)]
+    return Rule(tool=text[:open_paren].strip(), argument=argument.strip(), raw=text)
+
+
+def _same_tool(left: Rule, right: Rule) -> bool:
+    return left.tool.strip().lower() == right.tool.strip().lower()
+
+
+def subsumes(wider: str, narrower: str) -> bool | None:
+    """Whether every call ``narrower`` allows, ``wider`` allows too.
+
+    ``True`` and ``False`` are claims; ``None`` means this lattice cannot
+    decide the pair and no caller may infer a direction from it. The
+    decidable cases are the ones a reviewer actually meets:
+
+    * ``*`` allows everything.
+    * a bare tool name allows that whole tool.
+    * a prefix pattern allows everything sharing its prefix.
+    * identical rules allow the same thing, which is not widening.
+    """
+
+    left, right = parse_rule(wider), parse_rule(narrower)
+    if left.raw == right.raw:
+        return False
+    if left.everything:
+        return True
+    if right.everything:
+        return False
+    if not _same_tool(left, right):
+        if left.argument is None and right.argument is None:
+            # Two bare tool names. Claude Code spells MCP grants this way —
+            # `mcp__github__*` against `mcp__github__get_issue` — so without
+            # this the single most common real wildcard in a host config is
+            # undecidable, and widening to a whole MCP server goes unnamed.
+            # The same prefix rule applies; a tool token is just a pattern.
+            return _argument_subsumes(left.tool.strip(), right.tool.strip())
+        # Different tools are incomparable, not equal and not wider. Saying
+        # so is a claim this lattice can make soundly.
+        return False
+    if left.whole_tool:
+        return not right.whole_tool
+    if right.whole_tool:
+        return False
+    return _argument_subsumes(left.argument or "", right.argument or "")
+
+
+#: Glob syntax this lattice does not implement. A character class or an
+#: optional-character pattern makes `startswith` the wrong question:
+#: `a[bc]d` matches `abd` while not being a prefix of it, so treating the
+#: text as a literal answers "not wider" about something that is wider.
+_UNSUPPORTED_GLOB = frozenset("[]?{}")
+
+
+def _decidable(text: str) -> bool:
+    return not (_UNSUPPORTED_GLOB & set(text))
+
+
+def _simple_prefix(argument: str) -> str | None:
+    """``"npm *"`` -> ``"npm "``; ``None`` when the pattern is not a
+    single trailing star over otherwise literal text."""
+
+    if argument.endswith("*") and "*" not in argument[:-1] and _decidable(argument[:-1]):
+        return argument[:-1]
+    return None
+
+
+def _argument_subsumes(wider: str, narrower: str) -> bool | None:
+    """Decide prefix patterns and literals; stay quiet about the rest.
+
+    A ``*`` anywhere but the end, or any character class, is left
+    undecided, because guessing is how a narrowing gets reported as an
+    expansion. Where both sides *are* prefix patterns the answer is
+    exact in both directions, which is what lets a genuine narrowing be
+    named rather than merely not-misnamed.
+    """
+
+    if wider == narrower:
+        return False
+    if not _decidable(wider) or not _decidable(narrower):
+        # Not a decline for tidiness: `Bash(a[bc]d)` really does allow
+        # `Bash(abd)`, so calling it "not wider" would be a wrong answer
+        # rather than a missing one, and a wrong direction is the whole
+        # defect this module exists to stop.
+        return None
+    wider_prefix, narrower_prefix = _simple_prefix(wider), _simple_prefix(narrower)
+    if wider_prefix is not None and narrower_prefix is not None:
+        # `a*` allows everything `b*` allows exactly when `b` extends `a`.
+        return narrower_prefix.startswith(wider_prefix)
+    if wider_prefix is not None:
+        if "*" in narrower:
+            return None
+        # A literal is allowed by the prefix iff it carries it.
+        return narrower.startswith(wider_prefix)
+    if "*" in wider:
+        return None
+    # A literal allows only itself, and equality was handled above.
+    return False
+
+
+def tool_class(rule: str) -> str:
+    """The class a rule's tool belongs to, for severity."""
+
+    tool = parse_rule(rule).tool.strip().lower()
+    if tool == "*":
+        return "everything"
+    if tool in EXECUTION_TOOLS:
+        return "execution"
+    if tool in NETWORK_TOOLS:
+        return "network"
+    if tool in WRITE_TOOLS:
+        return "write"
+    if tool in READ_TOOLS:
+        return "read"
+    return "unknown"
+
+
+def whole_tool_risk(rule: str) -> tuple[str, str]:
+    """``(access, risk)`` for an allow rule that grants a whole tool.
+
+    Reading is not writing and writing is not executing, and a table that
+    rates them alike is one a reviewer stops reading. The ordering is what
+    the grant *reaches*:
+
+    * ``everything`` and ``execution`` — arbitrary commands: ``critical``.
+    * ``network`` — the egress half of an exfiltration: ``high``.
+    * ``write`` — can change the repository, including its own guardrails:
+      ``high``.
+    * ``read`` — bounded by a workspace the agent already has checked out.
+      Reading it whole is what a coding agent is for, and turning that into
+      an exfiltration needs a network or write grant, which is its own row:
+      ``low``.
+    * ``unknown`` — an unrecognised tool granted whole. Not ``critical``,
+      because nothing here establishes that, and not ``low``, because
+      nothing establishes that either: ``high``.
+    """
+
+    classification = tool_class(rule)
+    if classification in {"everything", "execution"}:
+        return "admin", "critical"
+    if classification in {"network", "write"}:
+        return "execute", "high"
+    if classification == "read":
+        return "read", "low"
+    return "execute", "high"
+
+
+def scoped_risk(rule: str) -> tuple[str, str]:
+    """``(access, risk)`` for an allow rule that names a bounded target.
+
+    A scoped rule is the *recommended* form, so rating every one of them
+    `high` reproduces the same flatness one level down: a
+    well-configured repository would still read as all-high, and the
+    column would still carry no information. What survives the narrowing
+    is the tool class, so that is what is left.
+    """
+
+    classification = tool_class(rule)
+    if classification == "read":
+        return "read", "low"
+    if classification in {"everything", "execution", "network", "write"}:
+        return "execute", "medium"
+    return "execute", "medium"
+
+
+__all__ = [
+    "Rule",
+    "parse_rule",
+    "subsumes",
+    "tool_class",
+    "scoped_risk",
+    "whole_tool_risk",
+]

--- a/tests/test_permission_lattice.py
+++ b/tests/test_permission_lattice.py
@@ -1,0 +1,475 @@
+"""#657: which way did a permission rule move, and is it worth a warning.
+
+Two defects, one cause. Grants are keyed by rule text, so replacing
+`Bash(npm *)` with `Bash(npm test:*)` arrives as a removal plus an
+addition — byte-for-byte the same shape as replacing it with `Bash(*)`.
+Set arithmetic cannot tell a tightening from a widening, so drift called
+both an expansion. And every wildcard allow was rated `critical`, so
+`Read(**)` sat beside `Bash(*)` at the top of the table.
+
+The fixture table below is the guard the issue asked for: twenty
+widen/narrow/unchanged pairs, each with the direction a reviewer would
+assign, replayed through the real reader for both hosts that have a rule
+vocabulary. Two pairs are marked `decided=False` on purpose — they are
+cases this lattice declines. They are in the table so that "we do not
+answer this" stays a tested property rather than an accident, and so the
+boundary moves visibly if someone widens it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.core.host_grants import (
+    HostStaticParseCache,
+    build_host_boundary_snapshot,
+    build_host_drift_payload,
+    build_host_grants_baseline,
+    host_audit_inventory,
+)
+from agents_shipgate.core.permission_lattice import (
+    scoped_risk,
+    subsumes,
+    whole_tool_risk,
+)
+
+
+@dataclass(frozen=True)
+class Pair:
+    """One before/after replacement and the direction a reviewer sees.
+
+    `truth` is the human reading. `decided` is whether this lattice is
+    expected to reach it — a widening it declines still has to *surface*
+    (the add signal does that), it just cannot be named.
+    """
+
+    before: tuple[str, ...]
+    after: tuple[str, ...]
+    truth: str
+    decided: bool = True
+
+    @property
+    def id(self) -> str:
+        return f"{self.truth}-{'+'.join(self.before)}-to-{'+'.join(self.after)}"
+
+
+def _pair(before: str, after: str, truth: str, decided: bool = True) -> Pair:
+    return Pair((before,), (after,), truth, decided)
+
+
+#: Twenty pairs. The vocabulary is shared by both hosts, which is the
+#: point of running the same table through each: the direction of a
+#: change must not depend on which file the rule was read from.
+PAIRS: tuple[Pair, ...] = (
+    # Widenings the lattice names.
+    _pair("Bash(npm test:*)", "Bash(npm *)", "widen"),
+    _pair("Bash(npm *)", "Bash(*)", "widen"),
+    _pair("Read(src/**)", "Read(**)", "widen"),
+    _pair("WebFetch(domain:example.com)", "WebFetch(domain:*)", "widen"),
+    _pair("Edit(src/*)", "Edit(*)", "widen"),
+    _pair("Bash(git log:*)", "Bash(git *)", "widen"),
+    _pair("Read(src/app.py)", "Read(src/*)", "widen"),
+    _pair("Bash(pytest tests/unit)", "Bash(pytest *)", "widen"),
+    _pair("Bash(a[bc]*)", "Bash(*)", "widen"),
+    _pair("mcp__github__get_issue", "mcp__github__*", "widen"),
+    # Narrowings. Each of these was reported as an expansion before #657.
+    _pair("Bash(npm *)", "Bash(npm test:*)", "narrow"),
+    _pair("Bash(*)", "Bash(npm *)", "narrow"),
+    _pair("Read(**)", "Read(src/**)", "narrow"),
+    _pair("WebFetch(domain:*)", "WebFetch(domain:example.com)", "narrow"),
+    _pair("Edit(*)", "Edit(src/*)", "narrow"),
+    _pair("Bash(git *)", "Bash(git log:*)", "narrow"),
+    _pair("mcp__github__*", "mcp__github__get_issue", "narrow"),
+    # A star that is not a trailing star. `Bash(*.py)` -> `Bash(test_*.py)`
+    # is a narrowing, but deciding it means implementing glob containment,
+    # and a wrong answer here is exactly the failure #657 is about. The
+    # lattice declines; the addition still surfaces.
+    _pair("Bash(*.py)", "Bash(test_*.py)", "narrow", decided=False),
+    # Unchanged: identical, and reordered. Neither is a change at all.
+    Pair(("Bash(npm *)",), ("Bash(npm *)",), "unchanged"),
+    Pair(
+        ("Read(**)", "Bash(pytest *)"),
+        ("Bash(pytest *)", "Read(**)"),
+        "unchanged",
+    ),
+)
+
+
+def test_the_table_covers_what_the_issue_asked_for() -> None:
+    """Twenty pairs, all three directions, and the declines are few."""
+
+    assert len(PAIRS) == 20
+    assert {pair.truth for pair in PAIRS} == {"widen", "narrow", "unchanged"}
+    assert sum(1 for pair in PAIRS if not pair.decided) == 1
+    assert len({pair.id for pair in PAIRS}) == 20
+
+
+def _claude_inventory(root: Path, rules: tuple[str, ...]) -> dict:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".claude").mkdir(exist_ok=True)
+    (root / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"allow": list(rules)}}), encoding="utf-8"
+    )
+    return build_host_boundary_snapshot(root, cache=HostStaticParseCache()).inventory
+
+
+def _cursor_inventory(
+    home: Path, workspace: Path, rules: tuple[str, ...], monkeypatch: pytest.MonkeyPatch
+) -> dict:
+    (home / ".cursor").mkdir(parents=True, exist_ok=True)
+    (home / ".cursor" / "cli-config.json").write_text(
+        json.dumps({"permissions": {"allow": list(rules)}}), encoding="utf-8"
+    )
+    workspace.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    return host_audit_inventory(workspace, scope="local_static")
+
+
+def _drift(before_inventory: dict, after_inventory: dict) -> dict:
+    return build_host_drift_payload(
+        baseline=build_host_grants_baseline(before_inventory),
+        inventory=after_inventory,
+        baseline_file="baseline.json",
+    )
+
+
+def _assert_direction(payload: dict, pair: Pair) -> None:
+    """The three acceptance criteria, on one replayed pair."""
+
+    signals = payload["expansion_signals"]
+    named = [item for item in signals if item.startswith("permission_widened:")]
+    about_after = [
+        item for item in signals if any(rule in item for rule in pair.after)
+    ]
+
+    if pair.truth == "unchanged":
+        # `has_drift` can still be true: reordering the allow list changes
+        # the file's bytes, and the audit says so through `artifact_changes`.
+        # What must not move is the capability reading — no grant changed,
+        # and nothing is worth a warning.
+        assert payload["changes"] == [], f"{pair.id}: {payload['changes']}"
+        assert not signals, f"{pair.id}: {signals}"
+        return
+
+    # No wrong direction is ever asserted, whatever the truth.
+    assert (named != []) == (pair.truth == "widen" and pair.decided), (
+        f"{pair.id}: permission_widened={named}"
+    )
+
+    if pair.truth == "widen":
+        # Zero missed widenings: named or not, it must reach the reader.
+        assert about_after, f"{pair.id}: widening produced no signal: {signals}"
+    elif pair.decided:
+        # Zero false expansions: this list is what `preflight` prints as
+        # "Expansion signals" and what the drift markdown flags with a ⚠.
+        assert not about_after, (
+            f"{pair.id}: narrowing reported as an expansion: {about_after}"
+        )
+
+
+@pytest.mark.parametrize("pair", PAIRS, ids=lambda pair: pair.id)
+def test_direction_on_claude_code(tmp_path: Path, pair: Pair) -> None:
+    before = _claude_inventory(tmp_path / "before", pair.before)
+    after = _claude_inventory(tmp_path / "after", pair.after)
+
+    _assert_direction(_drift(before, after), pair)
+
+
+@pytest.mark.parametrize("pair", PAIRS, ids=lambda pair: pair.id)
+def test_direction_on_cursor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pair: Pair
+) -> None:
+    workspace = tmp_path / "repo"
+    before = _cursor_inventory(tmp_path / "home-before", workspace, pair.before, monkeypatch)
+    after = _cursor_inventory(tmp_path / "home-after", workspace, pair.after, monkeypatch)
+
+    _assert_direction(_drift(before, after), pair)
+
+
+def test_a_narrowing_is_still_visible_as_a_change(tmp_path: Path) -> None:
+    """Suppressing the expansion signal must not suppress the fact.
+
+    The narrowing is not hidden — it is in `changes` as a removal and an
+    addition. Only the ⚠ is withheld, and only because the list carrying
+    it is one both readers label "Expansion signals".
+    """
+
+    before = _claude_inventory(tmp_path / "before", ("Bash(npm *)",))
+    after = _claude_inventory(tmp_path / "after", ("Bash(npm test:*)",))
+
+    payload = _drift(before, after)
+
+    assert payload["has_drift"]
+    rendered = json.dumps(payload["changes"])
+    assert "Bash(npm *)" in rendered and "Bash(npm test:*)" in rendered
+    assert payload["expansion_signals"] == []
+
+
+def test_several_rules_changing_at_once_claims_no_direction(tmp_path: Path) -> None:
+    """Two out and two in is no evidence about which replaced which.
+
+    Pairing them by position would be inventing the direction, so the
+    lattice is not consulted and the add signals stand alone.
+    """
+
+    before = _claude_inventory(tmp_path / "before", ("Bash(npm *)", "Read(src/**)"))
+    after = _claude_inventory(tmp_path / "after", ("Bash(npm test:*)", "Read(**)"))
+
+    signals = _drift(before, after)["expansion_signals"]
+
+    assert not [item for item in signals if item.startswith("permission_widened:")]
+    assert any("Read(**)" in item for item in signals)
+
+
+#: The configuration #657 measured the noise on: an ordinary, carefully
+#: written host config. Nothing here is a finding, so nothing here should
+#: be rated as one.
+WELL_CONFIGURED = (
+    "Read(**)",
+    "Glob(**)",
+    "Grep(**)",
+    "Bash(pytest *)",
+    "Bash(git status:*)",
+    "Edit(src/**)",
+)
+
+
+def test_a_well_configured_repository_raises_nothing_above_low(
+    tmp_path: Path,
+) -> None:
+    """The headline metric, measured on the grants a reviewer actually sees.
+
+    Before #657 every wildcard allow was `critical`, so three of these six
+    rules — the read tools — were rated the same as `Bash(*)`. A severity
+    column that cries critical at reading files is one a reviewer stops
+    reading, and stopping is how a real widening gets missed.
+    """
+
+    inventory = _claude_inventory(tmp_path / "repo", WELL_CONFIGURED)
+    rules = {
+        grant["rule"]: (grant["access"], grant["risk"])
+        for grant in inventory["grants"]
+        if grant["kind"] == "permission_rule"
+    }
+
+    assert rules["Read(**)"] == ("read", "low")
+    assert rules["Glob(**)"] == ("read", "low")
+    assert rules["Grep(**)"] == ("read", "low")
+    assert not [rule for rule, (_, risk) in rules.items() if risk == "critical"], (
+        f"nothing in a well-configured repository is critical: {rules}"
+    )
+
+
+def test_the_grants_that_should_alarm_still_do(tmp_path: Path) -> None:
+    """Quieting the column must not quiet the thing it exists to say."""
+
+    inventory = _claude_inventory(
+        tmp_path / "repo", ("Bash(*)", "Read(**)", "WebFetch(*)")
+    )
+    rules = {
+        grant["rule"]: grant["risk"]
+        for grant in inventory["grants"]
+        if grant["kind"] == "permission_rule"
+    }
+
+    assert rules["Bash(*)"] == "critical"
+    assert rules["WebFetch(*)"] == "high"
+    assert rules["Read(**)"] == "low"
+
+
+class TestTheGateAgrees:
+    """The audit table was not the only place this was decided.
+
+    `core/host_boundary.py` classified wildcard allows a second time, and
+    that copy is the one wired to the release decision — so adding
+    `Read(**)` did not merely look alarming in a table, it blocked the
+    release at `critical`. Both now read the same lattice; these pin that
+    they keep agreeing, which is the part that rots.
+    """
+
+    @pytest.mark.parametrize(
+        "rule", ["Read(**)", "Read", "Glob(**)", "Grep(**)", "Bash(npm test:*)"]
+    )
+    def test_reading_the_workspace_is_reviewed_not_blocked(self, rule: str) -> None:
+        from agents_shipgate.core.host_boundary import _allow_rule_id
+
+        assert _allow_rule_id(rule) == "HOST-PERMISSION-ALLOW-EXPANDED"
+
+    @pytest.mark.parametrize(
+        "rule", ["*", "Bash(*)", "Shell", "WebFetch(*)", "Write(*)", "mcp__x__*"]
+    )
+    def test_unbounded_authority_still_blocks(self, rule: str) -> None:
+        from agents_shipgate.core.host_boundary import _allow_rule_id
+
+        assert _allow_rule_id(rule) == "HOST-PERMISSION-WILDCARD-ALLOW"
+
+    def test_a_read_only_wildcard_no_longer_blocks_the_release(
+        self, tmp_path: Path
+    ) -> None:
+        """Driven through the real evaluator, not the helper.
+
+        This is the finding a repository got for writing the ordinary
+        coding-agent config: `blocks_release`, `critical`. It is the
+        reason the gate could not be left on.
+        """
+
+        from agents_shipgate.core.host_boundary import evaluate_host_boundary
+
+        settings = json.dumps({"permissions": {"allow": ["Read(**)", "Grep(**)"]}})
+        lines = settings.splitlines()
+        diff = (
+            "diff --git a/.claude/settings.json b/.claude/settings.json\n"
+            "new file mode 100644\n"
+            "index 0000000..1111111\n"
+            "--- /dev/null\n"
+            "+++ b/.claude/settings.json\n"
+            f"@@ -0,0 +1,{len(lines)} @@\n"
+            + "\n".join(f"+{line}" for line in lines)
+            + "\n"
+        )
+
+        violations, _ = evaluate_host_boundary(workspace=tmp_path, diff_text=diff)
+
+        assert violations, "reading the workspace is still an expansion worth review"
+        assert [item.id for item in violations] == [
+            "HOST-PERMISSION-ALLOW-EXPANDED"
+        ] * len(violations)
+
+    def test_the_gate_and_the_table_cannot_disagree(self) -> None:
+        """One lattice, two readers: whatever the gate blocks is what the
+        table rates above `low`, for every rule in the fixture table."""
+
+        from agents_shipgate.core.host_boundary import (
+            _allow_rule_id,
+            _is_wildcard_allow,
+        )
+
+        rules = sorted({rule for pair in PAIRS for rule in (*pair.before, *pair.after)})
+        for rule in [*rules, *WELL_CONFIGURED, "Bash(*)", "*", "WebFetch(*)"]:
+            blocks = _allow_rule_id(rule) == "HOST-PERMISSION-WILDCARD-ALLOW"
+            table_risk = (
+                whole_tool_risk(rule) if _is_wildcard_allow(rule) else scoped_risk(rule)
+            )[1]
+            assert blocks == (_is_wildcard_allow(rule) and table_risk != "low"), (
+                f"{rule}: gate blocks={blocks}, table risk={table_risk}"
+            )
+
+
+class TestPolicyRationale:
+    """#657 asked for a defensible severity, which means a written one."""
+
+    def test_every_policy_rule_records_why_its_severity_is_what_it_is(self) -> None:
+        import yaml
+
+        text = Path("policies/host-boundary.shipgate.yaml").read_text(encoding="utf-8")
+        rules = yaml.safe_load(text)["rules"]
+
+        # The loader ignores unknown keys, so a `why:` field would be
+        # silently dropped and look load-bearing. The rationale is a
+        # comment, and this reads it as one: each rule's block must carry
+        # a `# why:` line between its id and the next rule's.
+        blocks = text.split("  - id: ")[1:]
+        assert len(blocks) == len(rules)
+        for block in blocks:
+            rule_id = block.splitlines()[0].strip()
+            assert "# why:" in block, f"{rule_id} has no recorded rationale"
+
+    def test_the_policy_never_sits_below_the_safety_floor(self) -> None:
+        """An edit here that lowers a severity is refused and replaced, so
+        a file that looks lenient would be quietly ignored."""
+
+        import yaml
+
+        from agents_shipgate.core.host_boundary import _RISK_RANK, DEFAULT_RULES
+
+        rules = yaml.safe_load(
+            Path("policies/host-boundary.shipgate.yaml").read_text(encoding="utf-8")
+        )["rules"]
+
+        assert {rule["id"] for rule in rules} == set(DEFAULT_RULES)
+        for rule in rules:
+            floor = DEFAULT_RULES[rule["id"]]
+            assert _RISK_RANK[rule["risk_level"]] >= _RISK_RANK[floor.risk_level], (
+                f"{rule['id']} is below the floor and would be ignored"
+            )
+
+
+class TestSeverity:
+    """A severity column that rates reading files `critical` is one a
+    reviewer stops reading. These pin the ordering, not the words."""
+
+    @pytest.mark.parametrize(
+        ("rule", "expected"),
+        [
+            ("*", "critical"),
+            ("Bash(*)", "critical"),
+            ("Shell", "critical"),
+            ("WebFetch(*)", "high"),
+            ("Write(*)", "high"),
+            ("Edit", "high"),
+            ("Read(**)", "low"),
+            ("Grep", "low"),
+            ("mcp__github__*", "high"),
+        ],
+    )
+    def test_whole_tool_risk_follows_what_the_grant_reaches(
+        self, rule: str, expected: str
+    ) -> None:
+        assert whole_tool_risk(rule)[1] == expected
+
+    def test_an_unrecognised_whole_tool_grant_is_not_dismissed(self) -> None:
+        """Nothing establishes `low` for a tool we do not know."""
+
+        assert whole_tool_risk("mcp__unknown__*") == ("execute", "high")
+
+    @pytest.mark.parametrize(
+        ("rule", "expected"),
+        [
+            ("Bash(pytest *)", "medium"),
+            ("WebFetch(domain:example.com)", "medium"),
+            ("Read(src/**)", "low"),
+        ],
+    )
+    def test_scoping_a_rule_lowers_it_but_keeps_the_tool_class(
+        self, rule: str, expected: str
+    ) -> None:
+        assert scoped_risk(rule)[1] == expected
+
+    def test_reading_never_outranks_executing(self) -> None:
+        order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+        assert order[whole_tool_risk("Read(**)")[1]] < order[scoped_risk("Bash(npm *)")[1]]
+        assert order[scoped_risk("Bash(npm *)")[1]] < order[whole_tool_risk("Bash(*)")[1]]
+
+
+class TestLatticeSoundness:
+    """`subsumes` may answer `None`; it may not answer wrongly."""
+
+    def test_a_rule_does_not_widen_itself(self) -> None:
+        for pair in PAIRS:
+            for rule in pair.before:
+                assert subsumes(rule, rule) is False
+
+    def test_the_relation_is_antisymmetric_where_it_decides(self) -> None:
+        """Nothing may be reported wider than something wider than it."""
+
+        rules = sorted({rule for pair in PAIRS for rule in (*pair.before, *pair.after)})
+        for wider in rules:
+            for narrower in rules:
+                if subsumes(wider, narrower) is True:
+                    assert subsumes(narrower, wider) is not True, (
+                        f"{wider} and {narrower} each reported wider than the other"
+                    )
+
+    def test_an_undecidable_pair_says_so_rather_than_guessing(self) -> None:
+        assert subsumes("Bash(*.py)", "Bash(test_*.py)") is None
+        assert subsumes("Bash(a[bc]d)", "Bash(abd)") is None
+
+    def test_unrelated_tools_are_not_wider_than_each_other(self) -> None:
+        assert subsumes("Read(**)", "Bash(*)") is False
+        assert subsumes("mcp__gitlab__*", "mcp__github__get_issue") is False


### PR DESCRIPTION
Partially addresses #657. **Keep #657 open:** precedence resolution, scope-aware risk calibration and the broader acceptance measurements remain separate work.

Replacing an allow rule appears as one removal plus one addition. This change identifies direction only for a proven one-to-one replacement within the same host, scope, settings source and disposition. Narrowed grants remain visible in audit/diff without an expansion signal; independent additions in another file or scope retain theirs. Claude Code and Cursor's actual local boundary evaluators now use the same replacement predicate, so a proven narrowing also stops producing `HOST-PERMISSION-ALLOW-EXPANDED` there.

The comparison remains partial and host-specific. Claude path rules distinguish relative, project, home and absolute anchors and wildcard depth; supported Bash prefixes and MCP patterns are handled separately. Cursor comparisons are limited to supported Read/Write paths. Unsupported syntax and multiple-rule replacements remain undecidable and retain the existing addition signals.

The final review's unbounded-read concern is addressed by withdrawing the blanket low-risk assumption and restoring the existing wildcard gate for read-class grants. Read tools can reach sensitive files outside the workspace; their class alone does not prove containment. The audit class projection distinguishes read access from arbitrary execution, but does not call arbitrary reads low-risk. Scope-aware lowering remains in #657. Policy comments, release notes and tests now state this boundary; the older contrary documentation is removed.

## Validation and review

- Three formal GitHub reviews are already recorded; the final request is [5176774919](https://github.com/ThreeMoonsLab/agents-shipgate/pull/678#pullrequestreview-5176774919). The final author response addresses that request; no fourth formal review is added.
- Eight new negative-control failures reproduced the actual local narrowing interruption, cross-file warning leakage and unsupported read-scope assumption. All eleven new real-boundary/risk regressions pass after the fix.
- Permission lattice, real boundary and capability-diff selection: **132 passed**.
- Full repository regression: **9,715 passed, 5 skipped**; static-only **487 passed**, performance **4 passed**. Ruff and whitespace checks pass. Incoming main changes receive strict integrated-head CI before merge.

No new check ID, permission declaration, waiver or lowered wildcard safety floor. No runtime enforcement equivalence is inferred for an unsupported host syntax. This repair does not establish whole-v1 readiness or qualification.

Final correction: `adbc572ca80cc1264a2c6960b093051658f38ea2`; current-main integration: `c5502f5592afda0946454cb2290f4026c735eab1`. Integrated targeted regressions and Ruff pass; current-head GitHub CI is pending. The verifier's base scan succeeds. Control remains `review_publishable` for the protected policy-comment change: PR publication is allowed; merge/completion is not.
