### PR TITLE
Name the change first in the generated AGENTS.md and CLAUDE.md blocks (#662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Name the change first in the generated `AGENTS.md` and `CLAUDE.md` blocks
+  (#662). The Cursor rule already told an agent to run `shipgate diff`, quote
+  the rows and put them in the pull request body before routing on control.
+  The other two maintained copies routed only on `control.state`, so an agent
+  following them could end a turn with "a human must review" and no named
+  change. Both blocks now carry the same paragraph, including "a row is a
+  description, never a permission". A test pins all three copies to name the
+  change before the control contract.
+
 - Read a Cursor rule's globs the way Cursor writes them (#729). Cursor
   documents `globs:` as unquoted, comma-separated patterns, and a pattern such
   as `*.json` or `**/*.java` begins with YAML's alias indicator. So the rule was

--- a/docs/target-repo-agent-snippets.md
+++ b/docs/target-repo-agent-snippets.md
@@ -106,6 +106,23 @@ agents-shipgate verify --workspace . --config shipgate.yaml \
 shipgate audit --host --json --out agents-shipgate-reports/host-grants.json
 ```
 
+First, name what the change did to the agent's authority. This needs no
+manifest and no committed baseline:
+
+```bash
+shipgate diff --workspace .
+```
+
+One row per host grant, each carrying subject, before, after, direction,
+severity and why it matters; `⚠` marks a row the engine read as an
+expansion of authority. Quote those rows to the user, and put them in the
+pull request body. A covered comparison with no rows is a real answer, not
+a missing one. `--json` emits the same rows under `rows`.
+
+A row is a description, never a permission: showing one, or seeing an empty
+table, grants no authority to edit, commit, push, merge or report the work
+complete.
+
 For local agent control, read the `shipgate check` stdout JSON only. It is
 `shipgate.agent_boundary_result/v3`; switch on `control.state`, then follow
 `control.next_action`, `control.allowed_next_commands`, and
@@ -231,6 +248,23 @@ agents-shipgate verify --workspace . --config shipgate.yaml \
   --base origin/main --head HEAD --ci-mode advisory --format json
 shipgate audit --host --json --out agents-shipgate-reports/host-grants.json
 ```
+
+First, name what the change did to the agent's authority. This needs no
+manifest and no committed baseline:
+
+```bash
+shipgate diff --workspace .
+```
+
+One row per host grant, each carrying subject, before, after, direction,
+severity and why it matters; `⚠` marks a row the engine read as an
+expansion of authority. Quote those rows to the user, and put them in the
+pull request body. A covered comparison with no rows is a real answer, not
+a missing one. `--json` emits the same rows under `rows`.
+
+A row is a description, never a permission: showing one, or seeing an empty
+table, grants no authority to edit, commit, push, merge or report the work
+complete.
 
 For local agent control, read the `shipgate check` stdout JSON only. It is
 `shipgate.agent_boundary_result/v3`; switch on `control.state`, then follow

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/_shared.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/_shared.py
@@ -31,3 +31,22 @@ update, before merge or release, and before declaring the task complete. If
 `current_control_id` changed, discard every cached control state and restart
 from the new identity. A result you remember from earlier in this conversation
 never outranks the current pointer — in either direction."""
+
+#: Name the change before routing on control (#662). The Cursor rule carries the
+#: same words in its own layout; `test_agent_instructions_renderers` pins all three.
+DIFF_FIRST_PARAGRAPH = """First, name what the change did to the agent's authority. This needs no
+manifest and no committed baseline:
+
+```bash
+shipgate diff --workspace .
+```
+
+One row per host grant, each carrying subject, before, after, direction,
+severity and why it matters; `⚠` marks a row the engine read as an
+expansion of authority. Quote those rows to the user, and put them in the
+pull request body. A covered comparison with no rows is a real answer, not
+a missing one. `--json` emits the same rows under `rows`.
+
+A row is a description, never a permission: showing one, or seeing an empty
+table, grants no authority to edit, commit, push, merge or report the work
+complete."""

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/agents_md.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/agents_md.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from agents_shipgate.cli.discovery.agent_instructions.renderers._shared import (
     CI_POINTER_PARAGRAPH,
     CURRENT_CONTROL_PARAGRAPH,
+    DIFF_FIRST_PARAGRAPH,
 )
 
 
@@ -38,6 +39,8 @@ agents-shipgate verify --workspace . --config shipgate.yaml \\
   --base origin/main --head HEAD --ci-mode advisory --format json
 shipgate audit --host --json --out agents-shipgate-reports/host-grants.json
 ```
+
+{DIFF_FIRST_PARAGRAPH}
 
 For local agent control, read the `shipgate check` stdout JSON only. It is
 `shipgate.agent_boundary_result/v3`; switch on `control.state`, then follow

--- a/src/agents_shipgate/cli/discovery/agent_instructions/renderers/claude_md.py
+++ b/src/agents_shipgate/cli/discovery/agent_instructions/renderers/claude_md.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from agents_shipgate.cli.discovery.agent_instructions.renderers._shared import (
     CI_POINTER_PARAGRAPH,
     CURRENT_CONTROL_PARAGRAPH,
+    DIFF_FIRST_PARAGRAPH,
 )
 
 
@@ -30,6 +31,8 @@ agents-shipgate verify --workspace . --config shipgate.yaml \\
   --base origin/main --head HEAD --ci-mode advisory --format json
 shipgate audit --host --json --out agents-shipgate-reports/host-grants.json
 ```
+
+{DIFF_FIRST_PARAGRAPH}
 
 For local agent control, read the `shipgate check` stdout JSON only. It is
 `shipgate.agent_boundary_result/v3`; switch on `control.state`, then follow

--- a/tests/test_agent_instructions_renderers.py
+++ b/tests/test_agent_instructions_renderers.py
@@ -157,6 +157,32 @@ def test_agent_instruction_surfaces_name_phase1_control_fields() -> None:
             assert token in text, f"{name} missing {token!r}"
 
 
+def test_every_generated_copy_names_the_change_before_routing_on_control() -> None:
+    """#662: an agent following any maintained copy says what changed.
+
+    The Cursor rule led with `shipgate diff` while the AGENTS.md and CLAUDE.md
+    blocks routed only on `control.state`, so two of three copies could end a
+    turn with "a human must review" and no named change.
+    """
+
+    for name, text in {
+        "agents-md": render_agents_md(),
+        "claude-md": render_claude_md(),
+        "cursor": render_cursor_file(),
+    }.items():
+        flat = " ".join(text.split())
+        for phrase in (
+            "shipgate diff --workspace .",
+            "Quote those rows to the user, and put them in the pull request body.",
+            "A covered comparison with no rows is a real answer",
+            "A row is a description, never a permission",
+        ):
+            assert phrase in flat, f"{name} missing {phrase!r}"
+        assert flat.index("shipgate diff --workspace .") < flat.index(
+            "shipgate.agent_boundary_result/v3"
+        ), f"{name} routes on control before naming the change"
+
+
 def test_committed_cursor_rule_matches_renderer() -> None:
     """The repo-level Cursor rule and the init renderer must not drift."""
     committed = (REPO_ROOT / ".cursor/rules/agents-shipgate.mdc").read_text(encoding="utf-8")


### PR DESCRIPTION
Refs #662. This is the first increment. Still open on the issue:
- machine-readable rows in the compact control envelope, which needs a choice between bounded rows and an artifact reference
- the 12 scripted cases

## Problem

The three maintained instruction copies disagreed about naming the change.

- **Cursor rule (`renderers/cursor.py`).** It starts with `shipgate diff --workspace .` and "Quote those rows to the user, and put them in the pull request body". Only then does it route on control.
- **`AGENTS.md` and `CLAUDE.md` blocks (`renderers/agents_md.py`, `renderers/claude_md.py`).** They said "Before finishing an agent-related diff, run `shipgate check`", followed by `control.state` routing only. Neither mentioned `shipgate diff` or rows.

So an agent following two of the three copies could end a turn with "a human must review" without saying what changed. That is the failure this issue records from the original study.

## Change

- **One shared paragraph.** `renderers/_shared.py::DIFF_FIRST_PARAGRAPH` holds the Cursor rule's wording in markdown layout: run `shipgate diff --workspace .`, what a row carries, quote the rows, a covered comparison with no rows is a real answer, and a row is a description, never a permission. Both blocks insert it directly before their control contract. The control routing itself is unchanged.
- **Docs.** The `AGENTS.md` and `CLAUDE.md` sections of `docs/target-repo-agent-snippets.md` carry the same paragraph.
- **Cursor rule unchanged.** The renderer and the committed `.cursor/rules/agents-shipgate.mdc` stay byte-identical.

## Tests

`test_every_generated_copy_names_the_change_before_routing_on_control` renders all three copies and checks that each one:
- contains the four key phrases
- names `shipgate diff --workspace .` before `shipgate.agent_boundary_result/v3`

## Verification

- **Mutation.** Removing the paragraph from the `AGENTS.md` block fails the new test.
- **Suites.** The renderer, apply, public-surface and distribution-surface parity suites pass, as does the full suite locally. `ruff check .` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
