### PR TITLE
Treat an in-tree link to a file as a readable host file, not a coverage limit (#700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Stop counting a symlink to an in-tree regular file as a coverage limit (#700,
+  owner decision). The audit treated every link as a directory that might hide
+  a host-config match, so one symlinked file anywhere made every host's
+  inventory incomplete and refused its comparisons: #659 measured it on
+  `MetaMask/metamask-mobile#29139` and `bencherdev/bencher#673`. A link is now
+  resolved inside the tree, through at most eight links and never through a
+  linked directory. Its target's kind is recorded in the identity-bound read
+  session, which revalidates it when the snapshot finishes, so a target swapped
+  for a directory mid-read still fails. A dangling, external or directory target
+  is still a limit, and a link at a boundary path is still read as a link until
+  #700's second step. The scoped base tree gives such a link an empty
+  placeholder of its target's type, so both sides judge it the same way.
+
 - Compare host configuration in the Claude Code Stop hook when no manifest
   exists (#661). A narrowing and a widening edit to `.claude/settings.json` got
   the same two messages, neither named `Bash(*)`, and both advised initializing

--- a/src/agents_shipgate/cli/verify/git.py
+++ b/src/agents_shipgate/cli/verify/git.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import posixpath
 import re
 import subprocess
 import tempfile
@@ -1892,12 +1893,16 @@ def _materialize_isolated_tree(
     entries: list[tuple[str, str, str]] = []
     links: list[tuple[str, str]] = []
     portable_paths: dict[str, str] = {}
+    #: Every entry's object type, in or out of scope, so a link's target type
+    #: can be read from the tree rather than from what was materialized.
+    tree_types: dict[str, str] = {}
     for raw in listing.split(b"\0"):
         if not raw:
             continue
         metadata, raw_path = raw.split(b"\t", 1)
         mode, object_type, oid = metadata.decode("ascii").split(" ", 2)
         path_text = raw_path.decode("utf-8", errors="strict")
+        tree_types[path_text] = "link" if mode == "120000" else object_type
         if scope is not None and mode != "120000" and not scope(path_text):
             # Out of scope is not merely unmaterialized, it is unexamined:
             # the portability and collision checks below describe the tree
@@ -1967,6 +1972,7 @@ def _materialize_isolated_tree(
         if mode == "100755":
             os.chmod(target, 0o755)
 
+    link_texts: dict[str, str] = {}
     for oid, path_text in links:
         target = root / path_text
         if not _within(root, target.parent):
@@ -1978,15 +1984,93 @@ def _materialize_isolated_tree(
         # The link's own text is the blob. It may point anywhere, including
         # out of the tree — the reader opens it with O_NOFOLLOW and records
         # the failure, which is exactly what it does on the live worktree.
-        os.symlink(blob.decode("utf-8", errors="strict"), target)
+        link_text = blob.decode("utf-8", errors="strict")
+        os.symlink(link_text, target)
+        link_texts[path_text] = link_text
+
+    placeholders = (
+        _materialize_link_target_types(root, link_texts, tree_types)
+        if scope is not None
+        else set()
+    )
 
     materialized = {
-        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        relative: hashlib.sha256(path.read_bytes()).hexdigest()
         for path in root.rglob("*")
-        if path.is_file() and not path.is_symlink()
+        if path.is_file()
+        and not path.is_symlink()
+        and (relative := path.relative_to(root).as_posix()) not in placeholders
     }
     if materialized != expected_digests:
         raise ConfigError("Materialized Git tree differs from the verified object graph")
+
+
+#: How many links one resolution may pass through before it counts as unresolved.
+_MAX_TREE_LINK_HOPS = 8
+
+
+def _resolve_tree_link(path_text: str, link_texts: dict[str, str]) -> str | None:
+    """Where an in-tree link lands, by the tree's own names, or ``None``.
+
+    Lexical only, and deliberately narrow: an absolute target, a target that
+    leaves the tree, a chain longer than the hop bound, or any path with a link
+    as an *intermediate* component is unresolved. Unresolved is the answer the
+    reader already gives such a link, so nothing below is ever written through
+    one.
+    """
+
+    current = path_text
+    for _ in range(_MAX_TREE_LINK_HOPS):
+        text = link_texts.get(current)
+        if text is None:
+            return current
+        if not text or text.startswith("/"):
+            return None
+        joined = posixpath.normpath(posixpath.join(posixpath.dirname(current), text))
+        if joined in {".", ".."} or joined.startswith("../"):
+            return None
+        parts = joined.split("/")
+        if any("/".join(parts[:index]) in link_texts for index in range(1, len(parts))):
+            return None
+        current = joined
+    return None
+
+
+def _materialize_link_target_types(
+    root: Path, link_texts: dict[str, str], tree_types: dict[str, str]
+) -> set[str]:
+    """Give each recreated link a target of the type the tree says it has (#700).
+
+    A scoped archive writes only the paths a reader opens, so a link to an
+    out-of-scope file dangled here while it resolved in the worktree. The reader
+    types a link's target to decide whether it may conceal a recursive match,
+    and a dangling link does, so `changelog.md -> README.md` made the base side
+    incomplete and every comparison in the repository refused.
+
+    The placeholder carries the target's type, never its content: an empty file
+    or an empty directory, at a path the scope already excluded because no
+    reader opens it. Returns the placeholder files, which the digest check must
+    not count as materialized blobs.
+    """
+
+    placeholders: set[str] = set()
+    for path_text in sorted(link_texts):
+        resolved = _resolve_tree_link(path_text, link_texts)
+        if resolved is None:
+            continue
+        object_type = tree_types.get(resolved)
+        target = root / resolved
+        if object_type not in {"blob", "tree"} or os.path.lexists(target):
+            continue
+        if not _within(root, target.parent):
+            continue
+        if object_type == "tree":
+            target.mkdir(parents=True, exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"")
+            placeholders.add(resolved)
+    return placeholders
 
 
 def _within(root: Path, candidate: Path) -> bool:

--- a/src/agents_shipgate/core/host_grants.py
+++ b/src/agents_shipgate/core/host_grants.py
@@ -12,6 +12,7 @@ import errno
 import hashlib
 import json
 import os
+import posixpath
 import re
 import stat
 import sys
@@ -1197,7 +1198,12 @@ def _repository_paths(
                 if stat.S_ISLNK(metadata.st_mode):
                     if name not in skipped:
                         candidates.append((candidate, relative))
-                        symlink_directories.append(relative)
+                        # A link to an in-tree regular file has no descendants
+                        # to conceal (#700, owner decision). Everything else,
+                        # including a target this session cannot type, still
+                        # may hide a recursive match.
+                        if not _links_to_in_tree_file(reader, Path(relative)):
+                            symlink_directories.append(relative)
                     continue
                 if stat.S_ISDIR(metadata.st_mode):
                     if name not in skipped:
@@ -1242,6 +1248,47 @@ def _repository_paths(
                     _source_kind(relative),
                 )
     return [indexed[key] for key in sorted(indexed)], visited
+
+
+#: How many links one in-tree resolution may pass through.
+_MAX_IN_TREE_LINK_HOPS = 8
+
+
+def _links_to_in_tree_file(reader: IdentityBoundReadSession, relative: Path) -> bool:
+    """Whether a link resolves, inside the tree, to a regular file (#700).
+
+    The answer is bound to the identity-bound read rather than to a `stat()` at
+    enumeration: every link passed through is recorded by
+    :meth:`IdentityBoundReadSession.link_target`, and the target's kind by
+    :meth:`IdentityBoundReadSession.directory_entry_kind`, so :meth:`finish`
+    fails the snapshot if a link is re-pointed or the target is swapped for a
+    directory. An absolute or escaping target, a chain longer than the hop
+    bound, a link as an intermediate component, or anything the session cannot
+    type is not an in-tree file.
+    """
+
+    current = relative
+    try:
+        for _ in range(_MAX_IN_TREE_LINK_HOPS):
+            text = reader.link_target(current)
+            if not text or os.path.isabs(text) or text.startswith(("\\", "/")):
+                return False
+            joined = posixpath.normpath(posixpath.join(current.parent.as_posix(), text))
+            if joined in {".", ".."} or joined.startswith("../"):
+                return False
+            target = Path(joined)
+            for index in range(1, len(target.parts)):
+                if reader.directory_entry_kind(Path(*target.parts[:index])) != "directory":
+                    return False
+            kind = reader.directory_entry_kind(target)
+            if kind == "file":
+                return True
+            if kind != "symlink":
+                return False
+            current = target
+    except (OSError, ValueError):
+        return False
+    return False
 
 
 def _symlink_may_hide_boundary_glob(relative: str, pattern: str) -> bool:

--- a/src/agents_shipgate/core/trust_roots.py
+++ b/src/agents_shipgate/core/trust_roots.py
@@ -469,6 +469,32 @@ class IdentityBoundReadSession:
         snapshot.entry_kinds[relative.name] = kind
         return kind
 
+    def link_target(self, relative: Path) -> str:
+        """Read one enumerated symbolic link's target text, inside this session (#700).
+
+        The name must be in the directory inventory this session recorded, and
+        it must still be a link; nothing is followed or opened. Re-pointing a
+        link replaces a directory entry, which changes the containing
+        directory's own identity. That identity is recorded when the inventory
+        is taken and revalidated by :meth:`finish`, so a link re-pointed after
+        this read fails the snapshot there. A separate per-link record would
+        catch nothing that check does not.
+        """
+
+        if self._finished or relative.is_absolute() or ".." in relative.parts or not relative.name:
+            raise ValueError("invalid symbolic link observation")
+        directory = self.root / relative.parent
+        if directory not in self._snapshots:
+            self.directory_entries(relative.parent)
+        snapshot = self._snapshots[directory]
+        if relative.name not in snapshot.names:
+            raise ValueError("directory entry changed lexical identity")
+        path = self.root / relative
+        metadata = path.lstat()
+        if not stat.S_ISLNK(metadata.st_mode):
+            raise ValueError("entry is not a symbolic link")
+        return os.readlink(path)
+
     def _inspect_components(
         self,
         relative: Path,

--- a/tests/test_adapter_static_only.py
+++ b/tests/test_adapter_static_only.py
@@ -245,7 +245,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="import:subprocess",
-        line=6,
+        line=7,
         snippet="import subprocess",
         rationale=(
             "Verify uses local git commands to resolve refs, collect diffs, "
@@ -257,7 +257,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.Popen",
-        line=2161,
+        line=2245,
         snippet=(
             "subprocess.Popen(cmd, env=env, stderr=subprocess.PIPE, "
             "stdin=subprocess.PIPE if input is not None else "
@@ -276,7 +276,7 @@ ALLOWED_EXCEPTIONS: tuple[AllowedException, ...] = (
     AllowedException(
         relative_path="cli/verify/git.py",
         surface="attr_call:subprocess.run",
-        line=2405,
+        line=2489,
         snippet=(
             "subprocess.run(cmd, capture_output=capture_output, check=check, "
             "env=env, input=input, stderr=stderr, stdin=stdin, stdout=stdout, "

--- a/tests/test_host_file_links.py
+++ b/tests/test_host_file_links.py
@@ -1,0 +1,154 @@
+"""#700, step one: a symlinked in-tree file no host reads is not a coverage limit.
+
+The audit treated every link as a directory that might hide a `**/` match, so
+one symlinked asset anywhere refused every host's comparison. #659 measured it
+on `MetaMask/metamask-mobile#29139` (`android/app/src/main/assets/branch.json`)
+and `bencherdev/bencher#673` (`changelog.md`). By owner decision, a link whose
+target is an in-tree regular file, typed inside the identity-bound read, no
+longer counts. An external, dangling or directory target still does, and a link
+*at* a boundary path is still read as a link until step two.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agents_shipgate.cli.host_audit import host_audit_inventory
+from agents_shipgate.cli.main import app
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+
+def _settings(root: Path, allow: list[str]) -> None:
+    (root / ".claude").mkdir(exist_ok=True)
+    (root / ".claude" / "settings.json").write_text(json.dumps({"permissions": {"allow": allow}}), encoding="utf-8")
+
+
+def _issues(inventory: dict, source: str) -> list[dict]:
+    return [item for item in inventory["issues"] if item["source"] == source]
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True, env=_GIT_ENV
+    ).stdout.strip()
+
+
+@pytest.mark.parametrize("link", ["changelog.md", "android/app/src/main/assets/branch.json", "chain/LICENSE-APACHE"])
+def test_a_link_to_an_in_tree_file_is_not_a_limit(tmp_path: Path, link: str) -> None:
+    _settings(tmp_path, ["Read(**)"])
+    (tmp_path / "README.md").write_text("readme", encoding="utf-8")
+    target = tmp_path / link
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(os.path.relpath(tmp_path / "README.md", target.parent))
+
+    inventory = host_audit_inventory(tmp_path)
+
+    assert _issues(inventory, link) == []
+    assert [item for item in inventory["issues"] if item.get("blocking")] == []
+
+
+def test_a_chain_of_in_tree_links_to_a_file_is_not_a_limit(tmp_path: Path) -> None:
+    _settings(tmp_path, ["Read(**)"])
+    (tmp_path / "README.md").write_text("readme", encoding="utf-8")
+    (tmp_path / "middle.md").symlink_to("README.md")
+    (tmp_path / "changelog.md").symlink_to("middle.md")
+
+    assert [item for item in host_audit_inventory(tmp_path)["issues"] if item.get("blocking")] == []
+
+
+@pytest.mark.parametrize("shape", ["dangling", "directory", "external", "through-linked-directory"])
+def test_a_target_that_is_not_an_in_tree_file_still_conceals(tmp_path: Path, shape: str) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _settings(root, ["Read(**)"])
+    if shape == "dangling":
+        (root / "vendor").symlink_to("missing")
+    elif shape == "directory":
+        (root / "shared").mkdir()
+        (root / "vendor").symlink_to("shared", target_is_directory=True)
+    elif shape == "external":
+        outside = tmp_path / "outside.md"
+        outside.write_text("outside", encoding="utf-8")
+        (root / "vendor").symlink_to(outside)
+    else:
+        (root / "real").mkdir()
+        (root / "real" / "file.md").write_text("x", encoding="utf-8")
+        (root / "docs").symlink_to("real", target_is_directory=True)
+        (root / "vendor").symlink_to("docs/file.md")
+
+    issues = _issues(host_audit_inventory(root), "vendor")
+
+    assert issues, shape
+    assert all(item["kind"] == "unreadable" and item["blocking"] for item in issues), shape
+
+
+def test_a_link_at_a_boundary_path_is_still_read_as_a_link(tmp_path: Path) -> None:
+    """Step two of #700 reads through it; pinned so that step shows up as a change."""
+
+    _settings(tmp_path, ["Read(**)"])
+    (tmp_path / "AGENTS.md").write_text("# agents", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").symlink_to("AGENTS.md")
+
+    issues = _issues(host_audit_inventory(tmp_path), "CLAUDE.md")
+
+    assert issues
+    assert all(item["kind"] == "unreadable" for item in issues)
+
+
+def test_a_comparison_beside_an_unrelated_file_link_names_the_change(tmp_path: Path) -> None:
+    """The #659 shape end to end: the base tree must type the link the same way."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _settings(repo, ["Read(**)"])
+    (repo / "README.md").write_text("readme", encoding="utf-8")
+    (repo / "changelog.md").symlink_to("README.md")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+    _settings(repo, ["Bash(*)", "Read(**)"])
+
+    result = CliRunner().invoke(app, ["diff", "--workspace", str(repo), "--base", base, "--json"])
+    payload = json.loads(result.stdout)
+
+    assert payload["comparison_status"] == "comparable", payload
+    assert [(row["direction"], row["after"]) for row in payload["rows"]] == [("added", "Bash(*)")]
+
+
+def test_a_scoped_archive_never_writes_through_a_linked_directory(tmp_path: Path) -> None:
+    from agents_shipgate.cli.verify.git import archive_tree
+    from agents_shipgate.core.boundary_registry import is_boundary_surface_path
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _settings(repo, ["Read(**)"])
+    (repo / "real").mkdir()
+    (repo / "real" / "file.md").write_text("out of scope", encoding="utf-8")
+    (repo / "docs").symlink_to("real", target_is_directory=True)
+    (repo / "pointer.md").symlink_to("docs/file.md")
+    (repo / "README.md").write_text("never materialized", encoding="utf-8")
+    (repo / "changelog.md").symlink_to("README.md")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    archive = tmp_path / "archive"
+
+    archive_tree(repo, "HEAD", archive, scope=is_boundary_surface_path)
+
+    assert not (archive / "real" / "file.md").exists()
+    assert not (archive / "pointer.md").exists()
+    assert (archive / "changelog.md").is_file()
+    assert (archive / "README.md").read_bytes() == b""

--- a/tests/test_scoped_base_tree.py
+++ b/tests/test_scoped_base_tree.py
@@ -300,10 +300,12 @@ class TestNamesOutsideTheSurface:
             archive_tree(root, commit, tmp_path / "base", scope=is_boundary_surface_path)
 
 
-@pytest.mark.parametrize("kind", ["file", "directory", "dangling"])
+@pytest.mark.parametrize("kind", ["directory", "dangling"])
 def test_unbound_symlink_targets_remain_explicit_coverage_limits(tmp_path, kind):
-    # Target type is not part of the identity-bound read. It cannot justify
-    # dropping a candidate, even when it happens to be a regular file now.
+    # A directory can hide a recursive match and a dangling target cannot be
+    # typed, so both stay limits. An in-tree *file* target is typed inside the
+    # identity-bound read and is no longer one (#700, owner decision); see
+    # `test_an_in_tree_file_target_is_not_a_coverage_limit`.
     from agents_shipgate.core.host_grants import inventory_is_complete
 
     root = _host_repo(tmp_path)
@@ -343,3 +345,62 @@ def test_symlink_target_kind_is_not_unbound_negative_coverage(tmp_path, monkeypa
     assert not host_grants.inventory_is_complete(snapshot.inventory)
     assert not host_grants.inventory_is_complete(fresh.inventory)
     assert snapshot.inventory["issues"]
+
+
+def test_an_in_tree_file_target_is_not_a_coverage_limit(tmp_path):
+    from agents_shipgate.core.host_grants import inventory_is_complete
+
+    root = _host_repo(tmp_path)
+    (root / "target").write_text("file")
+    (root / "linked").symlink_to("target")
+    inventory = build_host_boundary_snapshot(root).inventory
+    assert inventory_is_complete(inventory), inventory["issues"]
+    assert not any(issue.get("source") == "linked" for issue in inventory["issues"])
+    assert inventory["grants"]
+
+
+def test_an_in_tree_file_target_swapped_for_a_directory_fails_the_snapshot(tmp_path, monkeypatch):
+    """The in-tree variant of the pinned race: the kind is revalidated at finish."""
+
+    from agents_shipgate.core import host_grants
+
+    root = _host_repo(tmp_path)
+    target = root / "target"
+    target.write_text("file")
+    (root / "linked").symlink_to("target")
+    original = host_grants._repository_paths
+
+    def enumerate_then_replace(*args, **kwargs):
+        result = original(*args, **kwargs)
+        target.unlink()
+        target.mkdir()
+        (target / "CLAUDE.md").write_text("instructions")
+        return result
+
+    with monkeypatch.context() as patch:
+        patch.setattr(host_grants, "_repository_paths", enumerate_then_replace)
+        snapshot = build_host_boundary_snapshot(root)
+    assert not host_grants.inventory_is_complete(snapshot.inventory)
+
+
+def test_a_retargeted_link_fails_the_session(tmp_path):
+    """Re-pointing a link after its target was read fails the snapshot (#700).
+
+    Re-pointing keeps the name and the kind, so neither check sees it; the
+    containing directory's recorded identity does, whether the link sits in the
+    session root or below it.
+    """
+
+    from agents_shipgate.core.trust_roots import IdentityBoundReadSession
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("a")
+    (docs / "b.md").write_text("b")
+    (docs / "link.md").symlink_to("a.md")
+    session = IdentityBoundReadSession(tmp_path, max_entries=1000, max_total_bytes=1_000_000)
+    assert session.link_target(Path("docs/link.md")) == "a.md"
+    (docs / "link.md").unlink()
+    (docs / "link.md").symlink_to("b.md")
+    with pytest.raises(ValueError):
+        session.finish()


### PR DESCRIPTION
Step one of #700. Refs #700; the issue stays open for step two, reading through in-tree links at boundary paths, which will carry `resolved_through` and the inventory schema bump.

## Decision

Owner decision on #700, step one: a repository-internal link to a regular file is not a coverage limit.
- The link's type comes from the identity-bound enumeration.
- That type is revalidated when the read session finishes.
- External and dangling links stay blocking.

## Change

- **`core/trust_roots.py`.** `IdentityBoundReadSession.link_target(relative)` returns the link text for a name the session enumerated as a symlink. Anything else is refused. It records nothing new, because retargeting a link changes the containing directory's identity, which `finish()` already checks.
- **`core/host_grants.py`.** `_links_to_in_tree_file` resolves a link lexically inside the repository, following at most 8 links.
  - Every intermediate component must be enumerated as a directory, and the final target as a regular file.
  - Anything outside the tree, dangling, or unreadable (`OSError` / `ValueError`) is not an in-tree file.
  - `_repository_paths` counts a link as a symlink limit only when it is not an in-tree file link.
- **`cli/verify/git.py`.** The scoped base tree records link texts and resolves an in-tree link's target type from the tree itself. Materialized placeholders are excluded from the digest check, so the base side agrees with the worktree side.
- **Static-only allowlist.** `tests/test_adapter_static_only.py` pins the `cli/verify/git.py` subprocess sites by line, so those pins move with the file: import 6→7, `Popen` 2104→2188, `run` 2348→2432. The snippets and rationale are unchanged.

## Tests

- **New: `tests/test_host_file_links.py`.**
- **`tests/test_scoped_base_tree.py`.**
  - The blocking-link parametrization is now `directory` and `dangling`.
  - `test_an_in_tree_file_target_is_not_a_coverage_limit`
  - `test_an_in_tree_file_target_swapped_for_a_directory_fails_the_snapshot`
  - `test_a_retargeted_link_fails_the_session`

## Verification

- **Full suite before the rebase.** 10,835 passed, 5 failed. All five failures were the static-only line pins above. With the pins moved, `tests/test_adapter_static_only.py` passes (494).
- **After rebasing onto main (after #727).** The focused host, verify and static-only suites pass. CI is authoritative for the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
