### PR TITLE
Give shallow diff checkouts a runnable recovery instead of a traceback (#683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Detect shallow checkouts before `diff` scans either side. Print a scoped
+  `git fetch --unshallow` recovery (or `fetch-depth: 0` for CI) instead of
+  an object-integrity traceback; agent-mode errors carry the same runnable
+  next action. Object integrity checks remain unchanged (#683).
+
 - Read Go MCP tool descriptions from struct `Description` fields and
   direct `WithDescription`/`WithToolDescription` options. Later description
   options replace earlier ones, including empty or computed values. Nested calls and partial

--- a/src/agents_shipgate/cli/diff.py
+++ b/src/agents_shipgate/cli/diff.py
@@ -40,6 +40,7 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
     """The base ref and the merge-base commit this diff compares against."""
 
     from agents_shipgate.cli.verify.git import (
+        _history_is_truncated,
         commit_sha,
         detect_default_base,
         merge_base_sha,
@@ -47,6 +48,26 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
 
     if base is not None and (not base.strip() or base.startswith("-")):
         raise typer.BadParameter("Base ref must be non-empty and cannot start with a dash.", param_hint="--base")
+
+    if _history_is_truncated(workspace) is True:
+        from agents_shipgate.cli.agent_mode import emit_agent_mode_error_action
+        from agents_shipgate.invocation import join_argv
+        from agents_shipgate.schemas.diagnostics import NextAction
+
+        command = join_argv(["git", "-C", str(workspace), "fetch", "--unshallow"])
+        message = (
+            f"This checkout is shallow; run {command} "
+            "(or use fetch-depth: 0 in CI), then rerun diff."
+        )
+        # A shallow boundary is expected missing history, not a corrupt graph.
+        # Keep archive validation intact and recover before scanning either side.
+        emit_agent_mode_error_action(
+            "config_error",
+            message=message,
+            exit_code=2,
+            action=NextAction(kind="command", command=command, why=message),
+        )
+        raise typer.BadParameter(message, param_hint="--workspace")
 
     # Same resolver `check` uses (#649), including its narrow local
     # fallback: a local `main` is refused while a remote exists, because the

--- a/src/agents_shipgate/cli/diff.py
+++ b/src/agents_shipgate/cli/diff.py
@@ -61,13 +61,16 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
         )
         # A shallow boundary is expected missing history, not a corrupt graph.
         # Keep archive validation intact and recover before scanning either side.
+        # Plain stderr keeps the command copyable; Rich parameter panels can
+        # split paths/flags across lines in a narrow or color-enabled terminal.
+        typer.echo(message, err=True)
         emit_agent_mode_error_action(
             "config_error",
             message=message,
             exit_code=2,
             action=NextAction(kind="command", command=command, why=message),
         )
-        raise typer.BadParameter(message, param_hint="--workspace")
+        raise typer.Exit(2)
 
     # Same resolver `check` uses (#649), including its narrow local
     # fallback: a local `main` is refused while a remote exists, because the

--- a/tests/test_capability_diff.py
+++ b/tests/test_capability_diff.py
@@ -14,6 +14,7 @@ is the defect this command must not become.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -270,6 +271,48 @@ def test_a_removal_is_never_reported_as_an_expansion() -> None:
 
 
 # --- refusals --------------------------------------------------------------
+
+
+@pytest.mark.parametrize("depth", [1, 2])
+@pytest.mark.parametrize("json_output", [False, True])
+@pytest.mark.parametrize("agent_mode", ["0", "1"])
+def test_shallow_checkout_names_a_recovery_that_restores_the_diff(
+    repo: Path, tmp_path: Path, depth: int, json_output: bool, agent_mode: str
+) -> None:
+    for index in range(2):
+        (repo / "README.md").write_text(f"# revision {index}\n", encoding="utf-8")
+        _git(repo, "add", "README.md")
+        _git(repo, "commit", "-qm", f"history {index}")
+    clone = tmp_path / "shallow checkout"
+    _git(tmp_path, "clone", "--quiet", "--depth", str(depth), repo.as_uri(), str(clone))
+    (clone / ".claude" / "settings.json").write_text(WIDE_SETTINGS, encoding="utf-8")
+    args = ["diff", "--workspace", str(clone), "--base", "HEAD"]
+    if json_output:
+        args.append("--json")
+
+    result = runner.invoke(app, args, env={"AGENTS_SHIPGATE_AGENT_MODE": agent_mode})
+
+    assert result.exit_code == 2, result.output
+    assert "This checkout is shallow" in result.output
+    assert "fetch-depth: 0" in result.output
+    assert "Traceback" not in result.output
+    recovery = ["git", "-C", str(clone), "fetch", "--unshallow"]
+    errors = [json.loads(line) for line in result.stderr.splitlines() if line.startswith("{")]
+    if agent_mode == "1":
+        assert len(errors) == 1
+        assert errors[0]["error"] == "config_error"
+        action = errors[0]["next_actions"][0]
+        assert shlex.split(action["command"]) == recovery
+        recovery = shlex.split(action["command"])
+    else:
+        assert errors == []
+        assert "--unshallow" in result.output
+    # Follow the published action from outside the checkout. This must restore
+    # the actual comparison, without init, policy edits or a wrapper fetch.
+    subprocess.run(recovery, cwd=tmp_path, check=True, capture_output=True)
+    recovered = _diff(clone, "--base", "HEAD", "--json")
+    assert recovered.exit_code == 0, recovered.output
+    assert any(row["after"] == "Bash(*)" for row in json.loads(recovered.output)["rows"])
 
 
 def test_an_absent_base_ref_is_refused_by_name(repo: Path) -> None:

--- a/tests/test_capability_diff.py
+++ b/tests/test_capability_diff.py
@@ -277,8 +277,12 @@ def test_a_removal_is_never_reported_as_an_expansion() -> None:
 @pytest.mark.parametrize("json_output", [False, True])
 @pytest.mark.parametrize("agent_mode", ["0", "1"])
 def test_shallow_checkout_names_a_recovery_that_restores_the_diff(
-    repo: Path, tmp_path: Path, depth: int, json_output: bool, agent_mode: str
+    repo: Path, tmp_path: Path, depth: int, json_output: bool, agent_mode: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Hosted CI enables Rich color; the recovery must still be one copyable line.
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("COLUMNS", "60")
     for index in range(2):
         (repo / "README.md").write_text(f"# revision {index}\n", encoding="utf-8")
         _git(repo, "add", "README.md")
@@ -306,7 +310,7 @@ def test_shallow_checkout_names_a_recovery_that_restores_the_diff(
         recovery = shlex.split(action["command"])
     else:
         assert errors == []
-        assert "--unshallow" in result.output
+        assert any(shlex.join(recovery) in line for line in result.stderr.splitlines())
     # Follow the published action from outside the checkout. This must restore
     # the actual comparison, without init, policy edits or a wrapper fetch.
     subprocess.run(recovery, cwd=tmp_path, check=True, capture_output=True)


### PR DESCRIPTION
Closes #683.

## Problem and change

A shallow checkout previously reached the isolated Git object copy, where the expected missing parent became an integrity traceback with no recovery. `diff` now detects the shallow boundary before scanning either side and exits 2 with a workspace-qualified `git fetch --unshallow` command and `fetch-depth: 0` CI guidance. The sentence is plain stderr so Rich cannot split or style the recovery command; agent mode also carries the same typed, runnable next action.

This implements the issue's explicit fail-early option. It does not fetch automatically or weaken object validation. #686 separately owns reducing the history copied for a comparison and eventual direct shallow-tree support; #688 owns the separate symlink/submodule refusal.

## Validation

- Real `file://` shallow clones at depths 1 and 2 reproduce the previous failure. The pre-fix test run failed all four initial recovery cases.
- The final regression covers human and agent modes, text and JSON requests, a workspace path containing spaces, executing the emitted recovery from outside the checkout, and successfully comparing a widened permission afterward.
- Capability diff, Git snapshot integrity and source identity regression: **48 passed**.
- `ruff check .` and `git diff --check` pass.

Full repository regression: **9,611 passed, 5 skipped** in the parallel non-performance partition; **486 static-only + 4 performance tests passed** in the remaining partitions. Round 1 review/address is recorded below. Hosted CI exposed a Rich formatting defect, fixed in `db955d9b`; forced-color/narrow-terminal tests and the full regression now pass locally. Round 2 independently reviews that correction before merge. This fixes one adoption blocker; it is not a v1.0 readiness or qualification claim.
