### PR TITLE
An empty frontmatter value means absent, not invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   every step of its history. An explicit null is now read as an absent key,
   which is what it means. Wrong types are still wrong, unknown keys are
   still unknown, and a skill with an empty `name` or `description` still
-  fails on identity rather than sliding through (#711).
+  fails on identity rather than sliding through (#712).
 
 - Manifest-free host PR review now names capability changes in verify, PR comments,
   and check. Interactive check defaults to readable text; agent mode keeps JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Read the Cursor rule format Cursor actually writes. `globs:` with nothing
+  after it — how Cursor spells a rule that is not glob-scoped — reads as
+  YAML null, and the frontmatter type check rejected null for every field.
+  That made the canonical `.cursor/rules/*.mdc` an unresolved instruction
+  structure, which is a blocking inventory issue, which made the whole
+  repository incomparable: `Doist/todoist-mcp` has eleven readable host
+  files and two such rules, and `diff` produced no rows for any of them on
+  every step of its history. An explicit null is now read as an absent key,
+  which is what it means. Wrong types are still wrong, unknown keys are
+  still unknown, and a skill with an empty `name` or `description` still
+  fails on identity rather than sliding through (#711).
+
 - Manifest-free host PR review now names capability changes in verify, PR comments,
   and check. Interactive check defaults to readable text; agent mode keeps JSON.
   Comparison evidence binds its input refs, excludes stale scan artifacts, and

--- a/src/agents_shipgate/core/instruction_structure.py
+++ b/src/agents_shipgate/core/instruction_structure.py
@@ -75,6 +75,18 @@ def _digest(value: object) -> str:
 
 def _valid_metadata(metadata: dict) -> bool:
     for key, value in metadata.items():
+        if value is None:
+            # `globs:` with nothing after it is how Cursor writes a rule that
+            # is not glob-scoped, and YAML reads that as None. Rejecting it
+            # made the canonical Cursor rule file an unresolved structure,
+            # which is a *blocking* inventory issue, which made every
+            # repository carrying one incomparable in full — `Doist/todoist-mcp`
+            # produced no rows for eleven readable host files because two
+            # `.cursor/rules/*.mdc` used the format Cursor itself generates.
+            # An explicit null is the same statement as an absent key: the
+            # field is not set. Where a field is genuinely required, the
+            # profile checks below still say so and still fire.
+            continue
         if key in {"disable-model-invocation", "user-invocable", "alwaysApply"}:
             if not isinstance(value, bool):
                 return False

--- a/src/agents_shipgate/core/instruction_structure.py
+++ b/src/agents_shipgate/core/instruction_structure.py
@@ -243,6 +243,10 @@ def classify_instruction(path: str, text: str | None) -> InstructionStructure | 
         commands = [] if profile == "cursor_instruction/v1" else _preprocessing_commands(body)
         if commands is None:
             return unresolved("preprocessing_unresolved")
+        # Optional null fields carry the same declaration as an omitted key.
+        # Normalize only after unknown-key/type/required-field validation;
+        # nested metadata and actual permission or hook values stay intact.
+        metadata = {key: value for key, value in metadata.items() if value is not None}
         structure = _digest([profile, metadata, commands])
     except (yaml.YAMLError, RecursionError, TypeError, ValueError):
         return unresolved("frontmatter_invalid")

--- a/tests/test_instruction_structure.py
+++ b/tests/test_instruction_structure.py
@@ -132,3 +132,80 @@ def test_mode_change_cannot_hide_behind_a_prose_change():
     parsed = parse_unified_diff(diff)[0]
     assert parsed.metadata_changed
     assert not unchanged_instruction_structure(parsed, ResolvedFileText(before, after, "fixture", None, None))
+
+
+# --- empty frontmatter values ------------------------------------------------
+#
+# `globs:` with nothing after it is how Cursor writes a rule that is not
+# glob-scoped, and YAML reads that as None. Rejecting it made the canonical
+# Cursor rule an unresolved structure — a *blocking* inventory issue — so a
+# repository carrying one produced no rows at all. `Doist/todoist-mcp` had
+# eleven readable host files and two such rules, and `shipgate diff` answered
+# `incomparable` for that whole repository on every step of its history.
+
+_CURSOR_RULE = ".cursor/rules/demo.mdc"
+
+
+def _cursor(fields: str) -> str:
+    return f"---\n{fields}---\nBe concise.\n"
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        # Exactly what Cursor generates for an always-apply rule.
+        "description: \nglobs: \nalwaysApply: true\n",
+        # ...and for a described rule that is not glob-scoped.
+        "description: Use context7 for library docs\nglobs: \nalwaysApply: false\n",
+        "description: \nglobs: \nalwaysApply: \n",
+        "globs: \n",
+    ],
+)
+def test_an_empty_cursor_field_is_absent_not_invalid(fields: str) -> None:
+    resolved = classify_instruction(_CURSOR_RULE, _cursor(fields))
+
+    assert resolved.status == "structured", resolved.reason
+
+
+def test_a_populated_cursor_rule_still_resolves() -> None:
+    """The fix must not be the only reason anything passes."""
+
+    resolved = classify_instruction(
+        _CURSOR_RULE, _cursor('description: TS rules\nglobs: "**/*.ts"\nalwaysApply: false\n')
+    )
+
+    assert resolved.status == "structured", resolved.reason
+
+
+@pytest.mark.parametrize(
+    ("fields", "reason"),
+    [
+        # A wrong *type* is still a wrong type. Only "not set" is forgiven.
+        ("description: TS\nglobs: 7\nalwaysApply: false\n", "frontmatter_invalid_structure"),
+        ("description: TS\nglobs: \nalwaysApply: yes-please\n", "frontmatter_invalid_structure"),
+        # An unknown key is still unknown, empty or not.
+        ("description: TS\nunexpected: \n", "frontmatter_unknown_fields"),
+    ],
+)
+def test_an_empty_value_does_not_excuse_a_real_structure_problem(
+    fields: str, reason: str
+) -> None:
+    resolved = classify_instruction(_CURSOR_RULE, _cursor(fields))
+
+    assert resolved.status == "unresolved"
+    assert resolved.reason == reason
+
+
+def test_a_skill_still_needs_a_real_name_and_description() -> None:
+    """The required-field check is separate and must keep firing.
+
+    Treating an explicit null as absent in the shared type check would be a
+    hole if identity were only enforced there.
+    """
+
+    for fields in ("name: demo\ndescription: \n", "name: \ndescription: Test\n"):
+        resolved = classify_instruction(
+            ".agents/skills/demo/SKILL.md", f"---\n{fields}---\nBody.\n"
+        )
+        assert resolved.status == "unresolved", fields
+        assert resolved.reason == "skill_identity_missing", fields

--- a/tests/test_instruction_structure.py
+++ b/tests/test_instruction_structure.py
@@ -209,3 +209,28 @@ def test_a_skill_still_needs_a_real_name_and_description() -> None:
         )
         assert resolved.status == "unresolved", fields
         assert resolved.reason == "skill_identity_missing", fields
+
+
+@pytest.mark.parametrize(
+    ("path", "required", "optional"),
+    [
+        (".cursor/rules/demo.mdc", "", "globs"),
+        (".cursor/rules/demo.mdc", "", "alwaysApply"),
+        (".claude/commands/demo.md", "", "allowed-tools"),
+        (".claude/commands/demo.md", "", "hooks"),
+        (".agents/skills/demo/SKILL.md", "name: demo\ndescription: Test\n", "allowed-tools"),
+    ],
+)
+def test_optional_null_and_omitted_fields_have_the_same_structure(path, required, optional):
+    absent = classify_instruction(path, f"---\n{required}---\nBody.\n")
+    explicit_null = classify_instruction(path, f"---\n{required}{optional}:\n---\nBody.\n")
+    assert absent.status == explicit_null.status == "structured"
+    assert absent.sha256 == explicit_null.sha256
+
+
+def test_normalizing_null_does_not_hide_an_actual_permission_change():
+    path = ".claude/commands/demo.md"
+    empty = classify_instruction(path, "---\nallowed-tools:\n---\nBody.\n")
+    granted = classify_instruction(path, "---\nallowed-tools: Bash(*)\n---\nBody.\n")
+    assert empty.status == granted.status == "structured"
+    assert empty.sha256 != granted.sha256


### PR DESCRIPTION
Found by the Gate 1 harness while re-measuring the twelve-repository sample. Independent of #703/#704 — branched off `main`.

## Why

`globs:` with nothing after it is how Cursor writes a rule that is not glob-scoped. This is the file Cursor generates:

```
---
description: 
globs: 
alwaysApply: true
---
```

YAML reads those empty values as `None`, and `_valid_metadata` rejected `None` for every field. So the canonical Cursor rule classified as `frontmatter_invalid_structure`.

That reason is a **blocking** inventory issue. One blocking issue makes the base inventory incomplete. An incomplete base inventory makes the whole comparison `incomparable`.

Measured on `Doist/todoist-mcp` — eleven readable host files (`.claude/settings.json`, `.mcp.json`, `.cursor/mcp.json`, five workflows, `AGENTS.md`, `CLAUDE.md`) and two Cursor rules in Cursor's own format:

| | before | after |
|---|---|---|
| `shipgate diff --base HEAD~1` | `incomparable`, `base_inventory_incomplete`, **0 rows** | `comparable`, 0 rows |
| across its history | all 40 first-parent steps incomparable | comparable |

A reviewer got nothing about eleven files that were read perfectly, because two files used a format we mis-read. This is the same shape as #688 — one unreadable path refusing the whole repository — arriving through a different door.

## The fix

An explicit null is the same statement as an absent key: the field is not set. `_valid_metadata` now skips `None` and lets the profile's own required-field checks speak.

## What still fails, and is pinned

Forgiving `None` in a shared type check would be a hole if identity were only enforced there, so the tests say what must still fire:

- a wrong **type** is still wrong — `globs: 7`, `alwaysApply: yes-please` → `frontmatter_invalid_structure`;
- an unknown key is still unknown, empty or not → `frontmatter_unknown_fields`;
- a skill with an empty `name` or `description` still fails → `skill_identity_missing`. (On pre-fix `main` it failed as `frontmatter_invalid_structure`; the specific reason is the better answer and this pins that it is reached.)

## Evidence

Eight cases in `tests/test_instruction_structure.py`. **Five fail against pre-fix `main`**; the three that pass on both are the contract-preservation half — a fully populated Cursor rule still resolves, and the two real-structure-problem cases still refuse.

Full suite green (`pytest -n auto`, exit 0), ruff clean.

## Scope

`.cursor/rules/*.mdc` is the case that was measured, but the fix is in the shared metadata check, so `claude_command/v1` and `skill_instruction/v1` gain the same reading. That is deliberate: an empty optional field means the same thing in all three, and the profile-specific required-field checks are what enforce the differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)