### PR TITLE
Resolve documented Claude skill and command frontmatter (#722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- Resolve documented Claude skill and command frontmatter instead of refusing it
+  (#722). An unresolved instruction is a blocking coverage issue, so one such
+  file made a repository's whole host inventory partial. Skills now accept
+  `when_to_use`, `arguments`, `disallowed-tools`, `effort`, `background`,
+  `paths` and `shell`. Commands accept `user-invocable`, `disallowed-tools`,
+  `effort`, `arguments`, `name` and `paths`, as the docs say they take the same
+  frontmatter as skills. `argument-hint` may use its documented bracket form,
+  which YAML reads as a list. A skill without `name` takes its directory name,
+  and the default enters the structure digest. Claude booleans accept `yes`,
+  `no`, `on`, `off`, `1` and `0`, while Cursor's `alwaysApply` stays exact.
+  `effort` and `shell` are checked against their documented values, and
+  `description` is still required. Undocumented keys such as `version` and
+  `author` are still refused. The #660 results now name the right cause for
+  `justinstimatze/winze`: its bracket-form `argument-hint`, not a string
+  `allowed-tools`, which was always accepted.
+
 - Add the cold-start harness under `benchmark/cold-start/` (#660). It measures
   whether `shipgate diff`, run from a fresh clone of a frozen population of 30
   public repositories, reaches a correct, covered comparison. Expected changes

--- a/benchmark/cold-start/results/2026-09-13-8d43106f/README.md
+++ b/benchmark/cold-start/results/2026-09-13-8d43106f/README.md
@@ -33,7 +33,7 @@ Every comparison that ran was correct: all 19 comparable cases named each expect
 | `absolute-aungkomyint/athapyar-htote-web` | incomparable | unchanged `.claude/skills/*` symlink; skill frontmatter | #700, #721, #722 |
 | `vmihalis/hacker-bob` | incomparable | unchanged skill with undocumented `skill:` key | #722, #721 |
 | `future-architect/uzomuzo-oss` | incomparable | unchanged skills without `name` (documented default); `.claude/rules/agents.md` | #722, #721 |
-| `justinstimatze/winze` | incomparable | unchanged command with string `allowed-tools` (documented); skill `version`/`author` | #722, #721 |
+| `justinstimatze/winze` | incomparable | unchanged command whose `argument-hint` uses the documented bracket form (a YAML list); skill `version`/`author` | #722, #721 |
 | `IgnacioBarEsp/PlanearIA` | incomparable | unchanged skills with `version`; command with `name`/`category`/`tags` | #722, #721 |
 | `BigSimmo/Database` | incomparable | unchanged skill whose frontmatter is invalid YAML (a correct refusal); when isolated, the changed Supabase URL query has no row | #721, #723 |
 | `solal3105/grandsprojets` | incomparable | no blocking issue; unchanged `.vscode/mcp.json` makes coverage `experimental` | #721 |

--- a/src/agents_shipgate/core/instruction_structure.py
+++ b/src/agents_shipgate/core/instruction_structure.py
@@ -25,12 +25,39 @@ _SKILL_FIELDS = frozenset({
     "name", "description", "license", "compatibility", "metadata",
     "allowed-tools", "argument-hint", "disable-model-invocation",
     "user-invocable", "model", "context", "agent", "hooks",
+    # Documented at code.claude.com/docs/en/skills and refused until #722, so a
+    # skill using any of them made its whole host inventory partial.
+    "when_to_use", "arguments", "disallowed-tools", "effort", "background",
+    "paths", "shell",
 })
 _CURSOR_FIELDS = frozenset({"description", "globs", "alwaysApply"})
 _COMMAND_FIELDS = frozenset({
     "description", "allowed-tools", "argument-hint", "model",
     "disable-model-invocation", "hooks",
+    # "Custom commands support the same YAML frontmatter as skills"; `name`
+    # and `paths` are documented as working differently there, not as absent.
+    "user-invocable", "disallowed-tools", "effort", "arguments", "name", "paths",
 })
+#: Undocumented keys (`version`, `author`, `category`, …) are still refused.
+#: Whether a host ignores them when loading is unspecified, so accepting them
+#: is a decision recorded on #722, not a side effect of this list.
+
+#: Fields a host reads as a list, written either way the docs allow: a YAML
+#: list, or one string it splits. `argument-hint` is documented as a string,
+#: but its documented example `[issue-number]` is a YAML list.
+_STRING_OR_LIST_FIELDS = frozenset({
+    "allowed-tools", "disallowed-tools", "globs", "arguments", "paths", "argument-hint",
+})
+_BOOLEAN_FIELDS = frozenset({
+    "disable-model-invocation", "user-invocable", "alwaysApply", "background",
+})
+#: Claude Code booleans also accept these spellings (any case); Cursor's
+#: `alwaysApply` does not document them and stays an exact boolean.
+_CLAUDE_BOOLEAN_STRINGS = frozenset({"true", "false", "yes", "no", "on", "off", "1", "0"})
+_ENUM_FIELDS = {
+    "effort": frozenset({"low", "medium", "high", "xhigh", "max"}),
+    "shell": frozenset({"bash", "powershell"}),
+}
 
 
 @dataclass(frozen=True)
@@ -87,13 +114,20 @@ def _valid_metadata(metadata: dict) -> bool:
             # field is not set. Where a field is genuinely required, the
             # profile checks below still say so and still fire.
             continue
-        if key in {"disable-model-invocation", "user-invocable", "alwaysApply"}:
-            if not isinstance(value, bool):
+        if key in _BOOLEAN_FIELDS:
+            if not isinstance(value, bool) and not (
+                key != "alwaysApply"
+                and isinstance(value, str)
+                and value.strip().lower() in _CLAUDE_BOOLEAN_STRINGS
+            ):
                 return False
-        elif key in {"allowed-tools", "globs"}:
+        elif key in _STRING_OR_LIST_FIELDS:
             if not isinstance(value, str) and not (
                 isinstance(value, list) and all(isinstance(item, str) for item in value)
             ):
+                return False
+        elif key in _ENUM_FIELDS:
+            if not isinstance(value, str) or value not in _ENUM_FIELDS[key]:
                 return False
         elif key == "hooks":
             if not _valid_hooks(value):
@@ -232,11 +266,18 @@ def classify_instruction(path: str, text: str | None) -> InstructionStructure | 
             return unresolved("frontmatter_unknown_fields")
         if not _valid_metadata(metadata):
             return unresolved("frontmatter_invalid_structure")
-        if profile == "skill_instruction/v1" and any(
-            not isinstance(metadata.get(key), str) or not metadata[key].strip()
-            for key in ("name", "description")
-        ):
-            return unresolved("skill_identity_missing")
+        if profile == "skill_instruction/v1":
+            description = metadata.get("description")
+            if not isinstance(description, str) or not description.strip():
+                return unresolved("skill_identity_missing")
+            name = metadata.get("name")
+            if name is None or (isinstance(name, str) and not name.strip()):
+                # "name — defaults to directory name" (code.claude.com/docs/en/skills).
+                # The default enters the digest, so renaming the directory is a change.
+                directory = PurePosixPath(path.replace("\\", "/")).parent.name
+                if not directory:
+                    return unresolved("skill_identity_missing")
+                metadata = {**metadata, "name": directory}
         # Claude skill/command preprocessing runs bang-backtick commands even
         # though ordinary fenced shell examples are just guidance. Preserve
         # command text exactly; an unterminated form cannot be called absent.

--- a/tests/test_documented_claude_frontmatter.py
+++ b/tests/test_documented_claude_frontmatter.py
@@ -1,0 +1,135 @@
+"""Documented Claude skill and command frontmatter resolves (#722).
+
+Each shape below is documented at code.claude.com/docs/en/skills or
+/docs/en/slash-commands, and each was refused as `unresolved` before this
+change. An `unresolved` instruction is a blocking coverage issue, so one such
+file made a repository's whole host inventory partial.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents_shipgate.core.instruction_structure import classify_instruction
+
+SKILL = ".claude/skills/helper/SKILL.md"
+COMMAND = ".claude/commands/review.md"
+
+
+def _doc(fields: str) -> str:
+    return f"---\n{fields}---\n\nBody.\n"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "when_to_use: When the user asks for a review\n",
+        "arguments: issue branch\n",
+        "arguments: [issue, branch]\n",
+        "disallowed-tools: AskUserQuestion\n",
+        "disallowed-tools: [AskUserQuestion, SendEmail]\n",
+        "effort: xhigh\n",
+        "background: false\n",
+        'background: "yes"\n',
+        'paths: "src/**/*.ts,lib/**/*.js"\n',
+        "paths: [src/**/*.ts, lib/**/*.js]\n",
+        "shell: powershell\n",
+        "argument-hint: [issue-number]\n",
+    ],
+)
+def test_a_documented_skill_field_resolves(field: str) -> None:
+    resolved = classify_instruction(SKILL, _doc(f"name: helper\ndescription: Helps.\n{field}"))
+
+    assert resolved.status == "structured", (field, resolved.reason)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "user-invocable: false\n",
+        "disallowed-tools: [Write]\n",
+        "effort: low\n",
+        "arguments: [pr]\n",
+        "name: review\n",
+        "paths: [src/**]\n",
+        "argument-hint: [--staged | --branch | --pr <url>]\n",
+    ],
+)
+def test_a_documented_command_field_resolves(field: str) -> None:
+    resolved = classify_instruction(COMMAND, _doc(f"description: Review.\n{field}"))
+
+    assert resolved.status == "structured", (field, resolved.reason)
+
+
+@pytest.mark.parametrize(
+    ("field", "reason"),
+    [
+        ("effort: extreme\n", "frontmatter_invalid_structure"),
+        ("shell: zsh\n", "frontmatter_invalid_structure"),
+        ("background: sometimes\n", "frontmatter_invalid_structure"),
+        ("paths: 7\n", "frontmatter_invalid_structure"),
+        ("version: 1.0.0\n", "frontmatter_unknown_fields"),
+        ("author: someone\n", "frontmatter_unknown_fields"),
+    ],
+)
+def test_wrong_types_and_undocumented_keys_stay_unresolved(field: str, reason: str) -> None:
+    resolved = classify_instruction(SKILL, _doc(f"name: helper\ndescription: Helps.\n{field}"))
+
+    assert resolved.status == "unresolved"
+    assert resolved.reason == reason
+
+
+def test_a_skill_without_a_name_takes_its_directory_name() -> None:
+    """ "name — defaults to directory name". The default is part of the digest."""
+
+    implicit = classify_instruction(SKILL, _doc("description: Helps.\n"))
+    explicit = classify_instruction(SKILL, _doc("name: helper\ndescription: Helps.\n"))
+    renamed = classify_instruction(".claude/skills/other/SKILL.md", _doc("description: Helps.\n"))
+
+    assert implicit.status == explicit.status == "structured"
+    assert implicit.sha256 == explicit.sha256
+    assert renamed.sha256 != implicit.sha256
+
+
+def test_cursor_booleans_stay_exact() -> None:
+    resolved = classify_instruction(
+        ".cursor/rules/demo.mdc", '---\ndescription: d\nalwaysApply: "yes"\n---\nBody.\n'
+    )
+
+    assert resolved.status == "unresolved"
+    assert resolved.reason == "frontmatter_invalid_structure"
+
+
+@pytest.mark.parametrize(
+    ("field", "before", "after"),
+    [
+        ("shell", "bash", "powershell"),
+        # Quoted: an unquoted `*` opens a YAML alias.
+        ("paths", "[src/**]", '["**"]'),
+        ("disallowed-tools", "[Write]", "[]"),
+        ("allowed-tools", "Read", "Read Bash(*)"),
+        ("effort", "low", "max"),
+    ],
+)
+def test_a_change_to_a_capability_bearing_field_changes_the_digest(field, before, after) -> None:
+    base = classify_instruction(SKILL, _doc(f"description: Helps.\n{field}: {before}\n"))
+    head = classify_instruction(SKILL, _doc(f"description: Helps.\n{field}: {after}\n"))
+
+    assert base.status == head.status == "structured"
+    assert base.sha256 != head.sha256
+
+
+def test_the_cold_start_shapes_that_were_documented_now_resolve() -> None:
+    """Two #660 stop points, as written in their repositories."""
+
+    command = (
+        "---\n"
+        "description: Review code changes with structured grading (A-F)\n"
+        "allowed-tools: Bash(git diff:*), Bash(git rev-parse:*), Bash(gh pr diff:*)\n"
+        "argument-hint: [--staged | --branch | --pr <url>]\n"
+        "---\n\nReview code and provide a structured assessment with grading.\n"
+    )
+    description_only_skill = "---\ndescription: Review a plan until it is clean.\n---\n\n# Plan review\n"
+
+    assert classify_instruction(COMMAND, command).status == "structured"
+    assert classify_instruction(".claude/skills/plan-review/SKILL.md", description_only_skill).status == "structured"

--- a/tests/test_instruction_structure.py
+++ b/tests/test_instruction_structure.py
@@ -196,14 +196,16 @@ def test_an_empty_value_does_not_excuse_a_real_structure_problem(
     assert resolved.reason == reason
 
 
-def test_a_skill_still_needs_a_real_name_and_description() -> None:
+def test_a_skill_still_needs_a_real_description() -> None:
     """The required-field check is separate and must keep firing.
 
     Treating an explicit null as absent in the shared type check would be a
-    hole if identity were only enforced there.
+    hole if identity were only enforced there. A `name` is not required: the
+    docs default it to the directory name (#722), which
+    `tests/test_documented_claude_frontmatter.py` covers.
     """
 
-    for fields in ("name: demo\ndescription: \n", "name: \ndescription: Test\n"):
+    for fields in ("name: demo\ndescription: \n", "name: demo\n"):
         resolved = classify_instruction(
             ".agents/skills/demo/SKILL.md", f"---\n{fields}---\nBody.\n"
         )


### PR DESCRIPTION
Fixes #722.

## Why

One Claude skill or command using documented frontmatter made the whole host inventory partial. An unresolved instruction is a blocking coverage issue, and that refuses every comparison in the repository. The #660 cold start hit this on public repositories.

## What changes

`core/instruction_structure.py` accepts what code.claude.com/docs/en/skills and /docs/en/slash-commands document, with type checks, and keeps every value in the structure digest:

| Shape | Before | After |
|---|---|---|
| Skill `when_to_use`, `arguments`, `disallowed-tools`, `effort`, `background`, `paths`, `shell` | `frontmatter_unknown_fields` | structured |
| Command `user-invocable`, `disallowed-tools`, `effort`, `arguments`, `name`, `paths` | `frontmatter_unknown_fields` | structured |
| `argument-hint: [issue-number]` (documented; YAML reads it as a list) | `frontmatter_invalid_structure` | structured |
| Skill with `description` and no `name` (docs: defaults to directory name) | `skill_identity_missing` | structured, with the directory name in the digest |
| Claude booleans `yes`/`no`/`on`/`off`/`1`/`0` | invalid | accepted; Cursor `alwaysApply` stays an exact boolean |
| `effort: extreme`, `shell: zsh`, `paths: 7` | — | still refused, checked against the documented values |
| Undocumented keys (`version`, `author`, `category`, `tags`, `skill`) | refused | **still refused**; the decision stays open on #722 |
| Skill without `description` | refused | still refused |

It also corrects the #660 results README. `justinstimatze/winze`'s command was refused for its bracket-form `argument-hint`, not for a string `allowed-tools`; the reader always accepted that string. #721 and #722 were corrected in place.

## Verification

- `tests/test_documented_claude_frontmatter.py`:
  - every documented field, and each wrong type;
  - the directory-name default and its digest;
  - Cursor booleans staying exact;
  - digest changes on every capability-bearing field;
  - both real #660 shapes.
- One pinned test changes by design: an empty `name` no longer refuses. That test now pins only the required `description`.
- **Mutations: 7 of 7 fire.** Each disables one rule: `background` as a boolean, the enum check, the Cursor-exact boolean, the name default, the default reaching the digest, the bracket `argument-hint`, and undocumented-key refusal.
- The broader instruction and boundary suites pass (30 files, 1670 tests), after one fixture fix: an unquoted `[**]` is a YAML alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
