### PR TITLE
Publish a version declared advisory through the release pipeline (#648)

### DIFF
--- a/.github/release-channels.json
+++ b/.github/release-channels.json
@@ -1,0 +1,6 @@
+{
+  "schema": "shipgate.release_channels/v1",
+  "channels": {
+    "1.0.0": "advisory"
+  }
+}

--- a/.github/workflows/release-advisory-rehearsal.yml
+++ b/.github/workflows/release-advisory-rehearsal.yml
@@ -1,0 +1,48 @@
+name: Advisory Release Rehearsal
+
+# The advisory line's counterpart to `release-rehearsal.yml` (#648). It calls
+# the same reusable workflow `release.yml` calls for a version declared
+# advisory, `release-advisory-verify.yml`, with nothing that can publish.
+#
+# `release.yml`'s `stage` job locates the mandatory rehearsal by workflow file,
+# and takes the file name from the declared channel. This is its own file, so a
+# run of it can never satisfy the qualified line's rehearsal, and a qualified
+# rehearsal can never satisfy an advisory release.
+#
+# The same three properties that keep `release-rehearsal.yml` from publishing
+# hold here: there is no publication job in this file, the workflow grants no
+# write, and nothing can mint an `id-token`. `actions: read` is read-only: the
+# verification locates and downloads the Release Engine Smoke run that
+# exercised the exact candidate.
+#
+# Before dispatching, run Release Engine Smoke on the same commit; see
+# docs/release-runbook.md § The advisory release channel.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: >-
+          Tag to rehearse against. Leave empty to derive v<pyproject version>,
+          which is what the real tag will be.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  rehearse:
+    name: Rehearse advisory candidate
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/release-advisory-verify.yml
+    with:
+      # `github.sha`, never a free-form ref: see the matching comment in
+      # `release-rehearsal.yml`.
+      ref: ${{ github.sha }}
+      release_tag: ${{ inputs.release_tag }}
+      mode: rehearsal

--- a/.github/workflows/release-advisory-verify.yml
+++ b/.github/workflows/release-advisory-verify.yml
@@ -1,0 +1,561 @@
+name: Advisory Release Verification
+
+# Read-only verification of an advisory release candidate (#648). Called by
+# release.yml, for a version `.github/release-channels.json` declares advisory,
+# and by release-advisory-rehearsal.yml.
+#
+# Why this is a separate file rather than a mode of `release-verify.yml`: an
+# advisory release carries no qualification claim, so it has no qualification
+# to verify. Skipping those steps behind a flag inside the qualified workflow
+# would make the separation a matter of getting `if:` conditions right, which
+# `docs/release-evidence-policy-decision.md` rejected for the preview channel
+# (Amendment 2, C3) and rejects again for this one (Amendment 5). This file has
+# no qualification step to skip.
+#
+# What it does verify is everything else a release needs, with the steps both
+# lines share copied byte for byte from `release-verify.yml` and held there by
+# `tests/test_release_advisory_pipeline.py`: the correctness suite, the
+# dependency locks and audit, the CHANGELOG section, the hash-locked build, the
+# wheel-scoped SBOM and the content-addressed handoff.
+#
+# In place of a downloaded qualified wheel, it publishes the wheel a Release
+# Engine Smoke run installed and exercised through both the CLI and the
+# composite Action for the exact source commit, proven byte-identical to the
+# wheel this checkout builds (#570). In place of the qualification artifact, it
+# writes an advisory statement that says what the release does not claim.
+#
+# This workflow never publishes. It holds `contents: read` and `actions: read`
+# and no `id-token`, and a reusable workflow cannot be handed more.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to verify. A tag for a release, any ref for a rehearsal.
+        required: true
+        type: string
+      release_tag:
+        description: >-
+          Tag the candidate claims. Empty means "derive v<pyproject version>",
+          which is what a rehearsal on a branch checks against.
+        required: false
+        type: string
+        default: ""
+      mode:
+        description: Either "release" or "rehearsal". Affects reporting only.
+        required: false
+        type: string
+        default: rehearsal
+    outputs:
+      version:
+        description: Package version of the verified candidate.
+        value: ${{ jobs.artifact.outputs.version }}
+      release_tag:
+        description: Tag the verified candidate is bound to.
+        value: ${{ jobs.artifact.outputs.release_tag }}
+      source_sha:
+        description: Commit the candidate was actually built from, resolved after checkout.
+        value: ${{ jobs.artifact.outputs.source_sha }}
+      wheel_filename:
+        description: Basename of the exercised wheel.
+        value: ${{ jobs.artifact.outputs.wheel_filename }}
+      wheel_sha256:
+        description: SHA-256 of the wheel that verification approved.
+        value: ${{ jobs.artifact.outputs.wheel_sha256 }}
+      manifest_sha256:
+        description: >-
+          SHA-256 of the candidate manifest, through the job-output channel so
+          publication can detect artifact substitution.
+        value: ${{ jobs.artifact.outputs.manifest_sha256 }}
+      release_notes_sha256:
+        description: SHA-256 of the changelog section this candidate publishes.
+        value: ${{ jobs.artifact.outputs.release_notes_sha256 }}
+      artifact_name:
+        description: Name of the uploaded candidate bundle.
+        value: ${{ jobs.artifact.outputs.artifact_name }}
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  tests:
+    name: Correctness suite
+    runs-on: ubuntu-latest
+    # The same budget as `release-verify.yml`'s suite, which runs the same
+    # selection; the measurement behind it is recorded there.
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      source_sha: ${{ steps.tested.outputs.source_sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+          # Tags, for the same reason `ci.yml`'s suite job fetches them: the
+          # candidate's own suite checks every pin `init` writes into an
+          # adopter's repository against this repository's release tags (#506).
+          # `ref` alone brings the tag under test and no other, so the newest
+          # *published* release — which the pins name until the constants are
+          # bumped after this tag lands — would be missing.
+          # `tests/test_action_metadata.py`'s
+          # `test_jobs_running_the_whole_suite_check_out_release_tags` asserts
+          # this for every job that runs the suite, in any workflow, because
+          # this one and `ci.yml` were fixed separately once already (#497).
+          fetch-tags: true
+
+      - name: Record the commit under test
+        id: tested
+        run: echo "source_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            constraints/dev.txt
+            constraints/build-backend.txt
+
+      - name: Install
+        # Byte-for-byte the environment CI installs — the same hash-locked
+        # closures, installed with the same commands. `pip install -e ".[dev]"`
+        # resolved fresh at tag time, so the run that decided whether to publish
+        # could differ from the run that approved the commit, and a release-only
+        # failure could not be reproduced from the same tree.
+        #
+        # Nothing here may resolve, including the PEP 517 backend: see the
+        # matching comment in ci.yml for why `--no-build-isolation` and a
+        # separate backend closure are what actually close that hole.
+        run: |
+          python -m pip install --require-hashes --requirement constraints/dev.txt
+          python -m pip install --require-hashes --requirement constraints/build-backend.txt
+          python -m pip install -e . --no-deps --no-build-isolation
+          python -m pip check
+
+      - name: Verify the dependency locks match the declared requirements
+        # A lock that no longer matches pyproject.toml means the release is
+        # testing something other than what it declares. Checked here, before
+        # the suite, so it fails as a named precondition rather than as a
+        # mystery import error inside the release.
+        run: python scripts/verify_dependency_lock.py
+
+      - name: Lint
+        run: python -m ruff check .
+
+      - name: Compile
+        run: python -m compileall -q src tests
+
+      - name: Verify generated schemas are up to date
+        run: python scripts/generate_schemas.py --check
+
+      - name: Trust-model invariant lint (static, no user code execution)
+        # Kept as its own step, and excluded from the aggregate run below, so a
+        # release candidate that introduces a dynamic-import surface in an
+        # adapter fails with a named check rather than inside coverage noise.
+        run: python -m pytest tests/test_adapter_static_only.py -q
+
+      - name: Test
+        # Deliberately differs from CI in two ways, and only two:
+        #
+        #   * `-n auto` matches CI's supported parallelism. Serial execution
+        #     made a release candidate spend the whole budget re-running work
+        #     CI already parallelises.
+        #   * `-m "not perf"` excludes the latency-budget tests. CI is the
+        #     merge-time enforcement point for latency; those tests assert
+        #     wallclock medians and are the one part of the suite that fails
+        #     from shared-runner timing noise rather than from a defect. A
+        #     release candidate must fail on deterministic correctness
+        #     evidence, not on how busy the runner was.
+        #
+        # The coverage floor stays at CI's 85 so release cannot bypass it.
+        run: >-
+          python -m pytest -n auto -m "not perf"
+          --ignore=tests/test_adapter_static_only.py
+          --cov=agents_shipgate --cov-report=term-missing --cov-fail-under=85
+
+      - name: Dependency audit
+        run: python -m pip_audit .
+
+  artifact:
+    name: Verify and seal the advisory candidate
+    # Runs after the suite, in its own runner, and executes none of the
+    # candidate's tests, for the reason recorded on `release-verify.yml`'s
+    # `artifact` job.
+    needs: tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      version: ${{ steps.candidate.outputs.version }}
+      release_tag: ${{ steps.candidate.outputs.release_tag }}
+      source_sha: ${{ steps.candidate.outputs.source_sha }}
+      wheel_filename: ${{ steps.exercised.outputs.wheel_filename }}
+      wheel_sha256: ${{ steps.handoff.outputs.wheel_sha256 }}
+      manifest_sha256: ${{ steps.handoff.outputs.manifest_sha256 }}
+      artifact_name: ${{ steps.handoff.outputs.artifact_name }}
+      release_notes_sha256: ${{ steps.notes.outputs.release_notes_sha256 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+      - name: Resolve candidate version and tag
+        id: candidate
+        env:
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          # The commit actually checked out, resolved after checkout rather than
+          # taken from the triggering event. Callers pass an immutable SHA, but
+          # this is what every downstream binding is keyed to, so it is measured
+          # here instead of assumed.
+          source_sha="$(git rev-parse HEAD)"
+          version="$(sed -n 's/^version = "\(.*\)"$/\1/p' pyproject.toml | head -n 1)"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read version from pyproject.toml."
+            exit 1
+          fi
+          tag="${REQUESTED_TAG:-v${version}}"
+          # Fail fast before the test/qualification pipeline if the tag was cut
+          # on a commit whose pyproject.toml disagrees (e.g. a v0.15.0 tag
+          # pushed while main still says 0.14.0). PyPI uploads are immutable,
+          # so this is the last cheap moment to catch a mistagged release.
+          if [ "${tag}" != "v${version}" ]; then
+            echo "::error::Tag ${tag} does not match pyproject.toml version ${version}; refusing to release."
+            exit 1
+          fi
+          {
+            echo "version=${version}"
+            echo "release_tag=${tag}"
+            echo "source_sha=${source_sha}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "OK: ${tag} matches pyproject.toml (${version}) at ${source_sha}."
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Refuse a version that is not declared advisory
+        # The mirror of `release.yml`'s channel switch, inside the workflow it
+        # selects. Called directly, or from a rehearsal, this file still cannot
+        # verify a version reviewed code assigned to the qualified line, so no
+        # such version can reach publication without its qualification.
+        # Standard library only, so it runs before any toolchain is installed.
+        env:
+          RELEASE_TAG: ${{ steps.candidate.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          channel="$(python scripts/release_channel.py resolve --tag "${RELEASE_TAG}")"
+          if [ "${channel}" != "advisory" ]; then
+            echo "::error::${RELEASE_TAG} is declared ${channel} in .github/release-channels.json; the advisory verification refuses it."
+            exit 1
+          fi
+          echo "OK: ${RELEASE_TAG} is declared advisory."
+
+      - name: Require a CHANGELOG section for this tag
+        id: notes
+        # The release body is the changelog section, so an absent section is a
+        # release nobody described. Required here, in the shared verification
+        # workflow, which means the rehearsal fails on it while the tag does
+        # not yet exist — the only point at which "rename `## Unreleased`" is
+        # still a cheap fix.
+        #
+        # This is also where the notes become content-addressed: `stage` and
+        # `finalize` extract independently and must land on this digest. The
+        # rehearsal therefore exercises the identical write, to the identical
+        # runner-owned path, that the release will perform — a candidate is
+        # never the thing that decides where this file goes.
+        #
+        # Standard library only, so it needs no installed toolchain and runs
+        # before the build, the downloads, and the qualification checks.
+        env:
+          RELEASE_TAG: ${{ steps.candidate.outputs.release_tag }}
+        run: |
+          python scripts/release_notes.py \
+            --tag "${RELEASE_TAG}" \
+            --output "${RUNNER_TEMP}/release-notes.md" \
+            --github-output "${GITHUB_OUTPUT}"
+      - name: Install the hash-locked sealing toolchain
+        # No editable install and no `dev` extra. An unlocked
+        # `pip install -e ".[dev]"` resolves dozens of packages by range and
+        # runs *before* the build, the qualification checks, the provenance
+        # comparison and the sealing — so one compromised compatible release
+        # could rewrite the verifier, both wheel copies, and the digests that
+        # delegate publication authority, with every later check agreeing.
+        run: |
+          python -m pip install --require-hashes \
+            --requirement constraints/release-seal.txt
+      - name: Confirm the sealer is verifying the tested commit
+        # `tests` and this job check out independently. If a caller passed a
+        # mutable ref, the two could resolve to different commits — testing A
+        # and sealing B.
+        env:
+          TESTED_SHA: ${{ needs.tests.outputs.source_sha }}
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [ "${TESTED_SHA}" != "${SOURCE_SHA}" ]; then
+            echo "::error::The suite ran against ${TESTED_SHA} but this job resolved ${SOURCE_SHA}."
+            exit 1
+          fi
+          echo "OK: suite and sealer agree on ${SOURCE_SHA}."
+      - name: Build a wheel from the checked-out source
+        # The provenance gate this feeds is the only thing tying the published
+        # bytes back to the tagged commit, and the archive records
+        # `Generator: hatchling <version>`, so a backend bump alone changes the
+        # wheel and fails the gate on a legitimate release.
+        #
+        # What actually pins the backend here is the hash-locked
+        # constraints/release-seal.txt installed above, together with
+        # `--no-isolation` below. PIP_CONSTRAINT is kept as a belt-and-braces
+        # declaration of intent for any future pip-driven path, but it is not
+        # the mechanism: current pip does not apply it to an isolated build
+        # environment at all — constraining hatchling to a version that does
+        # not exist still builds — and `--no-isolation` creates no such
+        # environment to constrain. See constraints/release-build.txt.
+        env:
+          PIP_CONSTRAINT: constraints/release-build.txt
+          AGENTS_SHIPGATE_CANDIDATE_SOURCE_COMMIT: ${{ steps.candidate.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [ -e source-build ] || [ -L source-build ]; then
+            echo "::error::source-build must not pre-exist in the release checkout."
+            exit 1
+          fi
+          # `--no-isolation` so the hash-locked hatchling installed above is
+          # the backend that actually runs. With isolation, `build` creates a
+          # fresh environment and re-resolves the `pyproject.toml` build
+          # requirements, which puts the backend's own transitive dependencies
+          # outside the lock — the locked closure would be bypassed for exactly
+          # the code that produces the artifact. Verified byte-equivalent to an
+          # isolated build.
+          # Keep build output outside the checkout until the hook has
+          # revalidated its clean source; it must not certify its own output
+          # as an untracked input. This mode is scoped to this step only.
+          candidate_build_dir="$(mktemp -d "${RUNNER_TEMP}/shipgate-source-build.XXXXXX")"
+          python -m build --wheel --no-isolation --outdir "${candidate_build_dir}" .
+          mkdir source-build
+          cp "${candidate_build_dir}"/*.whl source-build/
+      - name: Download the candidate the Release Engine Smoke exercised
+        # The advisory line's counterpart to downloading the qualified wheel,
+        # and #570's obligation: what this release publishes is what a
+        # pre-publication smoke installed and ran through both the CLI and the
+        # composite Action. The run is found by the exact source commit —
+        # `head_sha` also binds the smoke workflow's own revision, since both
+        # are one tree — and the steps below prove those bytes are what this
+        # checkout builds. Publishing a fresh build instead would publish bytes
+        # nothing exercised.
+        id: exercised
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          for directory in exercised-dist exercised-evidence; do
+            if [ -e "${directory}" ] || [ -L "${directory}" ]; then
+              echo "::error::${directory} must not pre-exist in the release checkout."
+              exit 1
+            fi
+          done
+          run_id="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/release-engine-smoke.yml/runs?head_sha=${SOURCE_SHA}&status=success&per_page=100" \
+            --jq '.workflow_runs[0].id // empty')"
+          if [ -z "${run_id}" ]; then
+            echo "::error::No successful Release Engine Smoke run for ${SOURCE_SHA}. Dispatch it on this commit before rehearsing or tagging; see docs/release-runbook.md."
+            exit 1
+          fi
+          gh run download "${run_id}" --repo "${GITHUB_REPOSITORY}" \
+            --name unqualified-engine-wheel --dir exercised-dist
+          gh run download "${run_id}" --repo "${GITHUB_REPOSITORY}" \
+            --name unqualified-engine-smoke --dir exercised-evidence
+          shopt -s nullglob
+          wheels=(exercised-dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::Release Engine Smoke run ${run_id} must carry exactly one wheel; found ${#wheels[@]}."
+            exit 1
+          fi
+          wheel_filename="$(basename "${wheels[0]}")"
+          if [[ ! "${wheel_filename}" =~ ^[A-Za-z0-9_.+-]+\.whl$ ]]; then
+            echo "::error::Exercised wheel filename contains unsafe characters or path components."
+            exit 1
+          fi
+          echo "EXERCISED_WHEEL=exercised-dist/${wheel_filename}" >> "${GITHUB_ENV}"
+          echo "EXERCISED_WHEEL_FILENAME=${wheel_filename}" >> "${GITHUB_ENV}"
+          {
+            echo "wheel_filename=${wheel_filename}"
+            echo "smoke_run_id=${run_id}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "OK: Release Engine Smoke run ${run_id} exercised ${wheel_filename}."
+
+      - name: Require the smoke evidence to cover this exact candidate
+        # A successful run is not taken as the claim. The evidence the smoke
+        # wrote must name this commit and these bytes, record that the
+        # installed CLI and the Action agreed, and still call the build
+        # unqualified.
+        env:
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+        run: |
+          python scripts/release_channel.py exercised \
+            --evidence exercised-evidence/distribution-evidence.json \
+            --wheel "${EXERCISED_WHEEL}" \
+            --source-commit "${SOURCE_SHA}"
+
+      - name: Bind the exercised wheel to the tagged source tree
+        # Byte equality with the wheel this checkout builds, by the same
+        # verifier the qualified line uses. The report names its subject
+        # `exercised_wheel`, so nothing this release publishes calls its wheel
+        # qualified.
+        env:
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+        run: |
+          python scripts/verify_wheel_provenance.py \
+            --built source-build/*.whl \
+            --exercised "${EXERCISED_WHEEL}" \
+            --source-commit "${SOURCE_SHA}" \
+            --report provenance.json
+
+      - name: Prove the provenance gate fails closed
+        # The rehearsal drill `release-verify.yml` runs, against this line's
+        # binding: a tampered copy of the exercised wheel must be rejected.
+        if: inputs.mode == 'rehearsal'
+        run: |
+          set -euo pipefail
+          cp -- "${EXERCISED_WHEEL}" fault-injected.whl
+          python - <<'PY'
+          import zipfile
+
+          with zipfile.ZipFile("fault-injected.whl", "a") as archive:
+              archive.writestr("agents_shipgate/_fault_injection.py", "raise SystemExit\n")
+          PY
+          if python scripts/verify_wheel_provenance.py \
+              --built source-build/*.whl \
+              --exercised fault-injected.whl > fault-injection.log 2>&1; then
+            echo "::error::Fault injection was accepted; the provenance gate does not fail closed."
+            exit 1
+          fi
+          rm -f fault-injected.whl
+          echo "OK: provenance gate rejected a tampered wheel:"
+          cat fault-injection.log
+
+      - name: Generate wheel-scoped SBOM
+        # The same isolated runtime-only inventory the qualified line signs.
+        run: |
+          set -euo pipefail
+          mkdir -p candidate
+          python scripts/release_sbom.py build \
+            --wheel "${EXERCISED_WHEEL}" \
+            --output candidate/agents-shipgate-sbom.json
+          python scripts/release_sbom.py verify \
+            --wheel "${EXERCISED_WHEEL}" \
+            --sbom candidate/agents-shipgate-sbom.json
+
+      - name: Write the advisory statement
+        # In place of a qualification artifact. Its claims are fixed in
+        # `scripts/release_channel.py`, not assembled from build output; it
+        # names the exercise run and the readiness record at this commit, and
+        # it is signed alongside the wheel and the SBOM.
+        env:
+          RELEASE_TAG: ${{ steps.candidate.outputs.release_tag }}
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+          SMOKE_RUN_ID: ${{ steps.exercised.outputs.smoke_run_id }}
+        run: |
+          python scripts/release_channel.py statement \
+            --tag "${RELEASE_TAG}" \
+            --source-commit "${SOURCE_SHA}" \
+            --wheel "${EXERCISED_WHEEL}" \
+            --smoke-run-id "${SMOKE_RUN_ID}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --output candidate/advisory-statement.json
+
+      - name: Assemble content-addressed candidate handoff
+        id: handoff
+        env:
+          RELEASE_TAG: ${{ steps.candidate.outputs.release_tag }}
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          # Re-assert the binding on the exact bytes being sealed, as the
+          # qualified line does: every later stage trusts these digests.
+          python scripts/verify_wheel_provenance.py \
+            --built source-build/*.whl \
+            --exercised "${EXERCISED_WHEEL}" \
+            --source-commit "${SOURCE_SHA}" \
+            --report provenance.json
+          cp -- "${EXERCISED_WHEEL}" "candidate/${EXERCISED_WHEEL_FILENAME}"
+          cp -- provenance.json candidate/provenance.json
+          cmp -- "${EXERCISED_WHEEL}" "candidate/${EXERCISED_WHEEL_FILENAME}"
+          # `--channel advisory` records the channel in the manifest and
+          # refuses any asset set but the advisory one.
+          python scripts/release_publication.py manifest \
+            --tag "${RELEASE_TAG}" \
+            --source-commit "${SOURCE_SHA}" \
+            --channel advisory \
+            --wheel "candidate/${EXERCISED_WHEEL_FILENAME}" \
+            --asset candidate/agents-shipgate-sbom.json \
+            --asset candidate/advisory-statement.json \
+            --asset candidate/provenance.json \
+            --output candidate/candidate-manifest.json
+          manifest_sha256="$(python -c 'import hashlib,pathlib,sys; sys.stdout.write(hashlib.sha256(pathlib.Path("candidate/candidate-manifest.json").read_bytes()).hexdigest())')"
+          wheel_sha256="$(python -c 'import hashlib,pathlib,os,sys; sys.stdout.write(hashlib.sha256(pathlib.Path("candidate/"+os.environ["EXERCISED_WHEEL_FILENAME"]).read_bytes()).hexdigest())')"
+          {
+            echo "manifest_sha256=${manifest_sha256}"
+            echo "wheel_sha256=${wheel_sha256}"
+            echo "artifact_name=release-candidate-${RELEASE_TAG}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload candidate bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.handoff.outputs.artifact_name }}
+          path: candidate/
+          if-no-files-found: error
+          retention-days: 14
+      - name: Readiness summary
+        env:
+          MODE: ${{ inputs.mode }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.release_tag }}
+          WHEEL_FILENAME: ${{ steps.exercised.outputs.wheel_filename }}
+          WHEEL_SHA256: ${{ steps.handoff.outputs.wheel_sha256 }}
+          MANIFEST_SHA256: ${{ steps.handoff.outputs.manifest_sha256 }}
+          SMOKE_RUN_ID: ${{ steps.exercised.outputs.smoke_run_id }}
+        run: |
+          {
+            echo "## Advisory release candidate ${RELEASE_TAG} (${MODE})"
+            echo
+            echo "This candidate makes **no qualification claim**. Its channel is declared"
+            echo "advisory in \`.github/release-channels.json\`; see"
+            echo "\`docs/release-evidence-policy-decision.md\` § Amendment 5."
+            echo
+            echo "| Control | Result |"
+            echo "| --- | --- |"
+            echo "| Tag matches pyproject version | pass |"
+            echo "| Declared channel is advisory | pass |"
+            echo "| CHANGELOG section for the tag | pass |"
+            echo "| Dependency locks match declarations | pass |"
+            echo "| Exact candidate exercised (Release Engine Smoke run ${SMOKE_RUN_ID}) | pass |"
+            echo "| Exercised wheel bound to tagged source | $(python -c 'import json,sys; sys.stdout.write(json.load(open("provenance.json"))["provenance_mode"])') |"
+            echo "| Correctness suite (-n auto, not perf) | pass |"
+            echo "| Dependency audit | pass |"
+            echo "| Wheel-scoped SBOM | pass |"
+            echo "| Advisory statement written | pass |"
+            echo
+            echo "- Wheel: \`${WHEEL_FILENAME}\`"
+            echo "- Wheel SHA-256: \`${WHEEL_SHA256}\`"
+            echo "- Candidate manifest SHA-256: \`${MANIFEST_SHA256}\`"
+            echo
+            if [ "${MODE}" = "rehearsal" ]; then
+              echo "Rehearsal only. This workflow holds no publication authority:"
+              echo "no PyPI upload, no tag, and no GitHub Release was created."
+            else
+              echo "Verification complete. Publication requires \`pypi\` environment approval."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,53 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  channel:
+    name: Resolve the declared release channel
+    # Which line this tag publishes on is decided here, from the declaration
+    # committed at the tagged commit, before anything is built (#648). Choosing
+    # by what verification happens to find — whether a qualification artifact
+    # downloads — would let a qualified release whose download broke publish
+    # as advisory, and PyPI never gives a version back.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      channel: ${{ steps.channel.outputs.channel }}
+    steps:
+      - name: Check out only the channel declaration and its reader
+        # Standard-library scripts and one JSON file, at the immutable SHA of
+        # the push event.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/release-channels.json
+            scripts/_release_support.py
+            scripts/release_channel.py
+            scripts/release_publication.py
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+
+      - name: Read the channel reviewed code declares for this version
+        id: channel
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: python scripts/release_channel.py resolve --tag "${RELEASE_TAG}"
+
   verify:
-    name: Verify candidate
+    name: Verify qualified candidate
+    needs: channel
+    # Exactly one of `verify` and `verify_advisory` runs, chosen by the
+    # declaration. They call separate workflow files, so the advisory line
+    # skips no qualification step inside the qualified workflow: it calls one
+    # that has none (Amendment 2, C3; Amendment 5).
+    if: needs.channel.outputs.channel == 'qualified'
     permissions:
       contents: read
     uses: ./.github/workflows/release-verify.yml
@@ -34,9 +79,89 @@ jobs:
       release_tag: ${{ github.ref_name }}
       mode: release
 
+  verify_advisory:
+    name: Verify advisory candidate
+    needs: channel
+    if: needs.channel.outputs.channel == 'advisory'
+    permissions:
+      contents: read
+      # Read-only: locates and downloads the Release Engine Smoke run that
+      # exercised this exact candidate (#570).
+      actions: read
+    uses: ./.github/workflows/release-advisory-verify.yml
+    with:
+      # The immutable SHA of the push event, for the reason given on `verify`.
+      ref: ${{ github.sha }}
+      release_tag: ${{ github.ref_name }}
+      mode: release
+
+  candidate:
+    name: Confirm exactly the declared verification ran
+    needs: [channel, verify, verify_advisory]
+    # One verification job is always skipped, and a skipped dependency skips
+    # every job downstream of it unless a condition says otherwise. So this job
+    # runs whenever the channel resolved, and `release_channel.py candidate`,
+    # not this condition, decides: the declared job must have succeeded, the
+    # other must have stayed skipped and exported nothing, and every value
+    # publication reads must be present and bound to the pushed tag. Every job
+    # after this one names each of its dependencies' success explicitly.
+    if: ${{ !cancelled() && needs.channel.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      channel: ${{ steps.select.outputs.channel }}
+      version: ${{ steps.select.outputs.version }}
+      release_tag: ${{ steps.select.outputs.release_tag }}
+      source_sha: ${{ steps.select.outputs.source_sha }}
+      wheel_filename: ${{ steps.select.outputs.wheel_filename }}
+      wheel_sha256: ${{ steps.select.outputs.wheel_sha256 }}
+      manifest_sha256: ${{ steps.select.outputs.manifest_sha256 }}
+      release_notes_sha256: ${{ steps.select.outputs.release_notes_sha256 }}
+      artifact_name: ${{ steps.select.outputs.artifact_name }}
+      rehearsal_workflow: ${{ steps.select.outputs.rehearsal_workflow }}
+      release_assets: ${{ steps.select.outputs.release_assets }}
+      signed_assets: ${{ steps.select.outputs.signed_assets }}
+    steps:
+      - name: Check out only the channel reader
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/_release_support.py
+            scripts/release_channel.py
+            scripts/release_publication.py
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+
+      - name: Select the declared channel's verified candidate
+        id: select
+        env:
+          CHANNEL: ${{ needs.channel.outputs.channel }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          QUALIFIED_RESULT: ${{ needs.verify.result }}
+          ADVISORY_RESULT: ${{ needs.verify_advisory.result }}
+          QUALIFIED_OUTPUTS: ${{ toJSON(needs.verify.outputs) }}
+          ADVISORY_OUTPUTS: ${{ toJSON(needs.verify_advisory.outputs) }}
+        run: |
+          python scripts/release_channel.py candidate \
+            --channel "${CHANNEL}" \
+            --tag "${RELEASE_TAG}" \
+            --qualified-result "${QUALIFIED_RESULT}" \
+            --advisory-result "${ADVISORY_RESULT}" \
+            --qualified-outputs "${QUALIFIED_OUTPUTS}" \
+            --advisory-outputs "${ADVISORY_OUTPUTS}"
+
   stage:
     name: Stage release
-    needs: verify
+    needs: candidate
+    if: ${{ !cancelled() && needs.candidate.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -50,7 +175,7 @@ jobs:
       - name: Checkout the verified source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ needs.verify.outputs.source_sha }}
+          ref: ${{ needs.candidate.outputs.source_sha }}
           persist-credentials: false
 
       - name: Set up Python
@@ -65,14 +190,14 @@ jobs:
         # choice as well as by digest.
         uses: ./.github/actions/install-release-toolchain
         with:
-          lockfile-url: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.verify.outputs.source_sha }}/constraints/release-publish.txt
+          lockfile-url: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.candidate.outputs.source_sha }}/constraints/release-publish.txt
 
       - name: Confirm the tag still points at the verified commit
         # Guards a tag moved (or deleted and recreated) after verification.
         # `^{}` peels annotated tags to the commit they name.
         env:
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          SOURCE_SHA: ${{ needs.verify.outputs.source_sha }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.candidate.outputs.source_sha }}
         run: |
           set -euo pipefail
           peeled="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${RELEASE_TAG}^{}" | cut -f1)"
@@ -94,15 +219,19 @@ jobs:
         # rehearsal and the tag is caught here.
         env:
           GH_TOKEN: ${{ github.token }}
-          SOURCE_SHA: ${{ needs.verify.outputs.source_sha }}
-          ARTIFACT_NAME: ${{ needs.verify.outputs.artifact_name }}
+          SOURCE_SHA: ${{ needs.candidate.outputs.source_sha }}
+          ARTIFACT_NAME: ${{ needs.candidate.outputs.artifact_name }}
+          # The declared channel's rehearsal file: `release-rehearsal.yml` for
+          # the qualified line, `release-advisory-rehearsal.yml` for the
+          # advisory one, so neither line's rehearsal satisfies the other.
+          REHEARSAL_WORKFLOW: ${{ needs.candidate.outputs.rehearsal_workflow }}
         run: |
           set -euo pipefail
           run_id="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/release-rehearsal.yml/runs?head_sha=${SOURCE_SHA}&status=success&per_page=100" \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/${REHEARSAL_WORKFLOW:?the candidate names no rehearsal workflow}/runs?head_sha=${SOURCE_SHA}&status=success&per_page=100" \
             --jq '.workflow_runs[0].id // empty')"
           if [ -z "${run_id}" ]; then
-            echo "::error::No successful Release Rehearsal run for ${SOURCE_SHA}. Rehearse the candidate before tagging; see docs/release-runbook.md."
+            echo "::error::No successful ${REHEARSAL_WORKFLOW} run for ${SOURCE_SHA}. Rehearse the candidate before tagging; see docs/release-runbook.md."
             exit 1
           fi
           echo "Rehearsal run: ${run_id}"
@@ -112,7 +241,7 @@ jobs:
       - name: Download verified candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: ${{ needs.verify.outputs.artifact_name }}
+          name: ${{ needs.candidate.outputs.artifact_name }}
           path: dist
 
       - name: Verify the candidate handoff
@@ -122,18 +251,20 @@ jobs:
         # is closed-world: an unlisted file in `dist/` is rejected rather than
         # silently uploaded.
         env:
-          MANIFEST_SHA256: ${{ needs.verify.outputs.manifest_sha256 }}
+          MANIFEST_SHA256: ${{ needs.candidate.outputs.manifest_sha256 }}
+          CHANNEL: ${{ needs.candidate.outputs.channel }}
         run: |
           set -euo pipefail
           python scripts/release_publication.py verify-manifest \
             --manifest dist/candidate-manifest.json \
-            --expected-sha256 "${MANIFEST_SHA256}"
+            --expected-sha256 "${MANIFEST_SHA256}" \
+            --expected-channel "${CHANNEL}"
           cmp -- rehearsed/candidate-manifest.json dist/candidate-manifest.json
           echo "OK: the tagged candidate is byte-identical to the rehearsed one."
 
       - name: Re-verify the wheel-scoped SBOM binding
         env:
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
         run: |
           python scripts/release_sbom.py verify \
             --wheel "dist/${WHEEL_FILENAME}" \
@@ -153,8 +284,8 @@ jobs:
         # let such a candidate pass the mandatory rehearsal and fail only after
         # the tag was pushed.
         env:
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          NOTES_SHA256: ${{ needs.verify.outputs.release_notes_sha256 }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          NOTES_SHA256: ${{ needs.candidate.outputs.release_notes_sha256 }}
         run: |
           python scripts/release_notes.py \
             --tag "${RELEASE_TAG}" \
@@ -166,7 +297,7 @@ jobs:
         # Runs *before* anything mutates the GitHub Release, so a divergent
         # version fails with both registries untouched.
         env:
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
         run: |
           python scripts/release_publication.py pypi-state \
             --wheel "dist/${WHEEL_FILENAME}" \
@@ -186,11 +317,14 @@ jobs:
         # published release replaces public attestations for no reason.
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
-          MANIFEST_SHA256: ${{ needs.verify.outputs.manifest_sha256 }}
-          NOTES_SHA256: ${{ needs.verify.outputs.release_notes_sha256 }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
+          MANIFEST_SHA256: ${{ needs.candidate.outputs.manifest_sha256 }}
+          NOTES_SHA256: ${{ needs.candidate.outputs.release_notes_sha256 }}
           INDEX_STATE: ${{ steps.index.outputs.state }}
+          CHANNEL: ${{ needs.candidate.outputs.channel }}
+          RELEASE_ASSETS: ${{ needs.candidate.outputs.release_assets }}
+          SIGNED_ASSETS: ${{ needs.candidate.outputs.signed_assets }}
         run: |
           set -euo pipefail
           # `v1.2.3` is a final release; anything else (v0.16.0b7, rc, a) is a
@@ -208,14 +342,16 @@ jobs:
             create_maturity="--prerelease"
           fi
 
-          assets=(
-            "dist/${WHEEL_FILENAME}"
-            dist/agents-shipgate-sbom.json
-            dist/safety-qualification.json
-            dist/safety-qualification.sigstore.json
-            dist/provenance.json
-            dist/candidate-manifest.json
-          )
+          # The declared channel's closed asset set, from
+          # `release_publication.CHANNEL_ASSETS` by way of `candidate`. The
+          # handoff check above has already refused a `dist/` holding any other.
+          read -r -a channel_assets <<< "${RELEASE_ASSETS:?the candidate names no release assets}"
+          read -r -a signed_assets <<< "${SIGNED_ASSETS:?the candidate names no signed assets}"
+          assets=("dist/${WHEEL_FILENAME}")
+          for asset in "${channel_assets[@]}"; do
+            assets+=("dist/${asset}")
+          done
+          assets+=(dist/candidate-manifest.json)
 
           if ! gh release view "${RELEASE_TAG}" > /dev/null 2>&1; then
             gh release create "${RELEASE_TAG}" "${assets[@]}" \
@@ -249,18 +385,20 @@ jobs:
           fi
           mkdir -p published
           gh release download "${RELEASE_TAG}" --dir published --clobber
-          # `--require`, not `--allow`: declaring the transaction complete makes
-          # both downstream signature-verifying jobs skip, so a release missing
-          # a bundle — or carrying arbitrary bytes under the expected name —
-          # must fail here rather than be waved through.
+          # Required, never merely allowed: declaring the transaction complete
+          # makes both downstream signature-verifying jobs skip, so a release
+          # missing a bundle — or carrying arbitrary bytes under the expected
+          # name — must fail here rather than be waved through.
+          # `--require-signatures` derives the bundles from the declared
+          # channel, so they are not re-listed here.
           python scripts/release_publication.py verify-manifest \
             --manifest published/candidate-manifest.json \
             --expected-sha256 "${MANIFEST_SHA256}" \
+            --expected-channel "${CHANNEL}" \
             --directory published \
-            --require "${WHEEL_FILENAME}.sigstore.json" \
-            --require agents-shipgate-sbom.json.sigstore.json
+            --require-signatures
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${RELEASE_TAG}"
-          for target in "${WHEEL_FILENAME}" agents-shipgate-sbom.json; do
+          for target in "${WHEEL_FILENAME}" "${signed_assets[@]}"; do
             sigstore verify identity \
               --bundle "published/${target}.sigstore.json" \
               --cert-identity "${identity}" \
@@ -283,11 +421,12 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [verify, stage]
-    # A completed transaction is left alone. Re-signing a published release
+    needs: [candidate, stage]
+    # Each dependency's success is named, never implied: see `candidate`. A
+    # completed transaction is left alone. Re-signing a published release
     # would mint fresh, non-reproducible Sigstore bundles and replace the
     # public attestations for no benefit.
-    if: needs.stage.outputs.release_state != 'published'
+    if: ${{ !cancelled() && needs.candidate.result == 'success' && needs.stage.result == 'success' && needs.stage.outputs.release_state != 'published' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # The human gate sits here, on the one irreversible action, and after the
@@ -315,7 +454,7 @@ jobs:
         # persisted.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ needs.verify.outputs.source_sha }}
+          ref: ${{ needs.candidate.outputs.source_sha }}
           persist-credentials: false
           sparse-checkout: .github/actions/install-release-toolchain
           sparse-checkout-cone-mode: false
@@ -334,12 +473,12 @@ jobs:
         # therefore uses curl and jq, which the runner provides.
         uses: ./.github/actions/install-release-toolchain
         with:
-          lockfile-url: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.verify.outputs.source_sha }}/constraints/release-publish.txt
+          lockfile-url: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.candidate.outputs.source_sha }}/constraints/release-publish.txt
 
       - name: Confirm the tag still points at the verified commit
         env:
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          SOURCE_SHA: ${{ needs.verify.outputs.source_sha }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.candidate.outputs.source_sha }}
         run: |
           set -euo pipefail
           peeled="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${RELEASE_TAG}^{}" | cut -f1)"
@@ -354,24 +493,33 @@ jobs:
       - name: Download verified candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: ${{ needs.verify.outputs.artifact_name }}
+          name: ${{ needs.candidate.outputs.artifact_name }}
           path: dist
 
       - name: Confirm the wheel digest verification approved
         env:
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
-          WHEEL_SHA256: ${{ needs.verify.outputs.wheel_sha256 }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
+          WHEEL_SHA256: ${{ needs.candidate.outputs.wheel_sha256 }}
         run: |
           set -euo pipefail
           echo "${WHEEL_SHA256}  dist/${WHEEL_FILENAME}" | sha256sum --check --strict
 
       - name: Sign release artifacts
+        # The wheel, and what the declared channel signs besides it: the SBOM
+        # on both lines, and on the advisory line the statement saying what the
+        # release does not claim. Plain shell, because this job runs no
+        # project code.
         env:
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
+          SIGNED_ASSETS: ${{ needs.candidate.outputs.signed_assets }}
         run: |
-          sigstore sign --output-directory dist --overwrite \
-            "dist/${WHEEL_FILENAME}" \
-            dist/agents-shipgate-sbom.json
+          set -euo pipefail
+          read -r -a signed_assets <<< "${SIGNED_ASSETS:?the candidate names no signed assets}"
+          targets=("dist/${WHEEL_FILENAME}")
+          for asset in "${signed_assets[@]}"; do
+            targets+=("dist/${asset}")
+          done
+          sigstore sign --output-directory dist --overwrite "${targets[@]}"
 
       - name: Publish to PyPI with Trusted Publishing
         # The index is reclassified here rather than reusing `stage`'s result.
@@ -382,11 +530,11 @@ jobs:
         # matter: absent -> upload, identical -> skip and continue, divergent
         # -> fail.
         env:
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
-          WHEEL_SHA256: ${{ needs.verify.outputs.wheel_sha256 }}
-          VERSION: ${{ needs.verify.outputs.version }}
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          SOURCE_SHA: ${{ needs.verify.outputs.source_sha }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
+          WHEEL_SHA256: ${{ needs.candidate.outputs.wheel_sha256 }}
+          VERSION: ${{ needs.candidate.outputs.version }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.candidate.outputs.source_sha }}
         run: |
           set -euo pipefail
           # Classified with curl and jq rather than a candidate-tree helper:
@@ -445,16 +593,17 @@ jobs:
       - name: Upload signatures for finalisation
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: release-signatures-${{ needs.verify.outputs.release_tag }}
+          name: release-signatures-${{ needs.candidate.outputs.release_tag }}
           path: dist/*.sigstore.json
           if-no-files-found: error
           retention-days: 14
 
   finalize:
     name: Finalise release
-    needs: [verify, stage, publish]
+    needs: [candidate, stage, publish]
+    # Each dependency's success is named, never implied: see `candidate`.
     # Nothing to finalise when the transaction already completed.
-    if: needs.stage.outputs.release_state != 'published'
+    if: ${{ !cancelled() && needs.candidate.result == 'success' && needs.stage.result == 'success' && needs.publish.result == 'success' && needs.stage.outputs.release_state != 'published' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Repository write, and no `id-token`: a dependency compromised here cannot
@@ -470,7 +619,7 @@ jobs:
         # runs no project code.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ needs.verify.outputs.source_sha }}
+          ref: ${{ needs.candidate.outputs.source_sha }}
           persist-credentials: false
           sparse-checkout: .github/actions/install-release-toolchain
           sparse-checkout-cone-mode: false
@@ -483,7 +632,7 @@ jobs:
       - name: Install the hash-locked verification toolchain
         uses: ./.github/actions/install-release-toolchain
         with:
-          lockfile-url: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.verify.outputs.source_sha }}/constraints/release-publish.txt
+          lockfile-url: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.candidate.outputs.source_sha }}/constraints/release-publish.txt
 
       - name: Fetch the standard-library verification scripts
         # Fetched by immutable SHA rather than checked out: this job mutates a
@@ -492,7 +641,7 @@ jobs:
         # immutable commit, so re-deriving the notes here reads exactly the
         # bytes verification read.
         env:
-          RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.verify.outputs.source_sha }}
+          RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.candidate.outputs.source_sha }}
         run: |
           set -euo pipefail
           mkdir -p tools
@@ -511,8 +660,8 @@ jobs:
         # by this point; if the tag moved to B, GitHub's source archives and
         # the release would resolve to different code than the index holds.
         env:
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          SOURCE_SHA: ${{ needs.verify.outputs.source_sha }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.candidate.outputs.source_sha }}
         run: |
           set -euo pipefail
           peeled="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${RELEASE_TAG}^{}" | cut -f1)"
@@ -527,18 +676,18 @@ jobs:
       - name: Download verified candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: ${{ needs.verify.outputs.artifact_name }}
+          name: ${{ needs.candidate.outputs.artifact_name }}
           path: dist
 
       - name: Download signatures
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: release-signatures-${{ needs.verify.outputs.release_tag }}
+          name: release-signatures-${{ needs.candidate.outputs.release_tag }}
           path: signatures
 
       - name: Confirm the index holds the verified bytes
         env:
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
         run: |
           python tools/release_publication.py pypi-state \
             --wheel "dist/${WHEEL_FILENAME}" | tee /dev/stderr | grep -q "published_identical"
@@ -546,7 +695,7 @@ jobs:
       - name: Require the release to still be a draft
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
         run: |
           set -euo pipefail
           if [ "$(gh release view "${RELEASE_TAG}" --json isDraft --jq .isDraft)" != "true" ]; then
@@ -557,7 +706,7 @@ jobs:
       - name: Attach signatures
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
         run: gh release upload "${RELEASE_TAG}" signatures/*.sigstore.json --clobber
 
       - name: Validate the exact remote asset set, byte for byte
@@ -567,32 +716,36 @@ jobs:
         # rather than assumed from the staging run.
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
-          MANIFEST_SHA256: ${{ needs.verify.outputs.manifest_sha256 }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
+          MANIFEST_SHA256: ${{ needs.candidate.outputs.manifest_sha256 }}
+          CHANNEL: ${{ needs.candidate.outputs.channel }}
         run: |
           set -euo pipefail
           rm -rf remote && mkdir -p remote
           gh release download "${RELEASE_TAG}" --dir remote --clobber
-          # Closed-world: the remote set must be exactly the candidate assets
-          # plus the two signature bundles, and every listed byte must match
-          # the digest the verification job recorded.
+          # Closed-world: the remote set must be exactly the declared channel's
+          # candidate assets plus the signature bundles that channel requires,
+          # and every listed byte must match the digest the verification job
+          # recorded.
           python tools/release_publication.py verify-manifest \
             --manifest remote/candidate-manifest.json \
             --expected-sha256 "${MANIFEST_SHA256}" \
+            --expected-channel "${CHANNEL}" \
             --directory remote \
-            --require "${WHEEL_FILENAME}.sigstore.json" \
-            --require agents-shipgate-sbom.json.sigstore.json
+            --require-signatures
           echo "OK: the remote asset set matches the verified candidate exactly."
 
       - name: Verify the attached signatures
         env:
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          WHEEL_FILENAME: ${{ needs.verify.outputs.wheel_filename }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          WHEEL_FILENAME: ${{ needs.candidate.outputs.wheel_filename }}
+          SIGNED_ASSETS: ${{ needs.candidate.outputs.signed_assets }}
         run: |
           set -euo pipefail
+          read -r -a signed_assets <<< "${SIGNED_ASSETS:?the candidate names no signed assets}"
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${RELEASE_TAG}"
-          for target in "${WHEEL_FILENAME}" agents-shipgate-sbom.json; do
+          for target in "${WHEEL_FILENAME}" "${signed_assets[@]}"; do
             sigstore verify identity \
               --bundle "remote/${target}.sigstore.json" \
               --cert-identity "${identity}" \
@@ -611,8 +764,8 @@ jobs:
         # verification published, and reapplied in the same API call that
         # undrafts, so whatever the body says in the meantime cannot survive.
         env:
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          NOTES_SHA256: ${{ needs.verify.outputs.release_notes_sha256 }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          NOTES_SHA256: ${{ needs.candidate.outputs.release_notes_sha256 }}
         run: |
           python tools/release_notes.py \
             --changelog tools/CHANGELOG.md \
@@ -623,8 +776,8 @@ jobs:
       - name: Finalise GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-          SOURCE_SHA: ${{ needs.verify.outputs.source_sha }}
+          RELEASE_TAG: ${{ needs.candidate.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.candidate.outputs.source_sha }}
         run: |
           set -euo pipefail
           # Re-peeled once more: undrafting is the moment the release becomes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- Publish a version that reviewed code declares advisory through the ordinary
+  release pipeline, with no qualification claim (#648). Each version's channel
+  is declared in `.github/release-channels.json`, and a missing or unknown
+  entry stops the release before anything is built. `release.yml` calls
+  exactly one of `release-verify.yml`, which is unchanged, and the new
+  `release-advisory-verify.yml`; one publisher serves both. An advisory release
+  publishes the wheel Release Engine Smoke exercised, proven byte-identical to
+  the tagged tree's build, with a wheel-scoped SBOM, a provenance record, the
+  candidate manifest and a signed `advisory-statement.json`. Staging and
+  finalisation refuse a manifest whose channel or asset set is not the declared
+  channel's, and the mandatory rehearsal is the declared channel's own file.
+  `release_cadence.py` reads each tag's declaration, so an advisory `v*` tag
+  never counts as a gate-line release. Policy:
+  `docs/release-evidence-policy-decision.md` § Amendment 5.
+
 - Run the FastMCP Context-injection SDK cross-checks on the SDK versions the
   `[mcp]` extra allows. FastMCP was renamed to MCPServer in mcp 2.x and the
   extra requires `mcp>=2.1.1,<3`, but both cross-checks imported only the 1.x

--- a/docs/distribution-surfaces.md
+++ b/docs/distribution-surfaces.md
@@ -156,7 +156,7 @@ pushes to `main`.
 
 | Channel | Metadata | Reader gets it with | Qualification |
 | --- | --- | --- | --- |
-| Published release | `agents_shipgate.published_release` → `LATEST_PUBLISHED_VERSION` and `LATEST_PUBLISHED_CONTRACT_VERSION`, bound to the tag and to `.well-known` by `tests/test_adopter_pins_resolve.py` | `pipx install agents-shipgate`, `uses: …@v<tag>` | Qualified |
+| Published release | `agents_shipgate.published_release` → `LATEST_PUBLISHED_VERSION` and `LATEST_PUBLISHED_CONTRACT_VERSION`, bound to the tag and to `.well-known` by `tests/test_adopter_pins_resolve.py` | `pipx install agents-shipgate`, `uses: …@v<tag>` | The declared channel's. **Qualified** for a version `.github/release-channels.json` declares `qualified`, and for every release before #648. **None** for a version it declares `advisory`, which ships a signed `advisory-statement.json` saying so — see `docs/release-evidence-policy-decision.md` § Amendment 5 |
 | Unqualified preview | GitHub pre-release in the `preview-*` namespace, cut by `.github/workflows/release-preview.yml` | `gh release download preview-<version> --pattern '*.whl'` | **None**, by construction — see `docs/release-evidence-policy-decision.md` § Amendment 2 |
 | Source checkout | `pyproject.toml` → `[project].version`, mirrored at `.well-known/agents-shipgate.json` → `version` | `./shipgate …` | Not a distributed build |
 | Final candidate wheel | Build-only `_meta/release-source.json` binds a clean full source SHA and package version; generated CI uses that SHA | Reviewed local wheel; exact-wheel Action smoke requires a local path plus SHA-256 | The provenance record alone grants **none**; qualification, signing and publication bind those same wheel bytes separately |

--- a/docs/release-evidence-policy-decision.md
+++ b/docs/release-evidence-policy-decision.md
@@ -572,6 +572,9 @@ to arrive after an interval lapses is not the one that can cut a release, and
 failing it punishes the wrong author. `--fail-when-overdue` exists for an
 operator or a scheduled job, and now covers both lines.
 
+*Amendment 5 (2026-09-13) lets the advisory line also publish an ordinary `v*`
+release for a version declared advisory. The rest of this amendment stands.*
+
 ## Amendment 3 — `insufficient_evidence` leaves the ground-truth vocabulary, and four cells hold one case
 
 **Status: decided.**
@@ -672,3 +675,123 @@ decided.
       relaxation.
 - [x] The reason each cell is short is written where a corpus owner reads it —
       `strata-inventory.md` § Why four cells hold one case and not two.
+
+## Amendment 5 — the advisory line may publish a `v*` release
+
+**Status: decided. Owner: Pengfei Hu (`pengfei-threemoonslab`), product/security.
+Recorded 2026-09-13.** Tracked by
+[#648](https://github.com/ThreeMoonsLab/agents-shipgate/issues/648).
+
+The owner decided that 1.0 is the advisory line's release: `v1.0.0`, published
+to PyPI, making no qualified blocking claim. This amendment records what that
+changes in this document, what it does not, and the structure that keeps the
+two claims apart now that they share one tag namespace.
+
+### The rule
+
+**The production-tier bar governs a release that makes a qualified blocking
+claim, not a version number.** Every release version is on one of two
+channels, declared in reviewed code in `.github/release-channels.json`:
+
+- a **qualified** release is unchanged in every respect: `release-verify.yml`,
+  the version-to-tier rule, the signed qualification artifact, the trust roots
+  and the mandatory `release-rehearsal.yml` run;
+- an **advisory** release publishes the wheel, a wheel-scoped SBOM, a
+  provenance record, the candidate manifest and a signed
+  `advisory-statement.json`, and carries no qualification artifact. It is
+  governed by the readiness criteria in
+  [`engineering/v1-release-readiness.md`](engineering/v1-release-readiness.md)
+  (#643), not by a qualification tier.
+
+"No shortcut to 1.0" stays true of the blocking claim. It never applied to a
+release that does not make one.
+
+### What it supersedes, and nothing else
+
+Amendment 4 said the advisory line publishes "through the preview
+pre-release". For a version declared advisory, it may now also publish through
+a `v*` tag and PyPI. The preview channel is unchanged, and so is the rest of
+Amendment 4: the advisory line keeps its own cadence and has no authority.
+
+Amendment 2's C1 kept an unqualified build from consuming a version the
+qualified line needs. An advisory `1.0.0` deliberately consumes `1.0.0`, so
+C1's purpose is restated as the rule it served: **no version carries both
+claims.** A version is declared once, and a tagged version's declaration
+cannot change (`release_channel.assert_history_preserved`, checked against
+this repository's tags by the suite). A qualified claim needs a later version.
+
+### The structure, and why each part has its shape
+
+1. **The channel comes from a declaration, not from what a run finds.**
+   Choosing the qualified path by the presence of a qualification artifact
+   fails open on intent: a qualified release whose download broke would
+   publish as advisory, permanently. A missing, malformed or unknown entry
+   stops the release before anything is built.
+2. **Two verification files, one switch.** `release.yml` calls exactly one of
+   `release-verify.yml` and `release-advisory-verify.yml`, gated on the
+   declared channel, and `release_channel.py candidate` refuses every other
+   outcome before publication reads anything. The advisory file has no
+   qualification step to skip, so C3's reasoning holds: the separation is
+   structural, not a set of `if:` conditions inside the qualified workflow.
+   The steps the two files share are copied byte for byte and held equal by a
+   test, and the advisory file refuses a version declared qualified.
+3. **One publisher.** Staging, index classification, signing, the PyPI upload
+   and finalisation stay single jobs for both channels. PyPI Trusted
+   Publishing is bound to `release.yml`, and a second publisher would mean
+   every integrity fix landing twice.
+4. **A closed asset set per channel.** `release_publication.CHANNEL_ASSETS` is
+   the one table. The manifest records the channel, and staging and
+   finalisation refuse a manifest whose channel or asset set is not the
+   declared channel's. A qualified release cannot drop its qualification
+   artifact, and an advisory release cannot carry one.
+5. **The exact candidate is exercised before publication (#570).** The
+   advisory path publishes the wheel a Release Engine Smoke run installed and
+   ran through both the CLI and the Action for the exact source commit. That
+   run's evidence must name those bytes and that commit, and the wheel must be
+   byte-identical to the one the tagged tree builds. The two builds use
+   different entry points over the same pinned backend; on `e6f1ddff` they
+   produced the same SHA-256.
+6. **The statement is reviewed text.** Its claims are fixed in
+   `scripts/release_channel.py`: no qualification, advisory by default,
+   blocking opt-in. It names no tier and has no key a tier could appear under,
+   and the release signs it with the wheel and the SBOM.
+7. **Rehearsal stays mandatory.** `stage` requires a successful run of the
+   declared channel's own rehearsal file, with a byte-identical candidate
+   manifest.
+8. **Cadence stays honest.** `scripts/release_cadence.py` reads each tag's own
+   declaration, so an advisory `v*` tag counts on the advisory line and never
+   as a gate-line release.
+
+### What is not weakened
+
+- No qualification evidence is marked satisfied. #512, #509 and #510 still
+  govern any qualified claim, and `accepted_qualification_tiers` still admits
+  only `beta` for `1.0` and later.
+- No publication control moves. Write and OIDC authority are never held
+  together, the tag is re-peeled before each irreversible step, the index is
+  classified before anything is mutated, only drafts are mutated, and the
+  remote asset set is verified byte for byte before undrafting.
+- The Action's default is unchanged: `ci_mode: advisory`, with an empty
+  `fail_on`. Blocking stays opt-in, and an advisory release says it is
+  unqualified.
+
+### What would have made this inadmissible
+
+- **Selecting the channel by artifact presence**, the fail-open case above.
+- **A mode in `release-verify.yml`** that skips its qualification steps.
+- **A second publishing workflow**, which would also have needed the PyPI
+  trusted publisher reconfigured outside this repository.
+- **A statement assembled from build output**, or one that names a tier.
+- **Counting an advisory tag on the gate line.**
+
+### Acceptance
+
+- [x] The owner decided the scope — 2026-09-13, on #648.
+- [x] The declaration, its reader and the fail-closed selection —
+      `tests/test_release_channel.py`.
+- [x] The advisory verification, its rehearsal and channel-keyed publication —
+      `tests/test_release_advisory_pipeline.py`, alongside the qualified
+      path's existing invariants in `tests/test_release_pipeline.py`.
+- [x] Cadence reads the declaration — `tests/test_release_channel_cadence.py`.
+- [ ] The first advisory tag publishes through this path; #570 owns its
+      post-publication replay.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -110,6 +110,11 @@ pipeline tested one artifact and published another.
 
 ### Which evidence bar the tag must meet
 
+This section governs a version `.github/release-channels.json` declares
+`qualified`. A version declared `advisory` carries no qualification artifact
+and is verified by `release-advisory-verify.yml` instead; see
+[§ The advisory release channel](#the-advisory-release-channel).
+
 Two named qualification policies exist, and the **version decides which one
 applies** — nothing in the artifact does:
 
@@ -496,7 +501,11 @@ The shape that holds:
    matching section, and refuses one over 125,000 characters.
 2. Stamp `<version>` on `STABILITY.md`'s title and on every
    `## Migration Note: unreleased` heading.
-3. Confirm `pyproject.toml` has the release version and a rehearsal is green.
+3. Confirm `pyproject.toml` has the release version,
+   `.github/release-channels.json` declares its channel, and that channel's
+   rehearsal is green: `release-rehearsal.yml` for a qualified release; for an
+   advisory one, Release Engine Smoke and then `release-advisory-rehearsal.yml`
+   on the same commit.
 4. Push the tag: `git tag v0.16.0 && git push origin v0.16.0`.
 5. The `verify` job runs unattended.
 6. Approve the `pypi` environment gate on the `publish` job, using the readiness
@@ -526,6 +535,39 @@ The shape that holds:
    `MINIMUM_CONTROL_CONTRACT_VERSION`, the adoption prompts say so in the same
    breath as the pin rather than quietly promising a floor the pinned build
    does not report.
+
+## The advisory release channel
+
+**Policy: `release-evidence-policy-decision.md`
+[§ Amendment 5](release-evidence-policy-decision.md#amendment-5--the-advisory-line-may-publish-a-v-release),
+decided 2026-09-13 (#648).** An advisory release is an ordinary `v*` tag and
+PyPI version that makes no qualified blocking claim. It shares every
+publication job with the qualified line; it differs in what verification
+proves and in what the release carries.
+
+| | Qualified release | Advisory release |
+|---|---|---|
+| Declared in `.github/release-channels.json` as | `qualified` | `advisory` |
+| Verification workflow | `release-verify.yml` | `release-advisory-verify.yml` |
+| Mandatory rehearsal | `release-rehearsal.yml` | `release-advisory-rehearsal.yml` |
+| Wheel published | the signed, qualified wheel | the wheel Release Engine Smoke exercised |
+| Bound to the tagged source by | `verify_wheel_provenance.py --qualified` | `verify_wheel_provenance.py --exercised` |
+| Assets besides the wheel and manifest | SBOM, provenance, `safety-qualification.json` and its bundle | SBOM, provenance, `advisory-statement.json` |
+| Signed by the release | wheel, SBOM | wheel, SBOM, advisory statement |
+
+To cut one:
+
+1. Land a reviewed change declaring the version `advisory`. Once a tag for a
+   version exists, its entry cannot change.
+2. Dispatch **Release Engine Smoke (unqualified)** on the release commit. Its
+   wheel is the one that will be published.
+3. Dispatch **Advisory Release Rehearsal** on the same commit.
+4. Tag, and continue from step 4 of [§ Cutting the release](#cutting-the-release).
+
+The advisory statement cites the newest successful Release Engine Smoke run for
+the commit. Re-running the smoke after the rehearsal therefore changes the
+tagged manifest, and `stage` refuses because it no longer matches the rehearsed
+one. Rehearse again.
 
 ## The unqualified preview channel
 

--- a/scripts/release_cadence.py
+++ b/scripts/release_cadence.py
@@ -32,8 +32,22 @@ from pathlib import Path
 
 if __package__:
     from scripts._release_support import is_release_version
+    from scripts.release_channel import (
+        ADVISORY,
+        DECLARATION_PATH,
+        QUALIFIED,
+        ChannelError,
+        parse_declaration,
+    )
 else:  # ``python scripts/release_cadence.py``
     from _release_support import is_release_version
+    from release_channel import (
+        ADVISORY,
+        DECLARATION_PATH,
+        QUALIFIED,
+        ChannelError,
+        parse_declaration,
+    )
 
 # The approved cadence, recorded in `docs/release-runbook.md` § Cadence. These
 # two numbers are the policy; every surface below renders them rather than
@@ -194,6 +208,50 @@ def read_release_tags(
 
 
 
+def tag_channel(repo: Path, ref: str) -> str | None:
+    """The channel ``ref``'s own committed tree declares for its version.
+
+    Read from the tag's tree, never the working checkout: the declaration
+    grows over time, and a tag's channel is what was reviewed when it was cut.
+    ``None`` means that tree has no declaration at all — every tag before
+    advisory ``v*`` releases existed — which makes it a gate-line release by
+    construction. A declaration that is present but unparseable, or that does
+    not name the version, yields ``"undeclared"``: the release workflow
+    refuses such a tag, so it was never published on either line (#648).
+    """
+
+    shown = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        ["git", "show", f"{ref}:{DECLARATION_PATH.as_posix()}"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if shown.returncode != 0:
+        return None
+    try:
+        channels = parse_declaration(shown.stdout)
+    except ChannelError:
+        return "undeclared"
+    return channels.get(ref[1:], "undeclared")
+
+
+def read_gate_line_tags(repo: Path) -> list[tuple[str, int]]:
+    """``v*`` tags on the qualified gate line.
+
+    An advisory ``v*`` release (#648) has the same tag shape, so shape alone
+    no longer separates the lines. Counting one here would let an advisory
+    release report the gate line's cadence as kept — the dishonesty the
+    preview namespace was created to prevent (Amendment 4).
+    """
+
+    return [
+        (ref, when)
+        for ref, when in read_release_tags(repo)
+        if tag_channel(repo, ref) in (None, QUALIFIED)
+    ]
+
+
 def read_advisory_tags(repo: Path) -> list[tuple[str, int]]:
     """Use the preview version's UTC build date as the offline cadence proxy.
 
@@ -203,6 +261,11 @@ def read_advisory_tags(repo: Path) -> list[tuple[str, int]]:
     in local Git, so expose the embedded build date and name that boundary.
     """
     tags = []
+    # An advisory ``v*`` release (#648) is on this line too; its date is the
+    # tag's own creator date, as for the gate line.
+    for ref, when in read_release_tags(repo):
+        if tag_channel(repo, ref) == ADVISORY:
+            tags.append((ref, when))
     for ref, _commit_time in read_release_tags(repo, predicate=is_advisory_tag):
         stamp = ref.partition("+preview.")[2].partition(".g")[0]
         built = datetime.strptime(stamp, "%Y%m%d").replace(tzinfo=UTC)
@@ -262,14 +325,18 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     now = int(datetime.now(tz=UTC).timestamp())
-    cadence = assess(read_release_tags(args.repo), now=now)
+    cadence = assess(read_gate_line_tags(args.repo), now=now)
+    advisory_tags = read_advisory_tags(args.repo)
+    newest_advisory = max(advisory_tags, key=lambda item: item[1])[0] if advisory_tags else ""
     advisory = assess(
-        read_advisory_tags(args.repo),
+        advisory_tags,
         now=now,
         interval_days=ADVISORY_INTERVAL_DAYS,
         overdue_days=ADVISORY_OVERDUE_DAYS,
         label="Advisory cadence",
-        date_basis="preview_build",
+        # A preview is dated by its embedded build stamp; an advisory v*
+        # release by its tag, so say which one produced the number.
+        date_basis="tag_creator" if newest_advisory.startswith("v") else "preview_build",
     )
 
     lines = (cadence, advisory)

--- a/scripts/release_channel.py
+++ b/scripts/release_channel.py
@@ -61,6 +61,13 @@ def load_declaration(path: Path = DECLARATION_PATH) -> dict[str, str]:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
         raise ChannelError(f"release channel declaration not found: {path}") from exc
+    return parse_declaration(raw)
+
+
+def parse_declaration(raw: str) -> dict[str, str]:
+    """Validate declaration text. Shared by the release run and the cadence
+    reader, which reads the declaration from each tag's own committed tree."""
+
     try:
         document = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
     except json.JSONDecodeError as exc:
@@ -104,7 +111,9 @@ def resolve(version: str, *, path: Path = DECLARATION_PATH) -> str:
 def resolve_tag(tag: str, *, path: Path = DECLARATION_PATH) -> str:
     """The declared channel for a ``v<version>`` release tag."""
 
-    if not tag.startswith("v") or not is_release_version(tag[1:]):
+    # ``is_release_version`` accepts a local segment, and no public index
+    # accepts one, so a ``v*`` release can never carry it.
+    if not tag.startswith("v") or not is_release_version(tag[1:]) or "+" in tag:
         raise ChannelError(f"release tag {tag!r} is not v<complete release version>")
     return resolve(tag[1:], path=path)
 

--- a/scripts/release_channel.py
+++ b/scripts/release_channel.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Which release line a version belongs to, declared in reviewed code (#648).
+
+A ``v*`` tag used to mean one thing: a qualified release, gated on signed
+qualification evidence. The advisory-1.0 decision gives the advisory line a
+``v*`` release too, so the tag alone no longer says which line it is on.
+
+The answer must not come from anything a release run can discover or lose.
+Choosing the qualified path "by the presence of the qualification artifact"
+fails open on intent: a qualified release whose qualification download is
+missing would silently publish as advisory, and PyPI never gives the version
+back. So each version's channel is declared in a committed, reviewed file,
+for the same reason the qualification trust roots are
+(``.github/release-trust-roots.json``): whoever can push a tag cannot choose
+its channel without a reviewed diff.
+
+Everything here fails closed. A missing or malformed declaration, an unknown
+channel, or a tag that is not ``v<version>`` stops the release before anything
+is built, and ``select`` refuses any verification outcome other than exactly
+the declared channel's.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+if __package__:
+    from scripts._release_support import is_release_version
+else:  # ``python scripts/release_channel.py``
+    from _release_support import is_release_version
+
+DECLARATION_PATH = Path(".github/release-channels.json")
+SCHEMA = "shipgate.release_channels/v1"
+ADVISORY = "advisory"
+QUALIFIED = "qualified"
+CHANNELS = frozenset({ADVISORY, QUALIFIED})
+VERIFY_RESULTS = frozenset({"success", "failure", "cancelled", "skipped"})
+
+
+class ChannelError(ValueError):
+    """The release channel cannot be established; the release must stop."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    document: dict[str, object] = {}
+    for key, value in pairs:
+        if key in document:
+            raise ChannelError(f"duplicate key {key!r} in the release channel declaration")
+        document[key] = value
+    return document
+
+
+def load_declaration(path: Path = DECLARATION_PATH) -> dict[str, str]:
+    """The reviewed version-to-channel map, validated in full before use."""
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ChannelError(f"release channel declaration not found: {path}") from exc
+    try:
+        document = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except json.JSONDecodeError as exc:
+        raise ChannelError(f"release channel declaration is not valid JSON: {exc}") from exc
+    if not isinstance(document, dict) or set(document) != {"schema", "channels"}:
+        raise ChannelError(
+            "release channel declaration must contain exactly 'schema' and 'channels'"
+        )
+    if document["schema"] != SCHEMA:
+        raise ChannelError(
+            f"unsupported release channel schema {document['schema']!r}; expected {SCHEMA!r}"
+        )
+    channels = document["channels"]
+    if not isinstance(channels, dict):
+        raise ChannelError("'channels' must map release versions to a channel")
+    for version, channel in channels.items():
+        # A local segment is refused by every public index, so no v* release
+        # can carry one; that is the preview channel's property, not this one.
+        if not is_release_version(version) or "+" in version:
+            raise ChannelError(f"{version!r} is not a complete public release version")
+        if channel not in CHANNELS:
+            raise ChannelError(
+                f"version {version} declares unknown channel {channel!r}; "
+                f"expected one of {sorted(CHANNELS)}"
+            )
+    return dict(channels)
+
+
+def resolve(version: str, *, path: Path = DECLARATION_PATH) -> str:
+    """The declared channel for ``version``; no declaration is no release."""
+
+    channels = load_declaration(path)
+    if version not in channels:
+        raise ChannelError(
+            f"no reviewed release channel is declared for {version}; add it to "
+            f"{DECLARATION_PATH} in a reviewed change before tagging"
+        )
+    return channels[version]
+
+
+def resolve_tag(tag: str, *, path: Path = DECLARATION_PATH) -> str:
+    """The declared channel for a ``v<version>`` release tag."""
+
+    if not tag.startswith("v") or not is_release_version(tag[1:]):
+        raise ChannelError(f"release tag {tag!r} is not v<complete release version>")
+    return resolve(tag[1:], path=path)
+
+
+def select(channel: str, *, qualified_result: str, advisory_result: str) -> str:
+    """Confirm exactly the declared channel's verification ran and succeeded.
+
+    ``release.yml`` gates two verification jobs on the declared channel, and
+    publication depends on this check rather than on either job directly. The
+    declared job must have succeeded and the other must have been skipped.
+    Anything else is refused — both ran, neither ran, the undeclared one ran,
+    or a cancellation — so publication can never proceed on the wrong line's
+    evidence.
+    """
+
+    if channel not in CHANNELS:
+        raise ChannelError(f"unknown channel {channel!r}")
+    for name, result in (("qualified", qualified_result), ("advisory", advisory_result)):
+        if result not in VERIFY_RESULTS:
+            raise ChannelError(f"unexpected {name} verification result {result!r}")
+    declared, other = (
+        (qualified_result, advisory_result)
+        if channel == QUALIFIED
+        else (advisory_result, qualified_result)
+    )
+    if declared != "success":
+        raise ChannelError(
+            f"the declared {channel} verification did not succeed (result: {declared})"
+        )
+    if other != "skipped":
+        raise ChannelError(
+            f"the undeclared channel's verification did not stay skipped (result: {other})"
+        )
+    return channel
+
+
+def _write_github_output(values: dict[str, str]) -> None:
+    target = os.environ.get("GITHUB_OUTPUT")
+    if not target:
+        return
+    with open(target, "a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve and confirm a release's channel.")
+    commands = parser.add_subparsers(dest="command", required=True)
+    resolver = commands.add_parser("resolve", help="declared channel for a v<version> tag")
+    resolver.add_argument("--tag", required=True)
+    resolver.add_argument("--declaration", type=Path, default=DECLARATION_PATH)
+    selector = commands.add_parser("select", help="confirm the declared verification ran alone")
+    selector.add_argument("--channel", required=True)
+    selector.add_argument("--qualified-result", required=True)
+    selector.add_argument("--advisory-result", required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "resolve":
+            channel = resolve_tag(args.tag, path=args.declaration)
+        else:
+            channel = select(
+                args.channel,
+                qualified_result=args.qualified_result,
+                advisory_result=args.advisory_result,
+            )
+    except ChannelError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    _write_github_output({"channel": channel})
+    print(channel)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_channel.py
+++ b/scripts/release_channel.py
@@ -16,8 +16,17 @@ its channel without a reviewed diff.
 
 Everything here fails closed. A missing or malformed declaration, an unknown
 channel, or a tag that is not ``v<version>`` stops the release before anything
-is built, and ``select`` refuses any verification outcome other than exactly
-the declared channel's.
+is built. ``candidate`` refuses any verification outcome other than exactly the
+declared channel's, and forwards only that channel's values to publication,
+together with the channel-keyed names publication needs — which rehearsal to
+require, which assets to upload, which to sign — so the release workflow itself
+spells no channel's asset set.
+
+Two further subcommands serve the advisory verification. ``exercised`` confirms
+that a Release Engine Smoke run installed and ran the exact candidate through
+both the CLI and the Action (#570). ``statement`` writes the signed
+``advisory-statement.json`` from fields fixed in this file, never from build
+output, so what the release claims about itself is reviewed text.
 """
 
 from __future__ import annotations
@@ -25,13 +34,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
 if __package__:
-    from scripts._release_support import is_release_version
+    from scripts._release_support import ReleaseError, inspect_wheel, is_release_version
+    from scripts.release_publication import CHANNEL_ASSETS, CHANNEL_SIGNED_ASSETS
 else:  # ``python scripts/release_channel.py``
-    from _release_support import is_release_version
+    from _release_support import ReleaseError, inspect_wheel, is_release_version
+    from release_publication import CHANNEL_ASSETS, CHANNEL_SIGNED_ASSETS
 
 DECLARATION_PATH = Path(".github/release-channels.json")
 SCHEMA = "shipgate.release_channels/v1"
@@ -39,6 +51,37 @@ ADVISORY = "advisory"
 QUALIFIED = "qualified"
 CHANNELS = frozenset({ADVISORY, QUALIFIED})
 VERIFY_RESULTS = frozenset({"success", "failure", "cancelled", "skipped"})
+
+#: The values publication reads from verification, by name. Both reusable
+#: verification workflows export at least these; ``candidate`` forwards exactly
+#: these, from the declared channel only.
+CANDIDATE_OUTPUTS = (
+    "version",
+    "release_tag",
+    "source_sha",
+    "wheel_filename",
+    "wheel_sha256",
+    "manifest_sha256",
+    "release_notes_sha256",
+    "artifact_name",
+)
+
+#: The rehearsal ``stage`` requires for the exact candidate, by workflow file.
+#: Separate files, so neither line's rehearsal can satisfy the other's.
+REHEARSAL_WORKFLOWS = {
+    QUALIFIED: "release-rehearsal.yml",
+    ADVISORY: "release-advisory-rehearsal.yml",
+}
+
+STATEMENT_FILENAME = "advisory-statement.json"
+STATEMENT_SCHEMA = "shipgate.advisory_release_statement/v1"
+EXERCISE_WORKFLOW = ".github/workflows/release-engine-smoke.yml"
+READINESS_RECORD = "docs/engineering/v1-release-readiness.md"
+GOVERNING_POLICY = "docs/release-evidence-policy-decision.md, Amendment 5"
+
+_FULL_SHA = re.compile(r"[0-9a-f]{40}")
+_RUN_ID = re.compile(r"[1-9][0-9]{0,19}")
+_REPOSITORY = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 
 
 class ChannelError(ValueError):
@@ -49,7 +92,7 @@ def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]
     document: dict[str, object] = {}
     for key, value in pairs:
         if key in document:
-            raise ChannelError(f"duplicate key {key!r} in the release channel declaration")
+            raise ChannelError(f"duplicate key {key!r}")
         document[key] = value
     return document
 
@@ -118,6 +161,27 @@ def resolve_tag(tag: str, *, path: Path = DECLARATION_PATH) -> str:
     return resolve(tag[1:], path=path)
 
 
+def assert_history_preserved(declared: dict[str, str], tagged: dict[str, str]) -> None:
+    """A version's channel is fixed once a tag for it exists.
+
+    ``tagged`` maps each tagged version to the channel its *own* tree declared.
+    Changing or removing that entry later would let the declaration say one
+    thing about a release whose tag, and whose published bytes, said another —
+    and would let a version that shipped advisory be re-declared qualified, so
+    that one version carried both claims.
+    """
+
+    changed = sorted(
+        f"{version} (tagged {channel}, now {declared.get(version, 'undeclared')})"
+        for version, channel in tagged.items()
+        if declared.get(version) != channel
+    )
+    if changed:
+        raise ChannelError(
+            "the channel of an already-tagged version cannot change: " + ", ".join(changed)
+        )
+
+
 def select(channel: str, *, qualified_result: str, advisory_result: str) -> str:
     """Confirm exactly the declared channel's verification ran and succeeded.
 
@@ -150,6 +214,164 @@ def select(channel: str, *, qualified_result: str, advisory_result: str) -> str:
     return channel
 
 
+def _parse_outputs(name: str, raw: str) -> dict[str, str]:
+    try:
+        outputs = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except json.JSONDecodeError as exc:
+        raise ChannelError(f"the {name} verification outputs are not valid JSON: {exc}") from exc
+    if not isinstance(outputs, dict) or not all(
+        isinstance(value, str) for value in outputs.values()
+    ):
+        raise ChannelError(f"the {name} verification outputs must map names to strings")
+    return outputs
+
+
+def candidate(
+    channel: str,
+    *,
+    tag: str,
+    qualified_result: str,
+    advisory_result: str,
+    qualified_outputs: str,
+    advisory_outputs: str,
+) -> dict[str, str]:
+    """Everything publication reads, from the declared channel's verification only.
+
+    The undeclared job must have exported nothing, the declared one every value
+    publication consumes, and it must have verified the tag that was pushed.
+    Values reach ``GITHUB_OUTPUT`` one per line, so a value spanning lines is
+    refused rather than allowed to write a second key.
+    """
+
+    select(channel, qualified_result=qualified_result, advisory_result=advisory_result)
+    other_channel = ADVISORY if channel == QUALIFIED else QUALIFIED
+    raw = {QUALIFIED: qualified_outputs, ADVISORY: advisory_outputs}
+    declared = _parse_outputs(channel, raw[channel])
+    other = _parse_outputs(other_channel, raw[other_channel])
+    if any(other.values()):
+        raise ChannelError(
+            f"the undeclared {other_channel} verification exported values "
+            f"({', '.join(sorted(key for key, value in other.items() if value))})"
+        )
+    missing = [key for key in CANDIDATE_OUTPUTS if not declared.get(key)]
+    if missing:
+        raise ChannelError(
+            f"the {channel} verification did not export {', '.join(missing)}"
+        )
+    values = {key: declared[key] for key in CANDIDATE_OUTPUTS}
+    if values["release_tag"] != tag:
+        raise ChannelError(
+            f"the {channel} verification bound {values['release_tag']!r}, "
+            f"not the pushed tag {tag!r}"
+        )
+    values.update(
+        channel=channel,
+        rehearsal_workflow=REHEARSAL_WORKFLOWS[channel],
+        release_assets=" ".join(sorted(CHANNEL_ASSETS[channel])),
+        signed_assets=" ".join(CHANNEL_SIGNED_ASSETS[channel]),
+    )
+    for key, value in values.items():
+        if "\n" in value or "\r" in value:
+            raise ChannelError(f"the {key} value spans lines")
+    return values
+
+
+def confirm_exercised(evidence_path: Path, *, source_commit: str, wheel_path: Path) -> str:
+    """Require smoke evidence that exercised exactly this wheel from this commit.
+
+    Reads the ``distribution-evidence.json`` that
+    ``scripts/release_engine_smoke.py compare`` writes only after the installed
+    CLI and the composite Action agreed. The run's success is not taken as the
+    claim: the record must name this commit and these bytes, say the two halves
+    agreed, and still say the build is unqualified.
+    """
+
+    if not _FULL_SHA.fullmatch(source_commit):
+        raise ChannelError("source commit must be a full lowercase 40-character SHA")
+    try:
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ChannelError(f"unreadable smoke evidence {evidence_path}: {exc}") from exc
+    if not isinstance(evidence, dict):
+        raise ChannelError(f"smoke evidence {evidence_path} is not a JSON object")
+    _, _, digest = inspect_wheel(wheel_path)
+    problems = []
+    if evidence.get("local_and_action_agree") is not True:
+        problems.append("it does not record the installed CLI and the Action agreeing")
+    if evidence.get("qualified") is not False:
+        problems.append("it does not record the build as unqualified")
+    if evidence.get("source_commit") != source_commit:
+        problems.append(f"it exercised source {evidence.get('source_commit')!r}, not {source_commit}")
+    if evidence.get("wheel_sha256") != digest:
+        problems.append(f"it exercised wheel {evidence.get('wheel_sha256')!r}, not {digest}")
+    if problems:
+        raise ChannelError(
+            "the Release Engine Smoke evidence does not cover this candidate: "
+            + "; ".join(problems)
+        )
+    return digest
+
+
+def advisory_statement(
+    *,
+    tag: str,
+    source_commit: str,
+    wheel_path: Path,
+    smoke_run_id: str,
+    repository: str,
+    declaration: Path = DECLARATION_PATH,
+) -> dict[str, object]:
+    """What an advisory release says about itself, from reviewed fields.
+
+    Written only for a version the declaration makes advisory. It names no
+    qualification tier — there is no key a reader could find one under — and
+    states the non-claims rather than leaving them to the absence of a file.
+    """
+
+    if resolve_tag(tag, path=declaration) != ADVISORY:
+        raise ChannelError(f"{tag} is not declared advisory; it gets no advisory statement")
+    if not _FULL_SHA.fullmatch(source_commit):
+        raise ChannelError("source commit must be a full lowercase 40-character SHA")
+    if not _RUN_ID.fullmatch(smoke_run_id):
+        raise ChannelError(f"smoke run id {smoke_run_id!r} is not a workflow run id")
+    if not _REPOSITORY.fullmatch(repository):
+        raise ChannelError(f"repository {repository!r} is not owner/name")
+    distribution, version, digest = inspect_wheel(wheel_path)
+    if tag != f"v{version}":
+        raise ChannelError(f"release tag {tag} does not match wheel version {version}")
+    return {
+        "schema": STATEMENT_SCHEMA,
+        "channel": ADVISORY,
+        "release_tag": tag,
+        "distribution": distribution,
+        "version": version,
+        "source_commit": source_commit,
+        "wheel_filename": wheel_path.name,
+        "wheel_sha256": digest,
+        "claims": {
+            "qualification": "none",
+            "default_ci_mode": "advisory",
+            "blocking": "opt_in",
+        },
+        "not_claimed": [
+            "No safety qualification was verified for this build, and no "
+            "qualification artifact exists for it.",
+            "A blocking result from this build is not a qualified verdict. Blocking "
+            "is opt-in, through ci_mode: strict or a fail_on list, and no evidence "
+            "bar stands behind it.",
+        ],
+        "channel_declaration": {"path": str(DECLARATION_PATH), "commit": source_commit},
+        "exact_candidate_evidence": {
+            "workflow": EXERCISE_WORKFLOW,
+            "run_id": int(smoke_run_id),
+            "run_url": f"https://github.com/{repository}/actions/runs/{smoke_run_id}",
+            "wheel_sha256": digest,
+        },
+        "readiness_record": {"path": READINESS_RECORD, "commit": source_commit},
+        "governing_policy": GOVERNING_POLICY,
+    }
+
+
 def _write_github_output(values: dict[str, str]) -> None:
     target = os.environ.get("GITHUB_OUTPUT")
     if not target:
@@ -159,7 +381,7 @@ def _write_github_output(values: dict[str, str]) -> None:
             handle.write(f"{key}={value}\n")
 
 
-def main(argv: list[str] | None = None) -> int:
+def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Resolve and confirm a release's channel.")
     commands = parser.add_subparsers(dest="command", required=True)
     resolver = commands.add_parser("resolve", help="declared channel for a v<version> tag")
@@ -169,21 +391,78 @@ def main(argv: list[str] | None = None) -> int:
     selector.add_argument("--channel", required=True)
     selector.add_argument("--qualified-result", required=True)
     selector.add_argument("--advisory-result", required=True)
-    args = parser.parse_args(argv)
+    chooser = commands.add_parser(
+        "candidate", help="forward the declared verification's values to publication"
+    )
+    chooser.add_argument("--channel", required=True)
+    chooser.add_argument("--tag", required=True)
+    chooser.add_argument("--qualified-result", required=True)
+    chooser.add_argument("--advisory-result", required=True)
+    chooser.add_argument("--qualified-outputs", required=True)
+    chooser.add_argument("--advisory-outputs", required=True)
+    exercised = commands.add_parser(
+        "exercised", help="confirm smoke evidence covers this exact candidate"
+    )
+    exercised.add_argument("--evidence", type=Path, required=True)
+    exercised.add_argument("--wheel", type=Path, required=True)
+    exercised.add_argument("--source-commit", required=True)
+    statement = commands.add_parser("statement", help="write the advisory release statement")
+    statement.add_argument("--tag", required=True)
+    statement.add_argument("--source-commit", required=True)
+    statement.add_argument("--wheel", type=Path, required=True)
+    statement.add_argument("--smoke-run-id", required=True)
+    statement.add_argument("--repository", required=True)
+    statement.add_argument("--output", type=Path, required=True)
+    statement.add_argument("--declaration", type=Path, default=DECLARATION_PATH)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
     try:
         if args.command == "resolve":
             channel = resolve_tag(args.tag, path=args.declaration)
-        else:
+            _write_github_output({"channel": channel})
+            print(channel)
+        elif args.command == "select":
             channel = select(
                 args.channel,
                 qualified_result=args.qualified_result,
                 advisory_result=args.advisory_result,
             )
-    except ChannelError as exc:
+            _write_github_output({"channel": channel})
+            print(channel)
+        elif args.command == "candidate":
+            values = candidate(
+                args.channel,
+                tag=args.tag,
+                qualified_result=args.qualified_result,
+                advisory_result=args.advisory_result,
+                qualified_outputs=args.qualified_outputs,
+                advisory_outputs=args.advisory_outputs,
+            )
+            _write_github_output(values)
+            print(json.dumps(values, indent=2, sort_keys=True))
+        elif args.command == "exercised":
+            digest = confirm_exercised(
+                args.evidence, source_commit=args.source_commit, wheel_path=args.wheel
+            )
+            print(f"OK: the smoke exercised {args.wheel.name} ({digest}) from {args.source_commit}.")
+        else:
+            document = advisory_statement(
+                tag=args.tag,
+                source_commit=args.source_commit,
+                wheel_path=args.wheel,
+                smoke_run_id=args.smoke_run_id,
+                repository=args.repository,
+                declaration=args.declaration,
+            )
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", "utf-8")
+            print(f"OK: wrote the advisory statement for {args.tag} to {args.output}.")
+    except (ChannelError, ReleaseError) as exc:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
-    _write_github_output({"channel": channel})
-    print(channel)
     return 0
 
 

--- a/scripts/release_publication.py
+++ b/scripts/release_publication.py
@@ -24,6 +24,15 @@ intact manifest sitting beside an unlisted sdist or executable that a
 subsequent ``dist/*`` upload would happily publish, so the directory contents
 must equal the manifest exactly, and every entry must be a regular file.
 
+Each release channel (#648) has its own closed asset set, ``CHANNEL_ASSETS``.
+``manifest --channel`` refuses any other set and records the channel, and
+``verify-manifest --expected-channel`` requires the manifest's channel and set
+to be the declared channel's, so a qualified release cannot drop its
+qualification artifact and an advisory release cannot carry one. A manifest
+with no ``channel`` predates #648 and was written by the qualified path, the
+only one there was. ``--require-signatures`` requires the channel's Sigstore
+bundles, derived from the same table rather than listed at each call site.
+
 ``pypi-state`` answers the question a retry must ask before re-uploading an
 immutable version. PyPI uploads cannot be replaced, so "just re-run the job" is
 not a recovery procedure — it either fails confusingly or, worse, succeeds
@@ -84,6 +93,63 @@ else:  # ``python scripts/release_publication.py``
 DEFAULT_INDEX = "https://pypi.org/pypi"
 _NETWORK_TIMEOUT_SECONDS = 30
 
+QUALIFIED = "qualified"
+ADVISORY = "advisory"
+
+#: Each release channel's closed asset set, besides the wheel and the manifest
+#: itself (#648). ``scripts/release_channel.py`` reads this table too; it lives
+#: here because ``finalize`` fetches only this module and its support file.
+CHANNEL_ASSETS: dict[str, frozenset[str]] = {
+    QUALIFIED: frozenset(
+        {
+            "agents-shipgate-sbom.json",
+            "provenance.json",
+            "safety-qualification.json",
+            "safety-qualification.sigstore.json",
+        }
+    ),
+    ADVISORY: frozenset(
+        {
+            "advisory-statement.json",
+            "agents-shipgate-sbom.json",
+            "provenance.json",
+        }
+    ),
+}
+
+#: What the release workflow signs besides the wheel, per channel. A
+#: qualification artifact carries its own trust root's signature; the advisory
+#: statement has no other signer, so the release signs it.
+CHANNEL_SIGNED_ASSETS: dict[str, tuple[str, ...]] = {
+    QUALIFIED: ("agents-shipgate-sbom.json",),
+    ADVISORY: ("agents-shipgate-sbom.json", "advisory-statement.json"),
+}
+
+
+def _assert_channel_asset_set(channel: str, names: set[str]) -> None:
+    if channel not in CHANNEL_ASSETS:
+        raise ReleaseError(f"Unknown release channel {channel!r}")
+    expected = CHANNEL_ASSETS[channel]
+    missing = sorted(expected - names)
+    unexpected = sorted(names - expected)
+    if missing or unexpected:
+        detail = []
+        if missing:
+            detail.append(f"missing {', '.join(missing)}")
+        if unexpected:
+            detail.append(f"not permitted {', '.join(unexpected)}")
+        raise ReleaseError(f"The {channel} release asset set is wrong ({'; '.join(detail)}).")
+
+
+def signature_bundles(channel: str, wheel_filename: str) -> set[str]:
+    """The Sigstore bundles a finished release on ``channel`` must carry."""
+
+    if channel not in CHANNEL_SIGNED_ASSETS:
+        raise ReleaseError(f"Unknown release channel {channel!r}")
+    return {
+        f"{name}.sigstore.json" for name in (wheel_filename, *CHANNEL_SIGNED_ASSETS[channel])
+    }
+
 
 def build_manifest(
     *,
@@ -92,6 +158,7 @@ def build_manifest(
     wheel_path: Path,
     asset_paths: list[Path],
     output_path: Path,
+    channel: str | None = None,
 ) -> dict[str, Any]:
     """Write a content-addressed record of every asset the release will ship."""
 
@@ -104,6 +171,10 @@ def build_manifest(
         if not path.is_file():
             raise ReleaseError(f"Candidate asset not found: {path}")
         assets.append({"filename": path.name, "sha256": sha256_file(path)})
+    if channel is not None:
+        _assert_channel_asset_set(
+            channel, {asset["filename"] for asset in assets} - {wheel_path.name}
+        )
 
     manifest = {
         "release_tag": tag,
@@ -114,6 +185,8 @@ def build_manifest(
         "wheel_sha256": wheel_sha256,
         "assets": assets,
     }
+    if channel is not None:
+        manifest["channel"] = channel
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return manifest
@@ -167,6 +240,8 @@ def verify_manifest(
     directory: Path | None = None,
     allowed_extra: set[str] | None = None,
     required_extra: set[str] | None = None,
+    expected_channel: str | None = None,
+    require_signatures: bool = False,
 ) -> dict[str, Any]:
     """Re-derive every digest the verification job recorded.
 
@@ -217,9 +292,26 @@ def verify_manifest(
     if errors:
         raise ReleaseError("Candidate handoff rejected: " + "; ".join(errors))
 
-    _assert_closed_world(
-        manifest_path, base, listed, allowed_extra or set(), required_extra or set()
-    )
+    required = set(required_extra or set())
+    if expected_channel is not None:
+        # A manifest with no channel predates #648 and was written by the
+        # qualified path, the only one there was.
+        recorded = manifest.get("channel", QUALIFIED)
+        if recorded != expected_channel:
+            raise ReleaseError(
+                f"Candidate manifest records the {recorded} channel, but this release was "
+                f"declared {expected_channel}."
+            )
+        wheel_filename = str(manifest.get("wheel_filename", ""))
+        if wheel_filename not in listed:
+            raise ReleaseError("Candidate manifest does not list its own wheel.")
+        _assert_channel_asset_set(expected_channel, listed - {wheel_filename})
+        if require_signatures:
+            required |= signature_bundles(expected_channel, wheel_filename)
+    elif require_signatures:
+        raise ReleaseError("Requiring the release signatures needs the declared channel.")
+
+    _assert_closed_world(manifest_path, base, listed, allowed_extra or set(), required)
     return manifest
 
 
@@ -316,6 +408,11 @@ def _parser() -> argparse.ArgumentParser:
     manifest.add_argument("--source-commit", required=True)
     manifest.add_argument("--wheel", type=Path, required=True)
     manifest.add_argument("--asset", type=Path, action="append", default=[])
+    manifest.add_argument(
+        "--channel",
+        choices=sorted(CHANNEL_ASSETS),
+        help="record the release channel and refuse any asset set but its own",
+    )
     manifest.add_argument("--output", type=Path, required=True)
 
     verify = subparsers.add_parser("verify-manifest", help="re-derive the handoff digests")
@@ -326,6 +423,23 @@ def _parser() -> argparse.ArgumentParser:
         help=(
             "manifest digest from the verification job output; required so a missing "
             "or redacted value cannot silently skip the binding"
+        ),
+    )
+    verify.add_argument(
+        "--expected-channel",
+        required=True,
+        choices=sorted(CHANNEL_ASSETS),
+        help=(
+            "the channel the release was declared; the manifest must record it and "
+            "list exactly its asset set"
+        ),
+    )
+    verify.add_argument(
+        "--require-signatures",
+        action="store_true",
+        help=(
+            "require the Sigstore bundles the declared channel signs, for the "
+            "final asset set of a finished release"
         ),
     )
     verify.add_argument("--directory", type=Path)
@@ -369,6 +483,7 @@ def main(argv: list[str] | None = None) -> int:
                 wheel_path=args.wheel,
                 asset_paths=list(args.asset),
                 output_path=args.output,
+                channel=args.channel,
             )
             digest = sha256_file(args.output)
             sys.stdout.write(
@@ -382,6 +497,8 @@ def main(argv: list[str] | None = None) -> int:
                 directory=args.directory,
                 allowed_extra=set(args.allow),
                 required_extra=set(args.require),
+                expected_channel=args.expected_channel,
+                require_signatures=args.require_signatures,
             )
             sys.stdout.write(
                 f"OK: all {len(manifest['assets'])} candidate assets match the verified digests.\n"

--- a/scripts/verify_wheel_provenance.py
+++ b/scripts/verify_wheel_provenance.py
@@ -33,6 +33,11 @@ difference. That is deliberate: the fix is to align the pinned build backend
 (``constraints/release-build.txt``), not to widen the comparison. The report
 names the differing member so the operator can see that immediately.
 
+An advisory release (#648) has no qualified wheel. It binds the wheel a Release
+Engine Smoke run exercised instead, with ``--exercised``: the comparison is the
+same, and the report names its subject ``exercised_wheel``, so nothing an
+advisory release publishes calls its wheel qualified.
+
 Run from the repo root:
 
     python scripts/verify_wheel_provenance.py \\
@@ -60,6 +65,7 @@ else:  # ``python scripts/verify_wheel_provenance.py``
     from _release_support import parse_wheel_filename
 
 ProvenanceMode = Literal["identical_bytes", "identical_payload", "mismatch"]
+ProvenanceSubject = Literal["qualified", "exercised"]
 
 # Number of differing members named in the failure message. A full listing of a
 # 500-member wheel buries the signal in CI logs; the first few are enough to
@@ -180,6 +186,7 @@ def verify_wheel_provenance(
     qualified_path: Path,
     allow_payload_equivalent: bool = False,
     source_commit: str | None = None,
+    subject: ProvenanceSubject = "qualified",
 ) -> dict[str, object]:
     """Return a provenance record, or raise ``ConfigError`` if unpublishable.
 
@@ -187,6 +194,8 @@ def verify_wheel_provenance(
     exception here is what keeps an unbound artifact off PyPI.
     """
 
+    if subject not in ("qualified", "exercised"):
+        raise ConfigError(f"Unknown provenance subject {subject!r}")
     if source_commit is not None:
         # Validate *both* records before the byte-equality fast path: two
         # identical wheels can be identically bound to the wrong commit.
@@ -200,8 +209,8 @@ def verify_wheel_provenance(
         if omitted > 0:
             detail += f"; (+{omitted} more)"
         raise ConfigError(
-            "Wheel built from the tagged source does not match the qualified wheel. "
-            "The qualified wheel was not produced by this source tree, or the build "
+            f"Wheel built from the tagged source does not match the {subject} wheel. "
+            f"The {subject} wheel was not produced by this source tree, or the build "
             "backend pin drifted. Differences: " + detail
         )
     if mode == "identical_payload" and not allow_payload_equivalent:
@@ -217,8 +226,8 @@ def verify_wheel_provenance(
         "provenance_mode": mode,
         "built_wheel": built_path.name,
         "built_wheel_sha256": _sha256_file(built_path),
-        "qualified_wheel": qualified_path.name,
-        "qualified_wheel_sha256": _sha256_file(qualified_path),
+        f"{subject}_wheel": qualified_path.name,
+        f"{subject}_wheel_sha256": _sha256_file(qualified_path),
         "source_commit": source_commit,
         "byte_reproducible": mode == "identical_bytes",
     }
@@ -251,8 +260,12 @@ def _parser() -> argparse.ArgumentParser:
         description="Verify the qualified wheel was produced by the tagged source tree."
     )
     parser.add_argument("--built", type=Path, required=True, help="wheel built from the checkout")
-    parser.add_argument(
-        "--qualified", type=Path, required=True, help="signed, qualified wheel to be published"
+    subject = parser.add_mutually_exclusive_group(required=True)
+    subject.add_argument("--qualified", type=Path, help="signed, qualified wheel to be published")
+    subject.add_argument(
+        "--exercised",
+        type=Path,
+        help="wheel a Release Engine Smoke run exercised, for an advisory release (#648)",
     )
     parser.add_argument("--report", type=Path, help="write a JSON provenance record here")
     parser.add_argument("--source-commit", help="commit SHA the built wheel came from")
@@ -269,10 +282,12 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    subject = "qualified" if args.qualified is not None else "exercised"
     try:
         record = verify_wheel_provenance(
             built_path=args.built,
-            qualified_path=args.qualified,
+            qualified_path=args.qualified if args.qualified is not None else args.exercised,
+            subject=subject,
             allow_payload_equivalent=args.allow_payload_equivalent,
             source_commit=args.source_commit,
         )
@@ -282,8 +297,8 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"Wheel provenance error: {exc}\n")
         return 1
     sys.stdout.write(
-        f"OK: qualified wheel is bound to the tagged source ({record['provenance_mode']}); "
-        f"sha256 {record['qualified_wheel_sha256']}.\n"
+        f"OK: {subject} wheel is bound to the tagged source ({record['provenance_mode']}); "
+        f"sha256 {record[f'{subject}_wheel_sha256']}.\n"
     )
     return 0
 

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -335,7 +335,7 @@ def test_release_workflow_uses_release_security_steps():
     # both files discuss the superseded `cyclonedx-py environment` scan in
     # comments explaining why it was replaced.
     commands = []
-    for name in ("release.yml", "release-verify.yml"):
+    for name in ("release.yml", "release-verify.yml", "release-advisory-verify.yml"):
         parsed = yaml.safe_load(Path(".github/workflows", name).read_text(encoding="utf-8"))
         for job in parsed["jobs"].values():
             commands.extend(step["run"] for step in (job.get("steps") or []) if "run" in step)

--- a/tests/test_release_advisory_pipeline.py
+++ b/tests/test_release_advisory_pipeline.py
@@ -1,0 +1,896 @@
+"""The advisory release path: two verifications, one publisher, chosen by reviewed code (#648).
+
+`docs/release-evidence-policy-decision.md` § Amendment 5 admits a `v*` release
+that makes no qualified blocking claim, on conditions this file holds. Each
+condition is a place where the advisory line could borrow the qualified line's
+authority, or the qualified line could silently lose its evidence, so each gets
+a check against the workflow graph or a refusal with a negative control.
+
+The qualified path's own invariants stay in `tests/test_release_pipeline.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts import release_channel as rc
+from scripts._release_support import ReleaseError
+from scripts.release_cadence import tag_channel
+from scripts.release_publication import (
+    ADVISORY,
+    CHANNEL_ASSETS,
+    CHANNEL_SIGNED_ASSETS,
+    QUALIFIED,
+    build_manifest,
+    signature_bundles,
+    verify_manifest,
+)
+from scripts.verify_wheel_provenance import verify_wheel_provenance
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github/workflows"
+VERSION = "9.9.9"
+TAG = f"v{VERSION}"
+SOURCE = "a" * 40
+WHEEL_FILENAME = f"agents_shipgate-{VERSION}-py3-none-any.whl"
+POLICY_STEP = "Exhaustive safety qualification policy re-derivation"
+SHARED_ARTIFACT_STEPS = (
+    "Checkout",
+    "Resolve candidate version and tag",
+    "Set up Python",
+    "Require a CHANGELOG section for this tag",
+    "Install the hash-locked sealing toolchain",
+    "Confirm the sealer is verifying the tested commit",
+    "Build a wheel from the checked-out source",
+    "Upload candidate bundle",
+)
+DERIVED_OUTPUTS = {"channel", "rehearsal_workflow", "release_assets", "signed_assets"}
+
+
+def _load(name: str) -> dict[str, Any]:
+    document = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    if True in document:
+        document["on"] = document.pop(True)
+    return document
+
+
+def _release() -> dict[str, Any]:
+    return _load("release.yml")
+
+
+def _advisory() -> dict[str, Any]:
+    return _load("release-advisory-verify.yml")
+
+
+def _steps(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {step["name"]: step for step in job["steps"]}
+
+
+def _index(job: dict[str, Any], name: str) -> int:
+    return [step["name"] for step in job["steps"]].index(name)
+
+
+def _commands(job: dict[str, Any]) -> str:
+    return "\n".join(_code(step["run"]) for step in job.get("steps") or [] if "run" in step)
+
+
+def _code(script: str) -> str:
+    """A shell script without its comment lines. The workflows explain their
+    flags in comments beside them, so a substring check over the raw text can
+    pass on the explanation after the flag itself is gone."""
+
+    return "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _wheel(path: Path, *, version: str = VERSION, source: str = SOURCE, extra: str = "") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            f"agents_shipgate-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: agents-shipgate\nVersion: {version}\n",
+        )
+        archive.writestr("agents_shipgate/__init__.py", f'__version__ = "{version}"\n{extra}')
+        archive.writestr(
+            "agents_shipgate/_meta/release-source.json",
+            json.dumps(
+                {
+                    "schema_version": "shipgate.release_source/v1",
+                    "source_commit": source,
+                    "package_version": version,
+                }
+            ),
+        )
+    return path
+
+
+def _declaration(tmp_path: Path, channels: dict[str, str]) -> Path:
+    path = tmp_path / "release-channels.json"
+    path.write_text(json.dumps({"schema": rc.SCHEMA, "channels": channels}), encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------
+# The switch: exactly one verification, chosen by the declaration
+# --------------------------------------------------------------------------
+
+
+def test_release_runs_exactly_one_verification_chosen_by_the_declared_channel() -> None:
+    jobs = _release()["jobs"]
+
+    assert list(jobs) == [
+        "channel",
+        "verify",
+        "verify_advisory",
+        "candidate",
+        "stage",
+        "publish",
+        "finalize",
+    ]
+    gates = {
+        jobs["verify"]["if"]: jobs["verify"]["uses"],
+        jobs["verify_advisory"]["if"]: jobs["verify_advisory"]["uses"],
+    }
+    assert gates == {
+        "needs.channel.outputs.channel == 'qualified'": "./.github/workflows/release-verify.yml",
+        "needs.channel.outputs.channel == 'advisory'": "./.github/workflows/release-advisory-verify.yml",
+    }
+    # Exhaustive over the channels reviewed code can declare, so a third
+    # channel cannot be added without a verification of its own.
+    assert {condition.rsplit("'", 2)[1] for condition in gates} == rc.CHANNELS
+    for name in ("verify", "verify_advisory"):
+        assert jobs[name]["needs"] == "channel"
+        assert jobs[name]["with"] == {
+            "ref": "${{ github.sha }}",
+            "release_tag": "${{ github.ref_name }}",
+            "mode": "release",
+        }
+
+
+def test_the_channel_is_read_from_the_tagged_tree_before_anything_is_built() -> None:
+    channel = _release()["jobs"]["channel"]
+
+    assert "needs" not in channel
+    assert channel["permissions"] == {"contents": "read"}
+    checkout = channel["steps"][0]
+    assert checkout["with"]["ref"] == "${{ github.sha }}"
+    assert ".github/release-channels.json" in checkout["with"]["sparse-checkout"]
+    resolve = _steps(channel)["Read the channel reviewed code declares for this version"]
+    assert resolve["run"] == 'python scripts/release_channel.py resolve --tag "${RELEASE_TAG}"'
+    assert resolve["env"] == {"RELEASE_TAG": "${{ github.ref_name }}"}
+    assert channel["outputs"] == {"channel": "${{ steps.channel.outputs.channel }}"}
+
+
+def test_the_candidate_job_hands_both_outcomes_to_the_fail_closed_selector() -> None:
+    candidate = _release()["jobs"]["candidate"]
+
+    assert candidate["needs"] == ["channel", "verify", "verify_advisory"]
+    assert candidate["if"] == "${{ !cancelled() && needs.channel.result == 'success' }}"
+    assert candidate["permissions"] == {"contents": "read"}
+    select = _steps(candidate)["Select the declared channel's verified candidate"]
+    assert select["env"] == {
+        "CHANNEL": "${{ needs.channel.outputs.channel }}",
+        "RELEASE_TAG": "${{ github.ref_name }}",
+        "QUALIFIED_RESULT": "${{ needs.verify.result }}",
+        "ADVISORY_RESULT": "${{ needs.verify_advisory.result }}",
+        "QUALIFIED_OUTPUTS": "${{ toJSON(needs.verify.outputs) }}",
+        "ADVISORY_OUTPUTS": "${{ toJSON(needs.verify_advisory.outputs) }}",
+    }
+    assert "python scripts/release_channel.py candidate" in select["run"]
+    for flag in ("--qualified-result", "--advisory-result", "--qualified-outputs", "--advisory-outputs", "--tag"):
+        assert flag in select["run"], flag
+    # Every value publication reads comes out of this job, and out of the
+    # selector's step, under its own name.
+    expected = set(rc.CANDIDATE_OUTPUTS) | DERIVED_OUTPUTS
+    assert set(candidate["outputs"]) == expected
+    for key, value in candidate["outputs"].items():
+        assert value == f"${{{{ steps.select.outputs.{key} }}}}", key
+
+
+def _names_each_dependency_success(job: dict[str, Any]) -> bool:
+    condition = str(job.get("if", ""))
+    needs = job["needs"] if isinstance(job["needs"], list) else [job["needs"]]
+    return (
+        condition.startswith("${{ !cancelled() && ")
+        and "||" not in condition
+        and all(f"needs.{name}.result == 'success'" in condition for name in needs)
+    )
+
+
+def test_every_job_after_the_switch_names_each_dependency_success() -> None:
+    """A skipped verification job would skip everything downstream on a default
+    condition, so the jobs after `candidate` override it. The override must not
+    become permission to run after a failure: each names the success of every
+    job it needs."""
+
+    jobs = _release()["jobs"]
+
+    for name in ("stage", "publish", "finalize"):
+        assert _names_each_dependency_success(jobs[name]), name
+    for name in ("publish", "finalize"):
+        assert "needs.stage.outputs.release_state != 'published'" in jobs[name]["if"], name
+
+    # Negative control: the checker notices one dependency going unnamed.
+    weakened = dict(jobs["finalize"])
+    weakened["if"] = weakened["if"].replace("needs.publish.result == 'success' && ", "")
+    assert not _names_each_dependency_success(weakened)
+
+
+def test_publication_reads_only_the_selected_candidate() -> None:
+    release = _release()
+    candidate_outputs = set(release["jobs"]["candidate"]["outputs"])
+
+    for name in ("stage", "publish", "finalize"):
+        text = yaml.safe_dump(release["jobs"][name])
+        referenced = set(re.findall(r"needs\.(\w+)\.", text))
+        assert referenced <= {"candidate", "stage", "publish"}, (name, referenced)
+        consumed = set(re.findall(r"needs\.candidate\.outputs\.(\w+)", text))
+        assert consumed, name
+        assert consumed <= candidate_outputs, (name, consumed - candidate_outputs)
+
+
+@pytest.mark.parametrize("workflow", ["release-verify.yml", "release-advisory-verify.yml"])
+def test_both_verifications_export_every_value_publication_reads(workflow: str) -> None:
+    exported = set(_load(workflow)["on"]["workflow_call"]["outputs"])
+
+    assert set(rc.CANDIDATE_OUTPUTS) <= exported, set(rc.CANDIDATE_OUTPUTS) - exported
+
+
+# --------------------------------------------------------------------------
+# The advisory verification: no qualification step, the shared steps unchanged
+# --------------------------------------------------------------------------
+
+
+def test_the_advisory_verification_holds_no_publication_authority() -> None:
+    advisory = _advisory()
+    release = _release()
+
+    assert advisory["permissions"] == {"contents": "read", "actions": "read"}
+    assert advisory["jobs"]["tests"]["permissions"] == {"contents": "read"}
+    assert advisory["jobs"]["artifact"]["permissions"] == {"contents": "read", "actions": "read"}
+    assert release["jobs"]["verify_advisory"]["permissions"] == {"contents": "read", "actions": "read"}
+    for job in (*advisory["jobs"].values(), release["jobs"]["channel"], release["jobs"]["candidate"]):
+        assert "id-token" not in job.get("permissions", {})
+        assert "write" not in job.get("permissions", {}).values()
+        assert "environment" not in job
+    text = (WORKFLOWS / "release-advisory-verify.yml").read_text(encoding="utf-8")
+    for verb in ("uv publish", "gh release create", "gh release upload", "sigstore sign"):
+        assert verb not in text, verb
+
+
+def test_the_advisory_verification_contains_no_qualification_step_to_skip() -> None:
+    """Amendment 2's C3, applied again: the advisory line calls a workflow with
+    no qualification step in it, rather than a qualified workflow with steps
+    turned off."""
+
+    text = (WORKFLOWS / "release-advisory-verify.yml").read_text(encoding="utf-8")
+
+    for qualified_only in (
+        "SAFETY_QUALIFICATION",
+        "safety-qualification",
+        "verify_qualification_binding",
+        "verify_safety_qualification_release",
+        "release-trust-roots",
+        "--qualified",
+    ):
+        assert qualified_only not in text, qualified_only
+    assert "inputs.mode ==" not in json.dumps(
+        [step for job in _advisory()["jobs"].values() for step in job["steps"]
+         if step["name"] != "Prove the provenance gate fails closed"]
+    )
+
+
+def test_the_steps_both_lines_share_are_identical() -> None:
+    """Held equal rather than trusted to stay in step: a fix to the suite, the
+    lock check, the build or the handoff upload lands once, in
+    `release-verify.yml`, and this fails until the advisory copy matches."""
+
+    qualified = _load("release-verify.yml")["jobs"]
+    advisory = _advisory()["jobs"]
+
+    assert [s for s in qualified["tests"]["steps"] if s["name"] != POLICY_STEP] == advisory["tests"]["steps"]
+    for key in ("runs-on", "timeout-minutes", "permissions"):
+        assert qualified["tests"][key] == advisory["tests"][key], key
+    qualified_steps, advisory_steps = _steps(qualified["artifact"]), _steps(advisory["artifact"])
+    for name in SHARED_ARTIFACT_STEPS:
+        assert advisory_steps[name] == qualified_steps[name], name
+
+
+def test_the_advisory_verification_refuses_a_version_declared_qualified() -> None:
+    artifact = _advisory()["jobs"]["artifact"]
+    refuse = _steps(artifact)["Refuse a version that is not declared advisory"]
+
+    assert 'python scripts/release_channel.py resolve --tag "${RELEASE_TAG}"' in refuse["run"]
+    assert '[ "${channel}" != "advisory" ]' in refuse["run"]
+    assert "exit 1" in refuse["run"]
+    assert _index(artifact, "Refuse a version that is not declared advisory") < _index(
+        artifact, "Build a wheel from the checked-out source"
+    )
+
+
+def test_the_advisory_release_publishes_the_exercised_wheel_bound_to_its_source() -> None:
+    """#570: the published bytes are the ones a pre-publication smoke ran
+    through both the CLI and the Action, and they are what the tag builds."""
+
+    artifact = _advisory()["jobs"]["artifact"]
+    steps = _steps(artifact)
+    order = [
+        "Build a wheel from the checked-out source",
+        "Download the candidate the Release Engine Smoke exercised",
+        "Require the smoke evidence to cover this exact candidate",
+        "Bind the exercised wheel to the tagged source tree",
+        "Generate wheel-scoped SBOM",
+        "Write the advisory statement",
+        "Assemble content-addressed candidate handoff",
+        "Upload candidate bundle",
+    ]
+    assert [_index(artifact, name) for name in order] == sorted(_index(artifact, name) for name in order)
+
+    download = steps["Download the candidate the Release Engine Smoke exercised"]["run"]
+    assert "actions/workflows/release-engine-smoke.yml/runs?head_sha=${SOURCE_SHA}&status=success" in download
+    assert "No successful Release Engine Smoke run" in download
+    assert '[ "${#wheels[@]}" -ne 1 ]' in download
+    # The artifact names are the smoke workflow's own, read from it.
+    smoke = _load("release-engine-smoke.yml")["jobs"]
+    uploaded = {
+        step["with"]["name"]
+        for job in smoke.values()
+        for step in job["steps"]
+        if "actions/upload-artifact" in str(step.get("uses"))
+    }
+    assert uploaded == {"unqualified-engine-wheel", "unqualified-engine-smoke"}
+    for name in uploaded:
+        assert f"--name {name}" in download, name
+    compare = _commands(smoke["downstream"])
+    assert "release_engine_smoke.py compare > .shipgate-smoke/distribution-evidence.json" in compare
+
+    evidence = steps["Require the smoke evidence to cover this exact candidate"]["run"]
+    assert "release_channel.py exercised" in evidence
+    assert "--evidence exercised-evidence/distribution-evidence.json" in evidence
+    for name in ("Bind the exercised wheel to the tagged source tree", "Assemble content-addressed candidate handoff"):
+        assert "--exercised \"${EXERCISED_WHEEL}\"" in steps[name]["run"], name
+        assert '--source-commit "${SOURCE_SHA}"' in steps[name]["run"], name
+    handoff = steps["Assemble content-addressed candidate handoff"]["run"]
+    assert "--channel advisory" in handoff
+    listed = set(re.findall(r"--asset candidate/([\w.-]+)", handoff))
+    assert listed == CHANNEL_ASSETS[ADVISORY]
+
+
+def test_every_advisory_rehearsal_proves_its_provenance_gate_fails_closed() -> None:
+    drill = _steps(_advisory()["jobs"]["artifact"])["Prove the provenance gate fails closed"]
+
+    assert drill["if"] == "inputs.mode == 'rehearsal'"
+    assert "if python scripts/verify_wheel_provenance.py" in drill["run"]
+    assert "--exercised fault-injected.whl" in drill["run"]
+    assert "does not fail closed" in drill["run"]
+
+
+def test_the_advisory_rehearsal_cannot_publish_and_calls_the_advisory_verification() -> None:
+    rehearsal = _load("release-advisory-rehearsal.yml")
+
+    assert set(rehearsal["on"]) == {"workflow_dispatch"}
+    assert "ref" not in rehearsal["on"]["workflow_dispatch"]["inputs"]
+    assert rehearsal["permissions"] == {"contents": "read", "actions": "read"}
+    assert list(rehearsal["jobs"]) == ["rehearse"]
+    job = rehearsal["jobs"]["rehearse"]
+    assert job["uses"] == "./.github/workflows/release-advisory-verify.yml"
+    assert job["with"] == {
+        "ref": "${{ github.sha }}",
+        "release_tag": "${{ inputs.release_tag }}",
+        "mode": "rehearsal",
+    }
+    assert "id-token" not in job["permissions"]
+
+
+# --------------------------------------------------------------------------
+# One publisher, keyed by the declared channel
+# --------------------------------------------------------------------------
+
+
+def test_staging_requires_the_declared_channels_own_rehearsal_and_asset_set() -> None:
+    stage = _release()["jobs"]["stage"]
+    steps = _steps(stage)
+
+    rehearsal = steps["Require a successful rehearsal of this exact candidate"]
+    assert rehearsal["env"]["REHEARSAL_WORKFLOW"] == "${{ needs.candidate.outputs.rehearsal_workflow }}"
+    assert "actions/workflows/${REHEARSAL_WORKFLOW:?" in _code(rehearsal["run"])
+    assert "head_sha=${SOURCE_SHA}&status=success" in rehearsal["run"]
+    assert rc.REHEARSAL_WORKFLOWS == {
+        QUALIFIED: "release-rehearsal.yml",
+        ADVISORY: "release-advisory-rehearsal.yml",
+    }
+    for workflow in rc.REHEARSAL_WORKFLOWS.values():
+        assert (WORKFLOWS / workflow).is_file(), workflow
+
+    handoff = steps["Verify the candidate handoff"]
+    assert '--expected-channel "${CHANNEL}"' in _code(handoff["run"])
+    assert handoff["env"]["CHANNEL"] == "${{ needs.candidate.outputs.channel }}"
+
+    draft = steps["Create or repair the draft release"]
+    assert draft["env"]["RELEASE_ASSETS"] == "${{ needs.candidate.outputs.release_assets }}"
+    assert draft["env"]["SIGNED_ASSETS"] == "${{ needs.candidate.outputs.signed_assets }}"
+    published = _code(draft["run"]).split("Published already", 1)[-1]
+    assert '--expected-channel "${CHANNEL}"' in published
+    assert "--require-signatures" in published
+    assert '"${signed_assets[@]}"' in published
+    # No channel's file names are spelled in the publisher any more; they come
+    # from `release_publication` through the candidate.
+    for asset in ("safety-qualification.json", "advisory-statement.json"):
+        assert asset not in _commands(stage), asset
+
+
+def test_signing_and_finalisation_follow_the_declared_channel() -> None:
+    jobs = _release()["jobs"]
+
+    sign = _steps(jobs["publish"])["Sign release artifacts"]
+    assert sign["env"]["SIGNED_ASSETS"] == "${{ needs.candidate.outputs.signed_assets }}"
+    assert 'sigstore sign --output-directory dist --overwrite "${targets[@]}"' in _code(sign["run"])
+
+    finalize = _steps(jobs["finalize"])
+    closed = _code(finalize["Validate the exact remote asset set, byte for byte"]["run"])
+    assert '--expected-channel "${CHANNEL}"' in closed
+    assert "--require-signatures" in closed
+    verify = _code(finalize["Verify the attached signatures"]["run"])
+    assert 'for target in "${WHEEL_FILENAME}" "${signed_assets[@]}"; do' in verify
+    assert "sigstore verify identity" in verify
+
+
+# --------------------------------------------------------------------------
+# One table of channels
+# --------------------------------------------------------------------------
+
+
+def test_every_channel_table_names_the_same_channels() -> None:
+    assert set(CHANNEL_ASSETS) == set(CHANNEL_SIGNED_ASSETS) == set(rc.REHEARSAL_WORKFLOWS) == rc.CHANNELS
+    assert (QUALIFIED, ADVISORY) == (rc.QUALIFIED, rc.ADVISORY)
+
+
+def test_each_channel_signs_only_what_it_ships_and_only_the_qualified_line_is_qualified() -> None:
+    for channel, signed in CHANNEL_SIGNED_ASSETS.items():
+        assert set(signed) <= CHANNEL_ASSETS[channel], channel
+    assert rc.STATEMENT_FILENAME in CHANNEL_ASSETS[ADVISORY]
+    assert rc.STATEMENT_FILENAME in CHANNEL_SIGNED_ASSETS[ADVISORY]
+    assert not any("qualification" in name for name in CHANNEL_ASSETS[ADVISORY])
+    assert {"safety-qualification.json", "safety-qualification.sigstore.json"} <= CHANNEL_ASSETS[QUALIFIED]
+    assert rc.STATEMENT_FILENAME not in CHANNEL_ASSETS[QUALIFIED]
+
+
+# --------------------------------------------------------------------------
+# The closed asset set per channel
+# --------------------------------------------------------------------------
+
+
+def _candidate_dir(tmp_path: Path, names: set[str]) -> tuple[Path, list[Path]]:
+    wheel = _wheel(tmp_path / WHEEL_FILENAME)
+    assets = []
+    for name in sorted(names):
+        path = tmp_path / name
+        path.write_text("{}\n", encoding="utf-8")
+        assets.append(path)
+    return wheel, assets
+
+
+@pytest.mark.parametrize("channel", sorted(CHANNEL_ASSETS))
+def test_a_manifest_records_its_channel_and_verifies_only_as_that_channel(tmp_path: Path, channel: str) -> None:
+    wheel, assets = _candidate_dir(tmp_path, set(CHANNEL_ASSETS[channel]))
+    manifest = tmp_path / "candidate-manifest.json"
+    build_manifest(
+        tag=TAG, source_commit=SOURCE, wheel_path=wheel, asset_paths=assets,
+        output_path=manifest, channel=channel,
+    )
+    digest = __import__("hashlib").sha256(manifest.read_bytes()).hexdigest()
+
+    assert json.loads(manifest.read_text(encoding="utf-8"))["channel"] == channel
+    assert verify_manifest(manifest_path=manifest, expected_sha256=digest, expected_channel=channel)
+    other = ADVISORY if channel == QUALIFIED else QUALIFIED
+    with pytest.raises(ReleaseError, match=f"records the {channel} channel"):
+        verify_manifest(manifest_path=manifest, expected_sha256=digest, expected_channel=other)
+
+
+@pytest.mark.parametrize(
+    ("channel", "names", "message"),
+    [
+        (ADVISORY, CHANNEL_ASSETS[ADVISORY] | {"safety-qualification.json"}, "not permitted safety-qualification.json"),
+        (ADVISORY, CHANNEL_ASSETS[ADVISORY] - {"advisory-statement.json"}, "missing advisory-statement.json"),
+        (QUALIFIED, CHANNEL_ASSETS[QUALIFIED] - {"safety-qualification.sigstore.json"}, "missing safety-qualification.sigstore.json"),
+        (QUALIFIED, CHANNEL_ASSETS[QUALIFIED] | {"advisory-statement.json"}, "not permitted advisory-statement.json"),
+        ("preview", set(), "Unknown release channel"),
+    ],
+)
+def test_a_channel_manifest_refuses_any_other_asset_set(tmp_path: Path, channel: str, names: set[str], message: str) -> None:
+    wheel, assets = _candidate_dir(tmp_path, set(names))
+
+    with pytest.raises(ReleaseError, match=message):
+        build_manifest(
+            tag=TAG, source_commit=SOURCE, wheel_path=wheel, asset_paths=assets,
+            output_path=tmp_path / "candidate-manifest.json", channel=channel,
+        )
+
+
+def test_a_manifest_from_before_channels_verifies_only_as_qualified(tmp_path: Path) -> None:
+    """`release-verify.yml` is unchanged and records no channel. Its manifest is
+    the qualified line's by construction; it must never pass as advisory."""
+
+    wheel, assets = _candidate_dir(tmp_path, set(CHANNEL_ASSETS[QUALIFIED]))
+    manifest = tmp_path / "candidate-manifest.json"
+    build_manifest(tag=TAG, source_commit=SOURCE, wheel_path=wheel, asset_paths=assets, output_path=manifest)
+    digest = __import__("hashlib").sha256(manifest.read_bytes()).hexdigest()
+
+    assert "channel" not in json.loads(manifest.read_text(encoding="utf-8"))
+    assert verify_manifest(manifest_path=manifest, expected_sha256=digest, expected_channel=QUALIFIED)
+    with pytest.raises(ReleaseError, match="records the qualified channel"):
+        verify_manifest(manifest_path=manifest, expected_sha256=digest, expected_channel=ADVISORY)
+
+
+@pytest.mark.parametrize("channel", sorted(CHANNEL_ASSETS))
+def test_a_finished_release_must_carry_every_bundle_its_channel_signs(tmp_path: Path, channel: str) -> None:
+    wheel, assets = _candidate_dir(tmp_path, set(CHANNEL_ASSETS[channel]))
+    manifest = tmp_path / "candidate-manifest.json"
+    build_manifest(
+        tag=TAG, source_commit=SOURCE, wheel_path=wheel, asset_paths=assets,
+        output_path=manifest, channel=channel,
+    )
+    digest = __import__("hashlib").sha256(manifest.read_bytes()).hexdigest()
+    bundles = signature_bundles(channel, WHEEL_FILENAME)
+    assert bundles == {f"{name}.sigstore.json" for name in (WHEEL_FILENAME, *CHANNEL_SIGNED_ASSETS[channel])}
+
+    for bundle in sorted(bundles):
+        for present in bundles - {bundle}:
+            (tmp_path / present).write_text("bundle", encoding="utf-8")
+        (tmp_path / bundle).unlink(missing_ok=True)
+        with pytest.raises(ReleaseError, match=re.escape(bundle)):
+            verify_manifest(
+                manifest_path=manifest, expected_sha256=digest,
+                expected_channel=channel, require_signatures=True,
+            )
+    for bundle in bundles:
+        (tmp_path / bundle).write_text("bundle", encoding="utf-8")
+    assert verify_manifest(
+        manifest_path=manifest, expected_sha256=digest, expected_channel=channel, require_signatures=True
+    )
+
+
+def test_requiring_signatures_without_a_declared_channel_is_refused(tmp_path: Path) -> None:
+    wheel, assets = _candidate_dir(tmp_path, set(CHANNEL_ASSETS[ADVISORY]))
+    manifest = tmp_path / "candidate-manifest.json"
+    build_manifest(
+        tag=TAG, source_commit=SOURCE, wheel_path=wheel, asset_paths=assets,
+        output_path=manifest, channel=ADVISORY,
+    )
+    digest = __import__("hashlib").sha256(manifest.read_bytes()).hexdigest()
+
+    with pytest.raises(ReleaseError, match="needs the declared channel"):
+        verify_manifest(manifest_path=manifest, expected_sha256=digest, require_signatures=True)
+
+
+def test_the_declared_channel_is_mandatory_on_the_command_line() -> None:
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts/release_publication.py"), "verify-manifest",
+         "--manifest", "missing.json", "--expected-sha256", "0" * 64],
+        capture_output=True, text=True, check=False,
+    )
+
+    assert result.returncode != 0
+    assert "--expected-channel" in result.stderr
+
+
+# --------------------------------------------------------------------------
+# Provenance names its subject
+# --------------------------------------------------------------------------
+
+
+def test_an_exercised_wheel_is_bound_by_bytes_and_never_called_qualified(tmp_path: Path) -> None:
+    built = _wheel(tmp_path / "built" / WHEEL_FILENAME)
+    exercised = _wheel(tmp_path / "exercised" / WHEEL_FILENAME)
+
+    record = verify_wheel_provenance(
+        built_path=built, qualified_path=exercised, source_commit=SOURCE, subject="exercised"
+    )
+
+    assert record["provenance_mode"] == "identical_bytes"
+    assert {"exercised_wheel", "exercised_wheel_sha256"} <= set(record)
+    assert not any("qualified" in key for key in record)
+
+    tampered = _wheel(tmp_path / "tampered" / WHEEL_FILENAME, extra="x = 2\n")
+    with pytest.raises(ReleaseError, match="does not match the exercised wheel"):
+        verify_wheel_provenance(built_path=built, qualified_path=tampered, subject="exercised")
+
+
+def test_the_provenance_command_takes_exactly_one_subject(tmp_path: Path) -> None:
+    import sys
+
+    built = _wheel(tmp_path / "built" / WHEEL_FILENAME)
+    script = str(REPO_ROOT / "scripts/verify_wheel_provenance.py")
+
+    both = subprocess.run(
+        [sys.executable, script, "--built", str(built), "--qualified", str(built), "--exercised", str(built)],
+        capture_output=True, text=True, check=False,
+    )
+    neither = subprocess.run(
+        [sys.executable, script, "--built", str(built)], capture_output=True, text=True, check=False
+    )
+
+    assert both.returncode != 0 and "not allowed with argument" in both.stderr
+    assert neither.returncode != 0 and "one of the arguments" in neither.stderr
+
+
+# --------------------------------------------------------------------------
+# `candidate`: forward the declared channel's values, and nothing else
+# --------------------------------------------------------------------------
+
+
+def _outputs(**overrides: str) -> str:
+    values = {
+        "version": VERSION,
+        "release_tag": TAG,
+        "source_sha": SOURCE,
+        "wheel_filename": WHEEL_FILENAME,
+        "wheel_sha256": "1" * 64,
+        "manifest_sha256": "2" * 64,
+        "release_notes_sha256": "3" * 64,
+        "artifact_name": f"release-candidate-{TAG}",
+    }
+    values.update(overrides)
+    return json.dumps(values, indent=2)
+
+
+@pytest.mark.parametrize("channel", sorted(rc.CHANNELS))
+def test_candidate_forwards_the_declared_channels_values(channel: str) -> None:
+    declared = _outputs()
+    values = rc.candidate(
+        channel,
+        tag=TAG,
+        qualified_result="success" if channel == QUALIFIED else "skipped",
+        advisory_result="success" if channel == ADVISORY else "skipped",
+        qualified_outputs=declared if channel == QUALIFIED else "{}",
+        advisory_outputs=declared if channel == ADVISORY else "{}",
+    )
+
+    assert {key: values[key] for key in rc.CANDIDATE_OUTPUTS} == json.loads(declared)
+    assert values["channel"] == channel
+    assert values["rehearsal_workflow"] == rc.REHEARSAL_WORKFLOWS[channel]
+    assert values["release_assets"].split() == sorted(CHANNEL_ASSETS[channel])
+    assert tuple(values["signed_assets"].split()) == CHANNEL_SIGNED_ASSETS[channel]
+
+
+@pytest.mark.parametrize(
+    ("advisory_outputs", "qualified_outputs", "message"),
+    [
+        (_outputs(release_tag="v9.9.8"), "{}", "not the pushed tag"),
+        (_outputs(manifest_sha256=""), "{}", "did not export manifest_sha256"),
+        (json.dumps({"version": VERSION}), "{}", "did not export release_tag"),
+        (_outputs(), _outputs(), "undeclared qualified verification exported"),
+        (_outputs(), json.dumps({"version": ""}), None),
+        (_outputs(artifact_name="x\nwheel_sha256=evil"), "{}", "spans lines"),
+        ("not json", "{}", "not valid JSON"),
+        ('{"version": "1", "version": "2"}', "{}", "duplicate key"),
+        (json.dumps({"version": 1}), "{}", "map names to strings"),
+    ],
+)
+def test_candidate_refuses_anything_but_the_declared_channels_complete_values(
+    advisory_outputs: str, qualified_outputs: str, message: str | None
+) -> None:
+    if message is None:
+        # An undeclared job's *empty* outputs are what a skipped job exports.
+        assert rc.candidate(
+            ADVISORY, tag=TAG, qualified_result="skipped", advisory_result="success",
+            qualified_outputs=qualified_outputs, advisory_outputs=advisory_outputs,
+        )["channel"] == ADVISORY
+        return
+    with pytest.raises(rc.ChannelError, match=message):
+        rc.candidate(
+            ADVISORY, tag=TAG, qualified_result="skipped", advisory_result="success",
+            qualified_outputs=qualified_outputs, advisory_outputs=advisory_outputs,
+        )
+
+
+def test_candidate_refuses_before_reading_outputs_when_the_wrong_job_ran() -> None:
+    with pytest.raises(rc.ChannelError, match="did not stay skipped"):
+        rc.candidate(
+            ADVISORY, tag=TAG, qualified_result="success", advisory_result="success",
+            qualified_outputs="{}", advisory_outputs=_outputs(),
+        )
+
+
+def test_the_candidate_command_writes_every_value_to_github_output(tmp_path, monkeypatch) -> None:
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+    assert rc.main([
+        "candidate", "--channel", "advisory", "--tag", TAG,
+        "--qualified-result", "skipped", "--advisory-result", "success",
+        "--qualified-outputs", "{}", "--advisory-outputs", _outputs(),
+    ]) == 0
+    written = dict(line.split("=", 1) for line in output.read_text(encoding="utf-8").splitlines())
+    assert set(written) == set(rc.CANDIDATE_OUTPUTS) | DERIVED_OUTPUTS
+    assert written["signed_assets"] == "agents-shipgate-sbom.json advisory-statement.json"
+
+
+# --------------------------------------------------------------------------
+# `exercised`: the smoke evidence must cover exactly this candidate
+# --------------------------------------------------------------------------
+
+
+def _evidence(tmp_path: Path, wheel: Path, **overrides: object) -> Path:
+    record: dict[str, object] = {
+        "source_commit": SOURCE,
+        "wheel_sha256": __import__("hashlib").sha256(wheel.read_bytes()).hexdigest(),
+        "local_and_action_agree": True,
+        "qualified": False,
+        "qualification_claim": "none: synthetic distribution smoke only",
+    }
+    record.update(overrides)
+    path = tmp_path / "distribution-evidence.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return path
+
+
+def test_smoke_evidence_for_this_commit_and_these_bytes_is_accepted(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path / WHEEL_FILENAME)
+
+    assert rc.confirm_exercised(_evidence(tmp_path, wheel), source_commit=SOURCE, wheel_path=wheel)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"local_and_action_agree": False}, "installed CLI and the Action agreeing"),
+        ({"local_and_action_agree": "true"}, "installed CLI and the Action agreeing"),
+        ({"qualified": True}, "as unqualified"),
+        ({"source_commit": "b" * 40}, "exercised source"),
+        ({"wheel_sha256": "0" * 64}, "exercised wheel"),
+    ],
+)
+def test_smoke_evidence_that_does_not_cover_this_candidate_is_refused(
+    tmp_path: Path, overrides: dict[str, object], message: str
+) -> None:
+    wheel = _wheel(tmp_path / WHEEL_FILENAME)
+
+    with pytest.raises(rc.ChannelError, match=message):
+        rc.confirm_exercised(_evidence(tmp_path, wheel, **overrides), source_commit=SOURCE, wheel_path=wheel)
+
+
+def test_unreadable_smoke_evidence_is_refused(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path / WHEEL_FILENAME)
+    (tmp_path / "broken.json").write_text("{", encoding="utf-8")
+
+    with pytest.raises(rc.ChannelError, match="unreadable smoke evidence"):
+        rc.confirm_exercised(tmp_path / "broken.json", source_commit=SOURCE, wheel_path=wheel)
+    with pytest.raises(rc.ChannelError, match="unreadable smoke evidence"):
+        rc.confirm_exercised(tmp_path / "absent.json", source_commit=SOURCE, wheel_path=wheel)
+
+
+def test_the_evidence_reader_agrees_with_what_the_smoke_writes() -> None:
+    """The fields `confirm_exercised` reads are the ones
+    `release_engine_smoke.py` writes, read from its source rather than assumed."""
+
+    source = (REPO_ROOT / "scripts/release_engine_smoke.py").read_text(encoding="utf-8")
+
+    for field in ('"source_commit": source_commit', '"wheel_sha256":', '"qualified": False', '"local_and_action_agree": True'):
+        assert field in source, field
+
+
+# --------------------------------------------------------------------------
+# The advisory statement
+# --------------------------------------------------------------------------
+
+
+def _statement(tmp_path: Path, **overrides: Any) -> dict[str, object]:
+    arguments: dict[str, Any] = {
+        "tag": TAG,
+        "source_commit": SOURCE,
+        "wheel_path": _wheel(tmp_path / WHEEL_FILENAME),
+        "smoke_run_id": "34726385422",
+        "repository": "ThreeMoonsLab/agents-shipgate",
+        "declaration": _declaration(tmp_path, {VERSION: ADVISORY, "9.9.10": QUALIFIED}),
+    }
+    arguments.update(overrides)
+    return rc.advisory_statement(**arguments)
+
+
+def test_the_statement_claims_nothing_qualified_and_names_its_evidence(tmp_path: Path) -> None:
+    statement = _statement(tmp_path)
+
+    assert statement["schema"] == rc.STATEMENT_SCHEMA
+    assert statement["channel"] == ADVISORY
+    assert statement["claims"] == {"qualification": "none", "default_ci_mode": "advisory", "blocking": "opt_in"}
+    assert statement["release_tag"] == TAG and statement["source_commit"] == SOURCE
+    assert statement["exact_candidate_evidence"] == {
+        "workflow": ".github/workflows/release-engine-smoke.yml",
+        "run_id": 34726385422,
+        "run_url": "https://github.com/ThreeMoonsLab/agents-shipgate/actions/runs/34726385422",
+        "wheel_sha256": statement["wheel_sha256"],
+    }
+    assert (REPO_ROOT / statement["readiness_record"]["path"]).is_file()
+    assert (REPO_ROOT / statement["exact_candidate_evidence"]["workflow"]).is_file()
+    # No tier anywhere: a reader looking for one finds nothing to misread.
+    assert "tier" not in json.dumps(statement)
+    assert all(statement["not_claimed"])
+
+
+def test_the_statements_default_claim_is_the_actions_actual_default() -> None:
+    inputs = yaml.safe_load((REPO_ROOT / "action.yml").read_text(encoding="utf-8"))["inputs"]
+
+    assert inputs["ci_mode"]["default"] == "advisory"
+    assert inputs["fail_on"]["default"] == ""
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"tag": "v9.9.10"}, "not declared advisory"),
+        ({"tag": "v9.9.11"}, "no reviewed release channel is declared"),
+        ({"source_commit": "abc"}, "full lowercase 40-character SHA"),
+        ({"smoke_run_id": "0"}, "not a workflow run id"),
+        ({"smoke_run_id": "12; rm -rf /"}, "not a workflow run id"),
+        ({"repository": "not a repository"}, "not owner/name"),
+    ],
+)
+def test_the_statement_is_refused_outside_its_preconditions(tmp_path: Path, overrides: dict[str, Any], message: str) -> None:
+    with pytest.raises(rc.ChannelError, match=message):
+        _statement(tmp_path, **overrides)
+
+
+def test_the_statement_is_refused_for_a_wheel_of_another_version(tmp_path: Path) -> None:
+    other = _wheel(tmp_path / "other" / "agents_shipgate-9.9.8-py3-none-any.whl", version="9.9.8")
+
+    with pytest.raises(rc.ChannelError, match="does not match wheel version"):
+        _statement(tmp_path, wheel_path=other)
+
+
+def test_the_statement_command_writes_deterministic_json(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path / WHEEL_FILENAME)
+    declaration = _declaration(tmp_path, {VERSION: ADVISORY})
+    arguments = [
+        "statement", "--tag", TAG, "--source-commit", SOURCE, "--wheel", str(wheel),
+        "--smoke-run-id", "7", "--repository", "o/r", "--declaration", str(declaration),
+    ]
+
+    assert rc.main([*arguments, "--output", str(tmp_path / "one.json")]) == 0
+    assert rc.main([*arguments, "--output", str(tmp_path / "two.json")]) == 0
+    # The rehearsal and the release must seal byte-identical manifests.
+    assert (tmp_path / "one.json").read_bytes() == (tmp_path / "two.json").read_bytes()
+
+
+# --------------------------------------------------------------------------
+# No version carries both claims
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("declared", "message"),
+    [
+        ({"1.0.0": QUALIFIED}, "1.0.0 \\(tagged advisory, now qualified\\)"),
+        ({}, "1.0.0 \\(tagged advisory, now undeclared\\)"),
+    ],
+)
+def test_a_tagged_versions_channel_cannot_change(declared: dict[str, str], message: str) -> None:
+    with pytest.raises(rc.ChannelError, match=message):
+        rc.assert_history_preserved(declared, {"1.0.0": ADVISORY})
+    rc.assert_history_preserved({"1.0.0": ADVISORY, "1.1.0": QUALIFIED}, {"1.0.0": ADVISORY})
+
+
+def test_no_tagged_version_in_this_repository_has_changed_channel() -> None:
+    """Each tag's channel is read from its own tree, the way the cadence reader
+    reads it. Tags from before #648 carry no declaration and bind nothing."""
+
+    tags = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "tag", "--list", "v*"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    tagged = {}
+    for tag in tags:
+        channel = tag_channel(REPO_ROOT, tag)
+        if channel in rc.CHANNELS:
+            tagged[tag[1:]] = channel
+
+    rc.assert_history_preserved(rc.load_declaration(REPO_ROOT / rc.DECLARATION_PATH), tagged)

--- a/tests/test_release_channel.py
+++ b/tests/test_release_channel.py
@@ -1,0 +1,133 @@
+"""Each release version's channel comes from reviewed code, and fails closed (#648)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import release_channel as rc
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _declaration(tmp_path: Path, channels: object, **extra: object) -> Path:
+    path = tmp_path / "release-channels.json"
+    path.write_text(json.dumps({"schema": rc.SCHEMA, "channels": channels, **extra}), encoding="utf-8")
+    return path
+
+
+def test_the_committed_declaration_records_the_advisory_1_0_decision() -> None:
+    assert rc.load_declaration(REPO_ROOT / rc.DECLARATION_PATH) == {"1.0.0": "advisory"}
+
+
+@pytest.mark.parametrize("channel", ["advisory", "qualified"])
+def test_a_declared_version_resolves_to_its_channel(tmp_path: Path, channel: str) -> None:
+    path = _declaration(tmp_path, {"1.0.0": channel})
+    assert rc.resolve("1.0.0", path=path) == channel
+    assert rc.resolve_tag("v1.0.0", path=path) == channel
+
+
+def test_an_undeclared_version_stops_the_release(tmp_path: Path) -> None:
+    """No declaration is no release — never a default channel."""
+
+    path = _declaration(tmp_path, {"1.0.0": "advisory"})
+    with pytest.raises(rc.ChannelError, match="no reviewed release channel is declared for 1.1.0"):
+        rc.resolve_tag("v1.1.0", path=path)
+
+
+def test_a_missing_declaration_file_stops_the_release(tmp_path: Path) -> None:
+    with pytest.raises(rc.ChannelError, match="not found"):
+        rc.resolve_tag("v1.0.0", path=tmp_path / "absent.json")
+
+
+@pytest.mark.parametrize(
+    ("channels", "extra", "message"),
+    [
+        ({"1.0.0": "preview"}, {}, "unknown channel"),
+        ({"1.0.0": ""}, {}, "unknown channel"),
+        ({"latest": "advisory"}, {}, "not a complete public release version"),
+        ({"1.0.0+local": "advisory"}, {}, "not a complete public release version"),
+        (["1.0.0"], {}, "must map release versions"),
+        ({"1.0.0": "advisory"}, {"note": "x"}, "exactly 'schema' and 'channels'"),
+    ],
+)
+def test_a_malformed_declaration_is_refused(tmp_path, channels, extra, message) -> None:
+    path = _declaration(tmp_path, channels, **extra)
+    with pytest.raises(rc.ChannelError, match=message):
+        rc.load_declaration(path)
+
+
+def test_a_wrong_schema_is_refused(tmp_path: Path) -> None:
+    path = tmp_path / "release-channels.json"
+    path.write_text(json.dumps({"schema": "shipgate.release_channels/v0", "channels": {}}), encoding="utf-8")
+    with pytest.raises(rc.ChannelError, match="unsupported release channel schema"):
+        rc.load_declaration(path)
+
+
+def test_a_duplicated_version_is_refused_not_last_one_wins(tmp_path: Path) -> None:
+    """``json`` keeps the last duplicate, so a later line could silently flip a channel."""
+
+    path = tmp_path / "release-channels.json"
+    path.write_text(
+        '{"schema": "%s", "channels": {"1.0.0": "qualified", "1.0.0": "advisory"}}' % rc.SCHEMA,
+        encoding="utf-8",
+    )
+    with pytest.raises(rc.ChannelError, match="duplicate key"):
+        rc.load_declaration(path)
+
+
+@pytest.mark.parametrize("tag", ["1.0.0", "preview-1.0.0", "v1.0", "vlatest", "v1.0.0+local", ""])
+def test_a_tag_that_is_not_v_version_is_refused(tmp_path: Path, tag: str) -> None:
+    path = _declaration(tmp_path, {"1.0.0": "advisory", "1.0": "advisory"})
+    if tag == "v1.0":
+        assert rc.resolve_tag(tag, path=path) == "advisory"
+        return
+    with pytest.raises(rc.ChannelError):
+        rc.resolve_tag(tag, path=path)
+
+
+@pytest.mark.parametrize(
+    ("channel", "qualified", "advisory"),
+    [("advisory", "skipped", "success"), ("qualified", "success", "skipped")],
+)
+def test_select_accepts_only_the_declared_verification_running_alone(channel, qualified, advisory) -> None:
+    assert rc.select(channel, qualified_result=qualified, advisory_result=advisory) == channel
+
+
+@pytest.mark.parametrize(
+    ("channel", "qualified", "advisory"),
+    [
+        ("advisory", "success", "skipped"),    # the undeclared line's evidence
+        ("advisory", "success", "success"),    # both ran
+        ("advisory", "skipped", "skipped"),    # neither ran
+        ("advisory", "skipped", "failure"),    # the declared one failed
+        ("advisory", "skipped", "cancelled"),
+        ("qualified", "skipped", "success"),
+        ("qualified", "failure", "skipped"),
+        ("qualified", "success", "failure"),   # the other did not stay skipped
+        ("advisory", "skipped", "neutral"),    # a result GitHub does not emit
+        ("preview", "skipped", "success"),     # an unknown channel
+    ],
+)
+def test_select_refuses_every_other_outcome(channel, qualified, advisory) -> None:
+    with pytest.raises(rc.ChannelError):
+        rc.select(channel, qualified_result=qualified, advisory_result=advisory)
+
+
+def test_cli_writes_the_channel_to_github_output(tmp_path, monkeypatch, capsys) -> None:
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    path = _declaration(tmp_path, {"1.0.0": "advisory"})
+    assert rc.main(["resolve", "--tag", "v1.0.0", "--declaration", str(path)]) == 0
+    assert output.read_text(encoding="utf-8") == "channel=advisory\n"
+
+
+def test_cli_refusal_exits_nonzero_and_writes_no_output(tmp_path, monkeypatch, capsys) -> None:
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    path = _declaration(tmp_path, {"1.0.0": "advisory"})
+    assert rc.main(["resolve", "--tag", "v2.0.0", "--declaration", str(path)]) == 1
+    assert not output.exists()
+    assert "::error::" in capsys.readouterr().err

--- a/tests/test_release_channel.py
+++ b/tests/test_release_channel.py
@@ -71,7 +71,7 @@ def test_a_duplicated_version_is_refused_not_last_one_wins(tmp_path: Path) -> No
 
     path = tmp_path / "release-channels.json"
     path.write_text(
-        '{"schema": "%s", "channels": {"1.0.0": "qualified", "1.0.0": "advisory"}}' % rc.SCHEMA,
+        '{"schema": "' + rc.SCHEMA + '", "channels": {"1.0.0": "qualified", "1.0.0": "advisory"}}',
         encoding="utf-8",
     )
     with pytest.raises(rc.ChannelError, match="duplicate key"):

--- a/tests/test_release_channel_cadence.py
+++ b/tests/test_release_channel_cadence.py
@@ -1,0 +1,93 @@
+"""An advisory v* release must not report the gate line's cadence as kept (#648)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from scripts import release_cadence as cadence
+from scripts import release_channel as rc
+
+
+def _git(repo: Path, *args: str, when: int | None = None) -> None:
+    env = {**os.environ}
+    if when is not None:
+        stamp = f"@{when} +0000"
+        env.update(GIT_AUTHOR_DATE=stamp, GIT_COMMITTER_DATE=stamp)
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, env=env)
+
+
+def _release(repo: Path, tag: str, when: int, channels: dict[str, str] | None) -> None:
+    declaration = repo / rc.DECLARATION_PATH
+    if channels is None:
+        declaration.unlink(missing_ok=True)
+    else:
+        declaration.parent.mkdir(parents=True, exist_ok=True)
+        declaration.write_text(json.dumps({"schema": rc.SCHEMA, "channels": channels}), encoding="utf-8")
+    (repo / "VERSION").write_text(tag, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", tag, when=when)
+    _git(repo, "tag", tag)
+
+
+def _history(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@e.invalid")
+    _git(repo, "config", "user.name", "T")
+    day = 86_400
+    _release(repo, "v0.15.0", 10 * day, None)                                   # before declarations
+    _release(repo, "v1.0.0", 20 * day, {"1.0.0": "advisory"})                   # advisory v*
+    _release(repo, "v1.1.0", 30 * day, {"1.0.0": "advisory", "1.1.0": "qualified"})
+    _release(repo, "v1.2.0", 40 * day, {"1.0.0": "advisory", "1.1.0": "qualified"})  # undeclared
+    return repo
+
+
+def test_each_tag_reads_the_channel_its_own_tree_declared(tmp_path: Path) -> None:
+    repo = _history(tmp_path)
+    assert cadence.tag_channel(repo, "v0.15.0") is None
+    assert cadence.tag_channel(repo, "v1.0.0") == "advisory"
+    assert cadence.tag_channel(repo, "v1.1.0") == "qualified"
+    assert cadence.tag_channel(repo, "v1.2.0") == "undeclared"
+
+
+def test_an_advisory_v_release_is_not_a_gate_line_release(tmp_path: Path) -> None:
+    repo = _history(tmp_path)
+    gate = [ref for ref, _ in cadence.read_gate_line_tags(repo)]
+    assert gate == ["v1.1.0", "v0.15.0"]
+
+
+def test_an_advisory_v_release_counts_on_the_advisory_line(tmp_path: Path) -> None:
+    repo = _history(tmp_path)
+    advisory = [ref for ref, _ in cadence.read_advisory_tags(repo)]
+    assert advisory == ["v1.0.0"]
+
+
+def test_an_undeclared_tag_is_on_neither_line(tmp_path: Path) -> None:
+    """The release workflow refuses it, so it was never a release of either kind."""
+
+    repo = _history(tmp_path)
+    gate = {ref for ref, _ in cadence.read_gate_line_tags(repo)}
+    advisory = {ref for ref, _ in cadence.read_advisory_tags(repo)}
+    assert "v1.2.0" not in gate | advisory
+
+
+def test_the_cli_gate_line_never_reports_an_advisory_tag_as_latest(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@e.invalid")
+    _git(repo, "config", "user.name", "T")
+    _release(repo, "v0.15.0", 86_400, None)
+    _release(repo, "v1.0.0", 2 * 86_400, {"1.0.0": "advisory"})
+    assert cadence.main(["--repo", str(repo), "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["latest_release_tag"] == "v0.15.0"
+    assert report["advisory"]["latest_release_tag"] == "v1.0.0"
+    # The cadence JSON names its date basis by key: a preview is dated by its
+    # build stamp (``built_at``), a tag by its own date (``tagged_at``).
+    assert "tagged_at" in report["advisory"]
+    assert "built_at" not in report["advisory"]

--- a/tests/test_release_engine_smoke.py
+++ b/tests/test_release_engine_smoke.py
@@ -239,7 +239,9 @@ def test_smoke_cannot_publish_or_substitute_for_qualification() -> None:
 
 
 def test_no_other_workflow_can_stamp_a_build_as_a_release_candidate() -> None:
-    """Only two build steps in the repository may claim a source identity.
+    """Only the candidate builds may claim a source identity: the smoke's, and
+    each release verification's sealer. The advisory sealer (#648) is a copy of
+    the qualified one, held identical by `tests/test_release_advisory_pipeline.py`.
 
     A preview, rehearsal or CI build that acquired the stamp would emit an
     adopter workflow pinning an Action SHA and a package version that no
@@ -256,6 +258,7 @@ def test_no_other_workflow_can_stamp_a_build_as_a_release_candidate() -> None:
                 if _ENV in (step.get("env") or {}):
                     stamped.append((path.name, name, step["name"]))
     assert stamped == [
+        ("release-advisory-verify.yml", "artifact", "Build a wheel from the checked-out source"),
         ("release-engine-smoke.yml", "candidate", "Build the exact source candidate"),
         ("release-verify.yml", "artifact", "Build a wheel from the checked-out source"),
     ]

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -469,7 +469,7 @@ def test_staging_rechecks_the_sbom_binding_before_publication() -> None:
     release = _load_workflow("release.yml")
 
     assert "scripts/release_sbom.py verify" in _job_commands(release["jobs"]["stage"])
-    assert release["jobs"]["publish"]["needs"] == ["verify", "stage"]
+    assert release["jobs"]["publish"]["needs"] == ["candidate", "stage"]
 
 
 # --------------------------------------------------------------------------
@@ -480,11 +480,21 @@ def test_staging_rechecks_the_sbom_binding_before_publication() -> None:
 def test_the_pipeline_separates_verification_staging_publication_and_finalisation() -> None:
     release = _load_workflow("release.yml")
 
-    assert list(release["jobs"]) == ["verify", "stage", "publish", "finalize"]
+    # The channel switch (#648) sits in front of the same four stages;
+    # `tests/test_release_advisory_pipeline.py` holds its shape.
+    assert list(release["jobs"]) == [
+        "channel",
+        "verify",
+        "verify_advisory",
+        "candidate",
+        "stage",
+        "publish",
+        "finalize",
+    ]
     assert release["jobs"]["verify"]["uses"] == "./.github/workflows/release-verify.yml"
-    assert release["jobs"]["stage"]["needs"] == "verify"
-    assert release["jobs"]["publish"]["needs"] == ["verify", "stage"]
-    assert release["jobs"]["finalize"]["needs"] == ["verify", "stage", "publish"]
+    assert release["jobs"]["stage"]["needs"] == "candidate"
+    assert release["jobs"]["publish"]["needs"] == ["candidate", "stage"]
+    assert release["jobs"]["finalize"]["needs"] == ["candidate", "stage", "publish"]
 
 
 def test_write_and_oidc_authority_are_never_held_together() -> None:
@@ -976,14 +986,18 @@ def test_publication_requires_a_rehearsal_of_this_exact_candidate() -> None:
     stage = _load_workflow("release.yml")["jobs"]["stage"]
     commands = _job_commands(stage)
 
-    # Bound to the source tree (and therefore the workflow revision)...
-    assert "actions/workflows/release-rehearsal.yml/runs?head_sha=${SOURCE_SHA}" in commands
-    assert "status=success" in commands
-    assert "No successful Release Rehearsal run" in commands
+    from scripts.release_channel import QUALIFIED, REHEARSAL_WORKFLOWS
+
+    # Bound to the source tree (and therefore the workflow revision), through
+    # the declared channel's own rehearsal file (#648)...
+    assert "actions/workflows/${REHEARSAL_WORKFLOW:?" in commands
+    assert "/runs?head_sha=${SOURCE_SHA}&status=success" in commands
+    assert "No successful ${REHEARSAL_WORKFLOW} run" in commands
+    assert REHEARSAL_WORKFLOWS[QUALIFIED] == "release-rehearsal.yml"
     # ...and to candidate identity, so a qualification artifact swapped between
     # the rehearsal and the tag is caught.
     assert "cmp -- rehearsed/candidate-manifest.json dist/candidate-manifest.json" in commands
-    assert _step_index(stage, "release-rehearsal.yml/runs") < _step_index(
+    assert _step_index(stage, "${REHEARSAL_WORKFLOW:?") < _step_index(
         stage, "gh release create"
     )
 
@@ -1065,16 +1079,26 @@ def test_every_caller_consumed_output_is_publicly_exported() -> None:
 
     import re
 
-    exported = set(_load_workflow("release-verify.yml")["on"]["workflow_call"]["outputs"])
+    from scripts.release_channel import CANDIDATE_OUTPUTS
+
+    # Publication reads verification through `candidate` (#648), which
+    # forwards exactly `CANDIDATE_OUTPUTS` from whichever workflow ran, plus
+    # the channel-keyed names it derives itself.
     consumed = set(
         re.findall(
-            r"needs\.verify\.outputs\.(\w+)",
+            r"needs\.candidate\.outputs\.(\w+)",
             (WORKFLOWS / "release.yml").read_text(encoding="utf-8"),
         )
     )
+    derived = {"channel", "rehearsal_workflow", "release_assets", "signed_assets"}
 
     assert consumed, "the caller consumes no outputs; the check would be vacuous"
-    assert consumed <= exported, f"not exported: {sorted(consumed - exported)}"
+    assert consumed <= set(CANDIDATE_OUTPUTS) | derived, sorted(
+        consumed - set(CANDIDATE_OUTPUTS) - derived
+    )
+    for workflow in ("release-verify.yml", "release-advisory-verify.yml"):
+        exported = set(_load_workflow(workflow)["on"]["workflow_call"]["outputs"])
+        assert set(CANDIDATE_OUTPUTS) <= exported, (workflow, set(CANDIDATE_OUTPUTS) - exported)
 
 
 def test_the_handoff_is_sealed_by_a_job_that_runs_no_candidate_tests() -> None:
@@ -1123,7 +1147,10 @@ def test_a_completed_transaction_is_left_entirely_alone() -> None:
     release = _load_workflow("release.yml")
 
     for job in ("publish", "finalize"):
-        assert release["jobs"][job]["if"] == "needs.stage.outputs.release_state != 'published'"
+        # The rest of the condition names each dependency's success (#648).
+        assert release["jobs"][job]["if"].endswith(
+            "&& needs.stage.outputs.release_state != 'published' }}"
+        )
     assert release["jobs"]["stage"]["outputs"]["release_state"] == (
         "${{ steps.release.outputs.release_state }}"
     )
@@ -1154,9 +1181,15 @@ def test_finalisation_verifies_remote_bytes_not_asset_names() -> None:
     assert "gh release download" in commands
     assert "verify-manifest" in commands
     assert '--expected-sha256 "${MANIFEST_SHA256}"' in commands
-    # `--require`, not `--allow`: a release missing a bundle is incomplete.
-    assert '--require "${WHEEL_FILENAME}.sigstore.json"' in commands
-    assert "--require agents-shipgate-sbom.json.sigstore.json" in commands
+    # Required, not merely allowed: a release missing a bundle is incomplete.
+    # Which bundles is the declared channel's, from `release_publication`.
+    # Checked on commands, not the comments that explain them.
+    commands = "\n".join(
+        line for line in commands.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "--require-signatures" in commands
+    assert '--expected-channel "${CHANNEL}"' in commands
+    assert "--allow" not in commands
     # The signature bundles are verified, not merely present.
     assert "sigstore verify identity" in commands
     assert _step_index(finalize, "sigstore verify identity") < _step_index(
@@ -1724,9 +1757,11 @@ def test_an_already_published_release_must_be_complete_and_signed() -> None:
     required and verified here."""
 
     stage = _job_commands(_load_workflow("release.yml")["jobs"]["stage"])
+    # Comment lines explain the flag beside it; only the command may satisfy this.
+    stage = "\n".join(line for line in stage.splitlines() if not line.lstrip().startswith("#"))
 
-    assert '--require "${WHEEL_FILENAME}.sigstore.json"' in stage
-    assert "--require agents-shipgate-sbom.json.sigstore.json" in stage
+    assert "--require-signatures" in stage
+    assert "--allow" not in stage
     assert "sigstore verify identity" in stage
 
 
@@ -2159,7 +2194,7 @@ def test_the_release_body_is_the_changelog_section_not_a_placeholder() -> None:
     # Extracted before anything is created, from the checkout pinned to the
     # verified commit rather than from the tag.
     assert _step_index(stage, "scripts/release_notes.py") < _step_index(stage, "gh release create")
-    assert stage["steps"][0]["with"]["ref"] == "${{ needs.verify.outputs.source_sha }}"
+    assert stage["steps"][0]["with"]["ref"] == "${{ needs.candidate.outputs.source_sha }}"
 
 
 def test_the_notes_are_written_to_a_path_no_candidate_controls() -> None:
@@ -2195,10 +2230,24 @@ def test_all_three_extractions_are_bound_to_one_digest() -> None:
         verify["jobs"]["artifact"]["outputs"]["release_notes_sha256"]
         == "${{ steps.notes.outputs.release_notes_sha256 }}"
     )
+    # Both verification workflows publish it, and `candidate` forwards
+    # whichever ran (#648).
+    advisory = _load_workflow("release-advisory-verify.yml")
+    assert "release_notes_sha256" in advisory["on"]["workflow_call"]["outputs"]
+    assert (
+        advisory["jobs"]["artifact"]["outputs"]["release_notes_sha256"]
+        == "${{ steps.notes.outputs.release_notes_sha256 }}"
+    )
+    assert (
+        release["jobs"]["candidate"]["outputs"]["release_notes_sha256"]
+        == "${{ steps.select.outputs.release_notes_sha256 }}"
+    )
     for job in ("stage", "finalize"):
         commands = _job_commands(release["jobs"][job])
         assert '--expected-sha256 "${NOTES_SHA256}"' in commands, job
-        assert "needs.verify.outputs.release_notes_sha256" in json.dumps(release["jobs"][job]), job
+        assert "needs.candidate.outputs.release_notes_sha256" in json.dumps(
+            release["jobs"][job]
+        ), job
 
 
 def test_the_published_body_is_reapplied_in_the_call_that_undrafts() -> None:
@@ -2673,7 +2722,7 @@ def test_the_token_bearing_jobs_check_out_the_installer_and_nothing_else() -> No
         assert with_["sparse-checkout"] == ".github/actions/install-release-toolchain", name
         assert with_["sparse-checkout-cone-mode"] is False, name
         assert with_["persist-credentials"] is False, name
-        assert with_["ref"] == "${{ needs.verify.outputs.source_sha }}", name
+        assert with_["ref"] == "${{ needs.candidate.outputs.source_sha }}", name
 
 
 # --------------------------------------------------------------------------
@@ -3152,7 +3201,10 @@ def test_a_preview_run_cannot_satisfy_the_mandatory_rehearsal() -> None:
 
     stage = _job_commands(_load_workflow("release.yml")["jobs"]["stage"])
 
-    assert "workflows/release-rehearsal.yml/runs" in stage
+    assert "workflows/${REHEARSAL_WORKFLOW:?" in stage
+    from scripts.release_channel import REHEARSAL_WORKFLOWS
+
+    assert not any("preview" in name for name in REHEARSAL_WORKFLOWS.values())
     assert "release-preview" not in (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
     # And the reverse, read from the graph rather than the text: the preview
     # calls no reusable workflow at all, so it cannot inherit a release job.

--- a/tests/test_safety_qualification_release.py
+++ b/tests/test_safety_qualification_release.py
@@ -558,7 +558,7 @@ def test_release_workflow_reuses_signed_qualified_wheel_before_publish() -> None
     # graph rather than by step position.
     assert "uv publish --trusted-publishing always" not in verify
     parsed_release = yaml.safe_load(release)
-    assert parsed_release["jobs"]["publish"]["needs"] == ["verify", "stage"]
+    assert parsed_release["jobs"]["publish"]["needs"] == ["candidate", "stage"]
 
     # The wheel is addressed by the filename verification approved, and the
     # source-built wheel never enters the publishable set.
@@ -568,7 +568,13 @@ def test_release_workflow_reuses_signed_qualified_wheel_before_publish() -> None
     assert "safety-qualification.json" in verify
     assert "safety-qualification.sigstore.json" in verify
 
-    for workflow in ("release.yml", "release-verify.yml", "release-rehearsal.yml"):
+    for workflow in (
+        "release.yml",
+        "release-verify.yml",
+        "release-rehearsal.yml",
+        "release-advisory-verify.yml",
+        "release-advisory-rehearsal.yml",
+    ):
         parsed = yaml.safe_load(
             (REPO_ROOT / ".github/workflows" / workflow).read_text(encoding="utf-8")
         )


### PR DESCRIPTION
Closes the implementation half of #648. After this merges, publishing `v1.0.0` needs only the version bump, the release notes and the owner's tag. That tag goes through the owner-decided advisory path, and no qualification claim is made.

## Why

The owner chose **advisory 1.0** ([decision](https://github.com/ThreeMoonsLab/agents-shipgate/issues/648)): the production-tier bar governs a qualified blocking claim, not a version number. Until now, every `v*` tag had to carry a signed `safety-qualification.json`. That artifact does not exist, so the pipeline could not publish 1.0 at all.

## What changes

**The channel comes from reviewed code, not from what a run finds.**
- `.github/release-channels.json` declares `{"1.0.0": "advisory"}`.
- A `channel` job reads the declaration at the tagged commit before anything is built.
- A missing, malformed or unknown entry stops the release.
- Why not select the channel by whether a qualification artifact is present: that fails open. A qualified release whose download broke would publish as advisory, and PyPI never gives a version back.

**Two verification files, one switch, one publisher.**
- `release.yml` calls exactly one of `release-verify.yml` (**unchanged**, byte for byte) and the new `release-advisory-verify.yml`.
- `release_channel.py candidate` refuses every outcome except exactly the declared job succeeding while the other stays skipped and exports nothing. The forwarded values must also be complete and bound to the pushed tag.
- Every job after `candidate` names each dependency's success explicitly. Without that, a skipped job would skip everything downstream (actions/runner#491).
- The advisory file has no qualification step to skip, so C3's reasoning holds. The steps both files share are held identical by a test.
- Staging, signing, the PyPI upload and finalisation stay single jobs. PyPI Trusted Publishing is bound to `release.yml`, so a second publisher would also need configuration outside this repository.

**The advisory candidate is the exact bytes a smoke exercised (#570).**
- `release-advisory-verify.yml` downloads the wheel from the successful Release Engine Smoke run for the exact source commit.
- That run's `distribution-evidence.json` must name this commit and these bytes, record that the CLI and the Action agreed, and still say `qualified: false`.
- `verify_wheel_provenance.py --exercised` then requires `identical_bytes` against the wheel the tagged tree builds. The report names its subject `exercised_wheel`, never `qualified_wheel`.
- Measured on `e6f1ddff`: the smoke build (`hatchling build`) and the release build (`build --no-isolation`) share a SHA-256 (`3403f8a4…`).

**A closed asset set per channel.**
- `release_publication.CHANNEL_ASSETS` is the single table.
- The advisory manifest records `channel: advisory`.
- `verify-manifest --expected-channel` is now mandatory. It refuses a manifest whose channel or asset set is not the declared one's: a qualified release cannot drop its qualification artifact, and an advisory release cannot carry one.
- `--require-signatures` derives the bundles from the same table. That covers the wheel and the SBOM, plus `advisory-statement.json` on the advisory line.
- A manifest with no channel is treated as qualified, since the qualified path was the only one, and never passes as advisory.

**A signed statement of what the release does not claim.**
- `advisory-statement.json` is written from fields fixed in `release_channel.py`: qualification `none`, default `ci_mode: advisory`, blocking opt-in.
- It cites the exercise run and the readiness record at the source commit.
- It names no tier anywhere, and it is signed with the wheel and SBOM.

**Rehearsal stays mandatory.** `stage` requires a successful run of the declared channel's own file: `release-rehearsal.yml` for the qualified line, the new `release-advisory-rehearsal.yml` for the advisory line.

**No version carries both claims.** A tagged version's declared channel cannot change or disappear. The suite checks this against this repository's tags, reading each tag's own tree.

**Cadence stays honest.** `release_cadence.py` reads each tag's declaration. An advisory `v*` tag counts on the advisory line; a tag whose declaration omits it counts on neither.

**Policy.** Amendment 5 in `docs/release-evidence-policy-decision.md` records the rule, what it supersedes (Amendment 4's preview-only clause, with C1 restated as "no version carries both claims"), what is not weakened, and what would have made it inadmissible. The runbook gains § The advisory release channel, and the channel table in `docs/distribution-surfaces.md` states each channel's qualification.

## Verification

- **Script checks on real bytes.** 20 checks ran against the real Release Engine Smoke artifact from run 34726385422, covering evidence acceptance and refusals, `--exercised` provenance, statement writing, manifest and channel refusals, and `candidate` selection. All passed.
- **Mutations.** Each disables one control; each must turn a test red. 12 of 12 fired: exclusive verify gates; finalize naming `publish` success; `--expected-channel` in finalize; `--require-signatures` on the published re-run; the asset-set check; the signed statement; a legacy manifest never passing as advisory; an undeclared job's outputs; the evidence digest; the history check; shared-step drift; the refuse step's exit. One first passed on a comment naming the removed flag, so those checks read commands with comment lines stripped.
- **Tests.** The full suite passes locally (exit 0). `tests/test_release_advisory_pipeline.py` adds 66 tests. The 18 release-related files, including every test that reads the release workflows, runbook, policy or surface registry, pass.
- **Updated pinned tests.** Tests that pinned the old graph or literals were updated to the same meaning:
  - The rehearsal is now found through the declared channel's file.
  - `--require-signatures` replaces the listed bundles, and `--allow` stays forbidden.
  - `needs.candidate.outputs.*` replaces `needs.verify.outputs.*`.
  - The stamping allowlist gains the advisory sealer.
  - The `bash -n` sweep covers the new files.

## Not in this PR

- The 0.16.0 → 1.0.0 version bump and its generated surfaces. That is its own PR, per the checklist, cut immediately before the tag.
- Pushing the tag. That is an owner action behind the `pypi` environment approval.
- #570's post-publication PyPI/tag replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
