### PR TITLE
Read Go MCP descriptions from options and translated struct fields (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,42 +2,17 @@
 
 ## Unreleased
 
-- Read a Go tool's description when it is an option, and when it is
-  translated. `mark3labs/mcp-go` registers a tool as a call carrying option
-  functions — `mcp.NewTool("get_job", mcp.WithDescription(...))` — and the
-  only Go description extractor looked for a `Description:` field in a
-  struct literal, which that shape does not have. So every tool registered
-  this way read `description=None`, plain literals included. On top of
-  that, `github/github-mcp-server` wraps all 114 of its descriptions in a
-  translation helper, `t("TOOL_GET_JOB_DESCRIPTION", "Get details ...")`,
-  so even a field reader would have found a call rather than a string. The
-  result was 114 `SHIP-DOC-MISSING-DESCRIPTION` findings against a
-  repository that documents every tool it ships, which is the kind of noise
-  that costs a reader's trust in everything else on the page.
+- Read Go MCP tool descriptions from struct `Description` fields and
+  direct `WithDescription`/`WithToolDescription` options. Later description options replace earlier
+  ones, including empty or computed values. Nested calls and partial
+  expressions cannot supply the parent tool's description.
 
-  `WithDescription`/`WithToolDescription` is now read for both Go
-  call-site idioms, and a translation helper is unwrapped to its default.
-  The unwrapping is deliberately narrow: the call must pass exactly two
-  string literals and the first must look like a lookup key — screaming
-  snake or dotted — so `wrap("some prose here", "invented")` is refused
-  rather than published as documentation its author never wrote. The key
-  itself is never read as the description; printing
-  `TOOL_GET_JOB_DESCRIPTION` at a human would be worse than printing
-  nothing. A computed description, a qualified call such as
-  `fmt.Sprintf(...)`, a three-argument call, a variable key, and a literal
-  concatenated with something else all still read nothing.
-
-  `tools/shipgate-detect.py` reads these idioms a second time, and the
-  shared conformance corpus caught the divergence the moment the engine
-  reader learned something the detector had not: both now carry the same
-  extractor, and the corpus keeps them honest.
-
-  `tests/test_go_tool_descriptions.py` pins three reads and seven refusals;
-  5 of its 13 cases fail against pre-fix `main`, and the 8 that pass there
-  are the refusals, which were already correct. The idioms' published
-  `reads` strings say what they now extract. First increment of #658; the
-  annotation half — `ReadOnlyHint` in source, and protocol-default effects
-  as coverage rows rather than findings — is not in this change.
+  A complete two-string call to a declared `TranslationHelperFunc` parameter
+  can supply its literal default. An arbitrary function with key-shaped
+  arguments, an unbound helper, or a shadowed/reassigned parameter cannot.
+  Go trailing commas and comments are supported. The package reader and
+  zero-install detector share regression inputs for these boundaries.
+  First increment of #658; source annotation projection remains separate.
 
 - Make every emitted next action lead somewhere, and prove it. Following
   `control.next_action` on a repository with recognized host configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+- Read a Go tool's description when it is an option, and when it is
+  translated. `mark3labs/mcp-go` registers a tool as a call carrying option
+  functions — `mcp.NewTool("get_job", mcp.WithDescription(...))` — and the
+  only Go description extractor looked for a `Description:` field in a
+  struct literal, which that shape does not have. So every tool registered
+  this way read `description=None`, plain literals included. On top of
+  that, `github/github-mcp-server` wraps all 114 of its descriptions in a
+  translation helper, `t("TOOL_GET_JOB_DESCRIPTION", "Get details ...")`,
+  so even a field reader would have found a call rather than a string. The
+  result was 114 `SHIP-DOC-MISSING-DESCRIPTION` findings against a
+  repository that documents every tool it ships, which is the kind of noise
+  that costs a reader's trust in everything else on the page.
+
+  `WithDescription`/`WithToolDescription` is now read for both Go
+  call-site idioms, and a translation helper is unwrapped to its default.
+  The unwrapping is deliberately narrow: the call must pass exactly two
+  string literals and the first must look like a lookup key — screaming
+  snake or dotted — so `wrap("some prose here", "invented")` is refused
+  rather than published as documentation its author never wrote. The key
+  itself is never read as the description; printing
+  `TOOL_GET_JOB_DESCRIPTION` at a human would be worse than printing
+  nothing. A computed description, a qualified call such as
+  `fmt.Sprintf(...)`, a three-argument call, a variable key, and a literal
+  concatenated with something else all still read nothing.
+
+  `tools/shipgate-detect.py` reads these idioms a second time, and the
+  shared conformance corpus caught the divergence the moment the engine
+  reader learned something the detector had not: both now carry the same
+  extractor, and the corpus keeps them honest.
+
+  `tests/test_go_tool_descriptions.py` pins three reads and seven refusals;
+  5 of its 13 cases fail against pre-fix `main`, and the 8 that pass there
+  are the refusals, which were already correct. The idioms' published
+  `reads` strings say what they now extract. First increment of #658; the
+  annotation half — `ReadOnlyHint` in source, and protocol-default effects
+  as coverage rows rather than findings — is not in this change.
+
 - Make every emitted next action lead somewhere, and prove it. Following
   `control.next_action` on a repository with recognized host configuration
   and no manifest went round three commands forever: `verify --preview`

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 
 import ast
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Literal
@@ -408,14 +408,26 @@ IDIOMS: tuple[RegistrationIdiom, ...] = (
         id="go_must_tool",
         label="Go MustTool call-site registration",
         language="go",
-        reads='A `MustTool("…", …)` call whose first argument is a string literal.',
+        reads=(
+            'A `MustTool("…", …)` call whose first argument is a string '
+            "literal. The description is a `WithDescription(\u2026)` option "
+            "carrying a string literal, or a two-argument translation helper "
+            "such as `t(\"KEY\", \"default\")`, in which case the default is "
+            "read and the key never is."
+        ),
         diff_tokens=("MustTool(",),
     ),
     RegistrationIdiom(
         id="go_new_tool",
         label="Go NewTool call-site registration",
         language="go",
-        reads='A `NewTool("…", …)` call whose first argument is a string literal.',
+        reads=(
+            'A `NewTool("…", …)` call whose first argument is a string '
+            "literal. The description is a `WithDescription(\u2026)` option "
+            "carrying a string literal, or a two-argument translation helper "
+            "such as `t(\"KEY\", \"default\")`, in which case the default is "
+            "read and the key never is."
+        ),
         diff_tokens=("NewTool(",),
     ),
     RegistrationIdiom(
@@ -1396,9 +1408,17 @@ def _literal_is_whole_value(
 
 
 def _call_sites(
-    source: MaskedSource, pattern: re.Pattern[str], idiom: str
+    source: MaskedSource,
+    pattern: re.Pattern[str],
+    idiom: str,
+    *,
+    describe: Callable[[MaskedSource, int, int], str | None] | None = None,
 ) -> list[RegistrationSite]:
-    """Sites for a ``Name(<literal>, …)`` idiom."""
+    """Sites for a ``Name(<literal>, …)`` idiom.
+
+    ``describe`` reads the description out of the call's own argument list
+    for idioms that carry one there rather than in a struct field.
+    """
 
     sites: list[RegistrationSite] = []
     for match in pattern.finditer(source.masked):
@@ -1440,6 +1460,11 @@ def _call_sites(
                 line=line,
                 column=column,
                 span=span,
+                description=(
+                    describe(source, open_paren, close)
+                    if describe is not None and close is not None
+                    else None
+                ),
                 unresolved_reason=unresolved,
             )
         )
@@ -1589,6 +1614,88 @@ def _child_braces(masked: str, open_brace: int, close: int) -> list[tuple[int, i
             continue
         index += 1
     return children
+
+
+#: The option-function shape: `NewTool("name", WithDescription("…"))`. This is
+#: how `mark3labs/mcp-go` declares a tool, which is the SDK behind
+#: `github/github-mcp-server` — so until #658 every one of its 114 tools read
+#: `description=None` and earned a `SHIP-DOC-MISSING-DESCRIPTION` finding. The
+#: struct extractor below never applied: there is no `Description:` field to
+#: find, the description is an argument to an option.
+_GO_WITH_DESCRIPTION_RE = re.compile(r"(?<![\w])With(?:Tool)?Description\s*\(\s*")
+
+#: A two-argument call whose arguments are both string literals, e.g.
+#: `t("TOOL_GET_JOB_DESCRIPTION", "Get details of a workflow job.")`. Every
+#: description in `github-mcp-server` is wrapped this way.
+_GO_HELPER_CALL_RE = re.compile(r"(?<![\w.])[A-Za-z_]\w*\s*\(\s*")
+
+#: What a translation *key* looks like: a lookup token, not prose. Requiring
+#: it is what keeps this from reading `wrap("a", "b")` as a description and
+#: publishing `b` as documentation its author never wrote.
+#:
+#: Two shapes are keys and nothing else is: screaming-snake
+#: (`TOOL_GET_JOB_DESCRIPTION`, what `github-mcp-server` uses) and dotted
+#: (`tools.get_job.description`, the other common i18n convention). A bare
+#: word like `a` is neither, and prose is excluded by both — a key has no
+#: spaces.
+_TRANSLATION_KEY_RE = re.compile(
+    r"\A(?:[A-Z0-9][A-Z0-9_]*[A-Z0-9]|[\w-]+(?:\.[\w-]+)+)\Z"
+)
+
+
+def _go_translated_default(source: MaskedSource, index: int) -> str | None:
+    """The English default inside a translation helper, or ``None``.
+
+    Deliberately narrow. The call must pass *exactly two string literals*,
+    the first must look like a lookup key rather than prose, and only the
+    second is read. Both halves of that matter: `wrap(cfg, x)` is refused for
+    having a non-literal argument, and `wrap("a", "b")` is refused because
+    `a` is not a key — without that second test this would publish `b` as the
+    documentation of a tool whose author never wrote it.
+
+    Reading the *key* instead would be worse than reading nothing: it would
+    publish `TOOL_GET_JOB_DESCRIPTION` to a human as the tool's documentation.
+    """
+
+    start = source.skip_space(index)
+    match = _GO_HELPER_CALL_RE.match(source.masked, start)
+    if match is None:
+        return None
+    open_paren = source.masked.rfind("(", match.start(), match.end())
+    close = _matching_close(source.masked, open_paren, "(", ")")
+    if close is None:
+        return None
+    key_found, key, key_end = source.literal_at(match.end())
+    if not key_found or not key or not _literal_is_whole_value(source, key_end, ","):
+        return None
+    if not _TRANSLATION_KEY_RE.match(key):
+        return None
+    after_key = source.skip_space(key_end)
+    if after_key >= len(source.masked) or source.masked[after_key] != ",":
+        return None
+    found, value, end = source.literal_at(after_key + 1)
+    if not found or not value or not _literal_is_whole_value(source, end, ")"):
+        return None
+    # Exactly two arguments: what follows the second literal closes the call.
+    # `_matching_close` returns the index *past* the `)`, so the literal ends
+    # where the call does only when `skip_space(end) + 1 == close`.
+    return value if source.skip_space(end) + 1 == close else None
+
+
+def _go_option_description(
+    source: MaskedSource, open_paren: int, close: int
+) -> str | None:
+    """The description an option-function registration carries."""
+
+    for match in _GO_WITH_DESCRIPTION_RE.finditer(source.masked, open_paren, close):
+        found, value, end = source.literal_at(match.end())
+        if found and value and _literal_is_whole_value(source, end, ")"):
+            return value
+        if not found:
+            translated = _go_translated_default(source, match.end())
+            if translated:
+                return translated
+    return None
 
 
 _GO_STRUCT_DESCRIPTION_FIELD_RE = re.compile(r"(?<![\w])Description\s*:\s*")
@@ -3084,8 +3191,22 @@ def scan_source(
         sites.extend(_ts_static_tool_name_sites(source))
         sites.extend(_call_sites(source, _TS_REGISTER_TOOL_RE, "ts_sdk_register_tool"))
     else:
-        sites.extend(_call_sites(source, _GO_MUST_TOOL_RE, "go_must_tool"))
-        sites.extend(_call_sites(source, _GO_NEW_TOOL_RE, "go_new_tool"))
+        sites.extend(
+            _call_sites(
+                source,
+                _GO_MUST_TOOL_RE,
+                "go_must_tool",
+                describe=_go_option_description,
+            )
+        )
+        sites.extend(
+            _call_sites(
+                source,
+                _GO_NEW_TOOL_RE,
+                "go_new_tool",
+                describe=_go_option_description,
+            )
+        )
         sites.extend(_go_tool_struct_sites(source))
 
     kept = [

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -411,7 +411,7 @@ IDIOMS: tuple[RegistrationIdiom, ...] = (
         reads=(
             'A `MustTool("…", …)` call whose first argument is a string '
             "literal. The description is a `WithDescription(\u2026)` option "
-            "carrying a string literal, or a two-argument translation helper "
+            "carrying a string literal, or a complete call to a declared TranslationHelperFunc parameter "
             "such as `t(\"KEY\", \"default\")`, in which case the default is "
             "read and the key never is."
         ),
@@ -424,7 +424,7 @@ IDIOMS: tuple[RegistrationIdiom, ...] = (
         reads=(
             'A `NewTool("…", …)` call whose first argument is a string '
             "literal. The description is a `WithDescription(\u2026)` option "
-            "carrying a string literal, or a two-argument translation helper "
+            "carrying a string literal, or a complete call to a declared TranslationHelperFunc parameter "
             "such as `t(\"KEY\", \"default\")`, in which case the default is "
             "read and the key never is."
         ),
@@ -436,7 +436,8 @@ IDIOMS: tuple[RegistrationIdiom, ...] = (
         language="go",
         reads=(
             'A `Tool{…}` composite literal carrying a `Name: "…"` field, the '
-            "official Go SDK's declaration shape."
+            "official Go SDK's declaration shape. Description is read from a literal "
+            "or a complete call to a declared TranslationHelperFunc parameter."
         ),
         diff_tokens=("mcp.Tool{",),
     ),
@@ -1622,96 +1623,130 @@ def _child_braces(masked: str, open_brace: int, close: int) -> list[tuple[int, i
 #: `description=None` and earned a `SHIP-DOC-MISSING-DESCRIPTION` finding. The
 #: struct extractor below never applied: there is no `Description:` field to
 #: find, the description is an argument to an option.
-_GO_WITH_DESCRIPTION_RE = re.compile(r"(?<![\w])With(?:Tool)?Description\s*\(\s*")
-
-#: A two-argument call whose arguments are both string literals, e.g.
-#: `t("TOOL_GET_JOB_DESCRIPTION", "Get details of a workflow job.")`. Every
-#: description in `github-mcp-server` is wrapped this way.
-_GO_HELPER_CALL_RE = re.compile(r"(?<![\w.])[A-Za-z_]\w*\s*\(\s*")
-
-#: What a translation *key* looks like: a lookup token, not prose. Requiring
-#: it is what keeps this from reading `wrap("a", "b")` as a description and
-#: publishing `b` as documentation its author never wrote.
-#:
-#: Two shapes are keys and nothing else is: screaming-snake
-#: (`TOOL_GET_JOB_DESCRIPTION`, what `github-mcp-server` uses) and dotted
-#: (`tools.get_job.description`, the other common i18n convention). A bare
-#: word like `a` is neither, and prose is excluded by both — a key has no
-#: spaces.
+_GO_WITH_DESCRIPTION_RE = re.compile(
+    r"(?:[A-Za-z_]\w*\.)?With(?:Tool)?Description\s*\(\s*"
+)
+_GO_HELPER_CALL_RE = re.compile(r"(?P<helper>[A-Za-z_]\w*)\s*\(\s*")
+_GO_FUNCTION_RE = re.compile(r"\bfunc\b\s*(?:[A-Za-z_]\w*\s*)?\(")
 _TRANSLATION_KEY_RE = re.compile(
     r"\A(?:[A-Z0-9][A-Z0-9_]*[A-Z0-9]|[\w-]+(?:\.[\w-]+)+)\Z"
 )
 
 
-def _go_translated_default(source: MaskedSource, index: int) -> str | None:
-    """The English default inside a translation helper, or ``None``.
+def _go_arguments(source: MaskedSource, opening: int, close: int) -> list[tuple[int, int]]:
+    """Whole argument ranges, excluding an optional Go trailing comma."""
+    result: list[tuple[int, int]] = []
+    start, depth = opening + 1, 0
+    for index in range(start, close - 1):
+        char = source.masked[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "," and depth == 0:
+            result.append((start, index))
+            start = index + 1
+    result.append((start, close - 1))
+    trimmed: list[tuple[int, int]] = []
+    for start, end in result:
+        start = source.skip_space(start)
+        while end > start and source.masked[end - 1].isspace():
+            end -= 1
+        if start < end:
+            trimmed.append((start, end))
+    return trimmed
 
-    Deliberately narrow. The call must pass *exactly two string literals*,
-    the first must look like a lookup key rather than prose, and only the
-    second is read. Both halves of that matter: `wrap(cfg, x)` is refused for
-    having a non-literal argument, and `wrap("a", "b")` is refused because
-    `a` is not a key — without that second test this would publish `b` as the
-    documentation of a tool whose author never wrote it.
 
-    Reading the *key* instead would be worse than reading nothing: it would
-    publish `TOOL_GET_JOB_DESCRIPTION` to a human as the tool's documentation.
+def _go_translation_parameter(source: MaskedSource, helper: str, index: int) -> bool:
+    """Recognize the declared fallback-helper contract, not arbitrary calls.
+
+    GitHub's tool constructors receive a TranslationHelperFunc parameter.
+    A function merely accepting two strings establishes no default-value
+    semantics. Unbound aliases, shadowed parameters and unsupported Go
+    signatures are deliberately left unread.
     """
+    cursor = index
+    while (position := source.masked.rfind("func", 0, cursor)) >= 0:
+        cursor = position
+        match = _GO_FUNCTION_RE.match(source.masked, position)
+        if match is None:
+            continue
+        opening = source.masked.rfind("(", match.start(), match.end())
+        close = _matching_close(source.masked, opening, "(", ")")
+        if close is None:
+            continue
+        body = source.masked.find("{", close, index)
+        body_end = _matching_close(source.masked, body, "{", "}") if body >= 0 else None
+        if body_end is None or not body < index < body_end:
+            continue
+        typed = re.search(
+            rf"(?<![\w.]){re.escape(helper)}\s+(?:[A-Za-z_]\w*\.)?TranslationHelperFunc\b",
+            source.masked[opening + 1:close - 1],
+        )
+        reassigned = re.search(
+            rf"(?<![\w.]){re.escape(helper)}\s*(?::=|=(?!=))",
+            source.masked[body + 1:index],
+        )
+        return typed is not None and reassigned is None
+    return False
 
-    start = source.skip_space(index)
+
+def _go_translated_default(source: MaskedSource, start: int, end: int) -> str | None:
+    """Read a complete call to a declared translation-helper parameter."""
     match = _GO_HELPER_CALL_RE.match(source.masked, start)
-    if match is None:
+    if match is None or not _go_translation_parameter(source, match["helper"], start):
         return None
-    open_paren = source.masked.rfind("(", match.start(), match.end())
-    close = _matching_close(source.masked, open_paren, "(", ")")
-    if close is None:
+    opening = source.masked.rfind("(", match.start(), match.end())
+    close = _matching_close(source.masked, opening, "(", ")")
+    if close != end:
         return None
-    key_found, key, key_end = source.literal_at(match.end())
-    if not key_found or not key or not _literal_is_whole_value(source, key_end, ","):
+    args = _go_arguments(source, opening, close)
+    if len(args) != 2:
         return None
-    if not _TRANSLATION_KEY_RE.match(key):
-        return None
-    after_key = source.skip_space(key_end)
-    if after_key >= len(source.masked) or source.masked[after_key] != ",":
-        return None
-    found, value, end = source.literal_at(after_key + 1)
-    if not found or not value or not _literal_is_whole_value(source, end, ")"):
-        return None
-    # Exactly two arguments: what follows the second literal closes the call.
-    # `_matching_close` returns the index *past* the `)`, so the literal ends
-    # where the call does only when `skip_space(end) + 1 == close`.
-    return value if source.skip_space(end) + 1 == close else None
+    values: list[str] = []
+    for arg_start, arg_end in args:
+        found, value, literal_end = source.literal_at(arg_start)
+        if not found or not value or literal_end != arg_end:
+            return None
+        values.append(value)
+    return values[1] if _TRANSLATION_KEY_RE.fullmatch(values[0]) else None
 
 
-def _go_option_description(
-    source: MaskedSource, open_paren: int, close: int
-) -> str | None:
-    """The description an option-function registration carries."""
-
-    for match in _GO_WITH_DESCRIPTION_RE.finditer(source.masked, open_paren, close):
-        found, value, end = source.literal_at(match.end())
-        if found and value and _literal_is_whole_value(source, end, ")"):
-            return value
-        if not found:
-            translated = _go_translated_default(source, match.end())
-            if translated:
-                return translated
-    return None
+def _go_option_description(source: MaskedSource, open_paren: int, close: int) -> str | None:
+    """Read direct options in SDK order; a later unknown value clears an earlier one."""
+    description: str | None = None
+    for start, end in _go_arguments(source, open_paren, close)[1:]:
+        match = _GO_WITH_DESCRIPTION_RE.match(source.masked, start)
+        if match is None:
+            continue
+        description = None
+        opening = source.masked.rfind("(", match.start(), match.end())
+        option_close = _matching_close(source.masked, opening, "(", ")")
+        if option_close != end:
+            continue
+        args = _go_arguments(source, opening, option_close)
+        if len(args) != 1:
+            continue
+        arg_start, arg_end = args[0]
+        description = _go_description_value(source, arg_start, arg_end)
+    return description
 
 
 _GO_STRUCT_DESCRIPTION_FIELD_RE = re.compile(r"(?<![\w])Description\s*:\s*")
 
 
-def _go_struct_description(
-    source: MaskedSource, open_brace: int, close: int
-) -> str | None:
-    for match in _GO_STRUCT_DESCRIPTION_FIELD_RE.finditer(
-        source.masked, open_brace + 1, close
-    ):
-        if _brace_depth(source.masked, open_brace, match.start()) != 1:
-            continue
-        found, value, literal_end = source.literal_at(match.end())
-        if found and value and _literal_is_whole_value(source, literal_end, ",}"):
-            return value
+def _go_description_value(source: MaskedSource, start: int, end: int) -> str | None:
+    found, value, literal_end = source.literal_at(start)
+    if found:
+        return (value or None) if literal_end == end else None
+    return _go_translated_default(source, start, end)
+
+
+def _go_struct_description(source: MaskedSource, open_brace: int, close: int) -> str | None:
+    for start, end in _go_arguments(source, open_brace, close):
+        match = _GO_STRUCT_DESCRIPTION_FIELD_RE.match(source.masked, start)
+        if match is not None:
+            return _go_description_value(source, source.skip_space(match.end()), end)
     return None
 
 

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -1679,15 +1679,34 @@ def _go_translation_parameter(source: MaskedSource, helper: str, index: int) -> 
         body_end = _matching_close(source.masked, body, "{", "}") if body >= 0 else None
         if body_end is None or not body < index < body_end:
             continue
-        typed = re.search(
-            rf"(?<![\w.]){re.escape(helper)}\s+(?:[A-Za-z_]\w*\.)?TranslationHelperFunc\b",
-            source.masked[opening + 1:close - 1],
+        tail = source.masked[close:body]
+        # A function type has no body. Do not borrow a later declaration's
+        # brace, or the enclosing signature's body after an inner func type.
+        if re.search(r"[^\w.()*\[\],\s]|\b(?:var|const|type|func|return|package|import)\b", tail):
+            continue
+        depth = 0
+        valid_tail = True
+        for char in tail:
+            if char in "([":
+                depth += 1
+            elif char in ")]":
+                depth -= 1
+                if depth < 0:
+                    valid_tail = False
+        if not valid_tail or depth:
+            continue
+        typed = any(
+            re.fullmatch(
+                rf"{re.escape(helper)}\s+(?:[A-Za-z_]\w*\.)?TranslationHelperFunc",
+                source.masked[start:end],
+            ) is not None
+            for start, end in _go_arguments(source, opening, close)
         )
         reassigned = re.search(
             rf"(?<![\w.]){re.escape(helper)}\s*(?::=|=(?!=))",
             source.masked[body + 1:index],
         )
-        return typed is not None and reassigned is None
+        return typed and reassigned is None
     return False
 
 

--- a/tests/mcp_idiom_corpus.py
+++ b/tests/mcp_idiom_corpus.py
@@ -2019,3 +2019,32 @@ SOURCE_CASES: tuple[SourceCase, ...] = (
         for name, entry in sorted(REGRESSIONS.items())
     ),
 )
+
+
+# Go description semantics are shared with the zero-install reader, including
+# the refusals that must not turn an unrelated string into documentation.
+GO_DESCRIPTION_CASES = (
+    ("last_option_wins", 'func F() mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription("old"), mcp.WithDescription("actual")) }', {"tool": "actual"}),
+    ("computed_override", 'func F() mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription("old"), mcp.WithDescription(compute())) }', {"tool": None}),
+    ("empty_override", 'func F() mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription("old"), mcp.WithDescription("")) }', {"tool": None}),
+    ("nested_unapplied_option", 'func F() mcp.Tool { return mcp.NewTool("tool", func(tool *mcp.Tool) { _ = mcp.WithDescription("not applied") }) }', {"tool": None}),
+    ("translated_suffix", 'func F(t TranslationHelperFunc) mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "partial") + suffix)) }', {"tool": None}),
+    ("arbitrary_key_shaped_helper", 'func F() mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(wrap("TOOL_KEY", "invented"))) }', {"tool": None}),
+    ("unbound_t", 'func F() mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "invented"))) }', {"tool": None}),
+    ("wrong_t_type", 'func F(t func(string, string) string) mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "invented"))) }', {"tool": None}),
+    ("declared_renamed_helper", 'func F(localize translations.TranslationHelperFunc) mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(localize("TOOL_KEY", "actual"))) }', {"tool": "actual"}),
+    ("reassigned_helper", 'func F(t TranslationHelperFunc) mcp.Tool { t = other; return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "invented"))) }', {"tool": None}),
+    ("shadowed_helper", 'func F(t TranslationHelperFunc) mcp.Tool { return func(t func(string, string) string) mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "invented"))) }(other) }', {"tool": None}),
+    ("trailing_commas", 'func F(t TranslationHelperFunc) mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "actual",),),) }', {"tool": "actual"}),
+    ("literal_comments", 'func F() mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription("actual" /* note */ ,)) }', {"tool": "actual"}),
+    ("default_comments", 'func F(t TranslationHelperFunc) mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY" /* note */, "actual" /* default */ ,))) }', {"tool": "actual"}),
+    ("translated_struct", 'func F(t translations.TranslationHelperFunc) mcp.Tool { return mcp.Tool{Name: "tool", Description: t("TOOL_KEY", "actual")} }', {"tool": "actual"}),
+    ("computed_struct_suffix", 'func F(t TranslationHelperFunc) mcp.Tool { return mcp.Tool{Name: "tool", Description: t("TOOL_KEY", "partial") + suffix} }', {"tool": None}),
+    ("unrelated_struct_helper", 'func F() mcp.Tool { return mcp.Tool{Name: "tool", Description: wrap("TOOL_KEY", "invented")} }', {"tool": None}),
+    ("nested_struct_field", 'func F() mcp.Tool { return mcp.Tool{Name: "tool", InputSchema: Schema{Description: "property docs"}} }', {"tool": None}),
+    ("func_prefix_is_not_a_scope", 'func F(t TranslationHelperFunc) mcp.Tool { return funcwrap(mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "actual")))) }', {"tool": "actual"}),
+)
+SOURCE_CASES += tuple(
+    SourceCase("go_description:" + name, "go", "package p\n" + body)
+    for name, body, _expected in GO_DESCRIPTION_CASES
+)

--- a/tests/mcp_idiom_corpus.py
+++ b/tests/mcp_idiom_corpus.py
@@ -2043,6 +2043,8 @@ GO_DESCRIPTION_CASES = (
     ("unrelated_struct_helper", 'func F() mcp.Tool { return mcp.Tool{Name: "tool", Description: wrap("TOOL_KEY", "invented")} }', {"tool": None}),
     ("nested_struct_field", 'func F() mcp.Tool { return mcp.Tool{Name: "tool", InputSchema: Schema{Description: "property docs"}} }', {"tool": None}),
     ("func_prefix_is_not_a_scope", 'func F(t TranslationHelperFunc) mcp.Tool { return funcwrap(mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "actual")))) }', {"tool": "actual"}),
+    ("callback_type_parameter_is_not_local", 'var t = wrap\nfunc F(callback func(t TranslationHelperFunc) string) mcp.Tool { return mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "invented"))) }', {"tool": None}),
+    ("function_type_has_no_body", 'var t = wrap\ntype Factory func(t TranslationHelperFunc) string\nvar tools = []mcp.Tool{mcp.NewTool("tool", mcp.WithDescription(t("TOOL_KEY", "invented")))}', {"tool": None}),
 )
 SOURCE_CASES += tuple(
     SourceCase("go_description:" + name, "go", "package p\n" + body)

--- a/tests/test_go_tool_descriptions.py
+++ b/tests/test_go_tool_descriptions.py
@@ -28,6 +28,7 @@ import pytest
 
 from agents_shipgate.inputs.mcp_server_source import load_mcp_server_source
 from agents_shipgate.schemas.manifest import ToolSourceConfig
+from tests.mcp_idiom_corpus import GO_DESCRIPTION_CASES
 
 GO_MOD = "module github.com/example/srv\nrequire github.com/mark3labs/mcp-go v0.1.0\n"
 
@@ -88,7 +89,7 @@ CASES: tuple[tuple[str, str, str | None], ...] = (
 def test_description_is_read_or_refused(
     tmp_path: Path, case: str, expression: str, expected: str | None
 ) -> None:
-    body = f'func F() mcp.Tool {{ return mcp.NewTool("{case}", mcp.WithDescription({expression})) }}\n'
+    body = f'func F(t TranslationHelperFunc) mcp.Tool {{ return mcp.NewTool("{case}", mcp.WithDescription({expression})) }}\n'
 
     assert _tools(tmp_path, body) == {case: expected}
 
@@ -125,7 +126,7 @@ def test_every_tool_in_a_translated_server_is_documented(tmp_path: Path) -> None
     """
 
     body = "".join(
-        f'func F{index}() mcp.Tool {{ return mcp.NewTool("tool_{index}", '
+        f'func F{index}(t TranslationHelperFunc) mcp.Tool {{ return mcp.NewTool("tool_{index}", '
         f'mcp.WithDescription(t("TOOL_{index}_DESCRIPTION", "Tool {index} does a thing."))) }}\n'
         for index in range(12)
     )
@@ -150,3 +151,8 @@ func Register(server *mcp.Server) {
 """
 
     assert _tools(tmp_path, body) == {"read_dashboard": "Read one dashboard."}
+
+
+@pytest.mark.parametrize("case,body,expected", GO_DESCRIPTION_CASES, ids=[case[0] for case in GO_DESCRIPTION_CASES])
+def test_description_argument_boundaries(tmp_path: Path, case: str, body: str, expected: dict) -> None:
+    assert _tools(tmp_path, body) == expected

--- a/tests/test_go_tool_descriptions.py
+++ b/tests/test_go_tool_descriptions.py
@@ -1,0 +1,152 @@
+"""#658: a Go tool's description, when it is not a bare literal in a struct.
+
+`github/github-mcp-server` declares 114 tools through `mark3labs/mcp-go`,
+whose registration shape is a call with option functions:
+
+    mcp.NewTool("get_job",
+        mcp.WithDescription(t("TOOL_GET_JOB_DESCRIPTION", "Get details …")),
+    )
+
+Two separate reasons this read nothing. The description is an *argument to
+an option*, not a `Description:` struct field, and the only Go description
+extractor looked for the field — so even a plain literal was missed. And
+every description in that repository is wrapped in a translation helper,
+so finding the literal means looking through the call.
+
+The result was 114 tools with no description and 114
+`SHIP-DOC-MISSING-DESCRIPTION` findings on a repository that documents
+every tool it ships. The cases below are the read, and — as much as they
+are the read — the refusals: this must not invent a description out of any
+nested call that happens to contain a string.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.inputs.mcp_server_source import load_mcp_server_source
+from agents_shipgate.schemas.manifest import ToolSourceConfig
+
+GO_MOD = "module github.com/example/srv\nrequire github.com/mark3labs/mcp-go v0.1.0\n"
+
+
+def _tools(tmp_path: Path, body: str) -> dict[str, str | None]:
+    (tmp_path / "go.mod").write_text(GO_MOD, encoding="utf-8")
+    package = tmp_path / "pkg"
+    package.mkdir(exist_ok=True)
+    (package / "tools.go").write_text(
+        'package pkg\n\nimport "github.com/mark3labs/mcp-go/mcp"\n\n' + body,
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(
+        ToolSourceConfig(id="srv", type="mcp_server_source", path="."), tmp_path
+    )
+    return {tool.name: getattr(tool, "description", None) for tool in loaded.tools}
+
+
+#: (case, Go expression for the description argument, what must be read).
+#: `None` means the reader must decline — every one of these is a shape
+#: where a literal is reachable but is not the tool's description.
+CASES: tuple[tuple[str, str, str | None], ...] = (
+    ("plain_literal", '"A plain literal."', "A plain literal."),
+    (
+        "screaming_snake_key",
+        't("TOOL_GET_JOB_DESCRIPTION", "Get details of a workflow job.")',
+        "Get details of a workflow job.",
+    ),
+    (
+        "dotted_key",
+        't("tools.get_job.description", "Dotted key default.")',
+        "Dotted key default.",
+    ),
+    # --- refusals ---------------------------------------------------------
+    # Two literals, but the first is prose, so this is not a lookup with a
+    # fallback. Reading it would publish `invented` as documentation the
+    # tool's author never wrote.
+    ("prose_first_argument", 'wrap("some prose here", "invented")', None),
+    # A bare word is not a key either.
+    ("bare_word_key", 'wrap("a", "b")', None),
+    # The key is computed, so nothing establishes that the second literal is
+    # this tool's default rather than some other tool's.
+    ("variable_key", "t(keyVar, \"Default for a key we cannot see.\")", None),
+    # Three arguments is not the `t(key, default)` shape.
+    ("three_arguments", 't("TOOL_F_DESCRIPTION", "One.", "Two.")', None),
+    # No literal at all.
+    ("computed", "buildDesc(cfg)", None),
+    # A qualified call is not a bare translation helper.
+    ("qualified_call", 'fmt.Sprintf("%s tool", name)', None),
+    # The literal is part of a larger expression, so it is not the value.
+    ("concatenation", '"Part one " + suffix', None),
+)
+
+
+@pytest.mark.parametrize(
+    ("case", "expression", "expected"), CASES, ids=[case[0] for case in CASES]
+)
+def test_description_is_read_or_refused(
+    tmp_path: Path, case: str, expression: str, expected: str | None
+) -> None:
+    body = f'func F() mcp.Tool {{ return mcp.NewTool("{case}", mcp.WithDescription({expression})) }}\n'
+
+    assert _tools(tmp_path, body) == {case: expected}
+
+
+def test_the_github_mcp_server_shape_end_to_end(tmp_path: Path) -> None:
+    """The reported repository's actual registration, reproduced."""
+
+    body = """
+func GetJob(t TranslationHelperFunc) mcp.Tool {
+	return mcp.NewTool("get_job",
+		mcp.WithDescription(t("TOOL_GET_JOB_DESCRIPTION", "Get details of a specific workflow job.")),
+		mcp.WithReadOnlyHintAnnotation(true),
+	)
+}
+
+func DeleteJob(t TranslationHelperFunc) mcp.Tool {
+	return mcp.NewTool("delete_job",
+		mcp.WithDescription(t("TOOL_DELETE_JOB_DESCRIPTION", "Delete one workflow job.")),
+	)
+}
+"""
+
+    assert _tools(tmp_path, body) == {
+        "get_job": "Get details of a specific workflow job.",
+        "delete_job": "Delete one workflow job.",
+    }
+
+
+def test_every_tool_in_a_translated_server_is_documented(tmp_path: Path) -> None:
+    """The headline: no tool in this shape lacks a description.
+
+    `SHIP-DOC-MISSING-DESCRIPTION` fires per undocumented tool, so this is
+    the 114-findings defect stated as a property.
+    """
+
+    body = "".join(
+        f'func F{index}() mcp.Tool {{ return mcp.NewTool("tool_{index}", '
+        f'mcp.WithDescription(t("TOOL_{index}_DESCRIPTION", "Tool {index} does a thing."))) }}\n'
+        for index in range(12)
+    )
+
+    described = _tools(tmp_path, body)
+
+    assert len(described) == 12
+    assert [name for name, text in described.items() if not text] == []
+
+
+def test_the_struct_shape_still_reads_its_field(tmp_path: Path) -> None:
+    """The other Go idiom is untouched; this change adds a reader, not a
+    replacement."""
+
+    body = """
+func Register(server *mcp.Server) {
+	server.AddTool(&mcp.Tool{
+		Name:        "read_dashboard",
+		Description: "Read one dashboard.",
+	}, readDashboard)
+}
+"""
+
+    assert _tools(tmp_path, body) == {"read_dashboard": "Read one dashboard."}

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -1828,15 +1828,34 @@ def _go_translation_parameter(source: MaskedSource, helper: str, index: int) -> 
         body_end = _matching_close(source.masked, body, "{", "}") if body >= 0 else None
         if body_end is None or not body < index < body_end:
             continue
-        typed = re.search(
-            rf"(?<![\w.]){re.escape(helper)}\s+(?:[A-Za-z_]\w*\.)?TranslationHelperFunc\b",
-            source.masked[opening + 1:close - 1],
+        tail = source.masked[close:body]
+        # A function type has no body. Do not borrow a later declaration's
+        # brace, or the enclosing signature's body after an inner func type.
+        if re.search(r"[^\w.()*\[\],\s]|\b(?:var|const|type|func|return|package|import)\b", tail):
+            continue
+        depth = 0
+        valid_tail = True
+        for char in tail:
+            if char in "([":
+                depth += 1
+            elif char in ")]":
+                depth -= 1
+                if depth < 0:
+                    valid_tail = False
+        if not valid_tail or depth:
+            continue
+        typed = any(
+            re.fullmatch(
+                rf"{re.escape(helper)}\s+(?:[A-Za-z_]\w*\.)?TranslationHelperFunc",
+                source.masked[start:end],
+            ) is not None
+            for start, end in _go_arguments(source, opening, close)
         )
         reassigned = re.search(
             rf"(?<![\w.]){re.escape(helper)}\s*(?::=|=(?!=))",
             source.masked[body + 1:index],
         )
-        return typed is not None and reassigned is None
+        return typed and reassigned is None
     return False
 
 

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -1772,80 +1772,113 @@ _GO_KEYED_FIELD_RE = re.compile(r"(?<![\w])[A-Za-z_]\w*\s*:")
 #: `description=None` and earned a `SHIP-DOC-MISSING-DESCRIPTION` finding. The
 #: struct extractor below never applied: there is no `Description:` field to
 #: find, the description is an argument to an option.
-_GO_WITH_DESCRIPTION_RE = re.compile(r"(?<![\w])With(?:Tool)?Description\s*\(\s*")
-
-#: A two-argument call whose arguments are both string literals, e.g.
-#: `t("TOOL_GET_JOB_DESCRIPTION", "Get details of a workflow job.")`. Every
-#: description in `github-mcp-server` is wrapped this way.
-_GO_HELPER_CALL_RE = re.compile(r"(?<![\w.])[A-Za-z_]\w*\s*\(\s*")
-
-#: What a translation *key* looks like: a lookup token, not prose. Requiring
-#: it is what keeps this from reading `wrap("a", "b")` as a description and
-#: publishing `b` as documentation its author never wrote.
-#:
-#: Two shapes are keys and nothing else is: screaming-snake
-#: (`TOOL_GET_JOB_DESCRIPTION`, what `github-mcp-server` uses) and dotted
-#: (`tools.get_job.description`, the other common i18n convention). A bare
-#: word like `a` is neither, and prose is excluded by both — a key has no
-#: spaces.
+_GO_WITH_DESCRIPTION_RE = re.compile(
+    r"(?:[A-Za-z_]\w*\.)?With(?:Tool)?Description\s*\(\s*"
+)
+_GO_HELPER_CALL_RE = re.compile(r"(?P<helper>[A-Za-z_]\w*)\s*\(\s*")
+_GO_FUNCTION_RE = re.compile(r"\bfunc\b\s*(?:[A-Za-z_]\w*\s*)?\(")
 _TRANSLATION_KEY_RE = re.compile(
     r"\A(?:[A-Z0-9][A-Z0-9_]*[A-Z0-9]|[\w-]+(?:\.[\w-]+)+)\Z"
 )
 
 
-def _go_translated_default(source: MaskedSource, index: int) -> str | None:
-    """The English default inside a translation helper, or ``None``.
+def _go_arguments(source: MaskedSource, opening: int, close: int) -> list[tuple[int, int]]:
+    """Whole argument ranges, excluding an optional Go trailing comma."""
+    result: list[tuple[int, int]] = []
+    start, depth = opening + 1, 0
+    for index in range(start, close - 1):
+        char = source.masked[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "," and depth == 0:
+            result.append((start, index))
+            start = index + 1
+    result.append((start, close - 1))
+    trimmed: list[tuple[int, int]] = []
+    for start, end in result:
+        start = source.skip_space(start)
+        while end > start and source.masked[end - 1].isspace():
+            end -= 1
+        if start < end:
+            trimmed.append((start, end))
+    return trimmed
 
-    Deliberately narrow. The call must pass *exactly two string literals*,
-    the first must look like a lookup key rather than prose, and only the
-    second is read. Both halves of that matter: `wrap(cfg, x)` is refused for
-    having a non-literal argument, and `wrap("a", "b")` is refused because
-    `a` is not a key — without that second test this would publish `b` as the
-    documentation of a tool whose author never wrote it.
 
-    Reading the *key* instead would be worse than reading nothing: it would
-    publish `TOOL_GET_JOB_DESCRIPTION` to a human as the tool's documentation.
+def _go_translation_parameter(source: MaskedSource, helper: str, index: int) -> bool:
+    """Recognize the declared fallback-helper contract, not arbitrary calls.
+
+    GitHub's tool constructors receive a TranslationHelperFunc parameter.
+    A function merely accepting two strings establishes no default-value
+    semantics. Unbound aliases, shadowed parameters and unsupported Go
+    signatures are deliberately left unread.
     """
+    cursor = index
+    while (position := source.masked.rfind("func", 0, cursor)) >= 0:
+        cursor = position
+        match = _GO_FUNCTION_RE.match(source.masked, position)
+        if match is None:
+            continue
+        opening = source.masked.rfind("(", match.start(), match.end())
+        close = _matching_close(source.masked, opening, "(", ")")
+        if close is None:
+            continue
+        body = source.masked.find("{", close, index)
+        body_end = _matching_close(source.masked, body, "{", "}") if body >= 0 else None
+        if body_end is None or not body < index < body_end:
+            continue
+        typed = re.search(
+            rf"(?<![\w.]){re.escape(helper)}\s+(?:[A-Za-z_]\w*\.)?TranslationHelperFunc\b",
+            source.masked[opening + 1:close - 1],
+        )
+        reassigned = re.search(
+            rf"(?<![\w.]){re.escape(helper)}\s*(?::=|=(?!=))",
+            source.masked[body + 1:index],
+        )
+        return typed is not None and reassigned is None
+    return False
 
-    start = source.skip_space(index)
+
+def _go_translated_default(source: MaskedSource, start: int, end: int) -> str | None:
+    """Read a complete call to a declared translation-helper parameter."""
     match = _GO_HELPER_CALL_RE.match(source.masked, start)
-    if match is None:
+    if match is None or not _go_translation_parameter(source, match["helper"], start):
         return None
-    open_paren = source.masked.rfind("(", match.start(), match.end())
-    close = _matching_close(source.masked, open_paren, "(", ")")
-    if close is None:
+    opening = source.masked.rfind("(", match.start(), match.end())
+    close = _matching_close(source.masked, opening, "(", ")")
+    if close != end:
         return None
-    key_found, key, key_end = source.literal_at(match.end())
-    if not key_found or not key or not _literal_is_whole_value(source, key_end, ","):
+    args = _go_arguments(source, opening, close)
+    if len(args) != 2:
         return None
-    if not _TRANSLATION_KEY_RE.match(key):
-        return None
-    after_key = source.skip_space(key_end)
-    if after_key >= len(source.masked) or source.masked[after_key] != ",":
-        return None
-    found, value, end = source.literal_at(after_key + 1)
-    if not found or not value or not _literal_is_whole_value(source, end, ")"):
-        return None
-    # Exactly two arguments: what follows the second literal closes the call.
-    # `_matching_close` returns the index *past* the `)`, so the literal ends
-    # where the call does only when `skip_space(end) + 1 == close`.
-    return value if source.skip_space(end) + 1 == close else None
+    values: list[str] = []
+    for arg_start, arg_end in args:
+        found, value, literal_end = source.literal_at(arg_start)
+        if not found or not value or literal_end != arg_end:
+            return None
+        values.append(value)
+    return values[1] if _TRANSLATION_KEY_RE.fullmatch(values[0]) else None
 
 
-def _go_option_description(
-    source: MaskedSource, open_paren: int, close: int
-) -> str | None:
-    """The description an option-function registration carries."""
-
-    for match in _GO_WITH_DESCRIPTION_RE.finditer(source.masked, open_paren, close):
-        found, value, end = source.literal_at(match.end())
-        if found and value and _literal_is_whole_value(source, end, ")"):
-            return value
-        if not found:
-            translated = _go_translated_default(source, match.end())
-            if translated:
-                return translated
-    return None
+def _go_option_description(source: MaskedSource, open_paren: int, close: int) -> str | None:
+    """Read direct options in SDK order; a later unknown value clears an earlier one."""
+    description: str | None = None
+    for start, end in _go_arguments(source, open_paren, close)[1:]:
+        match = _GO_WITH_DESCRIPTION_RE.match(source.masked, start)
+        if match is None:
+            continue
+        description = None
+        opening = source.masked.rfind("(", match.start(), match.end())
+        option_close = _matching_close(source.masked, opening, "(", ")")
+        if option_close != end:
+            continue
+        args = _go_arguments(source, opening, option_close)
+        if len(args) != 1:
+            continue
+        arg_start, arg_end = args[0]
+        description = _go_description_value(source, arg_start, arg_end)
+    return description
 
 
 _GO_STRUCT_DESCRIPTION_FIELD_RE = re.compile(r"(?<![\w])Description\s*:\s*")
@@ -2122,15 +2155,18 @@ def _child_braces(masked: str, open_brace: int, close: int) -> list[tuple[int, i
     return children
 
 
+def _go_description_value(source: MaskedSource, start: int, end: int) -> str | None:
+    found, value, literal_end = source.literal_at(start)
+    if found:
+        return (value or None) if literal_end == end else None
+    return _go_translated_default(source, start, end)
+
+
 def _go_struct_description(source: MaskedSource, open_brace: int, close: int) -> str | None:
-    for match in _GO_STRUCT_DESCRIPTION_FIELD_RE.finditer(
-        source.masked, open_brace + 1, close
-    ):
-        if _brace_depth(source.masked, open_brace, match.start()) != 1:
-            continue
-        found, value, literal_end = source.literal_at(match.end())
-        if found and value and _literal_is_whole_value(source, literal_end, ",}"):
-            return value
+    for start, end in _go_arguments(source, open_brace, close):
+        match = _GO_STRUCT_DESCRIPTION_FIELD_RE.match(source.masked, start)
+        if match is not None:
+            return _go_description_value(source, source.skip_space(match.end()), end)
     return None
 
 

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -103,7 +103,7 @@ import subprocess
 import sys
 import threading
 import tomllib
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal
@@ -1766,6 +1766,88 @@ _GO_NEW_TOOL_RE = re.compile(r"(?<![\w])NewTool\s*\(\s*")
 _GO_TOOL_STRUCT_RE = re.compile(r"(?<![\w])Tool\s*\{")
 _GO_STRUCT_NAME_FIELD_RE = re.compile(r"(?<![\w])Name\s*:\s*")
 _GO_KEYED_FIELD_RE = re.compile(r"(?<![\w])[A-Za-z_]\w*\s*:")
+#: The option-function shape: `NewTool("name", WithDescription("…"))`. This is
+#: how `mark3labs/mcp-go` declares a tool, which is the SDK behind
+#: `github/github-mcp-server` — so until #658 every one of its 114 tools read
+#: `description=None` and earned a `SHIP-DOC-MISSING-DESCRIPTION` finding. The
+#: struct extractor below never applied: there is no `Description:` field to
+#: find, the description is an argument to an option.
+_GO_WITH_DESCRIPTION_RE = re.compile(r"(?<![\w])With(?:Tool)?Description\s*\(\s*")
+
+#: A two-argument call whose arguments are both string literals, e.g.
+#: `t("TOOL_GET_JOB_DESCRIPTION", "Get details of a workflow job.")`. Every
+#: description in `github-mcp-server` is wrapped this way.
+_GO_HELPER_CALL_RE = re.compile(r"(?<![\w.])[A-Za-z_]\w*\s*\(\s*")
+
+#: What a translation *key* looks like: a lookup token, not prose. Requiring
+#: it is what keeps this from reading `wrap("a", "b")` as a description and
+#: publishing `b` as documentation its author never wrote.
+#:
+#: Two shapes are keys and nothing else is: screaming-snake
+#: (`TOOL_GET_JOB_DESCRIPTION`, what `github-mcp-server` uses) and dotted
+#: (`tools.get_job.description`, the other common i18n convention). A bare
+#: word like `a` is neither, and prose is excluded by both — a key has no
+#: spaces.
+_TRANSLATION_KEY_RE = re.compile(
+    r"\A(?:[A-Z0-9][A-Z0-9_]*[A-Z0-9]|[\w-]+(?:\.[\w-]+)+)\Z"
+)
+
+
+def _go_translated_default(source: MaskedSource, index: int) -> str | None:
+    """The English default inside a translation helper, or ``None``.
+
+    Deliberately narrow. The call must pass *exactly two string literals*,
+    the first must look like a lookup key rather than prose, and only the
+    second is read. Both halves of that matter: `wrap(cfg, x)` is refused for
+    having a non-literal argument, and `wrap("a", "b")` is refused because
+    `a` is not a key — without that second test this would publish `b` as the
+    documentation of a tool whose author never wrote it.
+
+    Reading the *key* instead would be worse than reading nothing: it would
+    publish `TOOL_GET_JOB_DESCRIPTION` to a human as the tool's documentation.
+    """
+
+    start = source.skip_space(index)
+    match = _GO_HELPER_CALL_RE.match(source.masked, start)
+    if match is None:
+        return None
+    open_paren = source.masked.rfind("(", match.start(), match.end())
+    close = _matching_close(source.masked, open_paren, "(", ")")
+    if close is None:
+        return None
+    key_found, key, key_end = source.literal_at(match.end())
+    if not key_found or not key or not _literal_is_whole_value(source, key_end, ","):
+        return None
+    if not _TRANSLATION_KEY_RE.match(key):
+        return None
+    after_key = source.skip_space(key_end)
+    if after_key >= len(source.masked) or source.masked[after_key] != ",":
+        return None
+    found, value, end = source.literal_at(after_key + 1)
+    if not found or not value or not _literal_is_whole_value(source, end, ")"):
+        return None
+    # Exactly two arguments: what follows the second literal closes the call.
+    # `_matching_close` returns the index *past* the `)`, so the literal ends
+    # where the call does only when `skip_space(end) + 1 == close`.
+    return value if source.skip_space(end) + 1 == close else None
+
+
+def _go_option_description(
+    source: MaskedSource, open_paren: int, close: int
+) -> str | None:
+    """The description an option-function registration carries."""
+
+    for match in _GO_WITH_DESCRIPTION_RE.finditer(source.masked, open_paren, close):
+        found, value, end = source.literal_at(match.end())
+        if found and value and _literal_is_whole_value(source, end, ")"):
+            return value
+        if not found:
+            translated = _go_translated_default(source, match.end())
+            if translated:
+                return translated
+    return None
+
+
 _GO_STRUCT_DESCRIPTION_FIELD_RE = re.compile(r"(?<![\w])Description\s*:\s*")
 
 
@@ -1857,7 +1939,11 @@ def _literal_is_whole_value(
 
 
 def _call_sites(
-    source: MaskedSource, pattern: re.Pattern[str], idiom: str
+    source: MaskedSource,
+    pattern: re.Pattern[str],
+    idiom: str,
+    *,
+    describe: Callable[[MaskedSource, int, int], str | None] | None = None,
 ) -> list[RegistrationSite]:
     """Sites for a ``Name(<literal>, …)`` idiom."""
     sites: list[RegistrationSite] = []
@@ -1895,6 +1981,11 @@ def _call_sites(
                 line=line,
                 column=column,
                 span=span,
+                description=(
+                    describe(source, open_paren, close)
+                    if describe is not None and close is not None
+                    else None
+                ),
                 unresolved_reason=unresolved,
             )
         )
@@ -3470,8 +3561,16 @@ def scan_source(
         sites.extend(_ts_static_tool_name_sites(source))
         sites.extend(_call_sites(source, _TS_REGISTER_TOOL_RE, "ts_sdk_register_tool"))
     else:
-        sites.extend(_call_sites(source, _GO_MUST_TOOL_RE, "go_must_tool"))
-        sites.extend(_call_sites(source, _GO_NEW_TOOL_RE, "go_new_tool"))
+        sites.extend(
+            _call_sites(
+                source, _GO_MUST_TOOL_RE, "go_must_tool", describe=_go_option_description
+            )
+        )
+        sites.extend(
+            _call_sites(
+                source, _GO_NEW_TOOL_RE, "go_new_tool", describe=_go_option_description
+            )
+        )
         sites.extend(_go_tool_struct_sites(source))
 
     kept = [


### PR DESCRIPTION
First increment of #658; the issue remains open for annotations and broader qualification.

The Go reader missed descriptions stored in option calls and translated struct fields. The latter is the actual shape reported in #658: `mcp.Tool{Description: t("KEY", "default")}`. The original PR added only option extraction, so it still returned no descriptions for all four registrations in the checked upstream Actions file.

The final change reads direct `WithDescription`/`WithToolDescription` options and direct struct `Description` fields. It accepts a whole string literal or a complete two-string call to a declared `TranslationHelperFunc` parameter. It does not infer fallback semantics from arbitrary function names or key-shaped arguments. Unbound, reassigned and shadowed helper parameters remain unread.

Option order follows the SDK: a later description replaces an earlier one, including empty or computed values. Nested unapplied options cannot document the parent tool, and a partial translated expression cannot stand in for its complete value. Go trailing commas and comments are supported. The package reader and zero-install detector run the same added source corpus.

Validation: 1,714 final integration tests passed with one skip; all four performance tests and Ruff passed. The new regression cases cover scope, expression boundaries, option precedence and translated struct fields. The pinned upstream [Actions source](https://github.com/github/github-mcp-server/blob/7d13a7ad6f2a17f351a6d77ce280c85ae1821f4d/pkg/github/actions.go) changes from 0/4 descriptions on the original PR code to 4/4 on the corrected reader. This is a representative source check, not a claim that the complete 114-tool acceptance criterion has been rerun.

Source annotations, contradiction detection and the ten-server qualification table are outside this increment. No idiom ID or diff token changes, so `IDIOM_REGISTRY_VERSION` is unchanged; the registry's published descriptions now state the supported reads.
