### PR TITLE
Resolve local Claude Code settings layers by documented precedence (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- Resolve local Claude Code settings layers by the documented precedence
+  instead of refusing them. `audit --host --scope local-static` raised a
+  blocking `unresolved_precedence` issue whenever two layers existed, so user
+  settings plus a project's `.claude/settings.json` — the ordinary developer
+  setup — could never save a local baseline. Permission rules, additional
+  directories and hooks now merge across layers; a scalar setting keeps the
+  highest layer that sets it (managed, project local, shared project, user),
+  and the remaining grant's `source` names that layer; a same-named MCP server
+  keeps the local-scope entry over `.mcp.json`; and `allowManagedPermissionRulesOnly`
+  and `allowManagedHooksOnly` restrict rules and hooks only from managed
+  settings. A `defaultMode` of `auto` or `bypassPermissions` in a project file
+  is still reported, beside the lower layer's mode, because older clients
+  honored it. Disagreeing `sandbox` or `enabledPlugins` values, a layer with no
+  documented rank, and Codex and Cursor layers still fail closed; the issue now
+  names the key and each layer. The repository scope, which the PR route uses,
+  is unchanged (#657).
+
 - Publish a version that reviewed code declares advisory through the ordinary
   release pipeline, with no qualification claim (#648). Each version's channel
   is declared in `.github/release-channels.json`, and a missing or unknown

--- a/docs/host-boundary-support.md
+++ b/docs/host-boundary-support.md
@@ -47,6 +47,20 @@ Shipgate never runs dynamic policy helpers. Sources that cannot be reconstructed
 deterministically are recorded as partial coverage rather than treated as
 absent.
 
+Local layers are combined the way the host documents, not listed as though
+each applied on its own. For Claude Code, permission rules, additional
+directories and hooks merge across layers. A scalar setting keeps the highest
+layer that sets it (managed, then project local, shared project and user), and
+the remaining grant's `source` names that layer. A same-named MCP server keeps
+the current workspace's local-scope entry over `.mcp.json`, and
+`allowManagedPermissionRulesOnly` and `allowManagedHooksOnly` restrict rules
+and hooks only from managed settings. A `defaultMode` of `auto` or
+`bypassPermissions` in a project file is still listed beside the lower layer's
+mode, because clients before v2.1.257 honored it. Where the documentation does
+not settle a case — disagreeing `sandbox` or `enabledPlugins` values, or a
+layer with no documented rank — and for Codex and Cursor layers, coverage stays
+partial and the issue names the key and each layer.
+
 Both scopes explicitly exclude:
 
 - transient permission prompts and approvals;

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -1291,14 +1291,180 @@ def _coverage(
     return coverage
 
 
+#: Claude Code's settings stack, highest first, as documented at
+#: code.claude.com/docs/en/settings § Settings precedence: managed settings,
+#: then `--settings` (a static audit never sees a session flag), then project
+#: local, shared project and user. A lower number wins.
+_CLAUDE_MANAGED_SOURCES = frozenset({
+    "/Library/Application Support/ClaudeCode/managed-settings.json",
+    "C:/Program Files/ClaudeCode/managed-settings.json",
+    "/etc/claude-code/managed-settings.json",
+})
+_CLAUDE_SETTINGS_RANK: dict[str, int] = {
+    **dict.fromkeys(_CLAUDE_MANAGED_SOURCES, 0),
+    ".claude/settings.local.json": 1,
+    ".claude/settings.json": 2,
+    "~/.claude/settings.json": 3,
+}
+#: One MCP server name defined in several scopes: "Claude Code connects to it
+#: once, using the definition from the highest-precedence source", whole
+#: entry, local over project (code.claude.com/docs/en/mcp).
+_CLAUDE_MCP_RANK: dict[str, int] = {
+    "~/.claude.json#current-workspace": 0,
+    ".mcp.json": 1,
+}
+#: Documented to take effect only from managed settings, where they restrict
+#: which permission rules or hooks any other source may contribute.
+_CLAUDE_MANAGED_ONLY_SETTINGS = {
+    "allowManagedPermissionRulesOnly": "permission_rule",
+    "allowManagedHooksOnly": "hook",
+}
+#: Kinds whose values the settings stack does not document how to combine
+#: when two layers disagree. Agreement is resolvable; disagreement fails
+#: closed and names both layers.
+_CLAUDE_UNDOCUMENTED_MERGE_KINDS = frozenset({"sandbox", "plugin_or_app"})
+
+
+def _claude_precedence_key(grant: dict[str, Any]) -> tuple[str, str] | None:
+    """The key two layers compete for, or ``None`` for a kind that merges.
+
+    Permission rules, additional directories and hooks merge across layers
+    ("Lists merge instead of overriding"; hook entries "merge across settings
+    levels rather than replacing each other"), so every layer's entry stays
+    effective and nothing competes.
+    """
+
+    kind = grant.get("kind")
+    if kind in {"permission_mode", "sandbox"}:
+        return (str(kind), str(grant.get("setting")))
+    if kind == "plugin_or_app":
+        return (str(kind), str(grant.get("name")))
+    if kind == "mcp_server":
+        return (str(kind), str(grant.get("server")))
+    return None
+
+
+def _claude_setting_ignored_in_source(grant: dict[str, Any]) -> bool:
+    """A value the documentation says this file cannot make take effect.
+
+    Such a grant never shadows a lower layer. It is still reported: the
+    restriction is recent (a project `bypassPermissions` took effect before
+    Claude Code v2.1.257) and a static audit cannot see the installed
+    version, so it over-reports rather than hide authority an older client
+    would grant.
+    """
+
+    if grant.get("kind") != "permission_mode":
+        return False
+    setting, value, source = grant.get("setting"), grant.get("value"), grant.get("source")
+    project_files = {".claude/settings.local.json", ".claude/settings.json"}
+    if setting == "defaultMode":
+        return value in {"auto", "bypassPermissions"} and source in project_files
+    if setting == "skipDangerousModePermissionPrompt":
+        return source == ".claude/settings.json"
+    return False
+
+
+def _project_claude_precedence(
+    grants: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Keep the Claude Code grants that take effect across local layers (#657).
+
+    Every layer used to raise a blocking ``unresolved_precedence`` issue as
+    soon as two existed, so the ordinary developer setup — user settings plus
+    a project's — could never record a local baseline. The projection follows
+    the documented stack instead: merged kinds keep every layer, a scalar key
+    keeps the highest layer that sets it, a same-named MCP server keeps the
+    highest scope's entry, and managed-only restrictions apply. What remains
+    names its effective layer in ``source``. Where the documentation does not
+    settle a disagreement, or a layer has no documented rank, every candidate
+    is kept and a blocking issue names the key and each layer.
+    """
+
+    claude = [grant for grant in grants if grant.get("host") == "claude-code"]
+    restricted_kinds = {
+        _CLAUDE_MANAGED_ONLY_SETTINGS[str(grant.get("setting"))]
+        for grant in claude
+        if grant.get("kind") == "permission_mode"
+        and grant.get("setting") in _CLAUDE_MANAGED_ONLY_SETTINGS
+        and grant.get("source") in _CLAUDE_MANAGED_SOURCES
+        and grant.get("value") == "True"
+    }
+    kept: list[dict[str, Any]] = []
+    contested: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for grant in grants:
+        if grant.get("host") != "claude-code":
+            kept.append(grant)
+            continue
+        managed = grant.get("source") in _CLAUDE_MANAGED_SOURCES
+        if (
+            grant.get("kind") == "permission_mode"
+            and grant.get("setting") in _CLAUDE_MANAGED_ONLY_SETTINGS
+            and not managed
+        ):
+            continue  # Documented as managed-only: no effect from any other file.
+        if grant.get("kind") in restricted_kinds and not managed:
+            continue  # A managed setting admits only managed rules or hooks.
+        key = _claude_precedence_key(grant)
+        if key is None:
+            kept.append(grant)
+        else:
+            contested.setdefault(key, []).append(grant)
+
+    issues: list[dict[str, Any]] = []
+    for (kind, name), group in sorted(contested.items()):
+        sources = sorted({str(grant.get("source")) for grant in group})
+        if len(sources) < 2:
+            kept.extend(group)
+            continue
+        rank = _CLAUDE_MCP_RANK if kind == "mcp_server" else _CLAUDE_SETTINGS_RANK
+        unranked = [source for source in sources if source not in rank]
+        disagreement = kind in _CLAUDE_UNDOCUMENTED_MERGE_KINDS and len({
+            str(grant.get("value") if kind == "sandbox" else grant.get("enabled"))
+            for grant in group
+        }) > 1
+        if unranked or disagreement:
+            reason = (
+                f"{', '.join(unranked)} has no documented place in Claude Code's precedence"
+                if unranked
+                else "Claude Code's documentation does not say which disagreeing value applies"
+            )
+            issues.append(
+                _inventory_issue(
+                    kind="unresolved_precedence",
+                    host="claude-code",
+                    source=f"claude-code:{kind}:{name}",
+                    message=(
+                        f"{kind} {name!r} is set in {', '.join(sources)}; {reason}, so its "
+                        "effective value is not statically projected."
+                    ),
+                    blocking=True,
+                )
+            )
+            kept.extend(group)
+            continue
+        shadowing = [grant for grant in group if not _claude_setting_ignored_in_source(grant)]
+        if not shadowing:
+            kept.extend(group)
+            continue
+        winner = min(rank[str(grant.get("source"))] for grant in shadowing)
+        # Anything ranked above the winner is a value its own file cannot make
+        # take effect; it stays, over-reported, for the reason given above.
+        kept.extend(grant for grant in group if rank[str(grant.get("source"))] <= winner)
+    return kept, issues
+
+
 def _local_precedence_issues(
     artifacts: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Fail closed where several static layers require an effective merge.
 
-    The inventory retains every redacted declaration, but it must not claim
-    effective-authority coverage until host-specific precedence is projected
-    at the individual setting/grant level.
+    Claude Code is projected by ``_project_claude_precedence``. For the other
+    hosts the inventory retains every redacted declaration, but it must not
+    claim effective-authority coverage while their layering is undocumented
+    or depends on state a static read cannot see (Codex loads a project
+    ``.codex/config.toml`` only for a trusted project; Cursor does not say
+    whether its user and project CLI files merge).
     """
 
     grouped: dict[tuple[str, str], list[str]] = {}
@@ -1319,8 +1485,9 @@ def _local_precedence_issues(
                 host=host,
                 source=f"{host}:{kind}",
                 message=(
-                    f"Multiple {host} {kind} layers were observed; their "
-                    "runtime-effective precedence is not statically projected."
+                    f"Multiple {host} {kind} layers were observed "
+                    f"({', '.join(unique_sources)}); their runtime-effective "
+                    "precedence is not statically projected."
                 ),
                 blocking=True,
             )
@@ -1396,7 +1563,11 @@ def build_host_boundary_snapshot(
         raise ValueError(f"Unsupported host audit scope: {scope!r}")
 
     if scope == "local_static":
-        issues.extend(_local_precedence_issues(artifacts))
+        grants, claude_precedence_issues = _project_claude_precedence(grants)
+        issues.extend(claude_precedence_issues)
+        issues.extend(_local_precedence_issues(
+            [item for item in artifacts if item.get("host") != "claude-code"]
+        ))
 
     try:
         cache.finish()

--- a/tests/test_host_audit.py
+++ b/tests/test_host_audit.py
@@ -372,9 +372,14 @@ def test_policy_helper_is_never_run_and_makes_coverage_partial(
     assert f"touch {marker}" not in json.dumps(inventory)
 
 
-def test_local_static_overlapping_layers_are_partial_until_precedence_is_projected(
+def test_local_static_overlapping_layers_resolve_by_documented_precedence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """User and project settings used to make local coverage partial forever.
+    Their permission lists merge, so both layers' rules are effective and the
+    setup can be baselined; tests/test_host_local_precedence.py covers each
+    rule and every case that still fails closed (#657)."""
+
     workspace = tmp_path / "repo"
     (workspace / ".claude").mkdir(parents=True)
     (workspace / ".claude/settings.json").write_text(
@@ -389,16 +394,14 @@ def test_local_static_overlapping_layers_are_partial_until_precedence_is_project
 
     inventory = host_audit_inventory(workspace, scope="local_static")
 
-    issue = next(
+    assert not [
         item for item in inventory["issues"] if item["kind"] == "unresolved_precedence"
-    )
-    assert issue["host"] == "claude-code"
+    ]
     coverage = next(
         item for item in inventory["host_coverage"] if item["host"] == "claude-code"
     )
-    assert coverage["status"] == "partial"
-    with pytest.raises(ValueError, match="cannot acknowledge missing evidence"):
-        build_host_grants_baseline(inventory)
+    assert coverage["status"] == "complete"
+    assert build_host_grants_baseline(inventory)["scope"] == "local_static"
 
 
 def test_invalid_config_is_structured_partial_coverage_and_cannot_baseline(tmp_path: Path) -> None:

--- a/tests/test_host_local_precedence.py
+++ b/tests/test_host_local_precedence.py
@@ -1,0 +1,325 @@
+"""Local Claude Code layers resolve by the documented settings precedence (#657).
+
+`audit --host --scope local-static` used to raise a blocking
+`unresolved_precedence` issue whenever two layers existed, so the ordinary
+setup — user settings plus a project's — could never save a local baseline.
+Each case below is one documented rule: code.claude.com/docs/en/settings
+§ Settings precedence and § Lists merge instead of overriding,
+code.claude.com/docs/en/hooks, and code.claude.com/docs/en/mcp. Where the
+documentation does not settle a case, the inventory still fails closed, and
+now names the key and each layer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agents_shipgate.core.host_grants import (
+    _project_claude_precedence,
+    build_host_grants_baseline,
+    host_audit_inventory,
+)
+
+USER = "~/.claude/settings.json"
+PROJECT = ".claude/settings.json"
+LOCAL = ".claude/settings.local.json"
+MANAGED = "/etc/claude-code/managed-settings.json"
+WORKSPACE_STATE = "~/.claude.json#current-workspace"
+
+
+def _audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    scope: str = "local_static",
+    user: dict[str, Any] | None = None,
+    project: dict[str, Any] | None = None,
+    local: dict[str, Any] | None = None,
+    mcp: dict[str, Any] | None = None,
+    workspace_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    workspace = tmp_path / "repo"
+    (workspace / ".claude").mkdir(parents=True)
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    files = {
+        home / ".claude/settings.json": user,
+        workspace / ".claude/settings.json": project,
+        workspace / ".claude/settings.local.json": local,
+        workspace / ".mcp.json": {"mcpServers": mcp} if mcp is not None else None,
+        home / ".claude.json": (
+            {"projects": {str(workspace.resolve()): workspace_state}}
+            if workspace_state is not None
+            else None
+        ),
+    }
+    for path, content in files.items():
+        if content is not None:
+            path.write_text(json.dumps(content), encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    return host_audit_inventory(workspace, scope=scope)
+
+
+def _claude(inventory: dict[str, Any], kind: str) -> list[dict[str, Any]]:
+    return [
+        grant
+        for grant in inventory["grants"]
+        if grant["host"] == "claude-code" and grant["kind"] == kind
+    ]
+
+
+def _precedence_issues(inventory: dict[str, Any]) -> list[dict[str, Any]]:
+    return [issue for issue in inventory["issues"] if issue["kind"] == "unresolved_precedence"]
+
+
+def test_user_and_project_permission_rules_merge_and_the_setup_can_be_baselined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inventory = _audit(
+        tmp_path,
+        monkeypatch,
+        user={"permissions": {"allow": ["Read"]}},
+        project={"permissions": {"deny": ["Bash(*)"], "allow": ["Bash(pytest *)"]}},
+    )
+
+    assert not _precedence_issues(inventory)
+    assert {
+        (grant["source"], grant["disposition"], grant["rule"])
+        for grant in _claude(inventory, "permission_rule")
+    } == {
+        (USER, "allow", "Read"),
+        (PROJECT, "deny", "Bash(*)"),
+        (PROJECT, "allow", "Bash(pytest *)"),
+    }
+    claude = next(item for item in inventory["host_coverage"] if item["host"] == "claude-code")
+    assert claude["status"] == "complete"
+    assert build_host_grants_baseline(inventory)["scope"] == "local_static"
+
+
+@pytest.mark.parametrize(
+    ("layers", "effective"),
+    [
+        ({"user": "acceptEdits", "project": "plan"}, PROJECT),
+        ({"user": "acceptEdits", "project": "plan", "local": "default"}, LOCAL),
+        ({"user": "acceptEdits", "local": "plan"}, LOCAL),
+        ({"user": "plan"}, USER),
+    ],
+)
+def test_a_scalar_setting_takes_the_highest_layer_that_sets_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, layers: dict[str, str], effective: str
+) -> None:
+    inventory = _audit(
+        tmp_path,
+        monkeypatch,
+        **{layer: {"permissions": {"defaultMode": mode}} for layer, mode in layers.items()},
+    )
+
+    modes = [grant for grant in _claude(inventory, "permission_mode") if grant["setting"] == "defaultMode"]
+    assert [grant["source"] for grant in modes] == [effective]
+    assert not _precedence_issues(inventory)
+
+
+def test_a_mode_its_file_cannot_apply_is_reported_beside_the_lower_layer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`bypassPermissions` does not take effect from project settings on current
+    Claude Code, but did before v2.1.257, and a static read cannot see the
+    installed version. It must neither shadow the user's mode nor disappear."""
+
+    inventory = _audit(
+        tmp_path,
+        monkeypatch,
+        user={"permissions": {"defaultMode": "acceptEdits"}},
+        project={"permissions": {"defaultMode": "bypassPermissions"}},
+    )
+
+    modes = {
+        (grant["source"], grant["value"])
+        for grant in _claude(inventory, "permission_mode")
+        if grant["setting"] == "defaultMode"
+    }
+    assert modes == {(USER, "acceptEdits"), (PROJECT, "bypassPermissions")}
+    assert not _precedence_issues(inventory)
+
+
+def test_hooks_from_every_layer_stay_effective(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hook = {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "true"}]}]}
+    inventory = _audit(tmp_path, monkeypatch, user={"hooks": hook}, project={"hooks": hook})
+
+    assert {grant["source"] for grant in _claude(inventory, "hook")} == {USER, PROJECT}
+    assert not _precedence_issues(inventory)
+
+
+def test_a_same_named_mcp_server_takes_the_local_scope_entry_and_others_combine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inventory = _audit(
+        tmp_path,
+        monkeypatch,
+        mcp={
+            "docs": {"command": "npx", "args": ["project-docs"]},
+            "shared": {"command": "npx", "args": ["shared"]},
+        },
+        workspace_state={"mcpServers": {"docs": {"command": "npx", "args": ["local-docs"]}}},
+    )
+
+    assert {
+        (grant["server"], grant["source"]) for grant in _claude(inventory, "mcp_server")
+    } == {("docs", WORKSPACE_STATE), ("shared", ".mcp.json")}
+    assert not _precedence_issues(inventory)
+
+
+@pytest.mark.parametrize(
+    ("user", "project", "key"),
+    [
+        ({"sandbox": {"enabled": True}}, {"sandbox": {"enabled": False}}, "claude-code:sandbox:sandbox.enabled"),
+        ({"enabledPlugins": {"tool@market": True}}, {"enabledPlugins": {"tool@market": False}}, "claude-code:plugin_or_app:tool@market"),
+    ],
+)
+def test_an_undocumented_disagreement_fails_closed_and_names_both_layers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    user: dict[str, Any],
+    project: dict[str, Any],
+    key: str,
+) -> None:
+    inventory = _audit(tmp_path, monkeypatch, user=user, project=project)
+
+    [issue] = _precedence_issues(inventory)
+    assert issue["source"] == key
+    assert issue["blocking"] is True
+    assert USER in issue["message"] and PROJECT in issue["message"]
+    with pytest.raises(ValueError, match="cannot acknowledge missing evidence"):
+        build_host_grants_baseline(inventory)
+
+
+def test_agreeing_layers_of_an_undocumented_kind_resolve_to_the_highest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inventory = _audit(
+        tmp_path,
+        monkeypatch,
+        user={"sandbox": {"enabled": True}},
+        project={"sandbox": {"enabled": True}},
+    )
+
+    assert [grant["source"] for grant in _claude(inventory, "sandbox")] == [PROJECT]
+    assert not _precedence_issues(inventory)
+
+
+def test_other_hosts_still_fail_closed_and_name_their_layers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cursor does not document whether its user and project files merge."""
+
+    workspace = tmp_path / "repo"
+    (workspace / ".cursor").mkdir(parents=True)
+    (workspace / ".cursor/mcp.json").write_text(json.dumps({"mcpServers": {"a": {"command": "a"}}}), encoding="utf-8")
+    home = tmp_path / "home"
+    (home / ".cursor").mkdir(parents=True)
+    (home / ".cursor/mcp.json").write_text(json.dumps({"mcpServers": {"b": {"command": "b"}}}), encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+
+    inventory = host_audit_inventory(workspace, scope="local_static")
+
+    [issue] = _precedence_issues(inventory)
+    assert issue["host"] == "cursor"
+    assert "~/.cursor/mcp.json" in issue["message"] and ".cursor/mcp.json" in issue["message"]
+
+
+def test_the_repository_scope_is_not_projected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The PR route reads committed files only and never resolved layers; a
+    shared and a local project file both stay visible there."""
+
+    inventory = _audit(
+        tmp_path,
+        monkeypatch,
+        scope="repository",
+        project={"permissions": {"defaultMode": "plan"}},
+        local={"permissions": {"defaultMode": "default"}},
+    )
+
+    assert {grant["source"] for grant in _claude(inventory, "permission_mode")} == {PROJECT, LOCAL}
+
+
+# --- The managed-only restrictions, on synthetic grants (a managed file is
+#     an operating-system path no test may write). ------------------------
+
+
+def _grant(source: str, kind: str, **fields: Any) -> dict[str, Any]:
+    return {"grant_id": f"{source}:{kind}:{sorted(fields.items())}", "host": "claude-code", "source": source, "kind": kind, **fields}
+
+
+def test_managed_rules_only_removes_every_other_layers_rules() -> None:
+    grants = [
+        _grant(MANAGED, "permission_mode", setting="allowManagedPermissionRulesOnly", value="True"),
+        _grant(MANAGED, "permission_rule", disposition="deny", rule="Bash(*)"),
+        _grant(USER, "permission_rule", disposition="allow", rule="Bash(*)"),
+        _grant(PROJECT, "hook", event="PreToolUse"),
+    ]
+
+    kept, issues = _project_claude_precedence(grants)
+
+    assert {(grant["source"], grant["kind"]) for grant in kept} == {
+        (MANAGED, "permission_mode"),
+        (MANAGED, "permission_rule"),
+        (PROJECT, "hook"),
+    }
+    assert issues == []
+
+
+def test_managed_hooks_only_removes_every_other_layers_hooks() -> None:
+    grants = [
+        _grant(MANAGED, "permission_mode", setting="allowManagedHooksOnly", value="True"),
+        _grant(MANAGED, "hook", event="Stop"),
+        _grant(LOCAL, "hook", event="PreToolUse"),
+        _grant(USER, "permission_rule", disposition="allow", rule="Read"),
+    ]
+
+    kept, _ = _project_claude_precedence(grants)
+
+    assert {(grant["source"], grant["kind"]) for grant in kept} == {
+        (MANAGED, "permission_mode"),
+        (MANAGED, "hook"),
+        (USER, "permission_rule"),
+    }
+
+
+def test_a_managed_only_setting_outside_managed_settings_restricts_nothing() -> None:
+    grants = [
+        _grant(PROJECT, "permission_mode", setting="allowManagedPermissionRulesOnly", value="True"),
+        _grant(USER, "permission_rule", disposition="allow", rule="Read"),
+    ]
+
+    kept, _ = _project_claude_precedence(grants)
+
+    assert [(grant["source"], grant["kind"]) for grant in kept] == [(USER, "permission_rule")]
+
+
+def test_a_layer_without_a_documented_rank_fails_closed() -> None:
+    grants = [
+        _grant(WORKSPACE_STATE, "permission_mode", setting="defaultMode", value="plan"),
+        _grant(USER, "permission_mode", setting="defaultMode", value="acceptEdits"),
+    ]
+
+    kept, [issue] = _project_claude_precedence(grants)
+
+    assert len(kept) == 2
+    assert issue["source"] == "claude-code:permission_mode:defaultMode"
+    assert WORKSPACE_STATE in issue["message"]
+
+
+def test_other_hosts_grants_pass_through_untouched() -> None:
+    other = {"grant_id": "x", "host": "codex", "source": "~/.codex/config.toml", "kind": "permission_mode", "setting": "approval_policy", "value": "never"}
+
+    kept, issues = _project_claude_precedence([other])
+
+    assert kept == [other] and issues == []


### PR DESCRIPTION
Part of #657: the precedence half. The lattice half landed in #678.

## Why

`audit --host --scope local-static` raised a **blocking** `unresolved_precedence` issue whenever a host had two config layers. A blocking issue makes coverage partial, and `build_host_grants_baseline` refuses partial coverage. So the ordinary developer setup could never save a local baseline: `~/.claude/settings.json` plus a project `.claude/settings.json`.

## What changes

Claude Code's local layers are now projected by the documented precedence rather than refused. The sources are code.claude.com/docs/en/settings (§ Settings precedence, § Lists merge instead of overriding), /docs/en/hooks and /docs/en/mcp.

| Case | Before | After |
|---|---|---|
| Permission rules, `additionalDirectories`, hooks in several layers | blocking, partial | **merge**: every layer's entries stay effective |
| A scalar setting (`defaultMode`, …) set in several layers | blocking, partial | the **highest layer** wins (managed > project local > shared project > user); the kept grant's `source` names that layer |
| A same-named MCP server in `~/.claude.json` (this workspace) and `.mcp.json` | blocking, partial | the **local-scope entry** wins, whole entry; differently named servers combine |
| `allowManagedPermissionRulesOnly` / `allowManagedHooksOnly` in managed settings | blocking, partial | only managed rules or hooks remain; the same key in any other file restricts nothing |
| `defaultMode: auto` or `bypassPermissions` in a project file | blocking, partial | **still listed**, beside the lower layer's mode: current clients ignore it there, but clients before v2.1.257 honored it, and a static read cannot see the installed version, so it over-reports rather than hide authority |
| Disagreeing `sandbox.*` or `enabledPlugins` values; a layer with no documented rank | blocking, partial | **still blocking**; the issue now names the key and each layer |
| Codex or Cursor layers | blocking, partial | **still blocking**, now naming each layer. Codex loads project config only for trusted projects, which is not statically visible. Cursor does not document whether its user and project files merge. |

The repository scope, which the PR route and every other consumer use, is not projected and is unchanged. No schema changes: the issue kind is the same, and `source` already names each grant's file.

## Verification

- `tests/test_host_local_precedence.py` holds one case per documented rule, plus each fail-closed case and the repository-scope control. The existing local-static test, which pinned "partial until precedence is projected", now asserts the resolution and a saved baseline.
- **Mutations: 7 of 7 fire**, one per rule:
  - hooks treated as competing
  - lowest layer winning
  - the version-dependent mode dropped
  - an undocumented disagreement accepted
  - the managed-only restriction ignored
  - a managed-only key applied outside managed settings
  - Claude layers fed back to the old blanket check
- Focused host audit and snapshot tests pass: 453 across 14 files. The full suite passed locally on the original base (exit 0). After rebasing onto `8d43106f`, the only conflict was the CHANGELOG, resolved as main verbatim plus this entry, and the focused files pass again.

## Not in this PR

- Printing a per-grant effective-layer column in the Markdown audit. The JSON rows carry it in `source`, and the Markdown lists counts per kind as before.
- Reading user-scope MCP servers from the top level of `~/.claude.json`. The local-static scope does not read them today; that is a coverage gap, not a precedence one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
