### PR TITLE
Compare host configuration in the Stop hook when no manifest exists (#661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Compare host configuration in the Claude Code Stop hook when no manifest
+  exists (#661). A narrowing and a widening edit to `.claude/settings.json` got
+  the same two messages, neither named `Bash(*)`, and both advised initializing
+  a manifest. When every changed file is host configuration, the Stop hook now
+  runs `shipgate diff`. It is quiet when no row expands, names each widening row
+  once, and is never quiet when it cannot compare. The PostToolUse hook no
+  longer nudges on those edits. Mixed changes and repositories with a manifest
+  keep their existing route. The path list is rendered from the boundary
+  registry at install time.
+
 - Compare past an unchanged partial or experimental surface instead of refusing
   every row (#721, runtime contract 37, verifier schema `0.19`). A comparison
   refused whenever either inventory was incomplete, including for a file the

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -200,6 +200,18 @@ exact remaining command, and `human_review_required` lets the turn end with a
 hand-off notice — a Stop-hook block forces the agent to keep working, which is
 the opposite of what `must_stop` means.
 
+Without a configured manifest, when every changed file is host configuration —
+`.claude/settings.json`, `.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml`,
+`.vscode/mcp.json` or a GitHub workflow — the Stop hook runs
+`agents-shipgate diff` instead of advising you to initialize a manifest. It
+stays quiet when no row widens what the agent can do. It names each widening
+row once, and repeats the announcement only when the change or its rows change.
+A missing base ref, an incomparable inventory or unparsed output is never
+quiet. The PostToolUse hook does not nudge on those edits, because the Stop
+hook compares them. Instruction files, skills, commands, rules and policies
+keep the route above, and a repository with a manifest always runs `verify`.
+The hook reads configuration, not the agent's runtime permissions.
+
 These hooks are advisory local feedback. Local setup failures such as a
 missing CLI or unavailable base ref are surfaced as context, and verifier
 output the hook cannot parse is surfaced as an explicit warning rather than

--- a/src/agents_shipgate/cli/install_hooks.py
+++ b/src/agents_shipgate/cli/install_hooks.py
@@ -12,6 +12,7 @@ import typer
 
 from agents_shipgate.checks.verify import TRUST_ROOT_SURFACES
 from agents_shipgate.cli.workspace_guard import require_workspace
+from agents_shipgate.core.boundary_registry import BOUNDARY_ADAPTERS
 from agents_shipgate.core.errors import ConfigError
 from agents_shipgate.core.trust_roots import inspect_lexical_path_identity
 
@@ -448,6 +449,30 @@ def _write_text_atomic(path: Path, content: str) -> None:
             temp_path.unlink(missing_ok=True)
 
 
+def host_config_change_patterns() -> list[str]:
+    """Paths the Stop hook compares with `shipgate diff` when no manifest exists (#661).
+
+    Host configuration files and GitHub workflows: what the capability diff
+    reads as host grants. Instruction files, skills, commands, Cursor rules and
+    policies keep their existing route, by the owner decision on #661. Rendered
+    from the boundary registry, so the hook and the reader cannot name a
+    different surface.
+    """
+
+    patterns: set[str] = set()
+    for adapter in BOUNDARY_ADAPTERS:
+        for pattern in (*adapter.exact_paths, *adapter.globs):
+            folded = pattern.casefold()
+            if adapter.id == "shared":
+                if "/.github/workflows/" in f"/{folded}":
+                    patterns.add(pattern)
+            elif folded.endswith((".json", ".toml")) and not folded.startswith(
+                (".claude/commands/", ".cursor/rules/")
+            ):
+                patterns.add(pattern)
+    return sorted(patterns)
+
+
 def _hook_script_text() -> str:
     # The protected-surface list is rendered at install time from the
     # same TRUST_ROOT_SURFACES the verify check classifies against, so
@@ -456,7 +481,10 @@ def _hook_script_text() -> str:
         [[kind, pattern] for kind, pattern in TRUST_ROOT_SURFACES],
         indent=4,
     )
-    return _HOOK_SCRIPT_TEMPLATE.replace("__PROTECTED_SURFACES_JSON__", surfaces)
+    host_config = json.dumps(host_config_change_patterns(), indent=4)
+    return _HOOK_SCRIPT_TEMPLATE.replace("__PROTECTED_SURFACES_JSON__", surfaces).replace(
+        "__HOST_CONFIG_SURFACES_JSON__", host_config
+    )
 
 
 _HOOK_SCRIPT_TEMPLATE = r'''#!/usr/bin/env python3
@@ -526,6 +554,10 @@ _UNPROMPTED_PERMISSION_MODES = frozenset({"bypasspermissions", "dontask"})
 # TRUST_ROOT_SURFACES — the same classification the PR-time verifier
 # uses. Each entry is [trust_root_class, glob_pattern].
 PROTECTED_SURFACES = __PROTECTED_SURFACES_JSON__
+
+# Rendered at install time from agents_shipgate.core.boundary_registry: the
+# host-configuration files and workflows `shipgate diff` compares (#661).
+HOST_CONFIG_SURFACES = __HOST_CONFIG_SURFACES_JSON__
 
 
 def main() -> int:
@@ -770,6 +802,15 @@ def _protected_surface_for(
     return None
 
 
+def _is_host_config_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").removeprefix("./")
+    return any(
+        _glob_match(pattern, normalized)
+        or _glob_match(pattern.casefold(), normalized.casefold())
+        for pattern in HOST_CONFIG_SURFACES
+    )
+
+
 def _glob_match(pattern: str, path: str) -> bool:
     """Mirror of agents_shipgate.core.globbing.glob_match (keep in sync)."""
     import re as _re
@@ -884,6 +925,10 @@ def _trigger(payload: dict[str, Any], root: Path, args: argparse.Namespace) -> i
     if not paths:
         return 0
     _record_in_session_approvals(payload, root, args)
+    if not (root / args.config).is_file() and all(_is_host_config_path(path) for path in paths):
+        # The Stop hook compares host configuration once per change (#661); a
+        # nudge on every edit would repeat itself without naming a row.
+        return 0
     diff_text = _git_diff_for_paths(root, paths)
     if diff_text is None:
         return _emit_context(
@@ -1015,6 +1060,10 @@ def _verify(payload: dict[str, Any], root: Path, args: argparse.Namespace) -> in
     if not config_path.is_file():
         if not snapshot["paths"]:
             return 0
+        if all(_is_host_config_path(path) for path in snapshot["paths"]):
+            # Only host configuration changed and nothing is configured: name
+            # what the change did rather than advise initializing a manifest.
+            return _route_host_diff(root, args, signature=str(snapshot["signature"]))
         trigger = _run_trigger_for_paths(
             root,
             snapshot["paths"],
@@ -1149,6 +1198,82 @@ _PUBLISH_ONLY_PERMISSIONS: dict[str, bool] = {
     "merge": False,
     "report_complete": False,
 }
+
+
+#: At most this many widening rows are quoted; the rest are counted.
+_MAX_ANNOUNCED_HOST_ROWS = 20
+
+
+def _route_host_diff(root: Path, args: argparse.Namespace, *, signature: str) -> int:
+    """Compare changed host configuration and speak only about widening (#661).
+
+    Quiet for a covered comparison with no row marked `expands`. Rows that
+    widen what the agent can do are named once: the announcement is bound to
+    the change's snapshot signature, the base and the rows, so an unchanged
+    repeat stays quiet and any change is announced again. An incomparable,
+    unparsed or unavailable comparison is never quiet. A row is a description,
+    never a permission, and this route grants no authority.
+    """
+
+    base = os.environ.get("AGENTS_SHIPGATE_VERIFY_BASE", args.base).strip()
+    manual = " ".join(
+        shlex.quote(part)
+        for part in ["agents-shipgate", "diff", "--workspace", ".", *(["--base", base] if base else [])]
+    )
+    if not base or not _safe_ref_token(base) or not _ref_exists(root, base):
+        return _emit_context(
+            "Stop",
+            "Agents Shipgate could not compare the host configuration this change "
+            f"edits: base ref {base!r} is not available locally. Make it available, "
+            f"then run `{manual}`.",
+        )
+    completed = _run(
+        [*_cli(), "diff", "--workspace", str(root), "--base", base, "--json"],
+        cwd=root,
+        timeout=VERIFY_TIMEOUT_SECONDS,
+        env={**os.environ, "AGENTS_SHIPGATE_AGENT_MODE": "1"},
+    )
+    try:
+        payload = json.loads(completed.stdout) if completed is not None else None
+    except json.JSONDecodeError:
+        payload = None
+    if not isinstance(payload, dict) or payload.get("comparison_status") != "comparable":
+        reasons = (
+            ", ".join(str(item) for item in payload.get("incomparable_reasons") or [])
+            if isinstance(payload, dict)
+            else ""
+        )
+        return _emit_context(
+            "Stop",
+            "Agents Shipgate could not compare the host configuration this change edits"
+            + (f" ({reasons})" if reasons else "")
+            + f". Treat it as unreviewed and run `{manual}`.",
+        )
+    rows = [row for row in payload.get("rows") or [] if isinstance(row, dict) and row.get("expands") is True]
+    if not rows:
+        return 0
+    digest = hashlib.sha256(
+        json.dumps([signature, base, rows], sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    state = _read_state(root)
+    if state.get("last_host_diff_announcement") == digest:
+        return 0
+    state["last_host_diff_announcement"] = digest
+    _write_state(root, state)
+    lines = [
+        f"- {row.get('subject')}: {row.get('before')} -> {row.get('after')} ({row.get('why')})"
+        for row in rows[:_MAX_ANNOUNCED_HOST_ROWS]
+    ]
+    if len(rows) > _MAX_ANNOUNCED_HOST_ROWS:
+        lines.append(f"- and {len(rows) - _MAX_ANNOUNCED_HOST_ROWS} more; run `{manual}`")
+    return _emit_context(
+        "Stop",
+        "Agents Shipgate compared the host configuration this change edits. "
+        "These rows widen what the agent can do:\n"
+        + "\n".join(lines)
+        + "\nQuote them to the user and in the pull request body. A row is a "
+        "description, never a permission.",
+    )
 
 
 def _authorizes_publication(control: dict[str, Any]) -> bool:

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -1121,6 +1121,12 @@ if args and args[0] == "verify":
         "control": {"state": "complete", "reason": "test pass"},
     }))
     raise SystemExit(0)
+if args and args[0] == "diff":
+    import os
+    override = os.environ.get("FAKE_DIFF_PAYLOAD")
+    if override is not None:
+        sys.stdout.write(override)
+        raise SystemExit(0)
 raise SystemExit(2)
 """.lstrip(),
         encoding="utf-8",
@@ -1549,3 +1555,169 @@ def test_post_tool_hook_stays_silent_on_an_evidence_backed_skip(
         == 0
     )
     assert capsys.readouterr().out == ""
+
+
+# --- #661: the Stop hook compares host configuration when no manifest exists --
+
+
+def _host_diff_workspace(tmp_path: Path) -> Path:
+    render_or_install_hooks(
+        workspace=tmp_path,
+        target="claude-code",
+        write=True,
+        config=Path("shipgate.yaml"),
+        base="origin/main",
+        head="",
+        ci_mode="advisory",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    for key, value in (("user.email", "shipgate@example.test"), ("user.name", "Shipgate Test")):
+        subprocess.run(["git", "config", key, value], cwd=tmp_path, check=True)
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    settings["permissions"] = {"allow": ["Read(**)"]}
+    settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=tmp_path, check=True)
+    settings["permissions"] = {"allow": ["Bash(*)", "Read(**)"]}
+    settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+    return tmp_path
+
+
+def _run_hook(tmp_path: Path, mode: str, payload: dict, *, diff_payload: str | None) -> subprocess.CompletedProcess[str]:
+    log = tmp_path.parent / f"{tmp_path.name}-cli.log"
+    fake_cli = _fake_shipgate_cli(tmp_path)
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(tmp_path)
+    env["AGENTS_SHIPGATE_CLI"] = f"{sys.executable} {fake_cli} {log}"
+    if diff_payload is not None:
+        env["FAKE_DIFF_PAYLOAD"] = diff_payload
+    return subprocess.run(
+        [sys.executable, str(tmp_path / HOOK_SCRIPT_RELATIVE_PATH), mode],
+        input=json.dumps({"cwd": str(tmp_path), **payload}),
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+        check=False,
+    )
+
+
+def _cli_calls(tmp_path: Path) -> list[list[str]]:
+    log = tmp_path.parent / f"{tmp_path.name}-cli.log"
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
+
+
+_WIDENING = {
+    "subject": "claude-code .claude/settings.json",
+    "before": "\u2014",
+    "after": "Bash(*)",
+    "direction": "added",
+    "severity": "critical",
+    "why": "matches any command of this kind, without a prompt",
+    "expands": True,
+}
+
+
+def test_stop_hook_without_manifest_is_quiet_when_no_host_row_expands(tmp_path: Path) -> None:
+    _host_diff_workspace(tmp_path)
+    narrowing = {**_WIDENING, "direction": "removed", "before": "Bash(*)", "after": "\u2014", "expands": False}
+    result = _run_hook(tmp_path, "verify", {}, diff_payload=json.dumps({"comparison_status": "comparable", "rows": [narrowing]}))
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+    assert any(call[0] == "diff" for call in _cli_calls(tmp_path))
+
+
+def test_stop_hook_without_manifest_names_widening_rows_once(tmp_path: Path) -> None:
+    _host_diff_workspace(tmp_path)
+    payload = json.dumps({"comparison_status": "comparable", "rows": [_WIDENING]})
+
+    first = _run_hook(tmp_path, "verify", {}, diff_payload=payload)
+    message = json.loads(first.stdout)["systemMessage"]
+    assert "Bash(*)" in message
+    assert "never a permission" in message
+    assert "decision" not in json.loads(first.stdout)
+
+    repeat = _run_hook(tmp_path, "verify", {}, diff_payload=payload)
+    assert repeat.stdout.strip() == ""
+
+    other = {**_WIDENING, "after": "WebFetch(*)"}
+    changed = _run_hook(tmp_path, "verify", {}, diff_payload=json.dumps({"comparison_status": "comparable", "rows": [other]}))
+    assert "WebFetch(*)" in json.loads(changed.stdout)["systemMessage"]
+
+
+@pytest.mark.parametrize(
+    "diff_payload",
+    [
+        json.dumps({"comparison_status": "incomparable", "incomparable_reasons": ["head_inventory_incomplete"], "rows": []}),
+        "not json",
+    ],
+    ids=["incomparable", "unparsed"],
+)
+def test_stop_hook_without_manifest_is_never_quiet_when_it_cannot_compare(tmp_path: Path, diff_payload: str) -> None:
+    _host_diff_workspace(tmp_path)
+    result = _run_hook(tmp_path, "verify", {}, diff_payload=diff_payload)
+
+    message = json.loads(result.stdout)["systemMessage"]
+    assert "could not compare the host configuration" in message
+    assert "agents-shipgate diff" in message
+
+
+def test_stop_hook_without_manifest_names_a_missing_base(tmp_path: Path) -> None:
+    _host_diff_workspace(tmp_path)
+    subprocess.run(["git", "update-ref", "-d", "refs/remotes/origin/main"], cwd=tmp_path, check=True)
+
+    result = _run_hook(tmp_path, "verify", {}, diff_payload=json.dumps({"comparison_status": "comparable", "rows": []}))
+
+    assert "not available locally" in json.loads(result.stdout)["systemMessage"]
+    assert not any(call[0] == "diff" for call in _cli_calls(tmp_path))
+
+
+def test_stop_hook_with_other_changes_keeps_the_manifest_advice(tmp_path: Path) -> None:
+    _host_diff_workspace(tmp_path)
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "prompts" / "refund.md").write_text("require approval\n", encoding="utf-8")
+
+    result = _run_hook(tmp_path, "verify", {}, diff_payload=json.dumps({"comparison_status": "comparable", "rows": []}))
+
+    assert "configured manifest 'shipgate.yaml' does not exist" in json.loads(result.stdout)["systemMessage"]
+    assert not any(call[0] == "diff" for call in _cli_calls(tmp_path))
+
+
+def test_post_tool_hook_is_quiet_on_host_config_edits_without_manifest(tmp_path: Path) -> None:
+    _host_diff_workspace(tmp_path)
+    payload = {"tool_input": {"file_path": str(tmp_path / ".claude" / "settings.json")}}
+
+    result = _run_hook(tmp_path, "trigger", payload, diff_payload=None)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+    assert not any(call[0] == "trigger" for call in _cli_calls(tmp_path))
+
+
+def test_rendered_host_config_surfaces_match_the_registry(tmp_path: Path) -> None:
+    from agents_shipgate.cli.install_hooks import host_config_change_patterns
+
+    namespace = _rendered_hook_namespace(tmp_path)
+    assert namespace["HOST_CONFIG_SURFACES"] == host_config_change_patterns()
+    classify = namespace["_is_host_config_path"]
+    for path, expected in {
+        ".claude/settings.json": True,
+        ".mcp.json": True,
+        "nested/.mcp.json": True,
+        ".cursor/mcp.json": True,
+        ".codex/config.toml": True,
+        ".vscode/mcp.json": True,
+        ".github/workflows/ci.yml": True,
+        "CLAUDE.md": False,
+        "AGENTS.md": False,
+        ".claude/commands/deploy.md": False,
+        ".cursor/rules/style.mdc": False,
+        "policies/host-boundary.shipgate.yaml": False,
+        "src/app.py": False,
+    }.items():
+        assert classify(path) is expected, path


### PR DESCRIPTION
Refs #661. This covers the Stop-hook route under the owner decisions recorded on #661. The 50-turn benign-session fixture and the 1.5 s latency budget remain on the issue.

## Problem, measured on main

Take a repository with no manifest and the hooks installed:
- A narrowing edit and a widening edit to `.claude/settings.json` got the same two messages, at PostToolUse and at Stop.
- Neither message named `Bash(*)`.
- Both advised initializing a manifest.

`shipgate diff` already separates the two cases, and each row carries `expands`.

## Change (generated hook, `cli/install_hooks.py`)

**Stop hook.** With no manifest, when every changed file is host configuration, the hook runs `shipgate diff --base <base> --json`:
- **Nothing expands:** a comparable result with no `expands: true` row stays quiet.
- **Something expands:** it names each widening row (subject, before → after, why), at most 20 plus a count. The announcement is bound to a digest of the change's snapshot signature, the base and the rows, stored in the existing hook state file. An unchanged repeat stays quiet, and any change announces again.
- **Can't compare:** an incomparable or unparsed result, or a missing or unsafe base ref, is never quiet. The hook says so and names the manual command.
- **No authority:** it never blocks the turn, and it tells the agent a row is a description, never a permission.

**PostToolUse hook.** It no longer nudges on those host-config-only edits, because the Stop hook compares them.

**Host-config paths.** The list is rendered at install time from the boundary registry by `host_config_change_patterns()`. It covers host configuration files (`.json`/`.toml`) and GitHub workflows. Instruction files, skills, commands, Cursor rules and policies are excluded, and keep their existing route, as do mixed changes. A repository with a manifest always runs `verify`, per the owner decision.

**Docs.** `docs/integrations.md` describes the new route and what it does not observe.

## Tests (`tests/test_install_hooks.py`)

The fake CLI now answers `diff`. New tests cover:
- quiet when no row expands
- a widening row named once, re-announced when the rows change
- incomparable and unparsed results never quiet
- a missing base named, without running `diff`
- mixed changes keeping the manifest advice
- PostToolUse quiet on host-config edits
- the rendered path list equal to the registry's, with a classification table

## Verification

- **Hook tests.** All 63 pass.
- **Mutations.** Each fails real assertions:
  - fast path removed
  - `expands` ignored
  - dedup ignored
  - incomparable treated as quiet
  - PostToolUse quiet removed
  - instruction files counted as host config
- **Full suite.** Green locally, and `ruff check .` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
