### PR TITLE
Make an MCP server URL's query part of its change digest (#723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Make a URL-based MCP server's query part of its change digest (#723). The
+  digest hashed only the redacted URL, which keeps the scheme and host and drops
+  everything else. So removing `read_only=true` from a Supabase MCP URL, adding
+  `features=` or switching projects produced no row. The #660 cold start found
+  the `features` case on a public repository. Published fields are unchanged and
+  still carry no path, query or secret. A secret-named query parameter
+  contributes only its name, and `env` and `headers` stay out. The path stays out
+  too: a webhook-style path is a secret whose rotation must stay quiet, so a
+  path-only capability change is still not seen. Servers without a query keep
+  their earlier digest. A baseline saved earlier shows each affected URL server
+  as `changed` once.
+
 - Resolve documented Claude skill and command frontmatter instead of refusing it
   (#722). An unresolved instruction is a blocking coverage issue, so one such
   file made a repository's whole host inventory partial. Skills now accept

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -3432,3 +3432,27 @@ Interactive `check` now defaults to text; detected agent mode defaults to the
 current boundary JSON. Automation should always select `--format
 agent-boundary-json` or `--format agent-control-json` explicitly. These existing
 explicit formats are retained, and `--format text` is available in either mode.
+
+### MCP URL capability digest (#723)
+
+A URL-based MCP server's query parameters now enter its `config_sha256`, and
+its file's `redacted_sha256`. A change carried in the query now produces a row:
+removing `read_only=true`, adding `features=`, or pointing at a different
+project. Before this change only the redacted URL was hashed, so none of these
+was visible.
+
+The URL path stays out of the digest. A webhook-style path is itself a secret,
+and rotating one must stay quiet, so a capability carried only in the path
+(`/read` → `/admin`) is still not seen.
+
+Published fields are unchanged. `endpoint` still replaces the path with
+`<redacted-path>` and drops the query, and nothing in the inventory, baseline
+or rows carries a path, query or secret. A secret-named query parameter
+contributes its name to the digest, never its value, and `env` and `headers`
+contribute nothing. A server with no URL query keeps its earlier digest.
+
+A host-grants baseline saved by an earlier build reports each URL server that
+has a query as `changed` once, because its digest now covers more.
+Review that row, then re-save the baseline. No schema version moves: the
+digest's inputs changed, not the inventory's shape.
+

--- a/benchmark/cold-start/cases/BigSimmo__Database__cursor_mcp.json/replay.json
+++ b/benchmark/cold-start/cases/BigSimmo__Database__cursor_mcp.json/replay.json
@@ -1,11 +1,11 @@
 {
   "expected_changes": 1,
-  "missing": 1,
-  "missing_detail": "mcp_server supabase changed",
-  "rows_on_file": 0,
+  "missing": 0,
+  "missing_detail": "",
+  "rows_on_file": 1,
   "scope": "supported",
   "stop_point": "comparison_comparable",
-  "success": false,
+  "success": true,
   "unexpected": 0,
   "unexpected_detail": ""
 }

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -19,7 +19,7 @@ import tomllib
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Literal
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 import yaml
 from pydantic import ValidationError
@@ -383,8 +383,82 @@ def _redact_secret_values(value: Any, *, parent_key: str | None = None) -> Any:
     return value
 
 
+def _url_capability_parts(value: Any, *, parent_key: str | None = None) -> list[dict[str, Any]]:
+    """The query of each URL, for the change digest only.
+
+    Published fields drop a URL's query because it carries tokens and project
+    identifiers. The change digest must still see it: a Supabase server's
+    `read_only=true` and `features=…` decide which tools an agent gets, and
+    removing one produced no row when only the redacted URL was hashed (#723).
+    Nothing returned here is published; it is hashed with the redacted config.
+
+    The path stays out on purpose. A webhook-style path is itself the secret,
+    and rotating one must stay quiet
+    (`test_drift_all_env_header_value_rotation_quiet_but_key_addition_fires`).
+    A digest cannot tell a capability path (`/read` → `/admin`) from a secret
+    one, so a path-only change remains unseen; that limit is recorded on #723.
+
+    It walks what `_redact_secret_values` keeps: secret keys, `env` and
+    `headers` contribute nothing, and a secret-named query parameter
+    contributes its name, never its value. A URL without a query adds nothing,
+    so a command server, a bare host or a path-only URL keeps its earlier digest.
+    """
+
+    if parent_key is not None and _is_secret_key(parent_key):
+        return []
+    parts: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        for key, inner in sorted(value.items(), key=lambda item: str(item[0])):
+            key_text = str(key)
+            if (
+                key_text == "policyHelper"
+                or _is_secret_key(key_text)
+                or parent_key in _CREDENTIAL_CONTAINER_KEYS
+                or key_text in {"env", "headers"}
+            ):
+                continue
+            parts.extend(_url_capability_parts(inner, parent_key=key_text))
+        return parts
+    if isinstance(value, list):
+        skip_next = False
+        for item in value:
+            if skip_next:
+                skip_next = False
+                continue
+            if isinstance(item, str) and (
+                _SECRET_ARG_RE.fullmatch(item)
+                or item.lower().lstrip("-").replace("-", "_") in _SECRET_KEY_MARKERS
+            ):
+                skip_next = not _SECRET_ARG_RE.fullmatch(item)
+                continue
+            parts.extend(_url_capability_parts(item, parent_key=parent_key))
+        return parts
+    if isinstance(value, str):
+        for match in _URL_RE.finditer(value):
+            try:
+                parsed = urlsplit(match.group(0))
+                query = parse_qsl(parsed.query, keep_blank_values=True)
+            except ValueError:
+                parts.append({"url": "<unparsable-url>", "raw": match.group(0)})
+                continue
+            if not query:
+                continue
+            parts.append({
+                "url": _sanitize_url(match.group(0)),
+                "query": sorted(
+                    [name, "<secret>" if _is_secret_key(name) else item]
+                    for name, item in query
+                ),
+            })
+    return parts
+
+
 def redacted_config_sha256(config: Any) -> str:
-    return _sha(_redact_secret_values(config))
+    redacted = _redact_secret_values(config)
+    url_parts = _url_capability_parts(config)
+    if not url_parts:
+        return _sha(redacted)
+    return _sha({"redacted": redacted, "url_capability": url_parts})
 
 
 def _display_path(path: Path, *, root: Path, home: Path) -> str:

--- a/tests/test_host_audit.py
+++ b/tests/test_host_audit.py
@@ -1104,8 +1104,12 @@ def test_drift_all_env_header_value_rotation_quiet_but_key_addition_fires(tmp_pa
     data["mcpServers"]["github"]["env"]["GITHUB_TOKEN"] = "rotated"
     data["mcpServers"]["github"]["env"]["READ_ONLY"] = "false"
     data["mcpServers"]["remote"]["headers"]["Authorization"] = "Bearer rotated"
+    # A rotation: the webhook path and the token *value* change, the token
+    # parameter itself stays. Its presence enters the change digest the way an
+    # env or header key does (#723); its value never does.
     data["mcpServers"]["remote"]["url"] = (
-        "https://mcp.example.test/services/ROTATED-WEBHOOK-PATH-TOP-SECRET"
+        "https://user:rotated@mcp.example.test/services/"
+        "ROTATED-WEBHOOK-PATH-TOP-SECRET?token=rotated"
     )
     path.write_text(json.dumps(data), encoding="utf-8")
     rotated = _drift_json(tmp_path)[1]
@@ -1116,6 +1120,14 @@ def test_drift_all_env_header_value_rotation_quiet_but_key_addition_fires(tmp_pa
     data["mcpServers"]["remote"]["headers"]["X-Scope"] = "admin"
     path.write_text(json.dumps(data), encoding="utf-8")
     assert _drift_json(tmp_path)[1]["has_drift"] is True
+
+    # The query analogue of adding a key: a new capability-shaping parameter.
+    _save_baseline(tmp_path)
+    data["mcpServers"]["remote"]["url"] += "&scope=admin"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    widened = _drift_json(tmp_path)[1]
+    assert widened["has_drift"] is True
+    assert "scope=admin" not in json.dumps(widened)
 
 
 def test_inline_permission_secret_rotation_is_redacted_and_hash_invariant(tmp_path: Path) -> None:

--- a/tests/test_mcp_url_capability_digest.py
+++ b/tests/test_mcp_url_capability_digest.py
@@ -1,0 +1,142 @@
+"""An MCP server URL's query reaches its change digest, never its published fields (#723)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+from agents_shipgate.core.host_grants import (
+    _redact_secret_values,
+    _sha,
+    host_audit_inventory,
+    redacted_config_sha256,
+)
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True).stdout.strip()
+
+
+def diff_rows(tmp_path: Path, before: dict, after: dict) -> list[dict]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.name", "Fixture")
+    git(repo, "config", "user.email", "fixture@example.invalid")
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"db": before}}), encoding="utf-8")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", "base")
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"db": after}}), encoding="utf-8")
+    result = CliRunner().invoke(app, ["diff", "--workspace", str(repo), "--base", "main", "--json"])
+    payload = json.loads(result.stdout)
+    assert payload["comparison_status"] == "comparable", payload
+    return payload["rows"]
+
+
+SUPABASE = "https://mcp.supabase.com/mcp?project_ref=abc&read_only=true"
+
+
+@pytest.mark.parametrize(
+    ("before", "after"),
+    [
+        (SUPABASE, "https://mcp.supabase.com/mcp?project_ref=abc"),
+        (SUPABASE, SUPABASE + "&features=development"),
+        ("https://mcp.supabase.com/mcp?project_ref=abc", "https://mcp.supabase.com/mcp?project_ref=xyz"),
+        ("https://a.example.com/mcp", "https://b.example.com/mcp"),
+    ],
+)
+def test_a_capability_change_carried_in_a_url_produces_a_row(tmp_path: Path, before: str, after: str) -> None:
+    rows = diff_rows(tmp_path, {"type": "http", "url": before}, {"type": "http", "url": after})
+
+    assert [row["direction"] for row in rows] in (["changed"], ["widened"]), rows
+    assert rows[0]["before"] == rows[0]["after"] == "db"
+
+
+def test_a_secret_query_value_alone_is_neither_digested_nor_a_row(tmp_path: Path) -> None:
+    rows = diff_rows(
+        tmp_path,
+        {"type": "http", "url": "https://mcp.example.com/mcp?api_key=first"},
+        {"type": "http", "url": "https://mcp.example.com/mcp?api_key=second"},
+    )
+
+    assert rows == []
+
+
+def test_adding_a_secret_query_parameter_is_still_a_row(tmp_path: Path) -> None:
+    rows = diff_rows(
+        tmp_path,
+        {"type": "http", "url": "https://mcp.example.com/mcp?project=a"},
+        {"type": "http", "url": "https://mcp.example.com/mcp?project=a&api_key=secret"},
+    )
+
+    assert len(rows) == 1
+
+
+def test_a_url_in_env_stays_out_of_the_digest(tmp_path: Path) -> None:
+    rows = diff_rows(
+        tmp_path,
+        {"command": "server", "env": {"API_BASE": "https://api.example.com/v1?key=a"}},
+        {"command": "server", "env": {"API_BASE": "https://api.example.com/v2?key=b"}},
+    )
+
+    assert rows == []
+
+
+def test_reordering_keys_is_not_a_change(tmp_path: Path) -> None:
+    rows = diff_rows(
+        tmp_path,
+        {"type": "http", "url": SUPABASE},
+        {"url": SUPABASE, "type": "http"},
+    )
+
+    assert rows == []
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"command": "npx", "args": ["-y", "server"]},
+        {"type": "http", "url": "https://mcp.example.com"},
+        {"type": "http", "url": "https://mcp.example.com/"},
+        {"type": "http", "url": "https://mcp.example.com/services/T00/B00/SECRETPATH"},
+    ],
+)
+def test_a_server_without_a_url_query_keeps_its_earlier_digest(config: dict) -> None:
+    """Upgrading must not churn every saved baseline: only URL servers with a
+    query are digested differently."""
+
+    assert redacted_config_sha256(config) == _sha(_redact_secret_values(config))
+
+
+def test_nothing_published_carries_the_path_query_or_secret(tmp_path: Path) -> None:
+    repo = tmp_path / "published"
+    repo.mkdir()
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"db": {
+        "type": "http",
+        "url": "https://mcp.supabase.com/private-path?project_ref=abc&read_only=true&api_key=TOPSECRET",
+    }}}), encoding="utf-8")
+
+    inventory = json.dumps(host_audit_inventory(repo))
+
+    for leaked in ("private-path", "project_ref", "read_only", "TOPSECRET", "api_key"):
+        assert leaked not in inventory, leaked
+    assert "https://mcp.supabase.com/<redacted-path>" in inventory
+
+
+def test_a_path_rotation_stays_quiet_because_a_path_can_be_the_secret(tmp_path: Path) -> None:
+    """The deliberate limit: `/read` → `/admin` is unseen, because a webhook path
+    rotation must stay quiet and a digest cannot tell the two apart."""
+
+    rows = diff_rows(
+        tmp_path,
+        {"type": "http", "url": "https://hooks.example.com/services/T00/B00/FIRST"},
+        {"type": "http", "url": "https://hooks.example.com/services/T00/B00/SECOND"},
+    )
+
+    assert rows == []
+


### PR DESCRIPTION
Fixes #723, with the scope correction recorded on the issue: the query, not the path.

## Why

A URL-based MCP server's change digest hashed only the redacted URL, which keeps the scheme and host. So removing `read_only=true` from a Supabase MCP URL, adding `features=` or switching `project_ref` produced **no row**. The #660 cold start found the `features` case on `BigSimmo/Database`.

## What changes

`core/host_grants.py` adds `_url_capability_parts` to the digest input of `redacted_config_sha256`, which feeds grant `config_sha256` and artifact `redacted_sha256`:

| URL change | Row before | Row after |
|---|---|---|
| `read_only=true` removed | none | `changed` |
| `features=development` added | none | `changed` |
| `project_ref=abc` → `xyz` | none | `changed` |
| host changed (control) | `widened` | `widened` |
| secret-named parameter's value rotated (`api_key=a` → `b`) | none | none |
| secret-named parameter added | none | a row |
| path changed (`/read` → `/admin`, or a webhook path rotation) | none | **none, deliberately** |
| a URL inside `env` or `headers` | none | none |

**Why the path stays out.** `test_drift_all_env_header_value_rotation_quiet_but_key_addition_fires` requires a webhook-path rotation to stay quiet, because that path is the secret. A digest cannot tell a capability path from a secret one, so a path-only capability change remains unseen. That limit is stated in `STABILITY.md` and on #723.

**One existing fixture corrected.** That test's "rotation" dropped the `?token=` parameter entirely, which is removing a key, not rotating a value. The fixture now rotates the value. The test also gains the query analogue of its own key-addition check: adding `&scope=admin` fires, and the value is never published.

**Compatibility.** Published fields are unchanged. `endpoint` is still `scheme://host/<redacted-path>`, and nothing in the inventory, baseline or rows carries a path, query or secret. Servers without a query keep their exact earlier digest, pinned by a test. A baseline saved earlier shows each URL server that has a query as `changed` once, and the migration note says so. No schema version moves.

## Verification

- `tests/test_mcp_url_capability_digest.py`: the issue's cases, the secret-value and secret-presence rules, `env` exclusion, key-order insensitivity, unchanged digests for no-query servers, no leakage into published output, and quiet path rotation.
- **Mutations: 6 of 6 fire** against a green suite:
  - the query left out
  - the path put back in (fails the existing webhook invariant)
  - path-only URLs digested
  - secret values digested
  - `env` digested
  - the projection ignored
- The broader host-grants, drift, audit and replay suites pass: 383 tests across 13 files.
- `BigSimmo/Database`'s cold-start replay now records no missing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
