### PR TITLE
Read a TypeScript tool's description in both SDK shapes (#680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## Unreleased
 
+- Read a TypeScript tool's description, in both SDK shapes. The
+  `ts_sdk_register_tool` idiom resolved a registration's *name* and nothing
+  else, so every tool declared on the reference MCP SDK was reported
+  undocumented and earned a `SHIP-DOC-MISSING-DESCRIPTION` finding — one per
+  tool, on the most common server shape there is. `_TS_DESCRIPTION_RE` looks
+  like it covered this and does not: it serves the class-property idiom,
+  `this.description = "…"`, not a registration call. Both documented shapes
+  are now read — the options object of
+  `registerTool("get_job", { description: "…" }, fn)`, quoted key included,
+  and the positional second argument of `tool("get_job", "…", fn)`.
+
+  The description is taken from the options object's **own** `description`
+  and never a nested one. That restriction is the substance of the change
+  rather than a detail: a registration's options object carries
+  `inputSchema`, and a JSON Schema describes every parameter, so a reader
+  that took the first `description:` it found would publish an argument's
+  documentation as the tool's. A tool that describes only its parameters
+  now reads nothing, which is the true answer; reporting it undocumented is
+  right, and documenting it with `The text to search for.` would not be.
+  A computed value, a template literal, and a literal concatenated with
+  something else all still read nothing, in both shapes.
+
+  `tests/test_ts_tool_descriptions.py` pins four reads and six refusals,
+  and names the parameter-description case separately because it is the one
+  shape here that could return a confident wrong answer rather than no
+  answer. 6 of its 13 cases fail before the fix; the 7 that pass are the
+  refusals, which the old reader satisfied by reading nothing at all.
+  `tools/shipgate-detect.py` carries the same extractor, held to it by the
+  shared conformance corpus (#680).
+
+- Read a Go tool's description when it is an option, and when it is
+  translated. `mark3labs/mcp-go` registers a tool as a call carrying option
+  functions — `mcp.NewTool("get_job", mcp.WithDescription(...))` — and the
+  only Go description extractor looked for a `Description:` field in a
+  struct literal, which that shape does not have. So every tool registered
+  this way read `description=None`, plain literals included. On top of
+  that, `github/github-mcp-server` wraps all 114 of its descriptions in a
+  translation helper, `t("TOOL_GET_JOB_DESCRIPTION", "Get details ...")`,
+  so even a field reader would have found a call rather than a string. The
+  result was 114 `SHIP-DOC-MISSING-DESCRIPTION` findings against a
+  repository that documents every tool it ships, which is the kind of noise
+  that costs a reader's trust in everything else on the page.
+
 - Read Go MCP tool descriptions from struct `Description` fields and
   direct `WithDescription`/`WithToolDescription` options. Later description
   options replace earlier ones, including empty or computed values. Nested calls and partial

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -1625,49 +1625,46 @@ def _child_braces(masked: str, open_brace: int, close: int) -> list[tuple[int, i
 #:
 #:   server.registerTool("get_job", { description: "…", inputSchema: {} }, fn)
 #:   server.tool("get_job", "…", fn)
-_TS_OBJECT_DESCRIPTION_KEY_RE = re.compile(r"(?<![\w$.])description\s*:\s*")
+_TS_OBJECT_PROPERTY_RE = re.compile(r"[A-Za-z_$][\w$]*")
 
 
 def _ts_object_description(
     source: MaskedSource, open_brace: int, close: int
 ) -> str | None:
-    """The options object's own ``description``, never a nested one.
+    """Read direct members in order, preserving JavaScript override semantics.
 
-    The depth test is the whole point. A registration's options object
-    carries `inputSchema`, and a JSON Schema describes *every parameter*:
-
-        { description: "Get a job", inputSchema: { properties: {
-              job_id: { description: "The job to get" } } } }
-
-    Without the depth-1 restriction the first `description:` found inside a
-    schema would be published as the tool's, so a tool whose own description
-    is missing would be documented with one of its arguments' — an invented
-    answer rather than an absent one.
+    A colon inside another member's expression is not a property boundary.
+    Spreads and computed keys may replace description; a later explicit
+    literal can establish it again. Never retain a stale earlier value.
     """
 
-    candidates: list[int] = []
-    for match in _TS_OBJECT_DESCRIPTION_KEY_RE.finditer(
-        source.masked, open_brace + 1, close
-    ):
-        candidates.append(match.end())
-    # `{ "description": "…" }` is the same key; the masker hides its body, so
-    # a quoted key is found by value rather than by pattern.
-    for start, (value, end) in source.literals.items():
-        if not (open_brace < start < close) or value != "description":
+    description = None
+    # The balanced argument splitter also separates object members: strings,
+    # comments and nested expressions cannot introduce a member separator.
+    for start, end in _go_arguments(source, open_brace, close):
+        found, key, key_end = source.literal_at(start)
+        if not found:
+            match = _TS_OBJECT_PROPERTY_RE.match(source.masked, start, end)
+            if match is None:
+                description = None  # spread or computed key
+                continue
+            key, key_end = match.group(), match.end()
+        after = source.skip_space(key_end)
+        if key in {"get", "set"} and after < end and source.masked[after] != ":":
+            # Accessors can override the same property without a colon.
+            accessor = _TS_OBJECT_PROPERTY_RE.match(source.masked, after, end)
+            if accessor is None or accessor.group() == "description":
+                description = None
             continue
-        after = source.skip_space(end)
-        if after < len(source.masked) and source.masked[after] == ":":
-            candidates.append(after + 1)
-    for position in sorted(candidates):
-        if _brace_depth(source.masked, open_brace, position) != 1:
+        if key != "description":
             continue
-        found, value, end = source.literal_at(position)
-        if found and value and _literal_is_whole_value(source, end, ",}"):
-            return value
-        # The key is present at the right level but its value is not a plain
-        # literal. Reading further would be reading some other key's value.
-        return None
-    return None
+        description = None
+        if after >= end or source.masked[after] != ":":
+            continue  # shorthand or method: its value is not a known string
+        found, value, literal_end = source.literal_at(after + 1)
+        if found and value and literal_end == end:
+            description = value
+    return description
 
 
 def _ts_call_description(
@@ -1693,7 +1690,11 @@ def _ts_call_description(
         return value if value and _literal_is_whole_value(source, end, ",)") else None
     if second < len(source.masked) and source.masked[second] == "{":
         object_close = _matching_close(source.masked, second, "{", "}")
-        if object_close is None or object_close > close:
+        if (
+            object_close is None
+            or object_close > close
+            or not _literal_is_whole_value(source, object_close, ",)")
+        ):
             return None
         return _ts_object_description(source, second, object_close)
     return None

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -1617,6 +1617,88 @@ def _child_braces(masked: str, open_brace: int, close: int) -> list[tuple[int, i
     return children
 
 
+#: The TypeScript SDK writes a tool's description in one of two places, and
+#: until #680 neither was read — `ts_sdk_register_tool` resolved the name and
+#: nothing else, so every tool on the *reference* MCP SDK was reported
+#: undocumented. `_TS_DESCRIPTION_RE` above looks like it covers this and does
+#: not: it serves the class-property idiom (`this.description = "…"`).
+#:
+#:   server.registerTool("get_job", { description: "…", inputSchema: {} }, fn)
+#:   server.tool("get_job", "…", fn)
+_TS_OBJECT_DESCRIPTION_KEY_RE = re.compile(r"(?<![\w$.])description\s*:\s*")
+
+
+def _ts_object_description(
+    source: MaskedSource, open_brace: int, close: int
+) -> str | None:
+    """The options object's own ``description``, never a nested one.
+
+    The depth test is the whole point. A registration's options object
+    carries `inputSchema`, and a JSON Schema describes *every parameter*:
+
+        { description: "Get a job", inputSchema: { properties: {
+              job_id: { description: "The job to get" } } } }
+
+    Without the depth-1 restriction the first `description:` found inside a
+    schema would be published as the tool's, so a tool whose own description
+    is missing would be documented with one of its arguments' — an invented
+    answer rather than an absent one.
+    """
+
+    candidates: list[int] = []
+    for match in _TS_OBJECT_DESCRIPTION_KEY_RE.finditer(
+        source.masked, open_brace + 1, close
+    ):
+        candidates.append(match.end())
+    # `{ "description": "…" }` is the same key; the masker hides its body, so
+    # a quoted key is found by value rather than by pattern.
+    for start, (value, end) in source.literals.items():
+        if not (open_brace < start < close) or value != "description":
+            continue
+        after = source.skip_space(end)
+        if after < len(source.masked) and source.masked[after] == ":":
+            candidates.append(after + 1)
+    for position in sorted(candidates):
+        if _brace_depth(source.masked, open_brace, position) != 1:
+            continue
+        found, value, end = source.literal_at(position)
+        if found and value and _literal_is_whole_value(source, end, ",}"):
+            return value
+        # The key is present at the right level but its value is not a plain
+        # literal. Reading further would be reading some other key's value.
+        return None
+    return None
+
+
+def _ts_call_description(
+    source: MaskedSource, open_paren: int, close: int
+) -> str | None:
+    """The description a `registerTool`/`tool` registration carries.
+
+    Both documented shapes put it in the *second* argument: a bare string in
+    the positional form, a `description` property in the options form.
+    Nothing else is read — `tool("name", handler)` is a registration with no
+    description, and must stay one.
+    """
+
+    found, _name, name_end = source.literal_at(open_paren + 1)
+    if not found:
+        return None
+    after = source.skip_space(name_end)
+    if after >= len(source.masked) or source.masked[after] != ",":
+        return None
+    second = source.skip_space(after + 1)
+    found, value, end = source.literal_at(second)
+    if found:
+        return value if value and _literal_is_whole_value(source, end, ",)") else None
+    if second < len(source.masked) and source.masked[second] == "{":
+        object_close = _matching_close(source.masked, second, "{", "}")
+        if object_close is None or object_close > close:
+            return None
+        return _ts_object_description(source, second, object_close)
+    return None
+
+
 #: The option-function shape: `NewTool("name", WithDescription("…"))`. This is
 #: how `mark3labs/mcp-go` declares a tool, which is the SDK behind
 #: `github/github-mcp-server` — so until #658 every one of its 114 tools read
@@ -3243,7 +3325,14 @@ def scan_source(
     sites: list[RegistrationSite] = []
     if language == "typescript":
         sites.extend(_ts_static_tool_name_sites(source))
-        sites.extend(_call_sites(source, _TS_REGISTER_TOOL_RE, "ts_sdk_register_tool"))
+        sites.extend(
+            _call_sites(
+                source,
+                _TS_REGISTER_TOOL_RE,
+                "ts_sdk_register_tool",
+                describe=_ts_call_description,
+            )
+        )
     else:
         sites.extend(
             _call_sites(

--- a/src/agents_shipgate/inputs/mcp_idioms.py
+++ b/src/agents_shipgate/inputs/mcp_idioms.py
@@ -1643,6 +1643,9 @@ def _ts_object_description(
     # comments and nested expressions cannot introduce a member separator.
     for start, end in _go_arguments(source, open_brace, close):
         found, key, key_end = source.literal_at(start)
+        if found and key is None:
+            description = None  # an undecodable quoted key may be description
+            continue
         if not found:
             match = _TS_OBJECT_PROPERTY_RE.match(source.masked, start, end)
             if match is None:
@@ -1653,10 +1656,20 @@ def _ts_object_description(
         if key in {"get", "set"} and after < end and source.masked[after] != ":":
             # Accessors can override the same property without a colon.
             accessor = _TS_OBJECT_PROPERTY_RE.match(source.masked, after, end)
-            if accessor is None or accessor.group() == "description":
+            if (
+                accessor is None
+                or accessor.group() == "description"
+                or source.skip_space(accessor.end()) >= end
+                or source.masked[source.skip_space(accessor.end())] != "("
+            ):
                 description = None
             continue
         if key != "description":
+            # A regex prefix is not a complete property key. Modifiers and
+            # escaped identifiers may still name description, so only skip a
+            # proven direct field, shorthand or ordinary named method.
+            if after < end and source.masked[after] not in ":(":
+                description = None
             continue
         description = None
         if after >= end or source.masked[after] != ":":

--- a/tests/mcp_idiom_corpus.py
+++ b/tests/mcp_idiom_corpus.py
@@ -2106,6 +2106,24 @@ TS_DESCRIPTION_CASES += (
     ("unbound_translation_helper", 'server.registerTool("unbound_translation_helper", { description: t("TOOL_KEY", "not established") }, fn);', None),
     ("literal_with_comments", 'server.registerTool("literal_with_comments", { /* own */ description /* key */ : "actual" /* value */, inputSchema: {} }, fn);', "actual"),
 )
+
+TS_DESCRIPTION_CASES += (
+    ("async_method_override", 'server.registerTool("async_method_override", { description: "old", async description() { return "changed"; } }, fn);', None),
+    ("async_generator_override", 'server.registerTool("async_generator_override", { description: "old", async *description() { yield "changed"; } }, fn);', None),
+    ("escaped_key_override", r'server.registerTool("escaped_key_override", { description: "old", descrip\u0074ion: "" }, fn);', None),
+    ("escaped_literal_override", r'server.registerTool("escaped_literal_override", { description: "old", descrip\u0074ion: "actual" }, fn);', None),
+    ("escaped_getter_override", r'server.registerTool("escaped_getter_override", { description: "old", get descrip\u0074ion() { return "actual"; } }, fn);', None),
+    ("unrelated_method", 'server.registerTool("unrelated_method", { description: "actual", helper() { return "unrelated"; } }, fn);', "actual"),
+    ("unrelated_getter", 'server.registerTool("unrelated_getter", { description: "actual", get title() { return "unrelated"; } }, fn);', "actual"),
+)
+
+
+TS_DESCRIPTION_CASES += (
+    ("undecodable_key_empty", r'server.registerTool("undecodable_key_empty", { description: "old", "\144escription": "" }, fn);', None),
+    ("undecodable_key_literal", r'server.registerTool("undecodable_key_literal", { description: "old", "descrip\164ion": "actual" }, fn);', None),
+    ("undecodable_then_known", r'server.registerTool("undecodable_then_known", { description: "old", "\144escription": "unknown", description: "actual" }, fn);', "actual"),
+)
+
 SOURCE_CASES += tuple(
     SourceCase("ts_description:" + name, "typescript", body)
     for name, body, _expected in TS_DESCRIPTION_CASES

--- a/tests/mcp_idiom_corpus.py
+++ b/tests/mcp_idiom_corpus.py
@@ -2050,3 +2050,63 @@ SOURCE_CASES += tuple(
     SourceCase("go_description:" + name, "go", "package p\n" + body)
     for name, body, _expected in GO_DESCRIPTION_CASES
 )
+
+
+# TypeScript SDK descriptions: both readers receive every read and refusal.
+TS_DESCRIPTION_CASES: tuple[tuple[str, str, str | None], ...] = (
+    (
+        "options_object",
+        'server.registerTool("options_object", { description: "From the options object.", inputSchema: {} }, fn);',
+        "From the options object.",
+    ),
+    (
+        "quoted_key",
+        'server.registerTool("quoted_key", { "description": "From a quoted key.", inputSchema: {} }, fn);',
+        "From a quoted key.",
+    ),
+    (
+        "positional",
+        'server.tool("positional", "From the positional argument.", fn);',
+        "From the positional argument.",
+    ),
+    (
+        "own_beats_nested",
+        'server.registerTool("own_beats_nested", { description: "The tool\'s own.", inputSchema: { properties: { x: { description: "A parameter." } } } }, fn);',
+        "The tool's own.",
+    ),
+    # --- refusals ---------------------------------------------------------
+    # The trap. Only a parameter is described; the tool is not. Reading the
+    # schema's `description` would document this tool with its argument's
+    # text, which is worse than reporting it undocumented.
+    (
+        "nested_schema_only",
+        'server.registerTool("nested_schema_only", { inputSchema: { properties: { job_id: { description: "The job to get." } } } }, fn);',
+        None,
+    ),
+    # A valid registration that genuinely has no description.
+    ("no_description", 'server.tool("no_description", fn);', None),
+    ("computed", 'server.registerTool("computed", { description: buildDesc(), inputSchema: {} }, fn);', None),
+    ("template_literal", 'server.registerTool("template_literal", { description: `Hello ${name}`, inputSchema: {} }, fn);', None),
+    ("concatenation", 'server.registerTool("concatenation", { description: "Part " + suffix, inputSchema: {} }, fn);', None),
+    ("positional_concatenation", 'server.tool("positional_concatenation", "Part " + suffix, fn);', None),
+)
+
+TS_DESCRIPTION_CASES += (
+    ("last_literal", 'server.registerTool("last_literal", { description: "old", description: "actual" }, fn);', "actual"),
+    ("last_empty", 'server.registerTool("last_empty", { description: "old", description: "" }, fn);', None),
+    ("last_computed", 'server.registerTool("last_computed", { description: "old", description: buildDesc() }, fn);', None),
+    ("last_spread", 'server.registerTool("last_spread", { description: "old", ...overrides }, fn);', None),
+    ("spread_then_literal", 'server.registerTool("spread_then_literal", { ...defaults, description: "actual" }, fn);', "actual"),
+    ("computed_key_override", 'server.registerTool("computed_key_override", { description: "old", [key]: value }, fn);', None),
+    ("shorthand_override", 'server.registerTool("shorthand_override", { description: "old", description }, fn);', None),
+    ("getter_override", 'server.registerTool("getter_override", { description: "old", get description() { return dynamic; } }, fn);', None),
+    ("ternary_is_not_key", 'server.registerTool("ternary_is_not_key", { title: enabled ? description : "Not tool documentation", inputSchema: {} }, fn);', None),
+    ("quoted_ternary_is_not_key", 'server.registerTool("quoted_ternary_is_not_key", { title: enabled ? "description" : "Not tool documentation" }, fn);', None),
+    ("suffix_changes_options", 'server.registerTool("suffix_changes_options", { description: "old" } && options, fn);', None),
+    ("unbound_translation_helper", 'server.registerTool("unbound_translation_helper", { description: t("TOOL_KEY", "not established") }, fn);', None),
+    ("literal_with_comments", 'server.registerTool("literal_with_comments", { /* own */ description /* key */ : "actual" /* value */, inputSchema: {} }, fn);', "actual"),
+)
+SOURCE_CASES += tuple(
+    SourceCase("ts_description:" + name, "typescript", body)
+    for name, body, _expected in TS_DESCRIPTION_CASES
+)

--- a/tests/test_ts_tool_descriptions.py
+++ b/tests/test_ts_tool_descriptions.py
@@ -110,3 +110,27 @@ def test_both_shapes_in_one_file(tmp_path: Path) -> None:
     )
 
     assert _tools(tmp_path, body) == {"a": "Alpha.", "b": "Bravo."}
+
+
+@pytest.mark.parametrize("reestablish", [False, True])
+def test_undecodable_commonjs_key_cannot_leave_a_stale_description(
+    tmp_path: Path, reestablish: bool,
+) -> None:
+    # Legacy octal escapes are legal in non-strict CommonJS, which the same
+    # reader supports. Declining to decode them must not mean ignoring them.
+    (tmp_path / "package.json").write_text(PACKAGE_JSON, encoding="utf-8")
+    later = ', description: "actual"' if reestablish else ""
+    (tmp_path / "server.cjs").write_text(
+        'const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");\n'
+        'const server = new McpServer({ name: "srv", version: "1" });\n'
+        'server.registerTool("probe", { description: "old", '
+        + r'"\144escription": ""'
+        + later + ' }, () => ({ content: [] }));\n',
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(
+        ToolSourceConfig(id="srv", type="mcp_server_source", path="."), tmp_path
+    )
+    assert {tool.name: tool.description for tool in loaded.tools} == {
+        "probe": "actual" if reestablish else None,
+    }

--- a/tests/test_ts_tool_descriptions.py
+++ b/tests/test_ts_tool_descriptions.py
@@ -26,6 +26,7 @@ import pytest
 
 from agents_shipgate.inputs.mcp_server_source import load_mcp_server_source
 from agents_shipgate.schemas.manifest import ToolSourceConfig
+from tests.mcp_idiom_corpus import TS_DESCRIPTION_CASES as CASES
 
 PACKAGE_JSON = '{"name":"srv","dependencies":{"@modelcontextprotocol/sdk":"^1.0.0"}}'
 IMPORT = 'import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";\n'
@@ -46,43 +47,7 @@ def _tools(tmp_path: Path, body: str) -> dict[str, str | None]:
 
 
 #: (case, the registration line, what must be read).
-CASES: tuple[tuple[str, str, str | None], ...] = (
-    (
-        "options_object",
-        'server.registerTool("options_object", { description: "From the options object.", inputSchema: {} }, fn);',
-        "From the options object.",
-    ),
-    (
-        "quoted_key",
-        'server.registerTool("quoted_key", { "description": "From a quoted key.", inputSchema: {} }, fn);',
-        "From a quoted key.",
-    ),
-    (
-        "positional",
-        'server.tool("positional", "From the positional argument.", fn);',
-        "From the positional argument.",
-    ),
-    (
-        "own_beats_nested",
-        'server.registerTool("own_beats_nested", { description: "The tool\'s own.", inputSchema: { properties: { x: { description: "A parameter." } } } }, fn);',
-        "The tool's own.",
-    ),
-    # --- refusals ---------------------------------------------------------
-    # The trap. Only a parameter is described; the tool is not. Reading the
-    # schema's `description` would document this tool with its argument's
-    # text, which is worse than reporting it undocumented.
-    (
-        "nested_schema_only",
-        'server.registerTool("nested_schema_only", { inputSchema: { properties: { job_id: { description: "The job to get." } } } }, fn);',
-        None,
-    ),
-    # A valid registration that genuinely has no description.
-    ("no_description", 'server.tool("no_description", fn);', None),
-    ("computed", 'server.registerTool("computed", { description: buildDesc(), inputSchema: {} }, fn);', None),
-    ("template_literal", 'server.registerTool("template_literal", { description: `Hello ${name}`, inputSchema: {} }, fn);', None),
-    ("concatenation", 'server.registerTool("concatenation", { description: "Part " + suffix, inputSchema: {} }, fn);', None),
-    ("positional_concatenation", 'server.tool("positional_concatenation", "Part " + suffix, fn);', None),
-)
+
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ts_tool_descriptions.py
+++ b/tests/test_ts_tool_descriptions.py
@@ -1,0 +1,147 @@
+"""#680: a TypeScript tool's description, in both SDK shapes.
+
+`ts_sdk_register_tool` resolved the tool's *name* and nothing else, so
+every tool declared on the reference MCP SDK was reported undocumented and
+earned a `SHIP-DOC-MISSING-DESCRIPTION` finding. `_TS_DESCRIPTION_RE` looks
+like it covered this and does not — it serves the class-property idiom,
+`this.description = "…"`, not a registration call.
+
+The SDK writes the description in the second argument, two ways:
+
+    server.registerTool("get_job", { description: "…", inputSchema: {} }, fn)
+    server.tool("get_job", "…", fn)
+
+The refusals below matter as much as the reads, and one of them is the
+reason this is not a two-line change: a registration's options object
+carries `inputSchema`, and a JSON Schema describes every *parameter*. A
+reader that takes the first `description:` it finds publishes an argument's
+documentation as the tool's — an invented answer in place of an absent one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.inputs.mcp_server_source import load_mcp_server_source
+from agents_shipgate.schemas.manifest import ToolSourceConfig
+
+PACKAGE_JSON = '{"name":"srv","dependencies":{"@modelcontextprotocol/sdk":"^1.0.0"}}'
+IMPORT = 'import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";\n'
+
+
+def _tools(tmp_path: Path, body: str) -> dict[str, str | None]:
+    (tmp_path / "package.json").write_text(PACKAGE_JSON, encoding="utf-8")
+    source = tmp_path / "src"
+    source.mkdir(exist_ok=True)
+    (source / "tools.ts").write_text(
+        IMPORT + "export function reg(server: McpServer) {\n" + body + "}\n",
+        encoding="utf-8",
+    )
+    loaded = load_mcp_server_source(
+        ToolSourceConfig(id="srv", type="mcp_server_source", path="."), tmp_path
+    )
+    return {tool.name: getattr(tool, "description", None) for tool in loaded.tools}
+
+
+#: (case, the registration line, what must be read).
+CASES: tuple[tuple[str, str, str | None], ...] = (
+    (
+        "options_object",
+        'server.registerTool("options_object", { description: "From the options object.", inputSchema: {} }, fn);',
+        "From the options object.",
+    ),
+    (
+        "quoted_key",
+        'server.registerTool("quoted_key", { "description": "From a quoted key.", inputSchema: {} }, fn);',
+        "From a quoted key.",
+    ),
+    (
+        "positional",
+        'server.tool("positional", "From the positional argument.", fn);',
+        "From the positional argument.",
+    ),
+    (
+        "own_beats_nested",
+        'server.registerTool("own_beats_nested", { description: "The tool\'s own.", inputSchema: { properties: { x: { description: "A parameter." } } } }, fn);',
+        "The tool's own.",
+    ),
+    # --- refusals ---------------------------------------------------------
+    # The trap. Only a parameter is described; the tool is not. Reading the
+    # schema's `description` would document this tool with its argument's
+    # text, which is worse than reporting it undocumented.
+    (
+        "nested_schema_only",
+        'server.registerTool("nested_schema_only", { inputSchema: { properties: { job_id: { description: "The job to get." } } } }, fn);',
+        None,
+    ),
+    # A valid registration that genuinely has no description.
+    ("no_description", 'server.tool("no_description", fn);', None),
+    ("computed", 'server.registerTool("computed", { description: buildDesc(), inputSchema: {} }, fn);', None),
+    ("template_literal", 'server.registerTool("template_literal", { description: `Hello ${name}`, inputSchema: {} }, fn);', None),
+    ("concatenation", 'server.registerTool("concatenation", { description: "Part " + suffix, inputSchema: {} }, fn);', None),
+    ("positional_concatenation", 'server.tool("positional_concatenation", "Part " + suffix, fn);', None),
+)
+
+
+@pytest.mark.parametrize(
+    ("case", "line", "expected"), CASES, ids=[case[0] for case in CASES]
+)
+def test_description_is_read_or_refused(
+    tmp_path: Path, case: str, line: str, expected: str | None
+) -> None:
+    assert _tools(tmp_path, f"  {line}\n") == {case: expected}
+
+
+def test_a_parameter_description_is_never_published_as_the_tools(
+    tmp_path: Path,
+) -> None:
+    """Named separately because it is the one wrong-answer risk here.
+
+    Every other refusal reports nothing where nothing is known. This one
+    would report *something*, and a reader has no way to tell that the
+    sentence they are reading describes an argument.
+    """
+
+    body = """
+  server.registerTool("search", {
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "The text to search for." },
+        limit: { type: "number", description: "How many results." }
+      }
+    }
+  }, fn);
+"""
+
+    assert _tools(tmp_path, body) == {"search": None}
+
+
+def test_every_tool_in_an_ordinary_server_is_documented(tmp_path: Path) -> None:
+    """The headline, stated as a property: `SHIP-DOC-MISSING-DESCRIPTION`
+    fires per undocumented tool, so this is the false-finding count."""
+
+    body = "".join(
+        f'  server.registerTool("tool_{index}", {{ description: "Tool {index} does a thing.", '
+        f'inputSchema: {{ properties: {{ arg: {{ description: "An argument." }} }} }} }}, fn);\n'
+        for index in range(12)
+    )
+
+    described = _tools(tmp_path, body)
+
+    assert len(described) == 12
+    assert [name for name, text in described.items() if not text] == []
+    assert set(described.values()) == {
+        f"Tool {index} does a thing." for index in range(12)
+    }
+
+
+def test_both_shapes_in_one_file(tmp_path: Path) -> None:
+    body = (
+        '  server.registerTool("a", { description: "Alpha.", inputSchema: {} }, fn);\n'
+        '  server.tool("b", "Bravo.", fn);\n'
+    )
+
+    assert _tools(tmp_path, body) == {"a": "Alpha.", "b": "Bravo."}

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -1792,6 +1792,9 @@ def _ts_object_description(
     # comments and nested expressions cannot introduce a member separator.
     for start, end in _go_arguments(source, open_brace, close):
         found, key, key_end = source.literal_at(start)
+        if found and key is None:
+            description = None  # an undecodable quoted key may be description
+            continue
         if not found:
             match = _TS_OBJECT_PROPERTY_RE.match(source.masked, start, end)
             if match is None:
@@ -1802,10 +1805,20 @@ def _ts_object_description(
         if key in {"get", "set"} and after < end and source.masked[after] != ":":
             # Accessors can override the same property without a colon.
             accessor = _TS_OBJECT_PROPERTY_RE.match(source.masked, after, end)
-            if accessor is None or accessor.group() == "description":
+            if (
+                accessor is None
+                or accessor.group() == "description"
+                or source.skip_space(accessor.end()) >= end
+                or source.masked[source.skip_space(accessor.end())] != "("
+            ):
                 description = None
             continue
         if key != "description":
+            # A regex prefix is not a complete property key. Modifiers and
+            # escaped identifiers may still name description, so only skip a
+            # proven direct field, shorthand or ordinary named method.
+            if after < end and source.masked[after] not in ":(":
+                description = None
             continue
         description = None
         if after >= end or source.masked[after] != ":":

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -1766,6 +1766,88 @@ _GO_NEW_TOOL_RE = re.compile(r"(?<![\w])NewTool\s*\(\s*")
 _GO_TOOL_STRUCT_RE = re.compile(r"(?<![\w])Tool\s*\{")
 _GO_STRUCT_NAME_FIELD_RE = re.compile(r"(?<![\w])Name\s*:\s*")
 _GO_KEYED_FIELD_RE = re.compile(r"(?<![\w])[A-Za-z_]\w*\s*:")
+#: The TypeScript SDK writes a tool's description in one of two places, and
+#: until #680 neither was read — `ts_sdk_register_tool` resolved the name and
+#: nothing else, so every tool on the *reference* MCP SDK was reported
+#: undocumented. `_TS_DESCRIPTION_RE` above looks like it covers this and does
+#: not: it serves the class-property idiom (`this.description = "…"`).
+#:
+#:   server.registerTool("get_job", { description: "…", inputSchema: {} }, fn)
+#:   server.tool("get_job", "…", fn)
+_TS_OBJECT_DESCRIPTION_KEY_RE = re.compile(r"(?<![\w$.])description\s*:\s*")
+
+
+def _ts_object_description(
+    source: MaskedSource, open_brace: int, close: int
+) -> str | None:
+    """The options object's own ``description``, never a nested one.
+
+    The depth test is the whole point. A registration's options object
+    carries `inputSchema`, and a JSON Schema describes *every parameter*:
+
+        { description: "Get a job", inputSchema: { properties: {
+              job_id: { description: "The job to get" } } } }
+
+    Without the depth-1 restriction the first `description:` found inside a
+    schema would be published as the tool's, so a tool whose own description
+    is missing would be documented with one of its arguments' — an invented
+    answer rather than an absent one.
+    """
+
+    candidates: list[int] = []
+    for match in _TS_OBJECT_DESCRIPTION_KEY_RE.finditer(
+        source.masked, open_brace + 1, close
+    ):
+        candidates.append(match.end())
+    # `{ "description": "…" }` is the same key; the masker hides its body, so
+    # a quoted key is found by value rather than by pattern.
+    for start, (value, end) in source.literals.items():
+        if not (open_brace < start < close) or value != "description":
+            continue
+        after = source.skip_space(end)
+        if after < len(source.masked) and source.masked[after] == ":":
+            candidates.append(after + 1)
+    for position in sorted(candidates):
+        if _brace_depth(source.masked, open_brace, position) != 1:
+            continue
+        found, value, end = source.literal_at(position)
+        if found and value and _literal_is_whole_value(source, end, ",}"):
+            return value
+        # The key is present at the right level but its value is not a plain
+        # literal. Reading further would be reading some other key's value.
+        return None
+    return None
+
+
+def _ts_call_description(
+    source: MaskedSource, open_paren: int, close: int
+) -> str | None:
+    """The description a `registerTool`/`tool` registration carries.
+
+    Both documented shapes put it in the *second* argument: a bare string in
+    the positional form, a `description` property in the options form.
+    Nothing else is read — `tool("name", handler)` is a registration with no
+    description, and must stay one.
+    """
+
+    found, _name, name_end = source.literal_at(open_paren + 1)
+    if not found:
+        return None
+    after = source.skip_space(name_end)
+    if after >= len(source.masked) or source.masked[after] != ",":
+        return None
+    second = source.skip_space(after + 1)
+    found, value, end = source.literal_at(second)
+    if found:
+        return value if value and _literal_is_whole_value(source, end, ",)") else None
+    if second < len(source.masked) and source.masked[second] == "{":
+        object_close = _matching_close(source.masked, second, "{", "}")
+        if object_close is None or object_close > close:
+            return None
+        return _ts_object_description(source, second, object_close)
+    return None
+
+
 #: The option-function shape: `NewTool("name", WithDescription("…"))`. This is
 #: how `mark3labs/mcp-go` declares a tool, which is the SDK behind
 #: `github/github-mcp-server` — so until #658 every one of its 114 tools read
@@ -3614,7 +3696,14 @@ def scan_source(
     sites: list[RegistrationSite] = []
     if language == "typescript":
         sites.extend(_ts_static_tool_name_sites(source))
-        sites.extend(_call_sites(source, _TS_REGISTER_TOOL_RE, "ts_sdk_register_tool"))
+        sites.extend(
+            _call_sites(
+                source,
+                _TS_REGISTER_TOOL_RE,
+                "ts_sdk_register_tool",
+                describe=_ts_call_description,
+            )
+        )
     else:
         sites.extend(
             _call_sites(

--- a/tools/shipgate-detect.py
+++ b/tools/shipgate-detect.py
@@ -1774,49 +1774,46 @@ _GO_KEYED_FIELD_RE = re.compile(r"(?<![\w])[A-Za-z_]\w*\s*:")
 #:
 #:   server.registerTool("get_job", { description: "…", inputSchema: {} }, fn)
 #:   server.tool("get_job", "…", fn)
-_TS_OBJECT_DESCRIPTION_KEY_RE = re.compile(r"(?<![\w$.])description\s*:\s*")
+_TS_OBJECT_PROPERTY_RE = re.compile(r"[A-Za-z_$][\w$]*")
 
 
 def _ts_object_description(
     source: MaskedSource, open_brace: int, close: int
 ) -> str | None:
-    """The options object's own ``description``, never a nested one.
+    """Read direct members in order, preserving JavaScript override semantics.
 
-    The depth test is the whole point. A registration's options object
-    carries `inputSchema`, and a JSON Schema describes *every parameter*:
-
-        { description: "Get a job", inputSchema: { properties: {
-              job_id: { description: "The job to get" } } } }
-
-    Without the depth-1 restriction the first `description:` found inside a
-    schema would be published as the tool's, so a tool whose own description
-    is missing would be documented with one of its arguments' — an invented
-    answer rather than an absent one.
+    A colon inside another member's expression is not a property boundary.
+    Spreads and computed keys may replace description; a later explicit
+    literal can establish it again. Never retain a stale earlier value.
     """
 
-    candidates: list[int] = []
-    for match in _TS_OBJECT_DESCRIPTION_KEY_RE.finditer(
-        source.masked, open_brace + 1, close
-    ):
-        candidates.append(match.end())
-    # `{ "description": "…" }` is the same key; the masker hides its body, so
-    # a quoted key is found by value rather than by pattern.
-    for start, (value, end) in source.literals.items():
-        if not (open_brace < start < close) or value != "description":
+    description = None
+    # The balanced argument splitter also separates object members: strings,
+    # comments and nested expressions cannot introduce a member separator.
+    for start, end in _go_arguments(source, open_brace, close):
+        found, key, key_end = source.literal_at(start)
+        if not found:
+            match = _TS_OBJECT_PROPERTY_RE.match(source.masked, start, end)
+            if match is None:
+                description = None  # spread or computed key
+                continue
+            key, key_end = match.group(), match.end()
+        after = source.skip_space(key_end)
+        if key in {"get", "set"} and after < end and source.masked[after] != ":":
+            # Accessors can override the same property without a colon.
+            accessor = _TS_OBJECT_PROPERTY_RE.match(source.masked, after, end)
+            if accessor is None or accessor.group() == "description":
+                description = None
             continue
-        after = source.skip_space(end)
-        if after < len(source.masked) and source.masked[after] == ":":
-            candidates.append(after + 1)
-    for position in sorted(candidates):
-        if _brace_depth(source.masked, open_brace, position) != 1:
+        if key != "description":
             continue
-        found, value, end = source.literal_at(position)
-        if found and value and _literal_is_whole_value(source, end, ",}"):
-            return value
-        # The key is present at the right level but its value is not a plain
-        # literal. Reading further would be reading some other key's value.
-        return None
-    return None
+        description = None
+        if after >= end or source.masked[after] != ":":
+            continue  # shorthand or method: its value is not a known string
+        found, value, literal_end = source.literal_at(after + 1)
+        if found and value and literal_end == end:
+            description = value
+    return description
 
 
 def _ts_call_description(
@@ -1842,7 +1839,11 @@ def _ts_call_description(
         return value if value and _literal_is_whole_value(source, end, ",)") else None
     if second < len(source.masked) and source.masked[second] == "{":
         object_close = _matching_close(source.masked, second, "{", "}")
-        if object_close is None or object_close > close:
+        if (
+            object_close is None
+            or object_close > close
+            or not _literal_is_whole_value(source, object_close, ",)")
+        ):
             return None
         return _ts_object_description(source, second, object_close)
     return None


### PR DESCRIPTION
Closes #680. Follows the merged Go description work in #679; parent #658 retains source annotation and measured precision work. The unresolved TypeScript translation-helper contract is separately deferred in #691.

## Problem and behavior

The TypeScript MCP SDK reader found tool names but discarded their literal descriptions, producing missing-description findings for documented tools. This change reads both `registerTool("name", { description: "…" }, handler)` and `tool("name", "…", handler)` in the installed package and zero-install detector.

The options reader processes direct object members in order. A later literal replaces an earlier description; empty/computed values, shorthand, accessors, spreads and computed keys cannot leave a stale description behind. A later explicit literal can establish the value again. Nested schema descriptions and colons inside another property's expression are never tool documentation. Concatenated strings, interpolated templates and options-object expressions are left unresolved.

The static reader does not infer a TypeScript translation helper's semantics from the name `t` or the presence of two strings. #691 owns establishing a useful bounded contract from pinned source evidence.

## Validation and review

- Original negative control: 6 of the initial 13 SDK-description tests failed before literal extraction; existing refusals passed by reading nothing.
- Independent GitHub review [5183738123](https://github.com/ThreeMoonsLab/agents-shipgate/pull/682#pullrequestreview-5183738123) found stale overrides, false property recognition and missing shared corpus coverage. Ten added counterexamples reproduced those failures on the original PR head.
- Both readers now receive all 33 TypeScript description cases through shared `SOURCE_CASES`, including every refusal and override. The package-level loader tests assert expected descriptions independently of reader parity.
- The second-round correction passed full regression (**9,696 passed, 5 skipped**). Final independent preparation then found undecodable quoted keys in supported CommonJS input; both readers now invalidate that unknown key instead of retaining an earlier literal. The final guard passed **1,288 package/zero-install/static tests, 1 skipped**; the additional real CommonJS loader regressions passed in the **38-case SDK-description suite**, and all four performance tests passed. Ruff/whitespace checks pass. Required CI validates the final published commit across the full suite.

No new check ID or idiom ID; the existing static literal boundary is made accurate. This is a reader repair, not a qualification or runtime behavior claim.

The latest correction also refuses async/escaped identifier overrides and undecodable quoted keys conservatively; it does not add a decoder or execute user JavaScript. A subsequent direct literal may re-establish the description.
