### PR TITLE
Lead the Cursor instructions with the named rows (#662)

### DIFF
--- a/.cursor/rules/agents-shipgate.mdc
+++ b/.cursor/rules/agents-shipgate.mdc
@@ -38,6 +38,21 @@ When a change affects agent tools, MCP exports, OpenAPI specs, prompts,
 permissions, approval policies, or release gates, run Agents Shipgate.
 Default to advisory verification while adopting the gate.
 
+First, name what the change did to the agent's authority. This needs no
+manifest and no committed baseline:
+
+  shipgate diff --workspace .
+
+One row per host grant, each carrying subject, before, after, direction,
+severity and why it matters; `⚠` marks a row the engine read as an
+expansion of authority. Quote those rows to the user, and put them in the
+pull request body. A covered comparison with no rows is a real answer, not
+a missing one. `--json` emits the same rows under `rows`.
+
+A row is a description, never a permission: showing one, or seeing an empty
+table, grants no authority to edit, commit, push, merge or report the work
+complete.
+
 For local agent control, run:
 
   shipgate check --agent cursor --workspace . --format agent-boundary-json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Lead the Cursor instruction surface with `shipgate diff`. It opened with
+  the control envelope, so an agent following it reported "a human must
+  review" without naming what changed, while `AGENTS.md` had led with the
+  named rows since #651. The generated file now names the row fields, says
+  a covered comparison with no rows is a real answer, and repeats that a
+  row is a description and never a permission. The committed rule file and
+  the copyable snippet in `docs/target-repo-agent-snippets.md` are
+  regenerated from the one renderer; both are pinned to it by tests (#662).
+
 - Read `.claude/hooks/hooks.json`. A `SessionStart` command is executable code
   around the agent and was invisible; the document is the same shape as
   `.codex/hooks.json`, which has been read since the Codex adapter landed, so

--- a/docs/target-repo-agent-snippets.md
+++ b/docs/target-repo-agent-snippets.md
@@ -332,6 +332,21 @@ When a change affects agent tools, MCP exports, OpenAPI specs, prompts,
 permissions, approval policies, or release gates, run Agents Shipgate.
 Default to advisory verification while adopting the gate.
 
+First, name what the change did to the agent's authority. This needs no
+manifest and no committed baseline:
+
+  shipgate diff --workspace .
+
+One row per host grant, each carrying subject, before, after, direction,
+severity and why it matters; `⚠` marks a row the engine read as an
+expansion of authority. Quote those rows to the user, and put them in the
+pull request body. A covered comparison with no rows is a real answer, not
+a missing one. `--json` emits the same rows under `rows`.
+
+A row is a description, never a permission: showing one, or seeing an empty
+table, grants no authority to edit, commit, push, merge or report the work
+complete.
+
 For local agent control, run:
 
   shipgate check --agent cursor --workspace . --format agent-boundary-json

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/cursor.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/cursor.py
@@ -58,6 +58,21 @@ When a change affects agent tools, MCP exports, OpenAPI specs, prompts,
 permissions, approval policies, or release gates, run Agents Shipgate.
 Default to advisory verification while adopting the gate.
 
+First, name what the change did to the agent's authority. This needs no
+manifest and no committed baseline:
+
+  shipgate diff --workspace .
+
+One row per host grant, each carrying subject, before, after, direction,
+severity and why it matters; `⚠` marks a row the engine read as an
+expansion of authority. Quote those rows to the user, and put them in the
+pull request body. A covered comparison with no rows is a real answer, not
+a missing one. `--json` emits the same rows under `rows`.
+
+A row is a description, never a permission: showing one, or seeing an empty
+table, grants no authority to edit, commit, push, merge or report the work
+complete.
+
 For local agent control, run:
 
   shipgate check --agent cursor --workspace . --format agent-boundary-json


### PR DESCRIPTION
Part of #662. **Stacked on #704** (which is stacked on #703) — this PR's diff is its last commit only.

## Why

The Cursor rule opened with the control envelope:

```
For local agent control, run:
  shipgate check --agent cursor --workspace . --format agent-boundary-json
Read the check stdout JSON only... switch on `control.state`
```

An agent following that reports `human_review_required` to its user without naming what changed — the original finding behind #662. `AGENTS.md` has led with `shipgate diff` and the row table since #651; the generated Cursor surface never caught up. Measured on the three-widening scenario: `AGENTS.md`'s route names all four widenings, the Cursor route names none of them before the control block.

## What changed

The Cursor instructions now open with `shipgate diff --workspace .`, name the row fields an agent should quote (subject, before, after, direction, severity, why), and say two things the control envelope alone does not:

- a covered comparison with **no rows is a real answer**, not a missing one — otherwise an agent treats quiet as failure and escalates;
- a row is a description and **never a permission**: showing one, or seeing an empty table, grants no authority to edit, commit, push, merge or report complete.

The existing control-envelope instructions are unchanged and still follow. This adds the named change in front of them; it does not replace operational routing.

## The guards did the work

Editing the renderer failed two existing tests, both correctly:

- `test_committed_cursor_rule_matches_renderer` — the checked-in `.cursor/rules/agents-shipgate.mdc`;
- `test_target_repo_cursor_snippet_matches_renderer` — the copyable block in `docs/target-repo-agent-snippets.md`.

Both are regenerated from the one renderer rather than hand-edited, so the three copies cannot drift. This is the same "second projection" class the registry work hit in #704.

No render-hash bump: those pin the Claude Code and Codex **skill** bundles, which this does not touch. The legacy skill stays suspended under #690 and is not repaired here.

## Not in this PR

The rest of #662 — the 12 deterministic entry-contract cases, and the after-readiness provider experiment — is separate. What is already true and was verified while measuring this: `check --format agent-boundary-json` carries `rows` (5 on the scenario, naming every widening) and `verify --preview --base main --format text` renders the full table with an `advisory: no application release policy configured` footer. Both arrived with #684.

## Evidence

Full suite green (`pytest -n auto`, exit 0), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)