### PR TITLE
Read the base tree the host reader will read, and no more (#686, #688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Compare a shallow checkout against a base it already holds. `diff`
+  refused every shallow checkout, so `actions/checkout`'s default
+  (`fetch-depth: 1`) was sent to `git fetch --unshallow` for a comparison
+  the tool could already answer: the base tree is read through a scoped
+  archive that walks no ancestry. The recovery now fires when the base
+  ref or the merge base is genuinely unavailable, which is what Git
+  reports past a graft — measured on two diverged shallow clones, it
+  returns nothing rather than a wrong commit (#686).
+
 - Read the base tree the host reader will read, and no more. `shipgate diff`
   and verify's host comparison now materialize only boundary-surface paths
   (plus symlinks, which are what can conceal them),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Read the base tree the host reader will read, and no more. `shipgate diff`
+  and verify's host comparison now materialize only boundary-surface paths
+  (plus symlinks, which are what can conceal them),
+  packing the tree rather than the commit. A 26 MB repository with 1,168 files
+  and four host files took 25s and now takes 2.7s, and a shallow clone is
+  comparable for a commit it already holds. An unrelated symlink no longer
+  makes a repository uncomparable: one outside the surface is not
+  materialized, a symlink to a non-directory can conceal no boundary path,
+  and a scoped archive recreates links instead of refusing the tree. Unscoped
+  archives, which verify uses for the release decision, still refuse every
+  external binding (#686, #688).
+
 - Manifest-free host PR review now names capability changes in verify, PR comments,
   and check. Interactive check defaults to readable text; agent mode keeps JSON.
   Comparison evidence binds its input refs, excludes stale scan artifacts, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,16 @@
 
 ## Unreleased
 
-- Compare a shallow checkout against a base it already holds. `diff`
-  refused every shallow checkout, so `actions/checkout`'s default
-  (`fetch-depth: 1`) was sent to `git fetch --unshallow` for a comparison
-  the tool could already answer: the base tree is read through a scoped
-  archive that walks no ancestry. The recovery now fires when the base
-  ref or the merge base is genuinely unavailable, which is what Git
-  reports past a graft — measured on two diverged shallow clones, it
-  returns nothing rather than a wrong commit (#686).
-
-- Read the base tree the host reader will read, and no more. `shipgate diff`
-  and verify's host comparison now materialize only boundary-surface paths
-  (plus symlinks, which are what can conceal them),
-  packing the tree rather than the commit. A 26 MB repository with 1,168 files
-  and four host files took 25s and now takes 2.7s, and a shallow clone is
-  comparable for a commit it already holds. An unrelated symlink no longer
-  makes a repository uncomparable: one outside the surface is not
-  materialized, a symlink to a non-directory can conceal no boundary path,
-  and a scoped archive recreates links instead of refusing the tree. Unscoped
-  archives, which verify uses for the release decision, still refuse every
-  external binding (#686, #688).
+- Advisory `diff` and manifest-free PR review materialize boundary paths and
+  symlinks from a verified tree instead of copying commit ancestry and writing
+  every file. The original sample improved from 25s to 2.7s; residual latency
+  remains #698, not a universal two-second promise. Shallow comparisons verify
+  that a visible common ancestor does not hide a newer one beyond a graft;
+  unresolved ancestry requests a fetch, while HEAD and proven ancestor
+  comparisons remain usable. Configured release archives retain their existing
+  whole-history validation. Scoped archives preserve links, but the reader
+  remains conservative until link-target identity can be bound (#700/#711):
+  successful materialization is not complete inventory coverage (#686/#688).
 
 - Manifest-free host PR review now names capability changes in verify, PR comments,
   and check. Interactive check defaults to readable text; agent mode keeps JSON.

--- a/src/agents_shipgate/cli/diff.py
+++ b/src/agents_shipgate/cli/diff.py
@@ -45,6 +45,7 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
         commit_sha,
         detect_default_base,
         merge_base_sha,
+        shallow_merge_base_is_proven,
     )
 
     if base is not None and (not base.strip() or base.startswith("-")):
@@ -108,24 +109,19 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
             "common point to compare from.",
             param_hint="--base",
         )
-    # Shallow is refused for the comparisons it actually breaks, not for
-    # being shallow. The base tree is read through a scoped archive that
-    # packs the tree and walks no ancestry, so a base this clone already
-    # holds is readable at `--depth 1`. What shallowness can still break is
-    # the *choice* of base: `git merge-base` cannot see past a graft, so a
-    # merge base that is itself a graft may not be the real one, and
-    # comparing against the wrong base silently is worse than refusing.
-    # Refusing unconditionally sent `actions/checkout`'s default
-    # (`fetch-depth: 1`) to `git fetch --unshallow` for a comparison the
-    # tool could already answer (#686).
-    # No graft check here on purpose. `git merge-base` does not guess past a
-    # shallow boundary — it reports nothing, which the branch above turns
-    # into the `--unshallow` recovery. Verified on two diverged shallow
-    # clones whose true base lay past the graft: both returned empty, never
-    # a wrong commit. So a merge base that *is* returned was proven through
-    # commits this clone holds, and no absent commit can be a more recent
-    # common ancestor. A graft check could not be made to fire on a wrong
-    # answer, and a guard that cannot fire is not a guard.
+    if truncated:
+        # A merge can expose an older common ancestor along one parent while
+        # a shallow graft hides a newer one along another. A nonempty answer
+        # alone is therefore insufficient. After excluding the candidate and
+        # its ancestry, every visible path from both tips must terminate: any
+        # remaining root may be a graft hiding a better common ancestor.
+        # HEAD/self and fully visible paths to the candidate remain usable.
+        base_commit = commit_sha(workspace, requested)
+        head_commit = commit_sha(workspace, "HEAD")
+        if base_commit is None or head_commit is None:
+            refuse_shallow()
+        if not shallow_merge_base_is_proven(workspace, base_commit, head_commit, resolved):
+            refuse_shallow()
     return requested, resolved
 
 

--- a/src/agents_shipgate/cli/diff.py
+++ b/src/agents_shipgate/cli/diff.py
@@ -50,7 +50,7 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
     if base is not None and (not base.strip() or base.startswith("-")):
         raise typer.BadParameter("Base ref must be non-empty and cannot start with a dash.", param_hint="--base")
 
-    if _history_is_truncated(workspace) is True:
+    def refuse_shallow() -> None:
         from agents_shipgate.cli.agent_mode import emit_agent_mode_error_action
         from agents_shipgate.invocation import join_argv
         from agents_shipgate.schemas.diagnostics import NextAction
@@ -73,6 +73,9 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
         )
         raise typer.Exit(2)
 
+    truncated = _history_is_truncated(workspace) is True
+
+
     # Same resolver `check` uses (#649), including its narrow local
     # fallback: a local `main` is refused while a remote exists, because the
     # remote is the authority it might be stale against, and used only where
@@ -87,6 +90,10 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
             param_hint="--base",
         )
     if commit_sha(workspace, requested) is None:
+        if truncated:
+            # The ref is missing and history is cut: fetching is the repair,
+            # and it is a more useful answer than "fetch it first".
+            refuse_shallow()
         raise typer.BadParameter(
             f"Base ref {requested!r} is not available locally. Fetch it first; "
             "this command never fetches.",
@@ -94,11 +101,31 @@ def _resolve_base(workspace: Path, base: str | None) -> tuple[str, str]:
         )
     resolved = merge_base_sha(workspace, requested, "HEAD")
     if resolved is None:
+        if truncated:
+            refuse_shallow()
         raise typer.BadParameter(
             f"No merge base between {requested!r} and HEAD, so there is no "
             "common point to compare from.",
             param_hint="--base",
         )
+    # Shallow is refused for the comparisons it actually breaks, not for
+    # being shallow. The base tree is read through a scoped archive that
+    # packs the tree and walks no ancestry, so a base this clone already
+    # holds is readable at `--depth 1`. What shallowness can still break is
+    # the *choice* of base: `git merge-base` cannot see past a graft, so a
+    # merge base that is itself a graft may not be the real one, and
+    # comparing against the wrong base silently is worse than refusing.
+    # Refusing unconditionally sent `actions/checkout`'s default
+    # (`fetch-depth: 1`) to `git fetch --unshallow` for a comparison the
+    # tool could already answer (#686).
+    # No graft check here on purpose. `git merge-base` does not guess past a
+    # shallow boundary — it reports nothing, which the branch above turns
+    # into the `--unshallow` recovery. Verified on two diverged shallow
+    # clones whose true base lay past the graft: both returned empty, never
+    # a wrong commit. So a merge base that *is* returned was proven through
+    # commits this clone holds, and no absent commit can be a more recent
+    # common ancestor. A graft check could not be made to fire on a wrong
+    # answer, and a guard that cannot fire is not a guard.
     return requested, resolved
 
 

--- a/src/agents_shipgate/cli/diff.py
+++ b/src/agents_shipgate/cli/diff.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import typer
 
 from agents_shipgate.cli.workspace_guard import require_workspace
+from agents_shipgate.core.boundary_registry import is_boundary_surface_path
 from agents_shipgate.core.capability_diff_rows import (
     ABSENT,
     CapabilityDiffRow,
@@ -151,7 +152,9 @@ def run_capability_diff(
 
         base_tree = Path(scratch) / "base"
         base_tree.mkdir()
-        archive_tree(workspace, base_commit, base_tree)
+        archive_tree(
+            workspace, base_commit, base_tree, scope=is_boundary_surface_path
+        )
         base_inventory = build_host_boundary_snapshot(
             base_tree, cache=HostStaticParseCache()
         ).inventory

--- a/src/agents_shipgate/cli/verify/git.py
+++ b/src/agents_shipgate/cli/verify/git.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import threading
 import unicodedata
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -1696,8 +1697,27 @@ def _reject_unbound_diff_configuration(workspace: Path) -> None:
         )
 
 
-def archive_tree(workspace: Path, ref: str, destination: Path) -> None:
-    """Materialize exact Git blobs without export-ignore or substitutions."""
+def archive_tree(
+    workspace: Path,
+    ref: str,
+    destination: Path,
+    *,
+    scope: Callable[[str], bool] | None = None,
+) -> None:
+    """Materialize exact Git blobs without export-ignore or substitutions.
+
+    ``scope`` narrows the materialized tree to the paths a reader will
+    actually open, plus every symlink — a linked directory is what can
+    conceal a scoped path from the reader, so the two sides must see the
+    same links. Without a scope every blob is written, which costs one
+    ``git cat-file`` per file: 1,168 subprocesses and 25 seconds on a 26 MB
+    repository whose host surface is four files (#686). A scoped archive
+    also packs the tree rather than the commit, so no history is walked.
+
+    Scoping changes what is *materialized*, never what is *verified*: every
+    blob written is still checked against its object ID, and the isolated
+    store is still fsck'd, on the same terms as an unscoped archive.
+    """
 
     destination.mkdir(parents=True, exist_ok=True)
     if any(destination.iterdir()):
@@ -1707,11 +1727,24 @@ def archive_tree(workspace: Path, ref: str, destination: Path) -> None:
         raise ConfigError(f"Git archive ref is unavailable: {ref}")
     with tempfile.TemporaryDirectory(prefix="agents-shipgate-git-snapshot-") as raw:
         git_dir = Path(raw) / "git"
-        _copy_verified_commit_graph(workspace, commit=commit, git_dir=git_dir)
-        _materialize_isolated_tree(git_dir, commit=commit, destination=destination)
+        # Peeled here, in the repository that certainly holds the commit: a
+        # tree pack does not carry it, so `<commit>^{tree}` cannot be
+        # resolved again inside the isolated store.
+        tree = _run_git(workspace, ["rev-parse", f"{commit}^{{tree}}"]).stdout.strip()
+        _copy_verified_commit_graph(
+            workspace,
+            commit=commit,
+            git_dir=git_dir,
+            tree=tree if scope is not None else None,
+        )
+        _materialize_isolated_tree(
+            git_dir, tree=tree, destination=destination, scope=scope
+        )
 
 
-def _copy_verified_commit_graph(workspace: Path, *, commit: str, git_dir: Path) -> None:
+def _copy_verified_commit_graph(
+    workspace: Path, *, commit: str, git_dir: Path, tree: str | None = None
+) -> None:
     """Copy one reachable object graph and verify it independently."""
 
     object_format = _run_git(workspace, ["rev-parse", "--show-object-format"]).stdout.strip()
@@ -1745,7 +1778,7 @@ def _copy_verified_commit_graph(workspace: Path, *, commit: str, git_dir: Path) 
                 "--stdout",
                 "--revs",
             ],
-            input=f"{commit}\n".encode("ascii"),
+            input=f"{tree or commit}\n".encode("ascii"),
             stdout=output,
             stderr=subprocess.PIPE,
             check=False,
@@ -1773,9 +1806,13 @@ def _copy_verified_commit_graph(workspace: Path, *, commit: str, git_dir: Path) 
     if indexed.returncode != 0:
         detail = indexed.stderr.decode("utf-8", errors="replace").strip()
         raise ConfigError(f"Copied Git objects failed index validation: {detail}")
+    # fsck the object the pack actually carries. A tree pack has no commit,
+    # and asking for one that is not there fails the check for the wrong
+    # reason; a tree also has no parents, which is why a scoped archive works
+    # on a shallow clone where a commit walk crosses the graft (#683).
     checked = _run_git_dir(
         git_dir,
-        ["fsck", "--strict", "--no-reflogs", "--no-dangling", commit],
+        ["fsck", "--strict", "--no-reflogs", "--no-dangling", tree or commit],
         check=False,
     )
     if checked.returncode != 0:
@@ -1783,10 +1820,17 @@ def _copy_verified_commit_graph(workspace: Path, *, commit: str, git_dir: Path) 
         raise ConfigError(f"Copied Git object graph failed integrity validation: {detail}")
 
 
-def _materialize_isolated_tree(git_dir: Path, *, commit: str, destination: Path) -> None:
-    listing = _run_git_dir(git_dir, ["ls-tree", "-r", "-z", commit], text=False).stdout
+def _materialize_isolated_tree(
+    git_dir: Path,
+    *,
+    tree: str,
+    destination: Path,
+    scope: Callable[[str], bool] | None = None,
+) -> None:
+    listing = _run_git_dir(git_dir, ["ls-tree", "-r", "-z", tree], text=False).stdout
     root = destination.resolve()
     entries: list[tuple[str, str, str]] = []
+    links: list[tuple[str, str]] = []
     portable_paths: dict[str, str] = {}
     for raw in listing.split(b"\0"):
         if not raw:
@@ -1794,6 +1838,16 @@ def _materialize_isolated_tree(git_dir: Path, *, commit: str, destination: Path)
         metadata, raw_path = raw.split(b"\t", 1)
         mode, object_type, oid = metadata.decode("ascii").split(" ", 2)
         path_text = raw_path.decode("utf-8", errors="strict")
+        if scope is not None and mode != "120000" and not scope(path_text):
+            # Out of scope is not merely unmaterialized, it is unexamined:
+            # the portability and collision checks below describe the tree
+            # this archive writes, and a name that never lands on the
+            # filesystem cannot collide there. A repository whose
+            # `src/templates/` holds `.AwS__CrEdEnTiAlS.html` beside
+            # `.aws__credentials.html` is comparable for its host surface.
+            # Symlinks are always examined: they are what conceals a
+            # boundary path from the reader.
+            continue
         if "\\" in path_text:
             raise ConfigError(f"Git tree path is not portable: {path_text}")
         portable_key = _portable_tree_path_key(path_text)
@@ -1803,11 +1857,30 @@ def _materialize_isolated_tree(git_dir: Path, *, commit: str, destination: Path)
                 "Git tree contains filesystem-colliding paths: "
                 f"{prior!r} and {path_text!r}"
             )
-        if object_type != "blob" or mode in {"120000", "160000"}:
+        if object_type != "blob" or mode == "160000" or (
+            mode == "120000" and scope is None
+        ):
             raise ConfigError(
                 f"Git tree contains unsupported external binding at {path_text} "
                 f"(mode {mode}, type {object_type})."
             )
+        if mode == "120000":
+            # Recreated as a link rather than refused, so the base tree
+            # presents the reader the same object the worktree does: a link,
+            # opened with O_NOFOLLOW, recorded as unreadable if it is a
+            # boundary path. Refusing instead made a third of a
+            # 12-repository sample uncomparable, several of them for a
+            # symlink no reader would ever open (#688).
+            #
+            # Nothing is written *through* a link. The escape this refusal
+            # used to cover needs a blob under a symlinked ancestor, which a
+            # valid tree cannot express — the name would be both a blob and
+            # a tree, a duplicate entry `fsck --strict` rejects before
+            # anything is written. Blobs are materialized before links
+            # regardless, so no write passes through one even if that check
+            # ever loosens.
+            links.append((oid, path_text))
+            continue
         entries.append((mode, oid, path_text))
 
     object_format = _run_git_dir(git_dir, ["rev-parse", "--show-object-format"]).stdout.strip()
@@ -1825,6 +1898,19 @@ def _materialize_isolated_tree(git_dir: Path, *, commit: str, destination: Path)
         if mode == "100755":
             os.chmod(target, 0o755)
 
+    for oid, path_text in links:
+        target = root / path_text
+        if not _within(root, target.parent):
+            raise ConfigError(f"Git tree path escapes destination: {path_text}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        blob = _run_git_dir(git_dir, ["cat-file", "blob", oid], text=False).stdout
+        if _git_object_id("blob", blob, algorithm=object_format) != oid:
+            raise ConfigError(f"Git blob failed object-ID validation: {path_text}")
+        # The link's own text is the blob. It may point anywhere, including
+        # out of the tree — the reader opens it with O_NOFOLLOW and records
+        # the failure, which is exactly what it does on the live worktree.
+        os.symlink(blob.decode("utf-8", errors="strict"), target)
+
     materialized = {
         path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
         for path in root.rglob("*")
@@ -1832,6 +1918,11 @@ def _materialize_isolated_tree(git_dir: Path, *, commit: str, destination: Path)
     }
     if materialized != expected_digests:
         raise ConfigError("Materialized Git tree differs from the verified object graph")
+
+
+def _within(root: Path, candidate: Path) -> bool:
+    resolved = candidate.resolve()
+    return resolved == root or root in resolved.parents
 
 
 def _portable_tree_path_key(path_text: str) -> str:

--- a/src/agents_shipgate/cli/verify/git.py
+++ b/src/agents_shipgate/cli/verify/git.py
@@ -2457,3 +2457,27 @@ __all__ = [
     "working_tree_context",
     "working_tree_paths",
 ]
+
+
+def shallow_merge_base_is_proven(workspace: Path, base: str, head: str, resolved: str) -> bool:
+    """Reject hidden better ancestors without requiring unrelated old history.
+
+    Inputs are resolved commit IDs. A returned common ancestor need not be the
+    best one when a merge exposes older ancestry around a shallow graft.
+    """
+    if resolved in {base, head}:
+        return True
+    shallow = _history_is_truncated(workspace)
+    if shallow is False:
+        return True
+    if shallow is None:
+        return False
+    roots = _run_git(
+        workspace,
+        ["rev-list", "--max-parents=0", "--max-count=1", base, head, "--not", resolved],
+        check=False,
+    )
+    # Removing the candidate's ancestry must leave no root (including grafts)
+    # reachable from either tip. Otherwise a hidden edge can conceal a newer
+    # common ancestor. This is conservative for unrelated shallow side branches.
+    return roots.returncode == 0 and not roots.stdout.strip()

--- a/src/agents_shipgate/cli/verify/host_comparison.py
+++ b/src/agents_shipgate/cli/verify/host_comparison.py
@@ -10,6 +10,7 @@ from agents_shipgate.cli.verify.git import (
     commit_sha,
     detect_default_base,
     require_merge_base_sha,
+    shallow_merge_base_is_proven,
     tree_sha,
 )
 from agents_shipgate.core.boundary_registry import is_boundary_surface_path
@@ -59,6 +60,10 @@ def compare_host_refs(
     )
     if base_ref and base_tip is None:
         raise ValueError("The requested base commit is not available locally")
+    if base_tip and not shallow_merge_base_is_proven(workspace, base_tip, head_commit, base_commit):
+        # Existing callers route a failed shallow comparison to fetch recovery;
+        # never publish rows relative to a potentially older common ancestor.
+        raise ValueError("Shallow history cannot establish the comparison merge base")
 
     def identity():
         bound, overlay = _safe_worktree_overlay(

--- a/src/agents_shipgate/cli/verify/host_comparison.py
+++ b/src/agents_shipgate/cli/verify/host_comparison.py
@@ -12,6 +12,7 @@ from agents_shipgate.cli.verify.git import (
     require_merge_base_sha,
     tree_sha,
 )
+from agents_shipgate.core.boundary_registry import is_boundary_surface_path
 from agents_shipgate.core.host_comparison import compare_host_inventories
 from agents_shipgate.core.host_grants import build_host_boundary_snapshot
 from agents_shipgate.schemas.host_comparison import HostComparison
@@ -83,12 +84,18 @@ def compare_host_refs(
     with tempfile.TemporaryDirectory(prefix="shipgate-host-comparison-") as scratch:
         before = Path(scratch) / "base"
         before.mkdir()
-        archive_tree(workspace, base_commit, before)
+        # The host comparison reads host surface only, so it archives host
+        # surface only: the same scope the live reader uses (#686, #688).
+        archive_tree(
+            workspace, base_commit, before, scope=is_boundary_surface_path
+        )
         after = workspace
         if head is not None:
             after = Path(scratch) / "head"
             after.mkdir()
-            archive_tree(workspace, head_commit, after)
+            archive_tree(
+                workspace, head_commit, after, scope=is_boundary_surface_path
+            )
         # Removing a configured gate, or selecting a historical head containing
         # one, is not first adoption. Leave the existing verifier route intact.
         if require_unconfigured and (

--- a/src/agents_shipgate/core/boundary_registry.py
+++ b/src/agents_shipgate/core/boundary_registry.py
@@ -138,3 +138,24 @@ __all__ = [
     "boundary_hosts_for_path",
     "is_agent_boundary_path",
 ]
+
+
+def is_boundary_surface_path(path: str) -> bool:
+    """Whether any adapter reads this path.
+
+    The one place that answers "would a reader open this file", so a
+    materialized base tree and the live reader agree on what the surface is
+    (#686, #688). Directory prefixes count: a reader that walks `.claude/`
+    needs the directory to exist before it can find `settings.json` in it.
+    """
+
+    normalized = path.replace("\\", "/").removeprefix("./")
+    if any(adapter.matches(normalized) for adapter in BOUNDARY_ADAPTERS):
+        return True
+    folded = normalized.casefold()
+    prefix = f"{folded}/"
+    return any(
+        expected.casefold().startswith(prefix)
+        for adapter in BOUNDARY_ADAPTERS
+        for expected in adapter.exact_paths
+    )

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -1095,7 +1095,8 @@ def _repository_paths(
                 if stat.S_ISLNK(metadata.st_mode):
                     if name not in skipped:
                         candidates.append((candidate, relative))
-                        symlink_directories.append(relative)
+                        if _symlink_may_be_directory(candidate):
+                            symlink_directories.append(relative)
                     continue
                 if stat.S_ISDIR(metadata.st_mode):
                     if name not in skipped:
@@ -1140,6 +1141,34 @@ def _repository_paths(
                     _source_kind(relative),
                 )
     return [indexed[key] for key in sorted(indexed)], visited
+
+
+def _symlink_may_be_directory(candidate: Path) -> bool:
+    """Whether this symlink could hold a boundary path underneath it.
+
+    Only a directory has descendants, so only a directory can conceal them.
+    Without this test every `**/`-prefixed pattern matched every symlink —
+    `_symlink_may_hide_boundary_glob` returns True for any non-empty path
+    once the pattern starts with `**/` — so a symlinked PNG under
+    `website/public/` became a boundary candidate, failed its O_NOFOLLOW
+    read, and left the whole inventory incomplete. Three such images made a
+    real repository uncomparable (#688).
+
+    Fail closed: a dangling or unreadable link is still treated as one that
+    may conceal, because nothing here established otherwise. Resolving is a
+    metadata question only — no content is read through the link, and a
+    boundary path that is *itself* a symlink is matched by its own name and
+    does not depend on this answer.
+    """
+
+    try:
+        return stat.S_ISDIR(os.stat(candidate).st_mode)
+    except OSError:
+        # `Path.is_dir()` answers False for a dangling link rather than
+        # raising, which would report "conceals nothing" about a link whose
+        # target nothing here could inspect. `os.stat` raises, so the
+        # unresolvable case reaches this branch and stays closed.
+        return True
 
 
 def _symlink_may_hide_boundary_glob(relative: str, pattern: str) -> bool:

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -1095,8 +1095,7 @@ def _repository_paths(
                 if stat.S_ISLNK(metadata.st_mode):
                     if name not in skipped:
                         candidates.append((candidate, relative))
-                        if _symlink_may_be_directory(candidate):
-                            symlink_directories.append(relative)
+                        symlink_directories.append(relative)
                     continue
                 if stat.S_ISDIR(metadata.st_mode):
                     if name not in skipped:
@@ -1141,34 +1140,6 @@ def _repository_paths(
                     _source_kind(relative),
                 )
     return [indexed[key] for key in sorted(indexed)], visited
-
-
-def _symlink_may_be_directory(candidate: Path) -> bool:
-    """Whether this symlink could hold a boundary path underneath it.
-
-    Only a directory has descendants, so only a directory can conceal them.
-    Without this test every `**/`-prefixed pattern matched every symlink —
-    `_symlink_may_hide_boundary_glob` returns True for any non-empty path
-    once the pattern starts with `**/` — so a symlinked PNG under
-    `website/public/` became a boundary candidate, failed its O_NOFOLLOW
-    read, and left the whole inventory incomplete. Three such images made a
-    real repository uncomparable (#688).
-
-    Fail closed: a dangling or unreadable link is still treated as one that
-    may conceal, because nothing here established otherwise. Resolving is a
-    metadata question only — no content is read through the link, and a
-    boundary path that is *itself* a symlink is matched by its own name and
-    does not depend on this answer.
-    """
-
-    try:
-        return stat.S_ISDIR(os.stat(candidate).st_mode)
-    except OSError:
-        # `Path.is_dir()` answers False for a dangling link rather than
-        # raising, which would report "conceals nothing" about a link whose
-        # target nothing here could inspect. `os.stat` raises, so the
-        # unresolvable case reaches this branch and stays closed.
-        return True
 
 
 def _symlink_may_hide_boundary_glob(relative: str, pattern: str) -> bool:

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -257,7 +257,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.Popen",
-        line=2001,
+        line=2092,
         snippet=(
             "subprocess.Popen(cmd, env=env, stderr=subprocess.PIPE, "
             "stdin=subprocess.PIPE if input is not None else "
@@ -276,7 +276,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.run",
-        line=2245,
+        line=2336,
         snippet=(
             "subprocess.run(cmd, capture_output=capture_output, check=check, "
             "env=env, input=input, stderr=stderr, stdin=stdin, stdout=stdout, "

--- a/tests/test_capability_diff.py
+++ b/tests/test_capability_diff.py
@@ -276,10 +276,19 @@ def test_a_removal_is_never_reported_as_an_expansion() -> None:
 @pytest.mark.parametrize("depth", [1, 2])
 @pytest.mark.parametrize("json_output", [False, True])
 @pytest.mark.parametrize("agent_mode", ["0", "1"])
-def test_shallow_checkout_names_a_recovery_that_restores_the_diff(
+def test_a_shallow_base_this_clone_does_not_have_names_a_recovery(
     repo: Path, tmp_path: Path, depth: int, json_output: bool, agent_mode: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The recovery is for a base the clone genuinely lacks.
+
+    It used to fire on *any* shallow checkout. The base tree is read through
+    a scoped archive that packs the tree and walks no ancestry (#686), so a
+    base the clone already holds is readable at `--depth 1`; sending that
+    caller to `git fetch --unshallow` is a repair for a problem they do not
+    have. `--base HEAD` — which this case used to pass — is now answerable
+    and is covered below.
+    """
     # Hosted CI enables Rich color; the recovery must still be one copyable line.
     monkeypatch.setenv("FORCE_COLOR", "1")
     monkeypatch.setenv("COLUMNS", "60")
@@ -290,7 +299,10 @@ def test_shallow_checkout_names_a_recovery_that_restores_the_diff(
     clone = tmp_path / "shallow checkout"
     _git(tmp_path, "clone", "--quiet", "--depth", str(depth), repo.as_uri(), str(clone))
     (clone / ".claude" / "settings.json").write_text(WIDE_SETTINGS, encoding="utf-8")
-    args = ["diff", "--workspace", str(clone), "--base", "HEAD"]
+    # A commit this shallow clone does not have: the graft's parent is the
+    # first thing past the boundary, and naming it by the graft is exact.
+    absent = _git_out(clone, "rev-parse", (clone / ".git" / "shallow").read_text().split()[0])
+    args = ["diff", "--workspace", str(clone), "--base", f"{absent}~1"]
     if json_output:
         args.append("--json")
 
@@ -314,9 +326,42 @@ def test_shallow_checkout_names_a_recovery_that_restores_the_diff(
     # Follow the published action from outside the checkout. This must restore
     # the actual comparison, without init, policy edits or a wrapper fetch.
     subprocess.run(recovery, cwd=tmp_path, check=True, capture_output=True)
-    recovered = _diff(clone, "--base", "HEAD", "--json")
+    recovered = _diff(clone, "--base", f"{absent}~1", "--json")
     assert recovered.exit_code == 0, recovered.output
     assert any(row["after"] == "Bash(*)" for row in json.loads(recovered.output)["rows"])
+
+
+def _git_out(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+@pytest.mark.parametrize("depth", [1, 2])
+def test_a_shallow_clone_compares_against_a_base_it_already_holds(
+    repo: Path, tmp_path: Path, depth: int
+) -> None:
+    """`actions/checkout` defaults to `fetch-depth: 1`.
+
+    Refusing every shallow checkout sent that default to `git fetch
+    --unshallow` for a comparison the tool can answer from objects it holds.
+    Measured on five public repositories: the scoped archive read all five
+    at `--depth 3` in 0.5-2.1 s while the command refused all five.
+    """
+
+    for index in range(3):
+        (repo / "README.md").write_text(f"# revision {index}\n", encoding="utf-8")
+        _git(repo, "add", "README.md")
+        _git(repo, "commit", "-qm", f"history {index}")
+    clone = tmp_path / "shallow checkout"
+    _git(tmp_path, "clone", "--quiet", "--depth", str(depth), repo.as_uri(), str(clone))
+    (clone / ".claude" / "settings.json").write_text(WIDE_SETTINGS, encoding="utf-8")
+
+    result = _diff(clone, "--base", "HEAD", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert "This checkout is shallow" not in result.output
+    assert any(row["after"] == "Bash(*)" for row in json.loads(result.output)["rows"])
 
 
 def test_an_absent_base_ref_is_refused_by_name(repo: Path) -> None:

--- a/tests/test_capability_diff.py
+++ b/tests/test_capability_diff.py
@@ -451,3 +451,44 @@ def test_invalid_base_cannot_fall_back_or_become_an_option(repo: Path, base: str
     result = _diff(repo, "--base", base)
     assert result.exit_code == 2
     assert "Base ref must be non-empty" in result.output
+
+
+@pytest.mark.parametrize("json_output", [False, True])
+def test_shallow_merge_cannot_select_an_older_visible_common_ancestor(
+    repo: Path, tmp_path: Path, json_output: bool,
+) -> None:
+    # A -> B -> L -> H, H also has parent A; R has parent B. A shallow
+    # graft at L hides B along H's first parent, but H's second exposes A.
+    a = _git_out(repo, "rev-parse", "HEAD")
+    (repo / ".claude" / "settings.json").write_text(WIDE_SETTINGS)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "B")
+    b = _git_out(repo, "rev-parse", "HEAD")
+    tree = _git_out(repo, "rev-parse", "HEAD^{tree}")
+    left = _git_out(repo, "commit-tree", tree, "-p", b, "-m", "L")
+    head = _git_out(repo, "commit-tree", tree, "-p", left, "-p", a, "-m", "H")
+    right = _git_out(repo, "commit-tree", tree, "-p", b, "-m", "R")
+    _git(repo, "update-ref", "refs/heads/head", head)
+    _git(repo, "update-ref", "refs/heads/base", right)
+    assert _git_out(repo, "merge-base", head, right) == b
+    clone = tmp_path / "partial history"
+    _git(tmp_path, "clone", "--quiet", "--depth", "2", "--branch", "head", repo.as_uri(), str(clone))
+    _git(clone, "fetch", "--quiet", "--depth", "3", "origin", "base")
+    assert _git_out(clone, "merge-base", "HEAD", "FETCH_HEAD") == a
+    # Objects can be present through R even though L's parent edge is cut.
+    assert _git_out(clone, "cat-file", "-t", b) == "commit"
+    from agents_shipgate.cli.verify.host_comparison import compare_host_refs
+    with pytest.raises(ValueError, match="Shallow history"):
+        compare_host_refs(workspace=clone, base="FETCH_HEAD", head="HEAD",
+                          auto_base=False, config_relative=Path("shipgate.yaml"))
+    # A visible ancestor remains the exact base even with another graft.
+    visible = _diff(clone, "--base", left, "--json")
+    assert visible.exit_code == 0, visible.output
+    assert json.loads(visible.output)["rows"] == []
+    result = _diff(clone, "--base", "FETCH_HEAD", *(["--json"] if json_output else []))
+    assert result.exit_code == 2, result.output
+    assert "fetch" in result.output and "--unshallow" in result.output
+    _git(clone, "fetch", "--quiet", "--unshallow", "origin")
+    result = _diff(clone, "--base", right, "--json")
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["rows"] == []

--- a/tests/test_manifest_free_pr_rows.py
+++ b/tests/test_manifest_free_pr_rows.py
@@ -237,28 +237,63 @@ def test_host_comparison_pointer_rejects_moved_base(s1):
     assert control.exit_code != 0, control.output
 
 
-def test_shallow_comparison_retains_recovery_instead_of_init(s1, tmp_path):
+def test_a_shallow_clone_compares_the_history_it_has(s1, tmp_path):
+    """A depth-1 clone holds the tree it was cloned at, so a comparison
+    against a commit it holds is answerable.
+
+    It was not, before the base tree was scoped: materializing it walked
+    the commit's ancestry, crossed the graft and failed the integrity
+    check, which was then classified as `shallow_history` and answered
+    with `fetch_base`. Telling someone to fetch history in order to
+    compare a commit they already have is a recovery for a problem they
+    do not have (#686).
+    """
+
     clone = tmp_path / "shallow"
     subprocess.run(["git", "clone", "-q", "--depth=1", s1.as_uri(), str(clone)], check=True)
     result = CliRunner().invoke(
         app,
-        [
-            "verify",
-            "--preview",
-            "--workspace",
-            str(clone),
-            "--base",
-            "HEAD",
-            "--head",
-            "HEAD",
-            "--json",
-        ],
+        ["verify", "--preview", "--workspace", str(clone),
+         "--base", "HEAD", "--head", "HEAD", "--json"],
     )
+
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
-    assert payload["host_comparison"]["comparison_status"] == "incomparable"
-    assert "shallow_history" in payload["host_comparison"]["incomparable_reasons"]
-    assert payload["control"]["next_action"]["kind"] == "fetch_base"
+    assert payload["host_comparison"]["comparison_status"] == "comparable"
+    assert "init --write" not in result.output
+
+
+def test_a_base_the_shallow_clone_does_not_have_still_routes_to_fetch(s1, tmp_path):
+    """The recovery #683 added, on the case that still needs it: the base
+    commit is genuinely absent, so no scoping makes it readable."""
+
+    clone = tmp_path / "shallow"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth=1", "--branch", "change", s1.as_uri(), str(clone)],
+        check=True,
+    )
+    absent = subprocess.run(
+        ["git", "-C", str(s1), "rev-parse", "main"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    assert subprocess.run(
+        ["git", "-C", str(clone), "cat-file", "-e", absent], capture_output=True
+    ).returncode != 0, "the base must really be missing for this to test anything"
+
+    result = CliRunner().invoke(
+        app,
+        ["verify", "--preview", "--workspace", str(clone),
+         "--base", absent, "--head", "HEAD", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    next_action = payload["control"]["next_action"]
+    assert next_action["kind"] == "fetch_base"
+    assert "refs_missing" in next_action["why"]
+    # Refused before the host comparison is attempted, which is why the
+    # block is absent rather than incomparable: there is no base to read.
+    assert payload["host_comparison"] is None
     assert "init --write" not in result.output
 
 

--- a/tests/test_scoped_base_tree.py
+++ b/tests/test_scoped_base_tree.py
@@ -1,0 +1,345 @@
+"""#686 / #688: read the base tree the reader will read, and no more.
+
+Two defects with one cause — the base tree was materialized whole:
+
+*Cost.* One `git cat-file` subprocess per blob. On a 26 MB repository with
+1,168 files and four host-surface files, `shipgate diff` took 25 seconds
+against 1 second on a toy scenario.
+
+*Reach.* Every entry was checked for portability, name collision and
+external binding, so one symlink anywhere refused the whole repository.
+Four of twelve public repositories with committed host configuration were
+uncomparable on every step of their history — one for a symlinked PNG under
+`website/public/`, nowhere near any file a reader opens.
+
+The scope is `is_boundary_surface_path`, the same predicate the live reader
+classifies with, so the archive and the reader cannot disagree about what
+the surface is.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agents_shipgate.cli.verify.git import archive_tree
+from agents_shipgate.core.boundary_registry import is_boundary_surface_path
+from agents_shipgate.core.errors import ConfigError
+from agents_shipgate.core.host_grants import (
+    HostStaticParseCache,
+    build_host_boundary_snapshot,
+)
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path, name: str = "repo") -> Path:
+    root = tmp_path / name
+    root.mkdir(parents=True)
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.invalid")
+    _git(root, "config", "user.name", "T")
+    return root
+
+
+def _commit(root: Path, message: str = "c") -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", message)
+    return _git(root, "rev-parse", "HEAD")
+
+
+def _host_repo(tmp_path: Path, name: str = "repo") -> Path:
+    """A repository shaped like the ones this was measured on."""
+
+    root = _repo(tmp_path, name)
+    (root / ".claude").mkdir()
+    (root / ".claude" / "settings.json").write_text(
+        '{"permissions": {"allow": ["Bash(pytest *)"]}}', encoding="utf-8"
+    )
+    (root / "src").mkdir()
+    for index in range(30):
+        (root / "src" / f"m{index}.py").write_text(f"X = {index}\n", encoding="utf-8")
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    return root
+
+
+class TestScopeMaterializesOnlyTheSurface:
+    def test_files_outside_the_surface_are_not_written(self, tmp_path: Path) -> None:
+        root = _host_repo(tmp_path)
+        _commit(root)
+        out = tmp_path / "base"
+
+        archive_tree(root, "HEAD", out, scope=is_boundary_surface_path)
+
+        assert (out / ".claude" / "settings.json").is_file()
+        assert not (out / "src").exists()
+        assert not (out / "README.md").exists()
+        written = sorted(p.relative_to(out).as_posix() for p in out.rglob("*") if p.is_file())
+        assert written == [".claude/settings.json"]
+
+    def test_without_a_scope_the_whole_tree_is_still_written(self, tmp_path: Path) -> None:
+        """The unscoped contract is unchanged: `verify` materializes trees for
+        the release decision and this must not quietly narrow them."""
+
+        root = _host_repo(tmp_path)
+        _commit(root)
+        out = tmp_path / "full"
+
+        archive_tree(root, "HEAD", out)
+
+        assert (out / "README.md").is_file()
+        assert len(list((out / "src").iterdir())) == 30
+
+    def test_the_scoped_archive_reads_the_same_grants(self, tmp_path: Path) -> None:
+        """Cheaper must not mean different. The inventory from the scoped
+        archive equals the inventory from the whole tree."""
+
+        root = _host_repo(tmp_path)
+        _commit(root)
+        scoped, whole = tmp_path / "scoped", tmp_path / "whole"
+        archive_tree(root, "HEAD", scoped, scope=is_boundary_surface_path)
+        archive_tree(root, "HEAD", whole)
+
+        def grants(where: Path) -> list[tuple[str, str, str]]:
+            inventory = build_host_boundary_snapshot(
+                where, cache=HostStaticParseCache()
+            ).inventory
+            return sorted(
+                (g["host"], g["source"], g.get("rule") or g["kind"])
+                for g in inventory["grants"]
+            )
+
+        assert grants(scoped) == grants(whole)
+        assert grants(scoped)
+
+
+class TestTheHistoryIsNotWalked:
+    def test_a_scoped_archive_packs_no_commit(self, tmp_path: Path) -> None:
+        """The 25 seconds were per-blob subprocesses, but the pack carried
+        every historical tree and blob too. A tree pack carries neither."""
+
+        root = _host_repo(tmp_path)
+        for index in range(4):
+            (root / "src" / f"extra{index}.py").write_text("Y = 1\n", encoding="utf-8")
+            _commit(root, f"c{index}")
+        out = tmp_path / "base"
+
+        archive_tree(root, "HEAD", out, scope=is_boundary_surface_path)
+
+        assert (out / ".claude" / "settings.json").is_file()
+
+    def test_a_shallow_clone_is_comparable_when_scoped(self, tmp_path: Path) -> None:
+        """A tree has no parents, so nothing crosses the graft (#683)."""
+
+        origin = _host_repo(tmp_path, "origin")
+        _commit(origin, "first")
+        (origin / "src" / "later.py").write_text("Z = 1\n", encoding="utf-8")
+        head = _commit(origin, "second")
+        shallow = tmp_path / "shallow"
+        subprocess.run(
+            ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(shallow)],
+            check=True, capture_output=True,
+        )
+        assert _git(shallow, "rev-parse", "--is-shallow-repository") == "true"
+
+        out = tmp_path / "base"
+        archive_tree(shallow, head, out, scope=is_boundary_surface_path)
+
+        assert (out / ".claude" / "settings.json").is_file()
+
+
+class TestSymlinks:
+    def test_a_symlink_outside_the_surface_does_not_refuse_the_tree(
+        self, tmp_path: Path
+    ) -> None:
+        """The measured case: three symlinked PNGs under `website/public/`."""
+
+        root = _host_repo(tmp_path)
+        (root / "website").mkdir()
+        (root / "website" / "shot.png").symlink_to("../src/m0.py")
+        _commit(root)
+        out = tmp_path / "base"
+
+        archive_tree(root, "HEAD", out, scope=is_boundary_surface_path)
+
+        assert (out / ".claude" / "settings.json").is_file()
+
+    def test_a_symlink_is_recreated_as_a_symlink(self, tmp_path: Path) -> None:
+        """Not resolved and not skipped: the live reader sees a link and
+        opens it with O_NOFOLLOW, so the base tree must present the same
+        thing or the two sides disagree about what the file is."""
+
+        root = _host_repo(tmp_path)
+        (root / "AGENTS.md").write_text("# agents\n", encoding="utf-8")
+        (root / "CLAUDE.md").symlink_to("AGENTS.md")
+        _commit(root)
+        out = tmp_path / "base"
+
+        archive_tree(root, "HEAD", out, scope=is_boundary_surface_path)
+
+        assert (out / "CLAUDE.md").is_symlink()
+        assert (out / "CLAUDE.md").readlink().as_posix() == "AGENTS.md"
+
+    def test_a_tree_that_puts_a_blob_under_a_symlinked_name_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """The escape recreating symlinks could have opened.
+
+        A valid tree cannot express it — `.claude` would have to be both a
+        symlink blob and a tree, which is a duplicate entry — so this builds
+        the invalid tree by hand and checks it is refused before anything is
+        written. `fsck --strict` is what refuses it, which is why the
+        materializer carries no separate ancestor check: that check could
+        never fire, and an unreachable guard is not a guard.
+        """
+
+        root = _repo(tmp_path)
+        (root / "seed").write_text("x\n", encoding="utf-8")
+        _commit(root)
+
+        def hash_object(text: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(root), "hash-object", "-w", "--stdin"],
+                input=text, check=True, capture_output=True, text=True,
+            ).stdout.strip()
+
+        def mktree(spec: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(root), "mktree"],
+                input=spec, check=True, capture_output=True, text=True,
+            ).stdout.strip()
+
+        inner = mktree(f"100644 blob {hash_object('{}')}\tsettings.json\n")
+        crafted = mktree(
+            f"120000 blob {hash_object('/etc')}\t.claude\n"
+            f"040000 tree {inner}\t.claude\n"
+        )
+        commit = subprocess.run(
+            ["git", "-C", str(root), "commit-tree", crafted, "-m", "crafted"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        with pytest.raises(ConfigError, match="integrity validation|duplicate"):
+            archive_tree(root, commit, tmp_path / "base", scope=is_boundary_surface_path)
+
+        assert not (tmp_path / "base" / ".claude").exists()
+
+
+class TestNamesOutsideTheSurface:
+    def test_case_colliding_paths_outside_the_surface_do_not_refuse(
+        self, tmp_path: Path
+    ) -> None:
+        """A repository of deception templates carried
+        `.AwS__CrEdEnTiAlS.html` beside `.aws__credentials.html`. Neither is
+        a file any reader opens, and on a case-insensitive filesystem the
+        pair refused every comparison."""
+
+        root = _host_repo(tmp_path)
+        templates = root / "templates"
+        templates.mkdir()
+        (templates / "A.html").write_text("a\n", encoding="utf-8")
+        _commit(root)
+        colliding = subprocess.run(
+            ["git", "-C", str(root), "hash-object", "-w", "--stdin"],
+            input="b\n", check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        inner = subprocess.run(
+            ["git", "-C", str(root), "mktree"],
+            input=f"100644 blob {colliding}\tA.html\n100644 blob {colliding}\ta.html\n",
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        claude = _git(root, "rev-parse", "HEAD:.claude")
+        top = subprocess.run(
+            ["git", "-C", str(root), "mktree"],
+            input=f"040000 tree {claude}\t.claude\n040000 tree {inner}\ttemplates\n",
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        commit = subprocess.run(
+            ["git", "-C", str(root), "commit-tree", top, "-m", "colliding"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        out = tmp_path / "base"
+        archive_tree(root, commit, out, scope=is_boundary_surface_path)
+
+        assert (out / ".claude" / "settings.json").is_file()
+
+    def test_the_same_collision_inside_the_surface_still_refuses(
+        self, tmp_path: Path
+    ) -> None:
+        """Narrowing what is examined must not narrow what is enforced."""
+
+        root = _host_repo(tmp_path)
+        _commit(root)
+        blob = subprocess.run(
+            ["git", "-C", str(root), "hash-object", "-w", "--stdin"],
+            input="{}", check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        inner = subprocess.run(
+            ["git", "-C", str(root), "mktree"],
+            input=f"100644 blob {blob}\tSettings.json\n100644 blob {blob}\tsettings.json\n",
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        top = subprocess.run(
+            ["git", "-C", str(root), "mktree"],
+            input=f"040000 tree {inner}\t.claude\n",
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        commit = subprocess.run(
+            ["git", "-C", str(root), "commit-tree", top, "-m", "colliding surface"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        with pytest.raises(ConfigError, match="colliding"):
+            archive_tree(root, commit, tmp_path / "base", scope=is_boundary_surface_path)
+
+
+class TestTheReaderAgrees:
+    def test_a_symlink_to_a_file_conceals_no_boundary_path(self, tmp_path: Path) -> None:
+        """`_symlink_may_hide_boundary_glob` returns True for any non-empty
+        path once a pattern starts with `**/`, so every symlink in the
+        repository became a boundary candidate, failed its O_NOFOLLOW read
+        and left the inventory incomplete. Only a directory has descendants."""
+
+        root = _host_repo(tmp_path)
+        (root / "website").mkdir()
+        (root / "website" / "shot.png").symlink_to("../src/m0.py")
+
+        inventory = build_host_boundary_snapshot(
+            root, cache=HostStaticParseCache()
+        ).inventory
+
+        assert not [
+            issue
+            for issue in inventory.get("issues", [])
+            if "shot.png" in str(issue.get("source"))
+        ], inventory.get("issues")
+        assert inventory["grants"]
+
+    def test_a_symlinked_directory_still_conceals(self, tmp_path: Path) -> None:
+        """The property the predicate exists for is unchanged: a directory
+        the walk cannot descend may hide a boundary path."""
+
+        from agents_shipgate.core.host_grants import _symlink_may_be_directory
+
+        root = _host_repo(tmp_path)
+        (root / "elsewhere").mkdir()
+        (root / "linked").symlink_to("elsewhere", target_is_directory=True)
+
+        assert _symlink_may_be_directory(root / "linked") is True
+
+    def test_a_dangling_symlink_fails_closed(self, tmp_path: Path) -> None:
+        """Nothing establishes that an unresolvable link is harmless."""
+
+        from agents_shipgate.core.host_grants import _symlink_may_be_directory
+
+        root = _host_repo(tmp_path)
+        (root / "dangling").symlink_to("nowhere-at-all")
+
+        assert _symlink_may_be_directory(root / "dangling") is True

--- a/tests/test_scoped_base_tree.py
+++ b/tests/test_scoped_base_tree.py
@@ -300,46 +300,46 @@ class TestNamesOutsideTheSurface:
             archive_tree(root, commit, tmp_path / "base", scope=is_boundary_surface_path)
 
 
-class TestTheReaderAgrees:
-    def test_a_symlink_to_a_file_conceals_no_boundary_path(self, tmp_path: Path) -> None:
-        """`_symlink_may_hide_boundary_glob` returns True for any non-empty
-        path once a pattern starts with `**/`, so every symlink in the
-        repository became a boundary candidate, failed its O_NOFOLLOW read
-        and left the inventory incomplete. Only a directory has descendants."""
+@pytest.mark.parametrize("kind", ["file", "directory", "dangling"])
+def test_unbound_symlink_targets_remain_explicit_coverage_limits(tmp_path, kind):
+    # Target type is not part of the identity-bound read. It cannot justify
+    # dropping a candidate, even when it happens to be a regular file now.
+    from agents_shipgate.core.host_grants import inventory_is_complete
 
-        root = _host_repo(tmp_path)
-        (root / "website").mkdir()
-        (root / "website" / "shot.png").symlink_to("../src/m0.py")
+    root = _host_repo(tmp_path)
+    target = root / "target"
+    if kind == "directory":
+        target.mkdir()
+    elif kind == "file":
+        target.write_text("file")
+    (root / "linked").symlink_to("target", target_is_directory=kind == "directory")
+    inventory = build_host_boundary_snapshot(root).inventory
+    assert not inventory_is_complete(inventory)
+    assert any(issue.get("source") == "linked" and issue.get("blocking")
+               for issue in inventory["issues"])
+    assert inventory["grants"]
 
-        inventory = build_host_boundary_snapshot(
-            root, cache=HostStaticParseCache()
-        ).inventory
 
-        assert not [
-            issue
-            for issue in inventory.get("issues", [])
-            if "shot.png" in str(issue.get("source"))
-        ], inventory.get("issues")
-        assert inventory["grants"]
+def test_symlink_target_kind_is_not_unbound_negative_coverage(tmp_path, monkeypatch):
+    from agents_shipgate.core import host_grants
 
-    def test_a_symlinked_directory_still_conceals(self, tmp_path: Path) -> None:
-        """The property the predicate exists for is unchanged: a directory
-        the walk cannot descend may hide a boundary path."""
+    root = _host_repo(tmp_path)
+    target = tmp_path / "external-target"
+    target.write_text("file")
+    (root / "linked").symlink_to(target)
+    original = host_grants._repository_paths
 
-        from agents_shipgate.core.host_grants import _symlink_may_be_directory
+    def enumerate_then_replace(*args, **kwargs):
+        result = original(*args, **kwargs)
+        target.unlink()
+        target.mkdir()
+        (target / "CLAUDE.md").write_text("instructions")
+        return result
 
-        root = _host_repo(tmp_path)
-        (root / "elsewhere").mkdir()
-        (root / "linked").symlink_to("elsewhere", target_is_directory=True)
-
-        assert _symlink_may_be_directory(root / "linked") is True
-
-    def test_a_dangling_symlink_fails_closed(self, tmp_path: Path) -> None:
-        """Nothing establishes that an unresolvable link is harmless."""
-
-        from agents_shipgate.core.host_grants import _symlink_may_be_directory
-
-        root = _host_repo(tmp_path)
-        (root / "dangling").symlink_to("nowhere-at-all")
-
-        assert _symlink_may_be_directory(root / "dangling") is True
+    with monkeypatch.context() as patch:
+        patch.setattr(host_grants, "_repository_paths", enumerate_then_replace)
+        snapshot = build_host_boundary_snapshot(root)
+    fresh = build_host_boundary_snapshot(root)
+    assert not host_grants.inventory_is_complete(snapshot.inventory)
+    assert not host_grants.inventory_is_complete(fresh.inventory)
+    assert snapshot.inventory["issues"]


### PR DESCRIPTION
Closes #686.
Related #688; remaining reader coverage is deferred under #700/#711.

## Why

`shipgate diff` and verify's host comparison materialized the whole base tree to read a handful of files. Two defects followed, both measured on twelve public repositories with committed host configuration.

**Cost.** Materialization runs one `git cat-file` per blob. On a 26 MB repository with 1,168 files whose host surface is four files, that is 1,168 subprocesses.

| | before | after |
|---|---:|---:|
| `DanielLavrushin/b4`, one `diff` | 25.3 s | **2.7 s** |
| the toy S1 scenario | 1 s | 1 s |

The pack was never the cost — 200 ms — the subprocesses were.

**Reach.** Every entry was checked for portability, name collision and external binding, so anything anywhere refused the whole repository. Four of twelve repositories were uncomparable on **every step** of their history:

| repository | refused for |
|---|---|
| `miantiao-me/bm.md` | `CLAUDE.md -> AGENTS.md` |
| `getsentry/sentry-mcp` | a symlinked `.claude/skills` |
| `gtkx-org/gtkx` | three symlinked PNGs under `website/public/` |
| `awslabs/nx-plugin-for-aws` | a symlinked git-hook helper |

Two of those four are refused for a path no reader would ever open.

## What changed

`archive_tree` takes a `scope` predicate. Scoped, it packs the tree rather than the commit — no ancestry, which is also why a shallow clone can be compared against a commit it already holds — and materializes only what the predicate accepts, plus symlinks. The predicate is `is_boundary_surface_path`, placed in the registry that already owns path classification, so the archive and the live reader cannot disagree about what the surface is.

Scoping narrows what is **materialized**, never what is **verified**: every blob written is still checked against its object ID and the isolated store is still `fsck`'d. An unscoped archive is unchanged in every respect, including refusing symlinks — verify materializes trees for the release decision, and narrowing the advisory host read must not loosen that.

A scoped archive recreates symlinks rather than refusing their tree. The reader still handles them conservatively; successful archive construction does not establish complete coverage. The attempted target-type optimization was withdrawn during independent round 2 because an unbound `os.stat` result could become stale and manufacture a complete inventory. #700/#711 retain identity-bound target handling as explicit later work.

## Review fixes

- A shallow merge can expose an older common ancestor around a graft that hides a newer one. Both CLI diff and manifest-free PR comparison now require proof that no remaining root lies outside the selected ancestor closure, while a visibly ancestral tip remains directly comparable. Real clone/fetch regressions cover the wrong-base case, known ancestor, HEAD and fetch recovery.
- A symlink-target replacement regression preserves incomplete coverage through enumeration and final validation. The old optimization-specific tests were replaced with explicit file/directory/dangling refusal checks; no safety assertion was weakened to keep the optimization.

## No guard was added where one could not fire

The recreated symlink invites a blob under a symlinked ancestor. A valid tree cannot express it: the name would be both a blob and a tree, a duplicate entry `fsck --strict` rejects before anything is written. An ancestor check in the materializer could therefore never fire, and an unreachable guard is not a guard. The invalid tree is built by hand in the tests and asserted to be refused; blobs are still written before links regardless.

## Two existing tests rewritten, not deleted

`test_shallow_comparison_retains_recovery_instead_of_init` asserted that a shallow clone is incomparable. It now asserts the comparison it can actually answer, and a second case covers a base the clone genuinely does not have, which still routes to `fetch_base` with `refs_missing`. Telling someone to fetch history in order to compare a commit they already have is a recovery for a problem they do not have.

Static-only allowlist line pins moved 2001 → 2092 and 2245 → 2336.

## Evidence

The original 13-case preparation included an unsafe symlink optimization withdrawn in review. The final tests retain scoped materialization, shallow trees, invalid trees, collisions and conservative link limits, with a new target-replacement regression. Final validation is recorded in the review/address response; the original negative-control count is not relabeled as final evidence.

The initial aggregate incorrectly counted `incomparable` as a benign zero-row result. The corrected combined-branch measurement is **8/12 usable repositories and 140 benign comparable steps with zero rows**, as recorded in [the correction](https://github.com/ThreeMoonsLab/agents-shipgate/pull/703#issuecomment-5644592850). That sample combines this PR with other changes; it is not standalone acceptance evidence for this head. The four incomplete repositories retain explicit symlink limits (#700/#711). Refusal becoming an honest incomplete result is useful diagnosis, not completed comparison coverage.

#698 retains the residual first-run latency criterion. The two-second every-run aspiration and #661's hook budget are not established by these measurements.


🤖 Generated with [Claude Code](https://claude.com/claude-code)