### PR TITLE
Read Claude Code extraKnownMarketplaces so a marketplace change produces a row (#720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Read Claude Code `extraKnownMarketplaces`, so adding, removing or
+  re-pointing a plugin marketplace produces a row (#720). `enabledPlugins`
+  entries install from those marketplaces, but only the plugins were read. The
+  #660 cold start saw `open-learning-exchange/myplanet` add a marketplace beside
+  its plugin, and the engine named only the plugin. Each marketplace is now a
+  `plugin_or_app` grant named `marketplace:<name>`, so no schema changes. Adding
+  or re-pointing one is an expansion; removing one is not. The cold-start oracle
+  now counts the key as supported, and `myplanet` replays as a covered success.
+
 - Read a FastMCP tool's literal `readOnlyHint` and `destructiveHint` from source,
   as claims for `SHIP-MCP-ANNOTATION-CONTRADICTION` to challenge (#658). The
   source route read no hints at all, so a server whose source says

--- a/benchmark/cold-start/cases/open-learning-exchange__myplanet__claude_settings.json/replay.json
+++ b/benchmark/cold-start/cases/open-learning-exchange__myplanet__claude_settings.json/replay.json
@@ -1,11 +1,11 @@
 {
-  "expected_changes": 1,
+  "expected_changes": 2,
   "missing": 0,
   "missing_detail": "",
-  "rows_on_file": 1,
-  "scope": "unsupported",
+  "rows_on_file": 2,
+  "scope": "supported",
   "stop_point": "comparison_comparable",
-  "success": false,
+  "success": true,
   "unexpected": 0,
   "unexpected_detail": ""
 }

--- a/benchmark/cold-start/expected.py
+++ b/benchmark/cold-start/expected.py
@@ -29,6 +29,8 @@ from typing import Any
 #: hooks" for Claude Code.
 CLAUDE_SUPPORTED_KEYS = frozenset({
     "permissions", "hooks", "sandbox", "enabledPlugins", "additionalDirectories",
+    # "plugins" in the matrix includes the marketplaces they install from (#720).
+    "extraKnownMarketplaces",
     "disableAllHooks", "allowManagedHooksOnly", "allowManagedPermissionRulesOnly",
     "skipDangerousModePermissionPrompt", "enableAllProjectMcpServers",
     # "MCP restrictions" in the matrix: which project `.mcp.json` servers load.
@@ -37,7 +39,6 @@ CLAUDE_SUPPORTED_KEYS = frozenset({
 CLAUDE_UNSUPPORTED_CAPABILITY_KEYS = frozenset({
     "apiKeyHelper", "awsAuthRefresh", "awsCredentialExport", "otelHeadersHelper",
     "statusLine", "fileSuggestion", "subagentStatusLine", "env",
-    "extraKnownMarketplaces",
     "forceLoginMethod", "forceLoginOrgUUID",
 })
 #: Keys with no capability effect: presentation, model choice, housekeeping.
@@ -125,6 +126,8 @@ def claude_settings(before_text: str | None, after_text: str | None) -> dict[str
             changes += _map_changes("setting", "sandbox.", old, new)
         elif key == "enabledPlugins":
             changes += _map_changes("plugin", "", old, new)
+        elif key == "extraKnownMarketplaces":
+            changes += _map_changes("plugin", "marketplace:", old, new)
         elif key == "additionalDirectories":
             changes += _list_changes("additional_path", "", old, new)
         elif key in {"enabledMcpjsonServers", "disabledMcpjsonServers"}:

--- a/benchmark/host-config/cases/open-learning-exchange__myplanet__pr16644/replay.json
+++ b/benchmark/host-config/cases/open-learning-exchange__myplanet__pr16644/replay.json
@@ -1,13 +1,13 @@
 {
   "benign_case": false,
   "benign_zero_row": false,
-  "correct_rows": 1,
-  "expected_changes": 1,
-  "expected_widenings": 1,
+  "correct_rows": 2,
+  "expected_changes": 2,
+  "expected_widenings": 2,
   "incomparable_reasons": "",
-  "rows_on_file": 1,
-  "scope": "unsupported",
+  "rows_on_file": 2,
+  "scope": "supported",
   "stop_point": "comparison_comparable",
   "unclassified_keys": "",
-  "widenings_named": 1
+  "widenings_named": 2
 }

--- a/docs/host-boundary-support.md
+++ b/docs/host-boundary-support.md
@@ -16,7 +16,7 @@ and `audit --host`.
 | Adapter | Status | Repository surfaces | Static semantics |
 |---|---|---|---|
 | Codex | first-class | `.codex/config.toml`, `.codex/hooks.json` | sandbox, approvals, network, MCP/app approvals, hooks |
-| Claude Code | first-class | `.claude/settings.json`, `.claude/settings.local.json`, `.mcp.json`, `CLAUDE.md`, Claude skills | permission modes/rules, sandbox/network, additional paths, MCP restrictions, plugins, hooks |
+| Claude Code | first-class | `.claude/settings.json`, `.claude/settings.local.json`, `.mcp.json`, `CLAUDE.md`, Claude skills | permission modes/rules, sandbox/network, additional paths, MCP restrictions, plugins and their marketplaces (`extraKnownMarketplaces`), hooks |
 | Cursor | first-class | `.cursor/cli.json`, `.cursor/mcp.json`, `.cursor/rules/**` | Shell/Read/Write rules, MCP declarations, instruction trust roots |
 | VS Code MCP | experimental | `.vscode/mcp.json` | MCP additions and changes; relevant changes fail closed |
 | Shared/GitHub | first-class | `AGENTS.md`, Shipgate policies/state, skills, `.github/workflows/*` | instruction/gate weakening, workflow permissions and triggers |

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -753,6 +753,20 @@ def _claude_grants(data: Any, *, scope: HostScope, source: str) -> list[dict[str
                 ),
                 "name": str(name), "enabled": bool(enabled),
             })
+    # `enabledPlugins` entries install from these, so a marketplace added or
+    # re-pointed changes what an enabled plugin runs (#720). Named with a
+    # prefix: a marketplace and a plugin never compete for one precedence key.
+    marketplaces = data.get("extraKnownMarketplaces")
+    if isinstance(marketplaces, dict):
+        for name, config in sorted(marketplaces.items()):
+            label = f"marketplace:{name}"
+            grants.append({
+                **_grant_base(
+                    host="claude-code", scope=scope, source=source, kind="plugin_or_app",
+                    identity=label, config=config, access="external", risk="high",
+                ),
+                "name": label, "enabled": None,
+            })
     grants.extend(_hooks_grants(data, host="claude-code", scope=scope, source=source))
     return grants
 

--- a/tests/test_claude_known_marketplaces.py
+++ b/tests/test_claude_known_marketplaces.py
@@ -1,0 +1,84 @@
+"""#720: a Claude Code plugin marketplace is a grant, so changing one produces a row.
+
+`extraKnownMarketplaces` decides which plugin marketplaces a project trusts, and
+`enabledPlugins` entries install from them. The adapter read only the plugins,
+so the #660 cold start saw `open-learning-exchange/myplanet` add a marketplace
+beside its plugin and named only the plugin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.main import app
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+}
+TEAM = {"source": {"source": "github", "repo": "acme/claude-plugins"}}
+FORK = {"source": {"source": "github", "repo": "someone-else/claude-plugins"}}
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True, env=_GIT_ENV
+    ).stdout.strip()
+
+
+def _rows(tmp_path: Path, before: dict, after: dict) -> list[tuple[str, str, str, bool]]:
+    repo = tmp_path / "repo"
+    (repo / ".claude").mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "main")
+    settings = repo / ".claude" / "settings.json"
+    settings.write_text(json.dumps(before), encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+    settings.write_text(json.dumps(after), encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["diff", "--workspace", str(repo), "--base", base, "--json"])
+    payload = json.loads(result.stdout)
+    assert payload["comparison_status"] == "comparable", payload
+    return [(row["direction"], row["before"], row["after"], row["expands"]) for row in payload["rows"]]
+
+
+def test_an_added_marketplace_is_named_and_expands(tmp_path: Path) -> None:
+    assert _rows(tmp_path, {}, {"extraKnownMarketplaces": {"acme": TEAM}}) == [
+        ("added", "—", "marketplace:acme", True)
+    ]
+
+
+def test_a_removed_marketplace_is_named_and_does_not_expand(tmp_path: Path) -> None:
+    assert _rows(tmp_path, {"extraKnownMarketplaces": {"acme": TEAM}}, {}) == [
+        ("removed", "marketplace:acme", "—", False)
+    ]
+
+
+def test_a_repointed_marketplace_is_one_widening_row(tmp_path: Path) -> None:
+    """The name stays and the source moves: what the enabled plugins run changed."""
+
+    assert _rows(
+        tmp_path,
+        {"extraKnownMarketplaces": {"acme": TEAM}},
+        {"extraKnownMarketplaces": {"acme": FORK}},
+    ) == [("widened", "marketplace:acme", "marketplace:acme", True)]
+
+
+def test_an_unchanged_marketplace_is_quiet(tmp_path: Path) -> None:
+    settings = {"extraKnownMarketplaces": {"acme": TEAM}}
+
+    assert _rows(tmp_path, settings, {**settings, "model": "claude-sonnet-5"}) == []
+
+
+def test_a_plugin_and_a_marketplace_of_one_name_are_two_grants(tmp_path: Path) -> None:
+    rows = _rows(tmp_path, {}, {"enabledPlugins": {"acme": True}, "extraKnownMarketplaces": {"acme": TEAM}})
+
+    assert sorted(row[2] for row in rows) == ["acme", "marketplace:acme"]


### PR DESCRIPTION
Closes #720.

## Problem

`extraKnownMarketplaces` decides which plugin marketplaces a Claude Code project trusts, and `enabledPlugins` entries install from them. The host adapter read the plugins but not the marketplaces. So adding a marketplace, removing one, or pointing an existing name at a different repository produced no row. The #660 cold start found this on `open-learning-exchange/myplanet`: the commit added a marketplace beside its plugin, and the engine named only the plugin.

## Change

- **Reader.** `_claude_grants` reads each `extraKnownMarketplaces` entry as a `plugin_or_app` grant named `marketplace:<name>`, with its `source` as the grant config.
  - Adding a marketplace, or re-pointing one (same name, different source, so a different config digest), raises the existing `plugin_or_app` expansion signal.
  - Removing one does not.
  - No schema or contract change.
- **Prefix.** A marketplace and a plugin can never compete for one precedence key.
- **Support doc.** The Claude Code row in `docs/host-boundary-support.md` now names marketplaces.
- **Cold-start oracle.** It moves the key from unsupported to supported and maps it the same way. The `myplanet` replay is re-recorded as a covered success, and no other case moved.

## Tests

`tests/test_claude_known_marketplaces.py` drives `shipgate diff --json` on a two-commit repository:

| Case | Rows | `expands` |
| --- | --- | --- |
| Marketplace added | one `added marketplace:acme` row | `true` |
| Marketplace removed | one `removed` row | `false` |
| Marketplace re-pointed | one `widened` row | `true` |
| Unchanged marketplace | no row | — |
| Plugin and marketplace with the same name | two separate grants | — |

## Verification

- **Mutation check.** Disabling the marketplace read fails the new tests.
- **Full suite:** green locally.
- **Lint and generated artifacts:** `ruff check .` is clean and `generate_schemas --check` passes.

## Host-config harness

The #659 harness (#733) merged first and scores Claude settings through this oracle, so this PR re-records `benchmark/host-config` replays in the same change (second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

