### PR TITLE
Run the mcp SDK injection cross-checks on the SDK the extra installs (#716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Run the FastMCP Context-injection SDK cross-checks on the SDK versions the
+  `[mcp]` extra allows. FastMCP was renamed to MCPServer in mcp 2.x and the
+  extra requires `mcp>=2.1.1,<3`, but both cross-checks imported only the 1.x
+  module, so the eight cases comparing the static reader with the real SDK's
+  `find_context_parameter` skipped on every install that satisfies the extra,
+  CI included; they still ran, but only against an out-of-range mcp 1.x such as 1.27.2. They now try the 2.x location first and the
+  1.x one second, skip only when `mcp` is absent, and fail when an installed
+  SDK exposes neither. All eight pass on mcp 2.2.0 and on 1.27.2 (#716).
+
 - Freeze the report contract at `1.0` and publish what that number promises.
   `report_schema_version` moves `0.43` → `1.0` and runtime contract `33` → `34`;
   `minimum_control_contract_version` stays `21`. The shape does not change:

--- a/tests/test_fastmcp_injection_contract.py
+++ b/tests/test_fastmcp_injection_contract.py
@@ -4,11 +4,72 @@ SDK probes below call only the installed framework's signature utility on
 functions authored in this test. No scanned server is imported or executed.
 """
 
+import importlib
+import importlib.metadata
+import importlib.util
 import typing
 
 import pytest
 
 from agents_shipgate.inputs.mcp_idioms import scan_source
+
+#: Where the installed SDK keeps the signature utility these probes compare
+#: against. FastMCP was renamed to MCPServer in mcp 2.x, and the `[mcp]` extra
+#: requires `mcp>=2.1.1,<3`, so importing only the 1.x path skipped on every
+#: supported install: the cross-checks against the real SDK never ran (#716).
+_SDK_LOCATIONS = (
+    ("mcp.server.mcpserver.utilities.context_injection", "mcp.server.mcpserver"),  # mcp 2.x
+    ("mcp.server.fastmcp.utilities.context_injection", "mcp.server.fastmcp"),  # mcp 1.x
+)
+
+
+def _installed_sdk():
+    """The installed SDK's injection utility and its ``Context`` class.
+
+    Skips only when ``mcp`` itself is absent. An installed SDK exposing
+    neither location is an API move this file has not followed, and skipping
+    it would hide the gap exactly the way the 1.x-only import did, so that
+    fails instead.
+    """
+
+    if importlib.util.find_spec("mcp") is None:
+        pytest.skip(
+            "the mcp SDK is not installed; install agents-shipgate[mcp] to run "
+            "the SDK cross-checks"
+        )
+    for utility, package in _SDK_LOCATIONS:
+        try:
+            module = importlib.import_module(utility)
+        except ModuleNotFoundError:
+            continue
+        return module, importlib.import_module(package).Context
+    try:
+        version = importlib.metadata.version("mcp")
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    pytest.fail(
+        f"mcp {version} is installed but exposes no context-injection utility at a "
+        "known location; extend _SDK_LOCATIONS rather than letting these cross-checks skip"
+    )
+
+
+def test_an_absent_sdk_skips_and_names_the_extra(monkeypatch):
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name, *a, **k: None)
+    with pytest.raises(pytest.skip.Exception, match=r"agents-shipgate\[mcp\]"):
+        _installed_sdk()
+
+
+def test_an_installed_sdk_at_an_unknown_location_fails_instead_of_skipping(monkeypatch):
+    """The skip that hid #716 must not come back with the next rename."""
+
+    def missing(name, *args, **kwargs):
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name, *a, **k: object())
+    monkeypatch.setattr(importlib, "import_module", missing)
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "9.9.9")
+    with pytest.raises(pytest.fail.Exception, match="no context-injection utility"):
+        _installed_sdk()
 
 
 def _parameters(signature, *, imports="", definitions="", family="mcp.server.fastmcp"):
@@ -69,8 +130,7 @@ def test_unresolved_whole_signature_does_not_hide_context(signature):
     "Dict[str]", "Dict[str, str, int]", "Union[()]",
 ])
 def test_invalid_typing_arity_cannot_hide_context(annotation):
-    sdk = pytest.importorskip("mcp.server.fastmcp.utilities.context_injection")
-    from mcp.server.fastmcp import Context
+    sdk, Context = _installed_sdk()
 
     # Authored test annotations only: get_type_hints must reach the same
     # semantic refusal that stops the real SDK's whole-signature resolver.
@@ -132,8 +192,7 @@ def test_unresolved_local_class_construction_cannot_hide_a_parameter(definition)
 
 
 def test_installed_sdk_whole_signature_and_generic_semantics():
-    sdk = pytest.importorskip("mcp.server.fastmcp.utilities.context_injection")
-    from mcp.server.fastmcp import Context
+    sdk, Context = _installed_sdk()
 
     def direct(ctx: Context) -> str:
         return ""


### PR DESCRIPTION
Closes #716.

## Why

Both SDK cross-checks in `tests/test_fastmcp_injection_contract.py` imported only `mcp.server.fastmcp`, the **1.x** module. FastMCP was renamed to MCPServer in `mcp` 2.x, and the `[mcp]` extra requires `mcp>=2.1.1,<3`. So on every install that satisfies the extra, CI included, the eight cases comparing our static reader with the real SDK's `find_context_parameter` skipped. They ran only against an out-of-range `mcp` 1.x.

The other cases in the file (through our own `scan_source`) always ran. The gap was only the cross-check against the actual SDK.

## What changed

`_installed_sdk()` tries `mcp.server.mcpserver` (2.x) and then `mcp.server.fastmcp` (1.x). It **skips only when `mcp` is absent**, with a reason naming the extra. It **fails** when an installed SDK exposes neither location. A skip there would hide the next rename the same way. Two new tests pin both branches, and neither needs `mcp` installed.

## Evidence (only measured cells)

| environment | `main` | this branch |
|---|---|---|
| `mcp` 2.2.0, satisfies the extra | **8 skipped** | **8 passed** |
| `mcp` 1.27.2, below the extra's floor | 8 passed (1.x path) | 8 passed (1.x fallback) |
| no `mcp`, a base install (it does not pull `mcp` in) | not measured | 8 skipped, reason names `agents-shipgate[mcp]`; 45 passed |

The 2.x `find_context_parameter` satisfies every existing assertion: whole-signature failure, typing-arity refusal, generics and parameterized `Context`. No expectation changed.

## Not solved here

CI installs only `constraints/dev.txt`, which has no `mcp`, so these still skip in CI. The durable fix is a job that installs `[mcp]`. That is a CI and lock change, so it is recorded on #716 rather than bundled into a test fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)